### PR TITLE
Update Firefox install card to link AMO and add source link

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -1010,9 +1010,12 @@
       <div class="browser-icon">🦊</div>
       <h3>Firefox</h3>
       <p>Manifest V2 &middot; Firefox 109+</p>
-      <a href="https://github.com/esokullu/webbrain/releases" target="_blank" class="btn btn-primary" style="background: #ff9800;">
+      <a href="https://addons.mozilla.org/en-US/firefox/addon/webbrain/" target="_blank" rel="noopener noreferrer" class="btn btn-primary" style="background: #ff9800;">
         <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" width="16" height="16"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>
-        Download for Firefox
+        Download from Firefox Add-ons
+      </a>
+      <a href="https://github.com/esokullu/webbrain/tree/main/firefox" target="_blank" rel="noopener noreferrer" class="btn btn-secondary" style="margin-top:10px;">
+        View Firefox source
       </a>
     </div>
   </div>


### PR DESCRIPTION
### Motivation
- Provide a direct download link to the approved Firefox Add-ons listing and an easy way for users to view the Firefox extension source from the website.

### Description
- In `web/index.html` replace the Firefox download anchor to point to `https://addons.mozilla.org/en-US/firefox/addon/webbrain/`, update the button label to "Download from Firefox Add-ons", add `rel="noopener noreferrer"`, and add a secondary `View Firefox source` link to `https://github.com/esokullu/webbrain/tree/main/firefox`.

### Testing
- No automated tests were run for this content-only change; the update was validated by reviewing the `git diff` of `web/index.html` and committing the change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d80a1c93b8832790d286b256192e8c)