### PR TITLE
Switch demo video to Shorts URL on narrow/mobile viewports

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -930,7 +930,7 @@
   <p class="section-subtitle">See how WebBrain reads pages, extracts data, and automates browser tasks.</p>
   <div class="video-showcase">
     <div class="video-frame">
-      <iframe src="https://www.youtube.com/embed/iPTjqDP5ApY" title="WebBrain demo video" loading="lazy" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+      <iframe id="demo-video" src="https://www.youtube.com/embed/iPTjqDP5ApY" data-desktop-src="https://www.youtube.com/embed/iPTjqDP5ApY" data-mobile-src="https://www.youtube.com/shorts/b9SwOB-LqAo" title="WebBrain demo video" loading="lazy" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
     </div>
   </div>
 </section>
@@ -1238,6 +1238,31 @@
     </div>
   </div>
 </footer>
+
+<script>
+  (function () {
+    const demoVideo = document.getElementById('demo-video');
+    if (!demoVideo) return;
+
+    const mobileQuery = window.matchMedia('(max-width: 768px)');
+
+    function syncDemoVideoSource(event) {
+      const isMobile = event.matches ?? mobileQuery.matches;
+      const nextSrc = isMobile ? demoVideo.dataset.mobileSrc : demoVideo.dataset.desktopSrc;
+      if (nextSrc && demoVideo.src !== nextSrc) {
+        demoVideo.src = nextSrc;
+      }
+    }
+
+    syncDemoVideoSource(mobileQuery);
+
+    if (typeof mobileQuery.addEventListener === 'function') {
+      mobileQuery.addEventListener('change', syncDemoVideoSource);
+    } else if (typeof mobileQuery.addListener === 'function') {
+      mobileQuery.addListener(syncDemoVideoSource);
+    }
+  })();
+</script>
 
 </body>
 </html>


### PR DESCRIPTION
### Motivation
- The demo iframe should use a Shorts URL on narrow/mobile viewports so the video is better optimized for mobile users.
- Keep the existing desktop embed unchanged while swapping to the requested Shorts URL for narrow widths.

### Description
- Updated the demo iframe in `web/index.html` to include `id="demo-video"` and `data-desktop-src` / `data-mobile-src` attributes with the Shorts URL `https://www.youtube.com/shorts/b9SwOB-LqAo` for mobile.
- Added a small responsive script that watches the `(max-width: 768px)` media query and swaps the iframe `src` on load and when the breakpoint changes.
- The desktop embed continues to use the original `https://www.youtube.com/embed/iPTjqDP5ApY` URL and the swap only occurs for narrow viewports.

### Testing
- Ran `npm test` and the test suite passed (`32 passed, 0 failed`).
- Verified the modified file is `web/index.html` and the script initializes and registers `matchMedia` listeners on supported browsers.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e1c1f5afa08327aad8c6dc770b8762)