### PR TITLE
Keep WebBrain tabs grouped near current context

### DIFF
--- a/src/chrome/src/agent/agent.js
+++ b/src/chrome/src/agent/agent.js
@@ -1453,8 +1453,41 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
     }
 
     if (name === 'new_tab') {
-      const tab = await chrome.tabs.create({ url: args.url });
-      return { success: true, tabId: tab.id, url: args.url };
+      const createProps = { url: args.url };
+      let sourceTab = null;
+      try {
+        sourceTab = await chrome.tabs.get(tabId);
+      } catch (_) {}
+      if (sourceTab?.windowId != null) {
+        createProps.windowId = sourceTab.windowId;
+      }
+      if (typeof sourceTab?.index === 'number') {
+        createProps.index = sourceTab.index + 1;
+      }
+      if (sourceTab?.id != null) {
+        createProps.openerTabId = sourceTab.id;
+      }
+
+      const tab = await chrome.tabs.create(createProps);
+      let groupId = -1;
+      // Group new tabs with the source tab so "research chains" stay visually
+      // together instead of scattering to the far right of the window.
+      if (sourceTab?.id != null && chrome.tabGroups) {
+        try {
+          if (typeof sourceTab.groupId === 'number' && sourceTab.groupId >= 0) {
+            groupId = sourceTab.groupId;
+            await chrome.tabs.group({ groupId, tabIds: [tab.id] });
+          } else {
+            groupId = await chrome.tabs.group({ tabIds: [sourceTab.id, tab.id] });
+            await chrome.tabGroups.update(groupId, {
+              title: 'WebBrain',
+              color: 'blue',
+              collapsed: false,
+            });
+          }
+        } catch (_) {}
+      }
+      return { success: true, tabId: tab.id, url: args.url, groupId: groupId >= 0 ? groupId : null };
     }
 
     if (name === 'screenshot') {
@@ -1651,7 +1684,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
       return await fetchUrl(args.url, args);
     }
     if (name === 'research_url') {
-      return await researchUrl(args.url, args);
+      return await researchUrl(args.url, { ...args, sourceTabId: tabId });
     }
     if (name === 'list_downloads') {
       return await listDownloads(args);

--- a/src/chrome/src/network/network-tools.js
+++ b/src/chrome/src/network/network-tools.js
@@ -138,7 +138,16 @@ export async function researchUrl(url, opts = {}) {
   const timeoutMs = Math.min(opts.timeout || 8000, 30000);
   let createdTab = null;
   try {
-    createdTab = await chrome.tabs.create({ url, active: false });
+    const createProps = { url, active: false };
+    if (opts.sourceTabId != null) {
+      try {
+        const sourceTab = await chrome.tabs.get(opts.sourceTabId);
+        if (sourceTab?.windowId != null) createProps.windowId = sourceTab.windowId;
+        if (typeof sourceTab?.index === 'number') createProps.index = sourceTab.index + 1;
+        if (sourceTab?.id != null) createProps.openerTabId = sourceTab.id;
+      } catch (_) {}
+    }
+    createdTab = await chrome.tabs.create(createProps);
     const tabId = createdTab.id;
 
     // Wait for the tab to finish loading.

--- a/src/firefox/src/agent/agent.js
+++ b/src/firefox/src/agent/agent.js
@@ -849,7 +849,21 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
     }
 
     if (name === 'new_tab') {
-      const tab = await browser.tabs.create({ url: args.url });
+      const createProps = { url: args.url };
+      let sourceTab = null;
+      try {
+        sourceTab = await browser.tabs.get(tabId);
+      } catch (_) {}
+      if (sourceTab?.windowId != null) {
+        createProps.windowId = sourceTab.windowId;
+      }
+      if (typeof sourceTab?.index === 'number') {
+        createProps.index = sourceTab.index + 1;
+      }
+      if (sourceTab?.id != null) {
+        createProps.openerTabId = sourceTab.id;
+      }
+      const tab = await browser.tabs.create(createProps);
       return { success: true, tabId: tab.id, url: args.url };
     }
 
@@ -917,7 +931,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
       return await fetchUrl(args.url, args);
     }
     if (name === 'research_url') {
-      return await researchUrl(args.url, args);
+      return await researchUrl(args.url, { ...args, sourceTabId: tabId });
     }
     if (name === 'list_downloads') {
       return await listDownloads(args);

--- a/src/firefox/src/network/network-tools.js
+++ b/src/firefox/src/network/network-tools.js
@@ -110,7 +110,16 @@ export async function researchUrl(url, opts = {}) {
   const timeoutMs = Math.min(opts.timeout || 8000, 30000);
   let createdTab = null;
   try {
-    createdTab = await browser.tabs.create({ url, active: false });
+    const createProps = { url, active: false };
+    if (opts.sourceTabId != null) {
+      try {
+        const sourceTab = await browser.tabs.get(opts.sourceTabId);
+        if (sourceTab?.windowId != null) createProps.windowId = sourceTab.windowId;
+        if (typeof sourceTab?.index === 'number') createProps.index = sourceTab.index + 1;
+        if (sourceTab?.id != null) createProps.openerTabId = sourceTab.id;
+      } catch (_) {}
+    }
+    createdTab = await browser.tabs.create(createProps);
     const tabId = createdTab.id;
 
     await new Promise((resolve, reject) => {


### PR DESCRIPTION
### Motivation

- Research tabs created by `research_url` and `new_tab` were appended to the end of the window, making it hard to follow a chain of related pages; this change keeps new tabs adjacent to the originating tab and groups them visually.

### Description

- Opened new tabs adjacent to the source tab by passing `windowId`, `index: source.index + 1`, and `openerTabId` when creating tabs in `executeTool` for both Chrome (`src/chrome/src/agent/agent.js`) and Firefox (`src/firefox/src/agent/agent.js`).
- In Chrome, automatically group new tabs with the source tab using `chrome.tabs.group` and create/update a `WebBrain` tab group via `chrome.tabGroups.update`, and return a `groupId` in the `new_tab` result.
- Propagated `sourceTabId` into `research_url` calls from the agent (`executeTool`) and updated `researchUrl` implementations in `src/chrome/src/network/network-tools.js` and `src/firefox/src/network/network-tools.js` to create hidden research tabs adjacent to the source tab using the same `createProps` (window/index/opener) when `opts.sourceTabId` is provided.
- Kept fallbacks and safety via `try/catch` when fetching the source tab or grouping fails so behavior is resilient across environments and API availability.

### Testing

- Ran the test suite with `npm test` and all automated tests passed (`32 passed, 0 failed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e50be96e6c8327aa11699aa49f7c29)