### PR TITLE
Scratchpad tool + tool-result digests in summary for long-horizon runs

### DIFF
--- a/src/chrome/src/agent/agent.js
+++ b/src/chrome/src/agent/agent.js
@@ -1388,6 +1388,103 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
     } catch (e) { /* ignore */ }
   }
 
+  // ─── Scratchpad ──────────────────────────────────────────────────────
+  // A single pinned user message (`[Agent scratchpad...]`) that lives near
+  // the top of the conversation. The model writes to it via the
+  // `scratchpad_write` tool; it survives summarization because both
+  // _manageContext and _emergencyTrim skip messages with this prefix when
+  // looking for the original task, and re-insert the scratchpad into the
+  // rebuilt messages array. Purpose: give the model a durable place to
+  // record facts (download IDs, file paths, progress counters) that it
+  // would otherwise lose when older tool results get compressed away.
+
+  _scratchpadHeader() {
+    return '[Agent scratchpad — your own persistent notes, pinned in context and surviving summarization. Update with scratchpad_write({text, replace?}). Current contents follow:]';
+  }
+
+  _isScratchpadMessage(msg) {
+    return msg && msg.role === 'user'
+      && typeof msg.content === 'string'
+      && msg.content.startsWith('[Agent scratchpad');
+  }
+
+  _findScratchpadIndex(messages) {
+    for (let i = 1; i < messages.length; i++) {
+      if (this._isScratchpadMessage(messages[i])) return i;
+    }
+    return -1;
+  }
+
+  _extractScratchpadBody(content) {
+    if (typeof content !== 'string') return '';
+    // Everything after the first blank line is the body; fall back to empty.
+    const idx = content.indexOf('\n\n');
+    return idx >= 0 ? content.slice(idx + 2) : '';
+  }
+
+  _buildScratchpadMessage(body) {
+    const trimmed = (body || '').replace(/^\s+|\s+$/g, '');
+    return {
+      role: 'user',
+      content: `${this._scratchpadHeader()}\n\n${trimmed || '(empty)'}`,
+    };
+  }
+
+  /**
+   * Handle the scratchpad_write tool. Creates the pinned scratchpad message
+   * the first time it's called, and updates it in place thereafter.
+   */
+  _scratchpadWrite(tabId, args) {
+    const text = (args && typeof args.text === 'string') ? args.text : '';
+    if (!text.trim() && !args?.replace) {
+      return { success: false, error: 'scratchpad_write: `text` is required (non-empty). Pass replace:true with an empty string to clear the pad.' };
+    }
+
+    const messages = this.conversations.get(tabId);
+    if (!messages) {
+      return { success: false, error: 'No active conversation on this tab.' };
+    }
+
+    const idx = this._findScratchpadIndex(messages);
+    const currentBody = idx >= 0 ? this._extractScratchpadBody(messages[idx].content) : '';
+    const replace = !!args?.replace;
+    // Hard cap per-pad at ~8k chars to prevent it from eating the whole
+    // context budget. Older lines get trimmed off the top when we hit it.
+    const MAX_BODY = 8000;
+    let nextBody = replace ? text : (currentBody ? `${currentBody}\n${text}` : text);
+    if (nextBody.length > MAX_BODY) {
+      nextBody = '[...older scratchpad lines dropped — pad is full, consider compacting with replace:true]\n' + nextBody.slice(nextBody.length - MAX_BODY + 100);
+    }
+
+    const msg = this._buildScratchpadMessage(nextBody);
+    if (idx >= 0) {
+      messages[idx] = msg;
+    } else {
+      // Insert just after the pinned original user task (or after system if
+      // no real task is pinned yet). Mirrors the originalTaskIdx lookup in
+      // _manageContext so the scratchpad lives at a stable, near-top spot.
+      let insertAt = 1;
+      for (let i = 1; i < messages.length; i++) {
+        const m = messages[i];
+        if (m.role !== 'user') continue;
+        const c = typeof m.content === 'string' ? m.content : '';
+        if (c.startsWith('[Site guidance') || c.startsWith('[Site context changed') || c.startsWith('[Context window was trimmed') || c.startsWith('[Agent scratchpad')) continue;
+        insertAt = i + 1;
+        break;
+      }
+      messages.splice(insertAt, 0, msg);
+    }
+
+    this._persist(tabId);
+    return {
+      success: true,
+      mode: replace ? 'replace' : 'append',
+      bytes: nextBody.length,
+      note: replace ? 'scratchpad replaced' : 'line appended to scratchpad',
+    };
+  }
+  // ─────────────────────────────────────────────────────────────────────
+
   /**
    * Manage context window — trim and summarize when conversation gets too long.
    * Keeps: system prompt, summary of old messages, recent messages.
@@ -1416,27 +1513,57 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
     const systemMsg = messages[0]; // always the system prompt
     // Find the first real user turn (skip any seeded site-guidance context
     // we may have prepended which uses role:'user' with a [Site guidance…]
-    // heading).
+    // heading, and the pinned scratchpad).
     let originalTaskIdx = -1;
     for (let i = 1; i < messages.length; i++) {
       const m = messages[i];
       if (m.role !== 'user') continue;
       const c = typeof m.content === 'string' ? m.content : '';
-      if (c.startsWith('[Site guidance') || c.startsWith('[Site context changed') || c.startsWith('[Context window was trimmed')) continue;
+      if (c.startsWith('[Site guidance') || c.startsWith('[Site context changed') || c.startsWith('[Context window was trimmed') || c.startsWith('[Agent scratchpad')) continue;
       originalTaskIdx = i;
       break;
     }
     const originalTask = originalTaskIdx >= 0 ? messages[originalTaskIdx] : null;
+    // Pin the scratchpad alongside the original task so the model's self-
+    // written notes survive summarization.
+    const scratchpadIdx = this._findScratchpadIndex(messages);
+    const scratchpadMsg = scratchpadIdx >= 0 ? messages[scratchpadIdx] : null;
 
-    const keepRecent = 16; // keep last N messages verbatim
+    // Keep last N messages verbatim. Agents doing heavy tool work (scraping,
+    // batch downloads) burn messages fast — each tool call is 2 messages
+    // (assistant + tool result), so 30 ≈ last 15 tool turns. 16 was too tight
+    // for long-horizon tasks and caused the model to "forget" outcomes from
+    // ~8 steps back (e.g. the file list from list_downloads).
+    const keepRecent = 30;
     // Exclude the pinned original task from both summary and recent slices.
     const afterPin = originalTaskIdx >= 0 ? originalTaskIdx + 1 : 1;
-    const oldMessages = messages.slice(afterPin, -keepRecent);
-    const recentMessages = messages.slice(-keepRecent);
+    const oldMessagesRaw = messages.slice(afterPin, -keepRecent);
+    const recentMessagesRaw = messages.slice(-keepRecent);
+    // Strip the scratchpad out of both slices — we re-pin a single copy of
+    // it in the rebuild step below. Without this we'd either lose it (if it
+    // fell into oldMessages and got summarized away) or duplicate it.
+    const oldMessages = oldMessagesRaw.filter(m => !this._isScratchpadMessage(m));
+    const recentMessages = recentMessagesRaw.filter(m => !this._isScratchpadMessage(m));
 
     if (oldMessages.length < 4) return; // not enough to summarize
 
-    // Build a summary of old messages
+    // Build tool_call_id → name map so each tool result in the summary can be
+    // labelled with the tool that produced it. Without this we'd lose the
+    // association when the assistant turn gets summarized away.
+    const toolNameById = new Map();
+    for (const msg of oldMessages) {
+      if (msg.role === 'assistant' && Array.isArray(msg.tool_calls)) {
+        for (const tc of msg.tool_calls) {
+          if (tc?.id) toolNameById.set(tc.id, tc.function?.name || 'tool');
+        }
+      }
+    }
+
+    // Build a summary of old messages.
+    // We DO emit one-line digests for tool results now — previously they were
+    // skipped ("too verbose"), which meant critical outcomes (e.g. "list_downloads
+    // returned 69 files") silently disappeared when the summarizer ran. On long
+    // tasks that caused the agent to restart work it had already finished.
     let summaryText = 'Previous conversation summary:\n';
     for (const msg of oldMessages) {
       if (msg.role === 'user') {
@@ -1444,10 +1571,18 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
       } else if (msg.role === 'assistant' && msg.content && !msg.tool_calls) {
         summaryText += `- Assistant answered: ${this._truncate(msg.content, 150)}\n`;
       } else if (msg.role === 'assistant' && msg.tool_calls) {
-        const toolNames = msg.tool_calls.map(tc => tc.function?.name).join(', ');
-        summaryText += `- Assistant used tools: ${toolNames}\n`;
+        // The *result* lines below carry the tool name and outcome, so we
+        // don't also need a "called X" line for every tool_call here.
+        // Emit a one-liner only if the assistant included prose reasoning
+        // alongside the tool calls.
+        if (msg.content) {
+          summaryText += `- Assistant: ${this._truncate(msg.content, 150)}\n`;
+        }
+      } else if (msg.role === 'tool') {
+        const toolName = toolNameById.get(msg.tool_call_id) || 'tool';
+        const digest = this._digestToolResult(toolName, msg.content);
+        summaryText += `- ${toolName} → ${digest}\n`;
       }
-      // Skip tool result messages in summary (too verbose)
     }
 
     // Try to compress the summary using the LLM if it's still huge
@@ -1476,6 +1611,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
     messages.length = 0;
     messages.push(systemMsg);
     if (originalTask) messages.push(originalTask);
+    if (scratchpadMsg) messages.push(scratchpadMsg);
     messages.push(summaryMsg, summaryAck, ...recentMessages);
 
     console.log(`[WebBrain] Context trimmed for tab ${tabId}: ${oldMessages.length} old messages → summary. ${messages.length} messages remain.`);
@@ -1484,6 +1620,107 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
   _truncate(str, len) {
     if (!str) return '';
     return str.length > len ? str.slice(0, len) + '...' : str;
+  }
+
+  /**
+   * One-line digest of a tool result, used when summarizing older turns so
+   * the model retains the key outcome (file count, download IDs, final URL)
+   * even after the full JSON is dropped. Target ≤ 140 chars.
+   *
+   * `content` is the stringified tool result from the messages array; we try
+   * to parse it as JSON and pick the most-useful fact per tool. For anything
+   * we don't recognize, fall back to a length-bounded truncate.
+   */
+  _digestToolResult(name, content) {
+    if (!content) return '(empty)';
+    let parsed = null;
+    try { parsed = JSON.parse(content); } catch { /* not JSON */ }
+    if (!parsed || typeof parsed !== 'object') {
+      return this._truncate(String(content).replace(/\s+/g, ' '), 140);
+    }
+    if (parsed.error) {
+      return `error: ${this._truncate(String(parsed.error), 120)}`;
+    }
+
+    switch (name) {
+      case 'list_downloads': {
+        if (Array.isArray(parsed.downloads)) {
+          const n = parsed.downloads.length;
+          const complete = parsed.downloads.filter(d => d.state === 'complete').length;
+          const latest = parsed.downloads[0];
+          const label = latest ? (latest.filename || latest.url || '') : '';
+          return `${n} downloads listed (${complete} complete)${label ? `; latest: ${this._truncate(label, 70)}` : ''}`;
+        }
+        break;
+      }
+      case 'download_file': {
+        if (parsed.downloadId != null) {
+          return `downloaded id=${parsed.downloadId}${parsed.filename ? `, file=${this._truncate(parsed.filename, 80)}` : ''}`;
+        }
+        break;
+      }
+      case 'download_files': {
+        if (Array.isArray(parsed.results)) {
+          const ok = parsed.results.filter(r => r?.success).length;
+          return `${ok}/${parsed.results.length} downloaded`;
+        }
+        if (parsed.count != null) return `${parsed.count} downloads queued`;
+        break;
+      }
+      case 'read_downloaded_file': {
+        if (parsed.filename) {
+          const len = parsed.originalLength ?? (typeof parsed.text === 'string' ? parsed.text.length : '?');
+          return `read ${this._truncate(parsed.filename, 80)} (${parsed.contentType || '?'}, ${len} chars)`;
+        }
+        break;
+      }
+      case 'navigate': {
+        if (parsed.url) return `now on ${this._truncate(parsed.url, 110)}`;
+        break;
+      }
+      case 'new_tab': {
+        if (parsed.url) return `opened tab ${this._truncate(parsed.url, 100)}`;
+        break;
+      }
+      case 'extract_data': {
+        if (Array.isArray(parsed)) {
+          const rows = parsed.reduce((s, t) => s + (Array.isArray(t?.rows) ? t.rows.length : 0), 0);
+          return `extracted ${parsed.length} item(s), ${rows} row(s)`;
+        }
+        break;
+      }
+      case 'fetch_url':
+      case 'research_url': {
+        const len = parsed.originalLength ?? (typeof parsed.text === 'string' ? parsed.text.length : '?');
+        const title = parsed.title ? ` - ${this._truncate(parsed.title, 60)}` : '';
+        return `${parsed.status ?? 200}${title} (${len} chars)`;
+      }
+      case 'get_accessibility_tree':
+      case 'read_page': {
+        const len = (typeof parsed.text === 'string' ? parsed.text.length : null)
+          ?? (typeof parsed.pageContent === 'string' ? parsed.pageContent.length : '?');
+        return `read page (${len} chars)`;
+      }
+      case 'scroll': {
+        if (parsed.success) {
+          return `scrolled${parsed.containerScrollY != null ? ` (containerY=${Math.round(parsed.containerScrollY)}/${Math.round(parsed.containerScrollHeight ?? 0)})` : ''}`;
+        }
+        break;
+      }
+      case 'screenshot':
+      case 'full_page_screenshot':
+        return parsed.success ? 'screenshot captured' : 'screenshot failed';
+      case 'scratchpad_write': {
+        return `scratchpad ${parsed.mode || 'write'} (${parsed.bytes ?? '?'} chars)`;
+      }
+    }
+
+    // Generic fallback — compact stringified JSON, bounded.
+    try {
+      return this._truncate(JSON.stringify(parsed), 140);
+    } catch {
+      return this._truncate(String(content), 140);
+    }
   }
 
   /**
@@ -1578,12 +1815,16 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
       const m = messages[i];
       if (m.role !== 'user') continue;
       const c = typeof m.content === 'string' ? m.content : '';
-      if (c.startsWith('[Site guidance') || c.startsWith('[Site context changed') || c.startsWith('[Context')) continue;
+      if (c.startsWith('[Site guidance') || c.startsWith('[Site context changed') || c.startsWith('[Context') || c.startsWith('[Agent scratchpad')) continue;
       originalTask = m;
       break;
     }
+    // Pin the scratchpad too — even under emergency trim, the model's own
+    // notes should survive.
+    const scratchpadIdx = this._findScratchpadIndex(messages);
+    const scratchpadMsg = scratchpadIdx >= 0 ? messages[scratchpadIdx] : null;
     const keepLast = 6; // keep only 6 most recent messages
-    const recent = messages.slice(-keepLast);
+    const recent = messages.slice(-keepLast).filter(m => !this._isScratchpadMessage(m));
 
     // Also truncate any huge tool results in remaining messages
     for (const msg of recent) {
@@ -1607,6 +1848,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
     messages.length = 0;
     messages.push(systemMsg);
     if (originalTask) messages.push(originalTask);
+    if (scratchpadMsg) messages.push(scratchpadMsg);
     messages.push(notice, ack, ...recent);
 
     console.log(`[WebBrain] Emergency context trim: kept ${messages.length} messages.`);
@@ -1768,6 +2010,10 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
       } catch (e) {
         return { success: false, error: `Screenshot failed: ${e.message}` };
       }
+    }
+
+    if (name === 'scratchpad_write') {
+      return this._scratchpadWrite(tabId, args);
     }
 
     if (name === 'done') {

--- a/src/chrome/src/agent/tools.js
+++ b/src/chrome/src/agent/tools.js
@@ -497,6 +497,21 @@ export const AGENT_TOOLS = [
   {
     type: 'function',
     function: {
+      name: 'scratchpad_write',
+      description: 'Write to your persistent scratchpad — a note pinned near the top of your context that survives conversation summarization. Use it for long tasks where facts need to persist across many tool calls: download IDs you\'ve collected, file paths on disk, pages/items you\'ve already processed, your running plan, intermediate CSV rows you\'ve built up. Without the scratchpad, older tool outcomes are compressed into a short summary as context fills up, so you WILL lose specific details (filenames, counts, which items are done) after ~15 tool turns. Default action appends `text` as a new line. Pass `replace:true` to overwrite the whole pad when you want to compact it. Keep entries short and factual — one line per fact is ideal. Read back your own pad anytime; it\'s visible in every future prompt.',
+      parameters: {
+        type: 'object',
+        properties: {
+          text: { type: 'string', description: 'The note to record. One line ideally. Examples: "Downloaded pages 1-69 as page{N}.html, ids 700-768." / "Pages extracted so far: 1,2,3. Next: 4." / "Plan: read each downloaded file, regex <tr> rows, emit CSV."' },
+          replace: { type: 'boolean', description: 'If true, replace the entire scratchpad with `text`. Default false — appends as a new line.' },
+        },
+        required: ['text'],
+      },
+    },
+  },
+  {
+    type: 'function',
+    function: {
       name: 'verify_form',
       description: 'Read all form field values and capture a viewport screenshot. Call this BEFORE submitting important forms to confirm every field has the intended value. Returns field names, types, current values, plus a screenshot.',
       parameters: {
@@ -623,6 +638,7 @@ Available tools:
 - new_tab: Open a new tab
 - done: Signal task completion
 - verify_form: Verify form fields before submitting
+- scratchpad_write: Pin a note in context that survives summarization (use on long tasks to remember download IDs, file paths, progress, plans)
 
 ACCESSIBILITY TREE — read this carefully:
 - Output format is FLAT INDENTED TEXT. Each node is one line:
@@ -672,6 +688,17 @@ CRITICAL — do NOT rush:
 - When creating something (product, post, account, etc.), after submitting the form, verify the result by checking: (a) a success message or confirmation appeared, (b) the newly created item's name/details match what you intended, (c) the creation timestamp is from NOW, not from the past. Do NOT assume an existing item is something you just created.
 - When filling a multi-field form, fill ONE field at a time: click the field → type the value → then move to the NEXT field. Never try to type multiple values without clicking each respective field first.
 - If the user's request contains multiple pieces of data (e.g. "product called X at $Y per Z"), parse them into separate values BEFORE starting: name="X", price="Y", interval="Z". Then fill each into its own form field.
+
+SCRATCHPAD — use this for long tasks:
+- As the conversation grows, older tool outputs get COMPRESSED INTO A SHORT SUMMARY. Specific facts (download IDs, filenames, which items you've finished, the exact row counts) DISAPPEAR. If you need a fact 15+ tool turns later, it will not be there.
+- The fix: \`scratchpad_write({text: "..."})\`. It appends a line to a pinned note that STAYS at the top of your context and survives summarization. Pass \`replace: true\` to rewrite the whole pad (use sparingly — e.g. to compact stale entries).
+- When to write to it:
+  (a) Right after a bulk operation completes — "Downloaded pages 1-69 as page{N}.html, IDs 700-768."
+  (b) Whenever you finalize a plan — "Plan: (1) download all pages (DONE), (2) read each, (3) regex <tr> rows, (4) emit CSV."
+  (c) When you finish a chunk of iterative work — "Processed pages 1-10. Next: 11."
+  (d) When you discover a non-obvious fact you'll need later — "API endpoint /api/investors 404s, use HTML scrape." "Download path: /Users/me/Downloads/page{N}.html."
+- Keep entries SHORT and FACTUAL. One line per fact. The pad is visible on every future turn — scan it before picking your next action, especially if you're about to restart something.
+- Don't use the scratchpad for short tasks (< 5 tool calls) or for prose reasoning. It's working memory, not a journal.
 
 UI vs API — read this carefully:
 - For ANY action that creates, modifies, deletes, sends, submits, buys, transfers, posts, or publishes anything: ALWAYS go through the visible UI of the current page. NEVER call REST/GraphQL/API endpoints directly via \`fetch_url\` with POST/PUT/PATCH/DELETE, NEVER use \`execute_js\` to call \`fetch()\` with mutation methods, NEVER attempt to "call the API directly to save time".
@@ -782,6 +809,7 @@ RULES:
 8. When done, call done({summary: "..."}). Verify success first — check for confirmation messages.
 9. If stuck, try a different approach. Don't repeat the same failing action.
 10. Interact through the visible UI. Do not call APIs directly.
+11. For long tasks, call scratchpad_write({text: "..."}) to remember facts (file paths, download IDs, progress) — older tool results get summarized and their details disappear.
 
 TYPING: Click the field first, then call type_text({text: "..."}) with NO selector. This is the most reliable method.
 


### PR DESCRIPTION
## Context

Long-horizon runs were thrashing. A trace using moonshotai/kimi-k2.6 on a 69-page scrape showed the agent successfully downloaded all 69 HTML files at step ~95, then forgot and restarted browser scraping from scratch. By step 106 it had spent ~19 minutes, ~$1.50 in tokens, and was still on page 1.

Root cause: [agent.js:1450](src/chrome/src/agent/agent.js:1450) said `// Skip tool result messages in summary (too verbose)`. When the conversation crossed 50 messages or 80k chars, `_manageContext` summarized older turns but dropped every tool result, keeping only "Assistant used tools: list_downloads". The outcome (69 files on disk) was gone. Secondary: `keepRecent: 16` ≈ 8 tool turns, too tight for any heavy-tool-use task.

## Summary

Three changes that together address the root cause, not just symptoms:

1. **New `scratchpad_write` tool** — a pinned user message (`[Agent scratchpad ...]`) that lives near the top of the conversation and survives both `_manageContext` and `_emergencyTrim`. The model writes download IDs, file paths, progress counters, and a running plan to it. Appends by default; `replace: true` overwrites. Body capped at 8KB with graceful truncation of older lines.

2. **Tool-result digests in the summary** — replaced the skip with `_digestToolResult`, which emits a one-liner per tool result. Example: `list_downloads → 69 downloads listed (69 complete); latest: /Users/barack/Downloads/page1.html`. Per-tool rules for the ones that matter for long tasks (`list_downloads`, `download_file(s)`, `read_downloaded_file`, `navigate`, `fetch_url`, `research_url`, `extract_data`, `scroll`, `screenshot`, `scratchpad_write`) plus a truncated-JSON fallback.

3. **`keepRecent` 16 → 30** — 16 verbatim messages ≈ 8 tool turns. 30 ≈ 15 tool turns and gives heavy-tool-use agents enough recent context to see their own work before summarization kicks in.

## Why

Even without the scratchpad, fix #2 alone would have kept the "69 files downloaded" fact alive in every future turn (as a one-line summary). The scratchpad is the belt-and-suspenders version: once the model writes `"Downloaded pages 1-69 as page{N}.html, IDs 700-768"` to the pad, that line is pinned near the top of the prompt and cannot be summarized away. For long tasks that span many tool calls, this is the standard fix — giving the agent a durable scratch area that persists across context compression.

## Files

- `src/chrome/src/agent/agent.js` — pinning + digest logic
  - [agent.js:1391](src/chrome/src/agent/agent.js:1391) scratchpad helpers + `_scratchpadWrite` handler
  - [agent.js:1446](src/chrome/src/agent/agent.js:1446) tool-result digests in summary loop
  - [agent.js:1633](src/chrome/src/agent/agent.js:1633) `_digestToolResult`
  - [agent.js:1431](src/chrome/src/agent/agent.js:1431) `keepRecent` 16 → 30
  - `_manageContext` + `_emergencyTrim` updated to pin scratchpad
  - `executeTool` dispatches `scratchpad_write`
- `src/chrome/src/agent/tools.js` — new tool + prompt guidance
  - `scratchpad_write` tool definition
  - SCRATCHPAD section in SYSTEM_PROMPT_ACT with concrete examples
  - one-liner in SYSTEM_PROMPT_ACT_COMPACT

## Test plan

- [x] `npm test` — all 32 existing tests pass
- [x] `node --check` both modified files
- [x] Smoke-test `_digestToolResult` against a 69-file `list_downloads` payload (returns `"69 downloads listed (69 complete); latest: /Users/barack/Downloads/page1.html"`)
- [x] Smoke-test scratchpad insert / append / replace behavior
- [ ] Manual: load the extension, run a multi-step task that crosses the 50-message trim threshold, confirm the scratchpad message shows up in the pinned position and its contents persist across summarization
- [ ] Manual: run the original OpenVC-scrape task (69 pages) with the same model (kimi-k2.6) and confirm it no longer loops

## Things a reviewer should look at

- The scratchpad message prefix `[Agent scratchpad` is now reserved — added to every place in `_manageContext`/`_emergencyTrim` that scans for the original user task so it isn't mistaken for one. Worth double-checking the prefix list wasn't missed anywhere.
- `_digestToolResult` is a new surface — per-tool cases are opinionated about what the "key fact" is. Easy to extend later if a specific tool needs a richer digest.
- `keepRecent` bump costs some tokens at steady state (slightly fewer turns get summarized). Net win for long tasks; minor cost for short ones.

🤖 Generated with [Claude Code](https://claude.com/claude-code)