### PR TITLE
Add StudioLM and VLLM provider badges and tighten providers layout/copy

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -521,21 +521,22 @@
     .providers-row {
       display: flex;
       justify-content: center;
-      gap: 32px;
-      flex-wrap: wrap;
+      gap: 14px;
+      flex-wrap: nowrap;
       margin-top: 40px;
     }
     .provider-badge {
       display: flex;
       align-items: center;
-      gap: 10px;
+      gap: 8px;
       background: var(--bg-card);
       border: 1px solid var(--border);
       border-radius: var(--radius-sm);
-      padding: 14px 24px;
-      font-size: 14px;
+      padding: 12px 16px;
+      font-size: 13px;
       font-weight: 600;
       transition: all 0.2s;
+      white-space: nowrap;
     }
     .provider-badge:hover {
       border-color: var(--accent);
@@ -554,6 +555,8 @@
     .provider-badge .p-icon.openai { background: rgba(16,163,127,0.15); color: #10a37f; }
     .provider-badge .p-icon.anthropic { background: rgba(204,149,96,0.15); color: #cc9560; }
     .provider-badge .p-icon.openrouter { background: rgba(108,99,255,0.15); color: var(--accent2); }
+    .provider-badge .p-icon.studiolm { background: rgba(245,158,11,0.15); color: #f59e0b; }
+    .provider-badge .p-icon.vllm { background: rgba(99,102,241,0.15); color: #6366f1; }
 
     /* ================================================================
        MODES
@@ -782,6 +785,7 @@
       .side-panel { width: 100%; border-left: none; border-top: 1px solid var(--border); min-height: 260px; }
       .modes-grid { grid-template-columns: 1fr; }
       .nav-links a:not(.nav-cta) { display: none; }
+      .providers-row { flex-wrap: wrap; justify-content: center; }
     }
     @media (max-width: 480px) {
       .hero { padding: 60px 16px 50px; }
@@ -930,7 +934,7 @@
     <div class="feature-card">
       <div class="feature-icon">🔌</div>
       <h3>Multi-Provider LLM</h3>
-      <p>Works with local llama.cpp, OpenAI, Anthropic Claude, and OpenRouter. Use your preferred model — or run completely offline with local AI.</p>
+      <p>Works with local llama.cpp, OpenAI, Claude, and OpenRouter. Use your preferred model — or run completely offline with local AI.</p>
     </div>
     <div class="feature-card">
       <div class="feature-icon">🛡️</div>
@@ -954,7 +958,7 @@
   <div class="providers-row">
     <div class="provider-badge">
       <div class="p-icon local">🦙</div>
-      llama.cpp (Local)
+      llama.cpp
     </div>
     <div class="provider-badge">
       <div class="p-icon ollama">◉</div>
@@ -966,11 +970,19 @@
     </div>
     <div class="provider-badge">
       <div class="p-icon anthropic">◈</div>
-      Anthropic Claude
+      Claude
     </div>
     <div class="provider-badge">
       <div class="p-icon openrouter">◆</div>
       OpenRouter
+    </div>
+    <div class="provider-badge">
+      <div class="p-icon studiolm">✦</div>
+      StudioLM
+    </div>
+    <div class="provider-badge">
+      <div class="p-icon vllm">▣</div>
+      VLLM
     </div>
   </div>
 </section>
@@ -1112,7 +1124,7 @@
 
     <details class="faq-item">
       <summary>Which AI models does WebBrain support?</summary>
-      <p>WebBrain supports four provider types: llama.cpp (any local GGUF model), OpenAI (GPT-4o, GPT-4, etc.), Anthropic Claude (Claude Opus, Sonnet, Haiku via native API), and OpenRouter (access to 100+ models from various providers). Any OpenAI-compatible API endpoint works, so you can also use services like Together AI, Groq, Mistral, or any local server with an OpenAI-compatible interface.</p>
+      <p>WebBrain supports four provider types: llama.cpp (any local GGUF model), OpenAI (GPT-4o, GPT-4, etc.), Claude (Claude Opus, Sonnet, Haiku via native API), and OpenRouter (access to 100+ models from various providers). Any OpenAI-compatible API endpoint works, so you can also use services like Together AI, Groq, Mistral, or any local server with an OpenAI-compatible interface.</p>
     </details>
 
     <details class="faq-item">


### PR DESCRIPTION
### Motivation
- Expose additional LLM providers (StudioLM and VLLM) in the landing UI so users can see supported options. 
- Make the providers row and badges more compact and visually consistent across breakpoints. 
- Simplify provider naming for clarity by removing redundant qualifiers like `(Local)` and `Anthropic` in labels.

### Description
- Adjusted providers layout CSS by changing `.providers-row` gap to `14px` and switching to `flex-wrap: nowrap` for desktop while restoring wrap in the `@media (max-width: 768px)` rule. 
- Updated `.provider-badge` sizing and spacing by reducing `gap`, `padding`, and `font-size`, and added `white-space: nowrap` to prevent wrapping inside badges. 
- Added new icon color styles for `StudioLM` and `VLLM` with `.p-icon.studiolm` and `.p-icon.vllm`. 
- Updated HTML provider badges: simplified labels (`llama.cpp` and `Claude`) and added new badges for `StudioLM` and `VLLM` in the providers list.

### Testing
- No automated tests were run for this markup/CSS change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da8d72df788327b326b0583685ff18)