### PR TITLE
Add embedded YouTube demo video to web landing page

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -728,6 +728,31 @@
     }
 
     /* ================================================================
+       DEMO VIDEO
+       ================================================================ */
+    .video-showcase {
+      max-width: 900px;
+      margin: 0 auto;
+    }
+    .video-frame {
+      position: relative;
+      width: 100%;
+      padding-bottom: 56.25%;
+      border-radius: var(--radius);
+      overflow: hidden;
+      border: 1px solid var(--border);
+      background: #000;
+      box-shadow: 0 20px 40px rgba(0,0,0,0.35);
+    }
+    .video-frame iframe {
+      position: absolute;
+      inset: 0;
+      width: 100%;
+      height: 100%;
+      border: 0;
+    }
+
+    /* ================================================================
        RESPONSIVE
        ================================================================ */
     @media (max-width: 768px) {
@@ -762,6 +787,7 @@
     </a>
     <div class="nav-links">
       <a href="#features">Features</a>
+      <a href="#demo">Demo</a>
       <a href="#providers">Providers</a>
       <a href="#compare">Compare</a>
       <a href="#download">Download</a>
@@ -841,6 +867,18 @@
           </div>
         </div>
       </div>
+    </div>
+  </div>
+</section>
+
+<!-- DEMO VIDEO -->
+<section class="section" id="demo" style="padding-top: 30px;">
+  <div class="section-label">Demo</div>
+  <h2 class="section-title">Watch WebBrain in action</h2>
+  <p class="section-subtitle">See how WebBrain reads pages, extracts data, and automates browser tasks.</p>
+  <div class="video-showcase">
+    <div class="video-frame">
+      <iframe src="https://www.youtube.com/embed/1NN2dweooKM" title="WebBrain demo video" loading="lazy" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
     </div>
   </div>
 </section>


### PR DESCRIPTION
### Motivation
- Provide a visible demo of WebBrain in action on the landing page to help visitors understand features quickly.
- Host the requested YouTube video inline so users can watch without leaving the site.
- Add a navigation anchor for quick access to the demo section from the top nav.

### Description
- Updated `web/index.html` to add a new `Demo` section containing an embedded YouTube iframe for `https://youtu.be/1NN2dweooKM`.
- Added responsive CSS rules (`.video-showcase`, `.video-frame`, and iframe styles) to maintain a 16:9 aspect ratio and card-like presentation.
- Inserted a `Demo` anchor link in the top navigation to jump to the new section.
- The change is a static HTML/CSS update and does not modify build tooling or runtime logic.

### Testing
- Ran `git diff -- web/index.html` to inspect the changes to `web/index.html` and verified the demo section and CSS were added, which succeeded.
- Printed the modified file region with `nl -ba web/index.html | sed -n '720,920p'` to validate the inserted block and confirmed the iframe and styles are present, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d40c48b2308327a6c6ce24f7dab33b)