### PR TITLE
Add OG image and favicon, and allow static asset rewrites in Vercel config

### DIFF
--- a/web/favicon.svg
+++ b/web/favicon.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <text x="50%" y="50%" text-anchor="middle" dominant-baseline="central" font-size="52">🧠</text>
+</svg>

--- a/web/index.html
+++ b/web/index.html
@@ -11,13 +11,18 @@
   <meta property="og:type" content="website">
   <meta property="og:url" content="https://webbrain.one">
   <meta property="og:site_name" content="WebBrain">
+  <meta property="og:image" content="https://webbrain.one/og-image.svg">
+  <meta property="og:image:secure_url" content="https://webbrain.one/og-image.svg">
+  <meta property="og:image:type" content="image/svg+xml">
+  <meta property="og:image:alt" content="WebBrain icon">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="WebBrain — Open-Source AI Browser Agent">
   <meta name="twitter:description" content="Free, open-source alternative to Claude browser plugin. AI agent for Chrome & Firefox. Works with local or cloud LLMs.">
+  <meta name="twitter:image" content="https://webbrain.one/og-image.svg">
+  <meta name="twitter:image:alt" content="WebBrain icon">
   <meta name="robots" content="index, follow">
+  <link rel="icon" type="image/svg+xml" href="/favicon.svg">
   <link rel="canonical" href="https://webbrain.one">
-  <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>🧠</text></svg>">
-
   <!-- JSON-LD Structured Data -->
   <script type="application/ld+json">
   {

--- a/web/og-image.svg
+++ b/web/og-image.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630" role="img" aria-label="WebBrain preview image">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#0f172a"/>
+      <stop offset="100%" stop-color="#1e293b"/>
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="630" fill="url(#bg)" rx="28"/>
+  <text x="120" y="250" font-size="160">🧠</text>
+  <text x="120" y="360" fill="#e2e8f0" font-size="86" font-family="Inter, Segoe UI, Roboto, Arial, sans-serif" font-weight="700">WebBrain</text>
+  <text x="120" y="430" fill="#94a3b8" font-size="42" font-family="Inter, Segoe UI, Roboto, Arial, sans-serif">Open-source AI browser agent</text>
+</svg>

--- a/web/vercel.json
+++ b/web/vercel.json
@@ -1,6 +1,7 @@
 {
   "rewrites": [
     { "source": "/privacy", "destination": "/privacy.html" },
+    { "source": "/:path*\\.(png|jpg|jpeg|gif|webp|svg|ico|css|js|map|txt|xml|json|woff|woff2|ttf|otf)", "destination": "/:path*" },
     { "source": "/(.*)", "destination": "/index.html" }
   ],
   "headers": [


### PR DESCRIPTION
### Motivation
- Improve social sharing and branding by adding a proper Open Graph/Twitter preview image and a site favicon. 
- Replace the inline data-URL favicon with a standalone file for better cacheability and compatibility. 
- Ensure static assets (images, fonts, CSS, JS) are served correctly by adding a Vercel rewrite rule. 

### Description
- Added `web/og-image.svg` as a 1200x630 Open Graph/Twitter preview image containing the WebBrain branding. 
- Added `web/favicon.svg` as the site favicon SVG (emoji brain) and updated `index.html` to reference it via a `<link rel="icon">`. 
- Updated `web/index.html` to include `og:image`, `og:image:secure_url`, `og:image:type`, `og:image:alt`, `twitter:image`, and `twitter:image:alt` meta tags and removed the inline data-URL favicon. 
- Modified `web/vercel.json` to add a rewrite for static asset paths matching common file extensions so files like `.svg`, `.png`, `.css`, and fonts are served directly. 

### Testing
- No automated tests were added or modified for this change. 
- No automated test suite was executed as part of this change since it only affects static assets and HTML metadata. 
- Manual verification is expected for social preview rendering and favicon serving in deployment preview environments.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d4131cd77083278e6a2c27f3d6a206)