### PR TITLE
Serve mobile-optimized demo video and improve responsive sizing

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -815,6 +815,8 @@
       .modes-grid { grid-template-columns: 1fr; }
       .nav-links a:not(.nav-cta) { display: none; }
       .providers-row { flex-wrap: wrap; justify-content: center; }
+      .video-showcase { max-width: 380px; }
+      .video-frame { padding-bottom: 177.78%; }
     }
     @media (max-width: 480px) {
       .hero { padding: 60px 16px 50px; }
@@ -930,7 +932,7 @@
   <p class="section-subtitle">See how WebBrain reads pages, extracts data, and automates browser tasks.</p>
   <div class="video-showcase">
     <div class="video-frame">
-      <iframe src="https://www.youtube.com/embed/iPTjqDP5ApY" title="WebBrain demo video" loading="lazy" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+      <iframe id="demo-video" src="https://www.youtube.com/embed/iPTjqDP5ApY" data-desktop-src="https://www.youtube.com/embed/iPTjqDP5ApY" data-mobile-src="https://www.youtube.com/embed/b9SwOB-LqAo?playsinline=1" title="WebBrain demo video" loading="lazy" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
     </div>
   </div>
 </section>
@@ -1238,6 +1240,31 @@
     </div>
   </div>
 </footer>
+
+<script>
+  (function () {
+    const demoVideo = document.getElementById('demo-video');
+    if (!demoVideo) return;
+
+    const mobileQuery = window.matchMedia('(max-width: 768px)');
+
+    function syncDemoVideoSource(event) {
+      const isMobile = event.matches ?? mobileQuery.matches;
+      const nextSrc = isMobile ? demoVideo.dataset.mobileSrc : demoVideo.dataset.desktopSrc;
+      if (nextSrc && demoVideo.src !== nextSrc) {
+        demoVideo.src = nextSrc;
+      }
+    }
+
+    syncDemoVideoSource(mobileQuery);
+
+    if (typeof mobileQuery.addEventListener === 'function') {
+      mobileQuery.addEventListener('change', syncDemoVideoSource);
+    } else if (typeof mobileQuery.addListener === 'function') {
+      mobileQuery.addListener(syncDemoVideoSource);
+    }
+  })();
+</script>
 
 </body>
 </html>


### PR DESCRIPTION
### Motivation

- Improve the demo video presentation and aspect ratio on small screens and serve a mobile-optimized video to avoid cropping and enable inline playback.

### Description

- Add responsive tweaks in the `@media (max-width: 768px)` block by setting `.video-showcase { max-width: 380px; }` and `.video-frame { padding-bottom: 177.78%; }` to better fit mobile layouts.
- Update the demo iframe to include `id="demo-video"` and `data-desktop-src` / `data-mobile-src` attributes so separate desktop and mobile video URLs can be used while preserving `loading="lazy"` and `allowfullscreen`.
- Add an inline script that uses `window.matchMedia('(max-width: 768px)')` to switch the iframe `src` to the mobile or desktop source and listens for viewport changes using `addEventListener` with a `addListener` fallback.

### Testing

- Ran the repository build and lint steps with `npm run build` and `npm run lint` in CI and both completed successfully.
- No new automated unit tests were added for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e1c1f5afa08327aad8c6dc770b8762)