### PR TITLE
Add Ollama provider badge to web 'Bring your own AI' section

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -550,6 +550,7 @@
       font-size: 18px;
     }
     .provider-badge .p-icon.local { background: rgba(52,211,153,0.15); color: var(--success); }
+    .provider-badge .p-icon.ollama { background: rgba(38,121,255,0.15); color: #2679ff; }
     .provider-badge .p-icon.openai { background: rgba(16,163,127,0.15); color: #10a37f; }
     .provider-badge .p-icon.anthropic { background: rgba(204,149,96,0.15); color: #cc9560; }
     .provider-badge .p-icon.openrouter { background: rgba(108,99,255,0.15); color: var(--accent2); }
@@ -954,6 +955,10 @@
     <div class="provider-badge">
       <div class="p-icon local">🦙</div>
       llama.cpp (Local)
+    </div>
+    <div class="provider-badge">
+      <div class="p-icon ollama">◉</div>
+      Ollama
     </div>
     <div class="provider-badge">
       <div class="p-icon openai">⬡</div>


### PR DESCRIPTION
### Motivation
- Surface support for the Ollama provider in the site UI so users can see it listed alongside other supported LLM providers.

### Description
- Added an `Ollama` provider badge to the "Bring your own AI" providers row in `web/index.html`.
- Added a `.provider-badge .p-icon.ollama` CSS rule in `web/index.html` to match the visual style of existing provider badges.
- Change is limited to `web/index.html` (HTML/CSS only).

### Testing
- No automated tests were run for this HTML/CSS-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da8c1286c48327bf1f39d390ec3fac)