### PR TITLE
Add .one suffix to Web landing side-panel brand

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -389,6 +389,10 @@
       -webkit-background-clip: text;
       -webkit-text-fill-color: transparent;
     }
+    .sp-header .sp-brand .sp-domain {
+      opacity: 0.5;
+      font-weight: 400;
+    }
     .sp-status {
       width: 7px; height: 7px;
       background: var(--success);
@@ -916,7 +920,7 @@
         </div>
         <div class="side-panel">
           <div class="sp-header">
-            <span class="sp-brand">🧠 WebBrain</span>
+            <span class="sp-brand">🧠 WebBrain<span class="sp-domain">.one</span></span>
             <span class="sp-status"></span>
           </div>
           <div class="sp-messages">


### PR DESCRIPTION
### Motivation
- Make the landing page side-panel header match the blog header branding by adding the ".one" suffix to the WebBrain brand.

### Description
- Updated `web/index.html` to add a `.sp-domain` CSS rule and to change the side-panel header from `<span class="sp-brand">🧠 WebBrain</span>` to `<span class="sp-brand">🧠 WebBrain<span class="sp-domain">.one</span></span>` so the suffix is rendered with lighter emphasis.

### Testing
- No automated tests were run because this is a static HTML/CSS text and style change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7bb2b9b24832799a0df420319ccda)