### PR TITLE
Update demo video and Chrome download card styling/content

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -617,6 +617,11 @@
       margin-top: auto;
     }
     .download-card .btn { width: 100%; justify-content: center; }
+    .download-card-chrome {
+      min-width: 340px;
+      padding: 42px 44px;
+      border-color: rgba(0, 212, 255, 0.45);
+    }
 
     /* ================================================================
        OPEN SOURCE
@@ -925,7 +930,7 @@
   <p class="section-subtitle">See how WebBrain reads pages, extracts data, and automates browser tasks.</p>
   <div class="video-showcase">
     <div class="video-frame">
-      <iframe src="https://www.youtube.com/embed/1NN2dweooKM" title="WebBrain demo video" loading="lazy" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+      <iframe src="https://www.youtube.com/embed/iPTjqDP5ApY" title="WebBrain demo video" loading="lazy" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
     </div>
   </div>
 </section>
@@ -1035,10 +1040,10 @@
   <p class="section-subtitle">Available for Chrome and Firefox. Free, open-source, no account required.</p>
 
   <div class="download-cards">
-    <div class="download-card">
+    <div class="download-card download-card-chrome">
       <div class="browser-icon">🌐</div>
-      <h3>Chrome</h3>
-      <p>Manifest V3 &middot; Chrome 116+</p>
+      <h3>Chrome & Chromium</h3>
+      <p>Manifest V3 &middot; Chrome 116+ &middot; Also works with Brave, Edge, Opera, Vivaldi, and other Chromium-compatible browsers.</p>
       <div class="download-card-actions">
         <a href="https://chromewebstore.google.com/detail/webbrain/ljhijonmfahplgbbacgcfnaihbjljhhb" target="_blank" rel="noopener noreferrer" class="btn btn-primary">
           <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" width="16" height="16"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>


### PR DESCRIPTION
### Motivation
- Clarify that the Chrome distribution supports Chromium-based browsers and improve the Chrome download card layout and styling, and update the demo video to the latest embed.

### Description
- Add a new CSS class `download-card-chrome` (sets `min-width`, `padding`, and accent `border-color`), add that class to the Chrome download card, change the Chrome card title to `Chrome & Chromium` and extend its compatibility text, and update the demo iframe `src` to `https://www.youtube.com/embed/iPTjqDP5ApY`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e0a22dd97c8327b10fd2655b20d7b5)