### PR TITLE
Add `press_keys` tool to agents and content scripts (supports Escape/Tab/Enter)

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "WebBrain",
-  "version": "1.6.7",
+  "version": "1.6.8",
   "description": "Open-source AI browser agent — chat with pages, automate tasks, multi-provider LLM support.",
   "permissions": [
     "sidePanel",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webbrain",
-  "version": "1.6.7",
+  "version": "1.6.8",
   "description": "Open-source AI browser agent — chat with pages, automate tasks, multi-provider LLM support.",
   "private": true,
   "type": "module",

--- a/src/chrome/manifest.json
+++ b/src/chrome/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "WebBrain",
-  "version": "1.6.7",
+  "version": "1.6.8",
   "description": "Open-source AI browser agent — chat with pages, automate tasks, multi-provider LLM support.",
   "permissions": [
     "sidePanel",

--- a/src/chrome/src/agent/agent.js
+++ b/src/chrome/src/agent/agent.js
@@ -194,7 +194,7 @@ export class Agent {
   // Tools whose successful completion should trigger an auto-screenshot when
   // the corresponding mode is active.
   static NAV_TOOLS = new Set(['navigate', 'new_tab']);
-  static STATE_CHANGE_TOOLS = new Set(['navigate', 'new_tab', 'click', 'type_text', 'scroll']);
+  static STATE_CHANGE_TOOLS = new Set(['navigate', 'new_tab', 'click', 'type_text', 'press_keys', 'scroll']);
 
   /**
    * Decide whether to capture an auto-screenshot after a tool call, based on
@@ -1361,12 +1361,50 @@ export class Agent {
       }
     }
 
+    if (name === 'press_keys') {
+      const key = args.key;
+      const repeatRaw = Number(args.repeat ?? 1);
+      const repeat = Math.max(1, Math.min(3, Number.isFinite(repeatRaw) ? Math.floor(repeatRaw) : 1));
+      if (!['Escape', 'Tab', 'Enter'].includes(key)) {
+        return { success: false, error: `Unsupported key "${key}". V1 supports Escape, Tab, and Enter.` };
+      }
+
+      try {
+        await cdpClient.attach(tabId);
+        const keyMeta = {
+          Escape: { code: 'Escape', windowsVirtualKeyCode: 27 },
+          Tab: { code: 'Tab', windowsVirtualKeyCode: 9 },
+          Enter: { code: 'Enter', windowsVirtualKeyCode: 13 },
+        }[key];
+
+        for (let i = 0; i < repeat; i++) {
+          await cdpClient.sendCommand(tabId, 'Input.dispatchKeyEvent', {
+            type: 'keyDown',
+            key,
+            code: keyMeta.code,
+            windowsVirtualKeyCode: keyMeta.windowsVirtualKeyCode,
+          });
+          await cdpClient.sendCommand(tabId, 'Input.dispatchKeyEvent', {
+            type: 'keyUp',
+            key,
+            code: keyMeta.code,
+            windowsVirtualKeyCode: keyMeta.windowsVirtualKeyCode,
+          });
+        }
+
+        return { success: true, method: 'cdp-key', key, repeat };
+      } catch (e) {
+        // Fall through to content-script path if CDP is unavailable.
+      }
+    }
+
     // Map tool names to content script actions
     const actionMap = {
       'read_page': 'get_page_info_cdp',
       'get_interactive_elements': 'get_interactive_elements_cdp',
       'click': 'click',
       'type_text': 'type',
+      'press_keys': 'press_keys',
       'scroll': 'scroll',
       'extract_data': 'extract_data',
       'wait_for_element': 'wait_for_element',

--- a/src/chrome/src/agent/tools.js
+++ b/src/chrome/src/agent/tools.js
@@ -77,6 +77,21 @@ export const AGENT_TOOLS = [
   {
     type: 'function',
     function: {
+      name: 'press_keys',
+      description: 'Press keyboard keys. V1 supports Escape, Tab, and Enter. Useful for dismissing modals/dropdowns (Escape), moving focus (Tab), and confirming dialogs/forms (Enter).',
+      parameters: {
+        type: 'object',
+        properties: {
+          key: { type: 'string', enum: ['Escape', 'Tab', 'Enter'], description: 'Key to press.' },
+          repeat: { type: 'number', description: 'How many times to press the key (default: 1, max: 3).' },
+        },
+        required: ['key'],
+      },
+    },
+  },
+  {
+    type: 'function',
+    function: {
       name: 'scroll',
       description: 'Scroll the page in a given direction.',
       parameters: {

--- a/src/chrome/src/content/content.js
+++ b/src/chrome/src/content/content.js
@@ -276,18 +276,54 @@
       return { success: false, error: `Unsupported key "${key}". V1 supports Escape, Tab, and Enter.` };
     }
 
+    const keyMeta = {
+      Escape: { code: 'Escape', keyCode: 27 },
+      Tab: { code: 'Tab', keyCode: 9 },
+      Enter: { code: 'Enter', keyCode: 13 },
+    }[key];
     const target = (document.activeElement && document.activeElement !== document.body)
       ? document.activeElement
       : document;
 
+    const moveTabFocus = () => {
+      const focusables = Array.from(document.querySelectorAll(
+        'a[href], button:not([disabled]), input:not([disabled]):not([type="hidden"]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])'
+      )).filter(el => {
+        const style = window.getComputedStyle(el);
+        return style.display !== 'none' && style.visibility !== 'hidden';
+      });
+      if (focusables.length === 0) return;
+      const active = document.activeElement;
+      const currentIndex = focusables.indexOf(active);
+      const nextIndex = (currentIndex + 1 + focusables.length) % focusables.length;
+      try { focusables[nextIndex].focus(); } catch (e) {}
+    };
+
     for (let i = 0; i < repeat; i++) {
-      const down = new KeyboardEvent('keydown', { key, code: key, bubbles: true, cancelable: true });
-      const up = new KeyboardEvent('keyup', { key, code: key, bubbles: true, cancelable: true });
+      const down = new KeyboardEvent('keydown', {
+        key,
+        code: keyMeta.code,
+        keyCode: keyMeta.keyCode,
+        which: keyMeta.keyCode,
+        bubbles: true,
+        cancelable: true,
+      });
+      const up = new KeyboardEvent('keyup', {
+        key,
+        code: keyMeta.code,
+        keyCode: keyMeta.keyCode,
+        which: keyMeta.keyCode,
+        bubbles: true,
+        cancelable: true,
+      });
       target.dispatchEvent(down);
+      document.dispatchEvent(down);
       target.dispatchEvent(up);
+      document.dispatchEvent(up);
+      if (key === 'Tab') moveTabFocus();
     }
 
-    return { success: true, key, repeat, method: 'keyboardevent' };
+    return { success: true, key, repeat, method: 'keyboardevent', focusedTag: document.activeElement?.tagName || null };
   }
 
   /**

--- a/src/chrome/src/content/content.js
+++ b/src/chrome/src/content/content.js
@@ -266,6 +266,31 @@
   }
 
   /**
+   * Press supported keyboard keys.
+   */
+  function pressKeys(params) {
+    const key = params?.key;
+    const repeatRaw = Number(params?.repeat ?? 1);
+    const repeat = Math.max(1, Math.min(3, Number.isFinite(repeatRaw) ? Math.floor(repeatRaw) : 1));
+    if (!['Escape', 'Tab', 'Enter'].includes(key)) {
+      return { success: false, error: `Unsupported key "${key}". V1 supports Escape, Tab, and Enter.` };
+    }
+
+    const target = (document.activeElement && document.activeElement !== document.body)
+      ? document.activeElement
+      : document;
+
+    for (let i = 0; i < repeat; i++) {
+      const down = new KeyboardEvent('keydown', { key, code: key, bubbles: true, cancelable: true });
+      const up = new KeyboardEvent('keyup', { key, code: key, bubbles: true, cancelable: true });
+      target.dispatchEvent(down);
+      target.dispatchEvent(up);
+    }
+
+    return { success: true, key, repeat, method: 'keyboardevent' };
+  }
+
+  /**
    * Scroll the page.
    */
   function scrollPage(params) {
@@ -512,6 +537,7 @@
       'get_interactive_elements_cdp': () => getInteractiveElementsFull(),
       'click': () => clickElement(msg.params || {}),
       'type': () => typeText(msg.params || {}),
+      'press_keys': () => pressKeys(msg.params || {}),
       'scroll': () => scrollPage(msg.params || {}),
       'extract_data': () => extractData(msg.params || {}),
       'wait_for_element': () => waitForElement(msg.params || {}),

--- a/src/chrome/src/ui/settings.html
+++ b/src/chrome/src/ui/settings.html
@@ -220,7 +220,7 @@
 </head>
 <body>
   <h1>WebBrain Settings</h1>
-  <p class="subtitle">Configure your LLM providers and display preferences · v1.6.7</p>
+  <p class="subtitle">Configure your LLM providers and display preferences · v1.6.8</p>
 
   <h2>Display</h2>
   <div id="display-settings">

--- a/src/firefox/manifest.json
+++ b/src/firefox/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "WebBrain",
-  "version": "1.6.7",
+  "version": "1.6.8",
   "description": "Open-source AI browser agent — chat with pages, automate tasks, multi-provider LLM support.",
   "permissions": [
     "activeTab",

--- a/src/firefox/src/agent/agent.js
+++ b/src/firefox/src/agent/agent.js
@@ -129,7 +129,7 @@ export class Agent {
   }
 
   static NAV_TOOLS = new Set(['navigate', 'new_tab']);
-  static STATE_CHANGE_TOOLS = new Set(['navigate', 'new_tab', 'click', 'type_text', 'scroll']);
+  static STATE_CHANGE_TOOLS = new Set(['navigate', 'new_tab', 'click', 'type_text', 'press_keys', 'scroll']);
 
   _shouldAutoScreenshot(toolName) {
     const mode = this.autoScreenshot;
@@ -872,6 +872,7 @@ export class Agent {
       'get_frames': 'get_frames',
       'click': 'click',
       'type_text': 'type',
+      'press_keys': 'press_keys',
       'scroll': 'scroll',
       'extract_data': 'extract_data',
       'wait_for_element': 'wait_for_element',

--- a/src/firefox/src/agent/tools.js
+++ b/src/firefox/src/agent/tools.js
@@ -77,6 +77,21 @@ export const AGENT_TOOLS = [
   {
     type: 'function',
     function: {
+      name: 'press_keys',
+      description: 'Press keyboard keys. V1 supports Escape, Tab, and Enter. Useful for dismissing modals/dropdowns (Escape), moving focus (Tab), and confirming dialogs/forms (Enter).',
+      parameters: {
+        type: 'object',
+        properties: {
+          key: { type: 'string', enum: ['Escape', 'Tab', 'Enter'], description: 'Key to press.' },
+          repeat: { type: 'number', description: 'How many times to press the key (default: 1, max: 3).' },
+        },
+        required: ['key'],
+      },
+    },
+  },
+  {
+    type: 'function',
+    function: {
       name: 'scroll',
       description: 'Scroll the page in a given direction.',
       parameters: {

--- a/src/firefox/src/content/content.js
+++ b/src/firefox/src/content/content.js
@@ -389,18 +389,54 @@
       return { success: false, error: `Unsupported key "${key}". V1 supports Escape, Tab, and Enter.` };
     }
 
+    const keyMeta = {
+      Escape: { code: 'Escape', keyCode: 27 },
+      Tab: { code: 'Tab', keyCode: 9 },
+      Enter: { code: 'Enter', keyCode: 13 },
+    }[key];
     const target = (document.activeElement && document.activeElement !== document.body)
       ? document.activeElement
       : document;
 
+    const moveTabFocus = () => {
+      const focusables = Array.from(document.querySelectorAll(
+        'a[href], button:not([disabled]), input:not([disabled]):not([type="hidden"]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])'
+      )).filter(el => {
+        const style = window.getComputedStyle(el);
+        return style.display !== 'none' && style.visibility !== 'hidden';
+      });
+      if (focusables.length === 0) return;
+      const active = document.activeElement;
+      const currentIndex = focusables.indexOf(active);
+      const nextIndex = (currentIndex + 1 + focusables.length) % focusables.length;
+      try { focusables[nextIndex].focus(); } catch (e) {}
+    };
+
     for (let i = 0; i < repeat; i++) {
-      const down = new KeyboardEvent('keydown', { key, code: key, bubbles: true, cancelable: true });
-      const up = new KeyboardEvent('keyup', { key, code: key, bubbles: true, cancelable: true });
+      const down = new KeyboardEvent('keydown', {
+        key,
+        code: keyMeta.code,
+        keyCode: keyMeta.keyCode,
+        which: keyMeta.keyCode,
+        bubbles: true,
+        cancelable: true,
+      });
+      const up = new KeyboardEvent('keyup', {
+        key,
+        code: keyMeta.code,
+        keyCode: keyMeta.keyCode,
+        which: keyMeta.keyCode,
+        bubbles: true,
+        cancelable: true,
+      });
       target.dispatchEvent(down);
+      document.dispatchEvent(down);
       target.dispatchEvent(up);
+      document.dispatchEvent(up);
+      if (key === 'Tab') moveTabFocus();
     }
 
-    return { success: true, key, repeat, method: 'keyboardevent' };
+    return { success: true, key, repeat, method: 'keyboardevent', focusedTag: document.activeElement?.tagName || null };
   }
 
   /**

--- a/src/firefox/src/content/content.js
+++ b/src/firefox/src/content/content.js
@@ -379,6 +379,31 @@
   }
 
   /**
+   * Press supported keyboard keys.
+   */
+  function pressKeys(params) {
+    const key = params?.key;
+    const repeatRaw = Number(params?.repeat ?? 1);
+    const repeat = Math.max(1, Math.min(3, Number.isFinite(repeatRaw) ? Math.floor(repeatRaw) : 1));
+    if (!['Escape', 'Tab', 'Enter'].includes(key)) {
+      return { success: false, error: `Unsupported key "${key}". V1 supports Escape, Tab, and Enter.` };
+    }
+
+    const target = (document.activeElement && document.activeElement !== document.body)
+      ? document.activeElement
+      : document;
+
+    for (let i = 0; i < repeat; i++) {
+      const down = new KeyboardEvent('keydown', { key, code: key, bubbles: true, cancelable: true });
+      const up = new KeyboardEvent('keyup', { key, code: key, bubbles: true, cancelable: true });
+      target.dispatchEvent(down);
+      target.dispatchEvent(up);
+    }
+
+    return { success: true, key, repeat, method: 'keyboardevent' };
+  }
+
+  /**
    * Scroll the page.
    */
   function scrollPage(params) {
@@ -505,6 +530,7 @@
       'get_interactive_elements_cdp': () => getInteractiveElementsFull(),
       'click': () => clickElement(msg.params || {}),
       'type': () => typeText(msg.params || {}),
+      'press_keys': () => pressKeys(msg.params || {}),
       'scroll': () => scrollPage(msg.params || {}),
       'extract_data': () => extractData(msg.params || {}),
       'wait_for_element': () => waitForElement(msg.params || {}),

--- a/src/firefox/src/ui/settings.html
+++ b/src/firefox/src/ui/settings.html
@@ -220,7 +220,7 @@
 </head>
 <body>
   <h1>WebBrain Settings</h1>
-  <p class="subtitle">Configure your LLM providers and display preferences · v1.6.7</p>
+  <p class="subtitle">Configure your LLM providers and display preferences · v1.6.8</p>
 
   <h2>Display</h2>
   <div id="display-settings">


### PR DESCRIPTION
### Motivation

- Provide a simple keyboard-press tool to allow the agent to dismiss modals, move focus, and confirm dialogs/forms via `Escape`, `Tab`, and `Enter` without relying on brittle selectors.
- Ensure the feature works across both Chrome and Firefox flows and is respected by auto-screenshot state-change logic.

### Description

- Add a new agent tool `press_keys` to the JSON tool specs in `src/*/agent/tools.js` with parameters `key` and `repeat` and allowed keys `Escape`, `Tab`, and `Enter`.
- Implement a content-script handler `pressKeys` in `src/*/content/content.js` that dispatches `keydown`/`keyup` `KeyboardEvent`s to the `document.activeElement` or `document`, enforces `repeat` between 1 and 3, and validates supported keys.
- Wire `press_keys` into each agent's `actionMap` and content message handlers so it can be called from the agent, and add `press_keys` to `STATE_CHANGE_TOOLS` so `autoScreenshot` mode treats it as a state-changing tool.
- Implement a Chrome CDP path in `src/chrome/src/agent/agent.js` to send `Input.dispatchKeyEvent` for `press_keys` (with repeat and key metadata), falling back to the content-script approach if CDP is unavailable.

### Testing

- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d90c3da89483278c4233e20119087f)