### PR TITLE
Add StudioLM to 'Bring your own AI' provider list

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -554,6 +554,7 @@
     .provider-badge .p-icon.openai { background: rgba(16,163,127,0.15); color: #10a37f; }
     .provider-badge .p-icon.anthropic { background: rgba(204,149,96,0.15); color: #cc9560; }
     .provider-badge .p-icon.openrouter { background: rgba(108,99,255,0.15); color: var(--accent2); }
+    .provider-badge .p-icon.studiolm { background: rgba(245,158,11,0.15); color: #f59e0b; }
 
     /* ================================================================
        MODES
@@ -971,6 +972,10 @@
     <div class="provider-badge">
       <div class="p-icon openrouter">◆</div>
       OpenRouter
+    </div>
+    <div class="provider-badge">
+      <div class="p-icon studiolm">✦</div>
+      StudioLM
     </div>
   </div>
 </section>


### PR DESCRIPTION
### Motivation
- Expose StudioLM as an available LLM provider in the "Bring your own AI" section so users can see it alongside other supported providers.

### Description
- Modified `web/index.html` to insert a new `StudioLM` provider badge and added a `.p-icon.studiolm` CSS rule so the badge matches existing provider styling.

### Testing
- Ran `git diff --check` and `git status --short` which reported no issues and committed the change; no automated unit tests were executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da8d72df788327b326b0583685ff18)