### PR TITLE
Update web demo video embeds for desktop and mobile

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -948,7 +948,7 @@
   <p class="section-subtitle">See how WebBrain reads pages, extracts data, and automates browser tasks.</p>
   <div class="video-showcase">
     <div class="video-frame">
-      <iframe id="demo-video" src="https://www.youtube.com/embed/iPTjqDP5ApY" data-desktop-src="https://www.youtube.com/embed/iPTjqDP5ApY" data-mobile-src="https://www.youtube.com/embed/b9SwOB-LqAo?playsinline=1" title="WebBrain demo video" loading="lazy" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+      <iframe id="demo-video" src="https://www.youtube.com/embed/3eFAQ-b65J0" data-desktop-src="https://www.youtube.com/embed/3eFAQ-b65J0" data-mobile-src="https://www.youtube.com/embed/Nov3sw7FE_Q?playsinline=1" title="WebBrain demo video" loading="lazy" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
     </div>
   </div>
 </section>


### PR DESCRIPTION
### Motivation
- Replace the landing page demo video embeds with the new desktop and mobile URLs so the site shows the up-to-date demo content.

### Description
- Updated the `iframe` in `web/index.html` to use the new desktop YouTube embed `3eFAQ-b65J0` and the new mobile Shorts embed `Nov3sw7FE_Q?playsinline=1` by changing the `src`, `data-desktop-src`, and `data-mobile-src` attributes.

### Testing
- No automated tests were run; manually verified that the `iframe` line in `web/index.html` now contains the updated `src`, `data-desktop-src`, and `data-mobile-src` URLs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e72805577c8327bedf042265184521)