### PR TITLE
web: point Chrome install links to Chrome Web Store

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -38,7 +38,7 @@
     },
     "description": "Free, open-source AI browser agent extension for Chrome and Firefox. Alternative to Claude browser plugin and OpenClaw. Read pages, extract data, automate tasks with local or cloud LLMs.",
     "url": "https://webbrain.one",
-    "downloadUrl": "https://github.com/esokullu/webbrain/releases",
+    "downloadUrl": "https://chromewebstore.google.com/detail/webbrain/ljhijonmfahplgbbacgcfnaihbjljhhb",
     "softwareVersion": "0.9.0",
     "author": {
       "@type": "Person",
@@ -1029,9 +1029,9 @@
       <div class="browser-icon">🌐</div>
       <h3>Chrome</h3>
       <p>Manifest V3 &middot; Chrome 116+</p>
-      <a href="https://github.com/esokullu/webbrain/releases" target="_blank" class="btn btn-primary">
+      <a href="https://chromewebstore.google.com/detail/webbrain/ljhijonmfahplgbbacgcfnaihbjljhhb" target="_blank" rel="noopener noreferrer" class="btn btn-primary">
         <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" width="16" height="16"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>
-        Download for Chrome
+        Download from Chrome Web Store
       </a>
     </div>
     <div class="download-card">


### PR DESCRIPTION
### Motivation
- Ensure the landing page and download CTA point to the published Chrome Web Store listing so users can install the extension directly from the store and structured metadata reflects the correct download location.

### Description
- Updated the JSON-LD `downloadUrl` in `web/index.html` to the Chrome Web Store URL `https://chromewebstore.google.com/detail/webbrain/ljhijonmfahplgbbacgcfnaihbjljhhb`.
- Replaced the Chrome download CTA link in the download section to open the same Chrome Web Store URL and added `rel="noopener noreferrer"` for the external link.
- Changed the Chrome button text to `Download from Chrome Web Store` for clearer guidance.

### Testing
- Verified the updated URL and button copy with `rg -n "downloadUrl|Chrome Web Store|chromewebstore" web/index.html`, which returned the expected matches.
- Inspected the modified regions with `nl -ba web/index.html | sed -n '32,48p;1024,1038p'` to confirm the JSON-LD and CTA changes, which showed the new URL and label.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df3c0f6fc883278afb4263af427ef7)