### PR TITLE
Tighten text-click with ambiguity detection and auto-fallback

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "WebBrain",
-  "version": "1.6.7",
+  "version": "1.7.0",
   "description": "Open-source AI browser agent — chat with pages, automate tasks, multi-provider LLM support.",
   "permissions": [
     "sidePanel",

--- a/manifest.json
+++ b/manifest.json
@@ -1,11 +1,7 @@
 {
   "manifest_version": 3,
   "name": "WebBrain",
-<<<<<<< codex/investigate-keypress-control-options
   "version": "1.7.0",
-=======
-  "version": "1.6.8",
->>>>>>> main
   "description": "Open-source AI browser agent — chat with pages, automate tasks, multi-provider LLM support.",
   "permissions": [
     "sidePanel",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webbrain",
-  "version": "1.6.7",
+  "version": "1.7.0",
   "description": "Open-source AI browser agent — chat with pages, automate tasks, multi-provider LLM support.",
   "private": true,
   "type": "module",

--- a/src/chrome/manifest.json
+++ b/src/chrome/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "WebBrain",
-  "version": "1.6.7",
+  "version": "1.7.0",
   "description": "Open-source AI browser agent — chat with pages, automate tasks, multi-provider LLM support.",
   "permissions": [
     "sidePanel",

--- a/src/chrome/src/agent/agent.js
+++ b/src/chrome/src/agent/agent.js
@@ -194,7 +194,7 @@ export class Agent {
   // Tools whose successful completion should trigger an auto-screenshot when
   // the corresponding mode is active.
   static NAV_TOOLS = new Set(['navigate', 'new_tab']);
-  static STATE_CHANGE_TOOLS = new Set(['navigate', 'new_tab', 'click', 'type_text', 'scroll']);
+  static STATE_CHANGE_TOOLS = new Set(['navigate', 'new_tab', 'click', 'type_text', 'press_keys', 'scroll']);
 
   /**
    * Decide whether to capture an auto-screenshot after a tool call, based on
@@ -1259,25 +1259,45 @@ export class Agent {
           };
         }
         if (args.text) {
-          // Text-based click: find the first interactive element whose text
-          // contains the given string (case-insensitive). Resolves in JS via
-          // a simple walker over common interactive selectors. Then clicks
-          // via the same robust CDP path.
+          // Text-based click with explicit match mode.
+          // Default is exact (safest): if multiple exact matches exist, fail
+          // with an ambiguity error instead of clicking an arbitrary one.
           const result = await cdpClient.evaluate(tabId, `
             (() => {
               const needle = ${JSON.stringify(args.text.toLowerCase())};
+              const mode = ${JSON.stringify(args.textMatch || 'exact')};
               const sels = 'a, button, [role="button"], [role="link"], [role="tab"], [role="menuitem"], input[type="button"], input[type="submit"], summary, [onclick], [data-action]';
               const all = Array.from(document.querySelectorAll(sels));
-              // Prefer exact text match, then prefix, then substring.
-              const exact = all.find(el => (el.innerText || el.value || el.ariaLabel || '').trim().toLowerCase() === needle);
-              const prefix = all.find(el => (el.innerText || el.value || el.ariaLabel || '').trim().toLowerCase().startsWith(needle));
-              const sub = all.find(el => (el.innerText || el.value || el.ariaLabel || '').toLowerCase().includes(needle));
-              const el = exact || prefix || sub;
-              if (!el) return { found: false };
+              const normalized = all.map(el => ({
+                el,
+                txt: (el.innerText || el.value || el.ariaLabel || '').trim().toLowerCase(),
+              })).filter(x => !!x.txt);
+              let matches = [];
+              if (mode === 'exact') {
+                matches = normalized.filter(x => x.txt === needle);
+              } else if (mode === 'prefix') {
+                matches = normalized.filter(x => x.txt.startsWith(needle));
+              } else if (mode === 'contains') {
+                matches = normalized.filter(x => x.txt.includes(needle));
+              } else {
+                return { found: false, error: 'Invalid textMatch. Use exact, prefix, or contains.' };
+              }
+              if (matches.length === 0) return { found: false, mode };
+              if (matches.length > 1) {
+                return {
+                  found: false,
+                  ambiguous: true,
+                  mode,
+                  count: matches.length,
+                  candidates: matches.slice(0, 5).map(m => m.txt.slice(0, 80)),
+                };
+              }
+              const el = matches[0].el;
               try { el.scrollIntoView({ block: 'center', inline: 'center' }); } catch (e) {}
               const r = el.getBoundingClientRect();
               return {
                 found: true,
+                mode,
                 x: r.left + r.width / 2,
                 y: r.top + r.height / 2,
                 tag: el.tagName,
@@ -1287,9 +1307,19 @@ export class Agent {
           `);
           const info = result?.result?.value;
           if (!info?.found) {
+            if (info?.error) {
+              return { success: false, error: info.error };
+            }
+            if (info?.ambiguous) {
+              return {
+                success: false,
+                error: `Ambiguous text match for "${args.text}" (mode=${info.mode}, matches=${info.count}). Use a more specific text, click({index:N}) from get_interactive_elements, or selector/x,y.`,
+                candidates: info.candidates || [],
+              };
+            }
             return {
               success: false,
-              error: `No clickable element found containing text "${args.text}". Try get_interactive_elements to see what's actually on the page, or take a screenshot.`,
+              error: `No clickable element found for text "${args.text}" (mode=${info?.mode || (args.textMatch || 'exact')}). Try a different textMatch (prefix/contains), get_interactive_elements, or a selector.`,
             };
           }
           // Wait for scroll to settle, then dispatch a real click via CDP.
@@ -1300,6 +1330,7 @@ export class Agent {
           return {
             success: true,
             method: 'cdp-by-text',
+            textMatch: info.mode || (args.textMatch || 'exact'),
             tag: info.tag,
             text: info.text,
             matched: args.text,
@@ -1361,12 +1392,50 @@ export class Agent {
       }
     }
 
+    if (name === 'press_keys') {
+      const key = args.key;
+      const repeatRaw = Number(args.repeat ?? 1);
+      const repeat = Math.max(1, Math.min(3, Number.isFinite(repeatRaw) ? Math.floor(repeatRaw) : 1));
+      if (!['Escape', 'Tab', 'Enter'].includes(key)) {
+        return { success: false, error: `Unsupported key "${key}". V1 supports Escape, Tab, and Enter.` };
+      }
+
+      try {
+        await cdpClient.attach(tabId);
+        const keyMeta = {
+          Escape: { code: 'Escape', windowsVirtualKeyCode: 27 },
+          Tab: { code: 'Tab', windowsVirtualKeyCode: 9 },
+          Enter: { code: 'Enter', windowsVirtualKeyCode: 13 },
+        }[key];
+
+        for (let i = 0; i < repeat; i++) {
+          await cdpClient.sendCommand(tabId, 'Input.dispatchKeyEvent', {
+            type: 'keyDown',
+            key,
+            code: keyMeta.code,
+            windowsVirtualKeyCode: keyMeta.windowsVirtualKeyCode,
+          });
+          await cdpClient.sendCommand(tabId, 'Input.dispatchKeyEvent', {
+            type: 'keyUp',
+            key,
+            code: keyMeta.code,
+            windowsVirtualKeyCode: keyMeta.windowsVirtualKeyCode,
+          });
+        }
+
+        return { success: true, method: 'cdp-key', key, repeat };
+      } catch (e) {
+        // Fall through to content-script path if CDP is unavailable.
+      }
+    }
+
     // Map tool names to content script actions
     const actionMap = {
       'read_page': 'get_page_info_cdp',
       'get_interactive_elements': 'get_interactive_elements_cdp',
       'click': 'click',
       'type_text': 'type',
+      'press_keys': 'press_keys',
       'scroll': 'scroll',
       'extract_data': 'extract_data',
       'wait_for_element': 'wait_for_element',

--- a/src/chrome/src/agent/agent.js
+++ b/src/chrome/src/agent/agent.js
@@ -1259,35 +1259,51 @@ export class Agent {
           };
         }
         if (args.text) {
-          // Text-based click with explicit match mode.
-          // Default is exact (safest): if multiple exact matches exist, fail
-          // with an ambiguity error instead of clicking an arbitrary one.
+          // Text-based click with auto-fallback matching.
+          // When textMatch is not specified (default), tries exact → prefix →
+          // contains in order. At each level, if multiple elements match, an
+          // ambiguity error is returned instead of clicking an arbitrary one.
+          // When textMatch IS specified, only that mode is used.
           const result = await cdpClient.evaluate(tabId, `
             (() => {
               const needle = ${JSON.stringify(args.text.toLowerCase())};
-              const mode = ${JSON.stringify(args.textMatch || 'exact')};
-              const sels = 'a, button, [role="button"], [role="link"], [role="tab"], [role="menuitem"], input[type="button"], input[type="submit"], summary, [onclick], [data-action]';
+              const explicit = ${JSON.stringify(args.textMatch || '')};
+              const sels = 'a, button, [role="button"], [role="link"], [role="tab"], [role="menuitem"], input[type="button"], input[type="submit"], summary, label, [onclick], [data-action]';
               const all = Array.from(document.querySelectorAll(sels));
               const normalized = all.map(el => ({
                 el,
                 txt: (el.innerText || el.value || el.ariaLabel || '').trim().toLowerCase(),
               })).filter(x => !!x.txt);
-              let matches = [];
-              if (mode === 'exact') {
-                matches = normalized.filter(x => x.txt === needle);
-              } else if (mode === 'prefix') {
-                matches = normalized.filter(x => x.txt.startsWith(needle));
-              } else if (mode === 'contains') {
-                matches = normalized.filter(x => x.txt.includes(needle));
-              } else {
+
+              function tryMode(mode) {
+                if (mode === 'exact') return normalized.filter(x => x.txt === needle);
+                if (mode === 'prefix') return normalized.filter(x => x.txt.startsWith(needle));
+                if (mode === 'contains') return normalized.filter(x => x.txt.includes(needle));
+                return [];
+              }
+
+              // Determine which modes to try.
+              const modes = explicit ? [explicit] : ['exact', 'prefix', 'contains'];
+              if (explicit && !['exact', 'prefix', 'contains'].includes(explicit)) {
                 return { found: false, error: 'Invalid textMatch. Use exact, prefix, or contains.' };
               }
-              if (matches.length === 0) return { found: false, mode };
+
+              let matches = [];
+              let usedMode = modes[0];
+              for (const m of modes) {
+                matches = tryMode(m);
+                usedMode = m;
+                if (matches.length === 1) break; // unique match — use it
+                if (matches.length > 1) break;   // ambiguous — report it
+                // 0 matches — try next mode
+              }
+
+              if (matches.length === 0) return { found: false, mode: usedMode };
               if (matches.length > 1) {
                 return {
                   found: false,
                   ambiguous: true,
-                  mode,
+                  mode: usedMode,
                   count: matches.length,
                   candidates: matches.slice(0, 5).map(m => m.txt.slice(0, 80)),
                 };
@@ -1297,7 +1313,7 @@ export class Agent {
               const r = el.getBoundingClientRect();
               return {
                 found: true,
-                mode,
+                mode: usedMode,
                 x: r.left + r.width / 2,
                 y: r.top + r.height / 2,
                 tag: el.tagName,
@@ -1319,7 +1335,7 @@ export class Agent {
             }
             return {
               success: false,
-              error: `No clickable element found for text "${args.text}" (mode=${info?.mode || (args.textMatch || 'exact')}). Try a different textMatch (prefix/contains), get_interactive_elements, or a selector.`,
+              error: `No clickable element found for text "${args.text}". Try get_interactive_elements to see what's on the page, or use a selector.`,
             };
           }
           // Wait for scroll to settle, then dispatch a real click via CDP.

--- a/src/chrome/src/agent/tools.js
+++ b/src/chrome/src/agent/tools.js
@@ -555,7 +555,9 @@ TYPING — read this:
 - If you're filling multiple fields, click each one before typing into it, even if it looks like Tab would work.
 
 CLICKING — read this:
-- For buttons and links you can SEE (in a screenshot or in get_interactive_elements output), the BEST way to click them is by visible text: \`click({text: "Publish release"})\`. This finds the first matching button/link and clicks it. No selector guessing required.
+- For buttons and links you can SEE, click by visible text: \`click({text: "Publish release"})\`. Default matching is EXACT (case-insensitive). If exact fails (no match), the system automatically tries prefix then substring matching — but if multiple elements match at any level, it returns an ambiguity error instead of guessing.
+- If you get an ambiguity error, use a more specific text string, switch to \`click({index: N})\` from \`get_interactive_elements\`, or use a selector.
+- You can explicitly control matching with \`textMatch\`: \`"exact"\` (default), \`"prefix"\`, or \`"contains"\`.
 - Order of preference:
   1. \`click({text: "..."})\` — visible button/link text. Most reliable.
   2. \`click({index: N})\` — index from a get_interactive_elements call MADE THIS SAME TURN.

--- a/src/chrome/src/agent/tools.js
+++ b/src/chrome/src/agent/tools.js
@@ -44,11 +44,12 @@ export const AGENT_TOOLS = [
     type: 'function',
     function: {
       name: 'click',
-      description: 'Click an element. FOUR ways to use it: (1) CSS selector, (2) visible text — `click({text: "Publish release"})` finds the first button/link/clickable element whose text contains the string (case-insensitive), (3) element index from get_interactive_elements, (4) x/y coordinates. PREFER text or index over selectors when possible — selectors are easy to get wrong. Note: jQuery/Playwright pseudo-classes like `:contains()` and `:has-text()` are NOT valid CSS and will fail; use the `text` parameter instead.',
+      description: 'Click an element. FOUR ways to use it: (1) CSS selector, (2) visible text, (3) element index from get_interactive_elements, (4) x/y coordinates. For text clicks, default matching is EXACT and case-insensitive. You can opt into broader matching with `textMatch: "prefix"` or `textMatch: "contains"`. Note: jQuery/Playwright pseudo-classes like `:contains()` and `:has-text()` are NOT valid CSS and will fail; use the `text` parameter instead.',
       parameters: {
         type: 'object',
         properties: {
-          text: { type: 'string', description: 'Visible text to match — finds the first button/link/clickable element whose text contains this string (case-insensitive). Use this for buttons you can see in a screenshot.' },
+          text: { type: 'string', description: 'Visible text to match against clickable elements.' },
+          textMatch: { type: 'string', enum: ['exact', 'prefix', 'contains'], description: 'Text matching mode for `text`. Default is `exact` (safest).' },
           selector: { type: 'string', description: 'CSS selector for the element to click' },
           index: { type: 'number', description: 'Index from get_interactive_elements result' },
           x: { type: 'number', description: 'X coordinate to click' },
@@ -71,6 +72,21 @@ export const AGENT_TOOLS = [
           clear: { type: 'boolean', description: 'Clear existing content before typing (default: false). Works for all three forms.' },
         },
         required: ['text'],
+      },
+    },
+  },
+  {
+    type: 'function',
+    function: {
+      name: 'press_keys',
+      description: 'Press keyboard keys. V1 supports Escape, Tab, and Enter. Useful for dismissing modals/dropdowns (Escape), moving focus (Tab), and confirming dialogs/forms (Enter).',
+      parameters: {
+        type: 'object',
+        properties: {
+          key: { type: 'string', enum: ['Escape', 'Tab', 'Enter'], description: 'Key to press.' },
+          repeat: { type: 'number', description: 'How many times to press the key (default: 1, max: 3).' },
+        },
+        required: ['key'],
       },
     },
   },

--- a/src/chrome/src/content/content.js
+++ b/src/chrome/src/content/content.js
@@ -166,15 +166,30 @@
     }
     if (params.text) {
       const needle = params.text.toLowerCase();
+      const mode = params.textMatch || 'exact';
       const sels = 'a, button, [role="button"], [role="link"], [role="tab"], [role="menuitem"], input[type="button"], input[type="submit"], summary, [onclick], [data-action]';
       const all = Array.from(document.querySelectorAll(sels));
-      const exact = all.find(e => (e.innerText || e.value || e.ariaLabel || '').trim().toLowerCase() === needle);
-      const prefix = all.find(e => (e.innerText || e.value || e.ariaLabel || '').trim().toLowerCase().startsWith(needle));
-      const sub = all.find(e => (e.innerText || e.value || e.ariaLabel || '').toLowerCase().includes(needle));
-      el = exact || prefix || sub;
-      if (!el) {
-        return { success: false, error: `No clickable element found containing text "${params.text}"` };
+      const normalized = all.map(e => ({
+        e,
+        txt: (e.innerText || e.value || e.ariaLabel || '').trim().toLowerCase(),
+      })).filter(x => !!x.txt);
+      let matches = [];
+      if (mode === 'exact') matches = normalized.filter(x => x.txt === needle);
+      else if (mode === 'prefix') matches = normalized.filter(x => x.txt.startsWith(needle));
+      else if (mode === 'contains') matches = normalized.filter(x => x.txt.includes(needle));
+      else return { success: false, error: `Invalid textMatch "${mode}". Use exact, prefix, or contains.` };
+
+      if (matches.length === 0) {
+        return { success: false, error: `No clickable element found for text "${params.text}" (mode=${mode})` };
       }
+      if (matches.length > 1) {
+        return {
+          success: false,
+          error: `Ambiguous text match for "${params.text}" (mode=${mode}, matches=${matches.length}).`,
+          candidates: matches.slice(0, 5).map(m => m.txt.slice(0, 80)),
+        };
+      }
+      el = matches[0].e;
     } else if (params.selector) {
       el = document.querySelector(params.selector);
     } else if (params.index != null) {
@@ -263,6 +278,67 @@
     el.dispatchEvent(new Event('change', { bubbles: true }));
 
     return { success: true, value: (el.value || '').slice(0, 100) };
+  }
+
+  /**
+   * Press supported keyboard keys.
+   */
+  function pressKeys(params) {
+    const key = params?.key;
+    const repeatRaw = Number(params?.repeat ?? 1);
+    const repeat = Math.max(1, Math.min(3, Number.isFinite(repeatRaw) ? Math.floor(repeatRaw) : 1));
+    if (!['Escape', 'Tab', 'Enter'].includes(key)) {
+      return { success: false, error: `Unsupported key "${key}". V1 supports Escape, Tab, and Enter.` };
+    }
+
+    const keyMeta = {
+      Escape: { code: 'Escape', keyCode: 27 },
+      Tab: { code: 'Tab', keyCode: 9 },
+      Enter: { code: 'Enter', keyCode: 13 },
+    }[key];
+    const target = (document.activeElement && document.activeElement !== document.body)
+      ? document.activeElement
+      : document;
+
+    const moveTabFocus = () => {
+      const focusables = Array.from(document.querySelectorAll(
+        'a[href], button:not([disabled]), input:not([disabled]):not([type="hidden"]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])'
+      )).filter(el => {
+        const style = window.getComputedStyle(el);
+        return style.display !== 'none' && style.visibility !== 'hidden';
+      });
+      if (focusables.length === 0) return;
+      const active = document.activeElement;
+      const currentIndex = focusables.indexOf(active);
+      const nextIndex = (currentIndex + 1 + focusables.length) % focusables.length;
+      try { focusables[nextIndex].focus(); } catch (e) {}
+    };
+
+    for (let i = 0; i < repeat; i++) {
+      const down = new KeyboardEvent('keydown', {
+        key,
+        code: keyMeta.code,
+        keyCode: keyMeta.keyCode,
+        which: keyMeta.keyCode,
+        bubbles: true,
+        cancelable: true,
+      });
+      const up = new KeyboardEvent('keyup', {
+        key,
+        code: keyMeta.code,
+        keyCode: keyMeta.keyCode,
+        which: keyMeta.keyCode,
+        bubbles: true,
+        cancelable: true,
+      });
+      target.dispatchEvent(down);
+      document.dispatchEvent(down);
+      target.dispatchEvent(up);
+      document.dispatchEvent(up);
+      if (key === 'Tab') moveTabFocus();
+    }
+
+    return { success: true, key, repeat, method: 'keyboardevent', focusedTag: document.activeElement?.tagName || null };
   }
 
   /**
@@ -512,6 +588,7 @@
       'get_interactive_elements_cdp': () => getInteractiveElementsFull(),
       'click': () => clickElement(msg.params || {}),
       'type': () => typeText(msg.params || {}),
+      'press_keys': () => pressKeys(msg.params || {}),
       'scroll': () => scrollPage(msg.params || {}),
       'extract_data': () => extractData(msg.params || {}),
       'wait_for_element': () => waitForElement(msg.params || {}),

--- a/src/chrome/src/content/content.js
+++ b/src/chrome/src/content/content.js
@@ -166,26 +166,42 @@
     }
     if (params.text) {
       const needle = params.text.toLowerCase();
-      const mode = params.textMatch || 'exact';
-      const sels = 'a, button, [role="button"], [role="link"], [role="tab"], [role="menuitem"], input[type="button"], input[type="submit"], summary, [onclick], [data-action]';
+      const explicit = params.textMatch || '';
+      const sels = 'a, button, [role="button"], [role="link"], [role="tab"], [role="menuitem"], input[type="button"], input[type="submit"], summary, label, [onclick], [data-action]';
       const all = Array.from(document.querySelectorAll(sels));
       const normalized = all.map(e => ({
         e,
         txt: (e.innerText || e.value || e.ariaLabel || '').trim().toLowerCase(),
       })).filter(x => !!x.txt);
+
+      function tryMode(mode) {
+        if (mode === 'exact') return normalized.filter(x => x.txt === needle);
+        if (mode === 'prefix') return normalized.filter(x => x.txt.startsWith(needle));
+        if (mode === 'contains') return normalized.filter(x => x.txt.includes(needle));
+        return [];
+      }
+
+      const modes = explicit ? [explicit] : ['exact', 'prefix', 'contains'];
+      if (explicit && !['exact', 'prefix', 'contains'].includes(explicit)) {
+        return { success: false, error: `Invalid textMatch "${explicit}". Use exact, prefix, or contains.` };
+      }
+
       let matches = [];
-      if (mode === 'exact') matches = normalized.filter(x => x.txt === needle);
-      else if (mode === 'prefix') matches = normalized.filter(x => x.txt.startsWith(needle));
-      else if (mode === 'contains') matches = normalized.filter(x => x.txt.includes(needle));
-      else return { success: false, error: `Invalid textMatch "${mode}". Use exact, prefix, or contains.` };
+      let usedMode = modes[0];
+      for (const m of modes) {
+        matches = tryMode(m);
+        usedMode = m;
+        if (matches.length === 1) break;
+        if (matches.length > 1) break;
+      }
 
       if (matches.length === 0) {
-        return { success: false, error: `No clickable element found for text "${params.text}" (mode=${mode})` };
+        return { success: false, error: `No clickable element found for text "${params.text}"` };
       }
       if (matches.length > 1) {
         return {
           success: false,
-          error: `Ambiguous text match for "${params.text}" (mode=${mode}, matches=${matches.length}).`,
+          error: `Ambiguous text match for "${params.text}" (mode=${usedMode}, matches=${matches.length}).`,
           candidates: matches.slice(0, 5).map(m => m.txt.slice(0, 80)),
         };
       }

--- a/src/chrome/src/ui/settings.html
+++ b/src/chrome/src/ui/settings.html
@@ -220,7 +220,7 @@
 </head>
 <body>
   <h1>WebBrain Settings</h1>
-  <p class="subtitle">Configure your LLM providers and display preferences · v1.6.7</p>
+  <p class="subtitle">Configure your LLM providers and display preferences · v1.7.0</p>
 
   <h2>Display</h2>
   <div id="display-settings">

--- a/src/firefox/manifest.json
+++ b/src/firefox/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "WebBrain",
-  "version": "1.6.7",
+  "version": "1.7.0",
   "description": "Open-source AI browser agent — chat with pages, automate tasks, multi-provider LLM support.",
   "permissions": [
     "activeTab",

--- a/src/firefox/src/agent/agent.js
+++ b/src/firefox/src/agent/agent.js
@@ -129,7 +129,7 @@ export class Agent {
   }
 
   static NAV_TOOLS = new Set(['navigate', 'new_tab']);
-  static STATE_CHANGE_TOOLS = new Set(['navigate', 'new_tab', 'click', 'type_text', 'scroll']);
+  static STATE_CHANGE_TOOLS = new Set(['navigate', 'new_tab', 'click', 'type_text', 'press_keys', 'scroll']);
 
   _shouldAutoScreenshot(toolName) {
     const mode = this.autoScreenshot;
@@ -872,6 +872,7 @@ export class Agent {
       'get_frames': 'get_frames',
       'click': 'click',
       'type_text': 'type',
+      'press_keys': 'press_keys',
       'scroll': 'scroll',
       'extract_data': 'extract_data',
       'wait_for_element': 'wait_for_element',

--- a/src/firefox/src/agent/tools.js
+++ b/src/firefox/src/agent/tools.js
@@ -492,7 +492,9 @@ TYPING — read this:
 - Click each field before typing into it, even if Tab seems like it would work.
 
 CLICKING — read this:
-- For buttons and links you can SEE, the BEST way is to click by visible text: \`click({text: "Publish release"})\`. No selector guessing.
+- For buttons and links you can SEE, click by visible text: \`click({text: "Publish release"})\`. Default matching is EXACT (case-insensitive). If exact fails (no match), the system automatically tries prefix then substring matching — but if multiple elements match at any level, it returns an ambiguity error instead of guessing.
+- If you get an ambiguity error, use a more specific text string, switch to \`click({index: N})\` from \`get_interactive_elements\`, or use a selector.
+- You can explicitly control matching with \`textMatch\`: \`"exact"\` (default), \`"prefix"\`, or \`"contains"\`.
 - Order of preference:
   1. \`click({text: "..."})\` — visible text. Most reliable.
   2. \`click({index: N})\` — index from get_interactive_elements MADE THIS SAME TURN.

--- a/src/firefox/src/agent/tools.js
+++ b/src/firefox/src/agent/tools.js
@@ -44,11 +44,12 @@ export const AGENT_TOOLS = [
     type: 'function',
     function: {
       name: 'click',
-      description: 'Click an element. FOUR ways to use it: (1) visible text — `click({text: "Publish release"})` finds the first button/link whose text contains the string (case-insensitive); (2) element index from get_interactive_elements; (3) CSS selector; (4) x/y coordinates. PREFER text or index over selectors. jQuery/Playwright pseudo-classes like `:contains()` and `:has-text()` are NOT valid CSS — use the text parameter instead.',
+      description: 'Click an element. FOUR ways to use it: (1) visible text, (2) element index from get_interactive_elements, (3) CSS selector, (4) x/y coordinates. For text clicks, default matching is EXACT and case-insensitive. You can opt into broader matching with `textMatch: "prefix"` or `textMatch: "contains"`. jQuery/Playwright pseudo-classes like `:contains()` and `:has-text()` are NOT valid CSS — use the text parameter instead.',
       parameters: {
         type: 'object',
         properties: {
-          text: { type: 'string', description: 'Visible text — finds first matching button/link/clickable.' },
+          text: { type: 'string', description: 'Visible text to match against clickable elements.' },
+          textMatch: { type: 'string', enum: ['exact', 'prefix', 'contains'], description: 'Text matching mode for `text`. Default is `exact` (safest).' },
           selector: { type: 'string', description: 'CSS selector for the element to click.' },
           index: { type: 'number', description: 'Index from get_interactive_elements result.' },
           x: { type: 'number', description: 'X coordinate to click.' },
@@ -71,6 +72,21 @@ export const AGENT_TOOLS = [
           clear: { type: 'boolean', description: 'Clear existing content before typing (default: false).' },
         },
         required: ['text'],
+      },
+    },
+  },
+  {
+    type: 'function',
+    function: {
+      name: 'press_keys',
+      description: 'Press keyboard keys. V1 supports Escape, Tab, and Enter. Useful for dismissing modals/dropdowns (Escape), moving focus (Tab), and confirming dialogs/forms (Enter).',
+      parameters: {
+        type: 'object',
+        properties: {
+          key: { type: 'string', enum: ['Escape', 'Tab', 'Enter'], description: 'Key to press.' },
+          repeat: { type: 'number', description: 'How many times to press the key (default: 1, max: 3).' },
+        },
+        required: ['key'],
       },
     },
   },

--- a/src/firefox/src/content/content.js
+++ b/src/firefox/src/content/content.js
@@ -280,15 +280,30 @@
     // substring.
     if (params.text) {
       const needle = params.text.toLowerCase();
+      const mode = params.textMatch || 'exact';
       const sels = 'a, button, [role="button"], [role="link"], [role="tab"], [role="menuitem"], input[type="button"], input[type="submit"], summary, [onclick], [data-action]';
       const all = Array.from(document.querySelectorAll(sels));
-      const exact = all.find(e => (e.innerText || e.value || e.ariaLabel || '').trim().toLowerCase() === needle);
-      const prefix = all.find(e => (e.innerText || e.value || e.ariaLabel || '').trim().toLowerCase().startsWith(needle));
-      const sub = all.find(e => (e.innerText || e.value || e.ariaLabel || '').toLowerCase().includes(needle));
-      el = exact || prefix || sub;
-      if (!el) {
-        return { success: false, error: `No clickable element found containing text "${params.text}"` };
+      const normalized = all.map(e => ({
+        e,
+        txt: (e.innerText || e.value || e.ariaLabel || '').trim().toLowerCase(),
+      })).filter(x => !!x.txt);
+      let matches = [];
+      if (mode === 'exact') matches = normalized.filter(x => x.txt === needle);
+      else if (mode === 'prefix') matches = normalized.filter(x => x.txt.startsWith(needle));
+      else if (mode === 'contains') matches = normalized.filter(x => x.txt.includes(needle));
+      else return { success: false, error: `Invalid textMatch "${mode}". Use exact, prefix, or contains.` };
+
+      if (matches.length === 0) {
+        return { success: false, error: `No clickable element found for text "${params.text}" (mode=${mode})` };
       }
+      if (matches.length > 1) {
+        return {
+          success: false,
+          error: `Ambiguous text match for "${params.text}" (mode=${mode}, matches=${matches.length}).`,
+          candidates: matches.slice(0, 5).map(m => m.txt.slice(0, 80)),
+        };
+      }
+      el = matches[0].e;
     } else if (params.selector) {
       el = document.querySelector(params.selector);
     } else if (params.index != null) {
@@ -376,6 +391,67 @@
     el.dispatchEvent(new Event('change', { bubbles: true }));
 
     return { success: true, value: (el.value || '').slice(0, 100) };
+  }
+
+  /**
+   * Press supported keyboard keys.
+   */
+  function pressKeys(params) {
+    const key = params?.key;
+    const repeatRaw = Number(params?.repeat ?? 1);
+    const repeat = Math.max(1, Math.min(3, Number.isFinite(repeatRaw) ? Math.floor(repeatRaw) : 1));
+    if (!['Escape', 'Tab', 'Enter'].includes(key)) {
+      return { success: false, error: `Unsupported key "${key}". V1 supports Escape, Tab, and Enter.` };
+    }
+
+    const keyMeta = {
+      Escape: { code: 'Escape', keyCode: 27 },
+      Tab: { code: 'Tab', keyCode: 9 },
+      Enter: { code: 'Enter', keyCode: 13 },
+    }[key];
+    const target = (document.activeElement && document.activeElement !== document.body)
+      ? document.activeElement
+      : document;
+
+    const moveTabFocus = () => {
+      const focusables = Array.from(document.querySelectorAll(
+        'a[href], button:not([disabled]), input:not([disabled]):not([type="hidden"]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])'
+      )).filter(el => {
+        const style = window.getComputedStyle(el);
+        return style.display !== 'none' && style.visibility !== 'hidden';
+      });
+      if (focusables.length === 0) return;
+      const active = document.activeElement;
+      const currentIndex = focusables.indexOf(active);
+      const nextIndex = (currentIndex + 1 + focusables.length) % focusables.length;
+      try { focusables[nextIndex].focus(); } catch (e) {}
+    };
+
+    for (let i = 0; i < repeat; i++) {
+      const down = new KeyboardEvent('keydown', {
+        key,
+        code: keyMeta.code,
+        keyCode: keyMeta.keyCode,
+        which: keyMeta.keyCode,
+        bubbles: true,
+        cancelable: true,
+      });
+      const up = new KeyboardEvent('keyup', {
+        key,
+        code: keyMeta.code,
+        keyCode: keyMeta.keyCode,
+        which: keyMeta.keyCode,
+        bubbles: true,
+        cancelable: true,
+      });
+      target.dispatchEvent(down);
+      document.dispatchEvent(down);
+      target.dispatchEvent(up);
+      document.dispatchEvent(up);
+      if (key === 'Tab') moveTabFocus();
+    }
+
+    return { success: true, key, repeat, method: 'keyboardevent', focusedTag: document.activeElement?.tagName || null };
   }
 
   /**
@@ -505,6 +581,7 @@
       'get_interactive_elements_cdp': () => getInteractiveElementsFull(),
       'click': () => clickElement(msg.params || {}),
       'type': () => typeText(msg.params || {}),
+      'press_keys': () => pressKeys(msg.params || {}),
       'scroll': () => scrollPage(msg.params || {}),
       'extract_data': () => extractData(msg.params || {}),
       'wait_for_element': () => waitForElement(msg.params || {}),

--- a/src/firefox/src/content/content.js
+++ b/src/firefox/src/content/content.js
@@ -280,26 +280,42 @@
     // substring.
     if (params.text) {
       const needle = params.text.toLowerCase();
-      const mode = params.textMatch || 'exact';
-      const sels = 'a, button, [role="button"], [role="link"], [role="tab"], [role="menuitem"], input[type="button"], input[type="submit"], summary, [onclick], [data-action]';
+      const explicit = params.textMatch || '';
+      const sels = 'a, button, [role="button"], [role="link"], [role="tab"], [role="menuitem"], input[type="button"], input[type="submit"], summary, label, [onclick], [data-action]';
       const all = Array.from(document.querySelectorAll(sels));
       const normalized = all.map(e => ({
         e,
         txt: (e.innerText || e.value || e.ariaLabel || '').trim().toLowerCase(),
       })).filter(x => !!x.txt);
+
+      function tryMode(mode) {
+        if (mode === 'exact') return normalized.filter(x => x.txt === needle);
+        if (mode === 'prefix') return normalized.filter(x => x.txt.startsWith(needle));
+        if (mode === 'contains') return normalized.filter(x => x.txt.includes(needle));
+        return [];
+      }
+
+      const modes = explicit ? [explicit] : ['exact', 'prefix', 'contains'];
+      if (explicit && !['exact', 'prefix', 'contains'].includes(explicit)) {
+        return { success: false, error: `Invalid textMatch "${explicit}". Use exact, prefix, or contains.` };
+      }
+
       let matches = [];
-      if (mode === 'exact') matches = normalized.filter(x => x.txt === needle);
-      else if (mode === 'prefix') matches = normalized.filter(x => x.txt.startsWith(needle));
-      else if (mode === 'contains') matches = normalized.filter(x => x.txt.includes(needle));
-      else return { success: false, error: `Invalid textMatch "${mode}". Use exact, prefix, or contains.` };
+      let usedMode = modes[0];
+      for (const m of modes) {
+        matches = tryMode(m);
+        usedMode = m;
+        if (matches.length === 1) break;
+        if (matches.length > 1) break;
+      }
 
       if (matches.length === 0) {
-        return { success: false, error: `No clickable element found for text "${params.text}" (mode=${mode})` };
+        return { success: false, error: `No clickable element found for text "${params.text}"` };
       }
       if (matches.length > 1) {
         return {
           success: false,
-          error: `Ambiguous text match for "${params.text}" (mode=${mode}, matches=${matches.length}).`,
+          error: `Ambiguous text match for "${params.text}" (mode=${usedMode}, matches=${matches.length}).`,
           candidates: matches.slice(0, 5).map(m => m.txt.slice(0, 80)),
         };
       }

--- a/src/firefox/src/ui/settings.html
+++ b/src/firefox/src/ui/settings.html
@@ -220,7 +220,7 @@
 </head>
 <body>
   <h1>WebBrain Settings</h1>
-  <p class="subtitle">Configure your LLM providers and display preferences · v1.6.7</p>
+  <p class="subtitle">Configure your LLM providers and display preferences · v1.7.0</p>
 
   <h2>Display</h2>
   <div id="display-settings">

--- a/src/firefox/src/ui/settings.html
+++ b/src/firefox/src/ui/settings.html
@@ -220,11 +220,7 @@
 </head>
 <body>
   <h1>WebBrain Settings</h1>
-<<<<<<< codex/investigate-keypress-control-options
   <p class="subtitle">Configure your LLM providers and display preferences · v1.7.0</p>
-=======
-  <p class="subtitle">Configure your LLM providers and display preferences · v1.6.8</p>
->>>>>>> main
 
   <h2>Display</h2>
   <div id="display-settings">


### PR DESCRIPTION
## Summary
- **Ambiguity detection**: `click({text: "Save"})` now returns an error with candidate list when multiple elements match, instead of silently clicking the first one
- **Auto-fallback matching**: Default behavior cascades exact → prefix → contains (with ambiguity check at each level), so buttons like "Create subscription →" still work without needing explicit `textMatch: "contains"`
- **`textMatch` parameter**: New optional param (`exact`, `prefix`, `contains`) for explicit control when needed
- **Selector alignment**: Added `label` to text-click selector lists to match `INTERACTIVE_SELECTORS` (fixes inconsistency where `get_interactive_elements` showed labels as clickable but `click({text})` couldn't find them)
- **System prompt updated**: CLICKING section in both Chrome and Firefox explains new behavior
- **Version bump**: 1.6.8 → 1.7.0 across all manifests/settings

## Test plan
- [x] `npm test` — all 31 tests pass
- [x] No merge conflict markers remain
- [ ] Manual: load page with duplicate button labels → text-click returns ambiguity error with candidates
- [ ] Manual: unique button text → text-click works as before
- [ ] Manual: button with trailing icon/arrow text → auto-fallback finds it via prefix/contains

🤖 Generated with [Claude Code](https://claude.com/claude-code)