### PR TITLE
agent: token-conscious screenshots (resize + iterative JPEG compress)

### DIFF
--- a/src/chrome/src/agent/agent.js
+++ b/src/chrome/src/agent/agent.js
@@ -1023,31 +1023,55 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
       await cdpClient.attach(tabId);
       await cdpClient.sendCommand(tabId, 'Page.enable');
       await this._bringToFrontForCapture(tabId);
+
+      // Probe the CSS viewport first so we can either (a) clip exactly
+      // to it for pixel-accurate captures, or (b) compute a budget-aware
+      // CDP-side scale that downsizes during capture rather than after.
+      const vp = await cdpClient.evaluate(tabId, '({w: window.innerWidth, h: window.innerHeight})');
+      const cssW = Math.max(1, Math.round(vp?.result?.value?.w || 1024));
+      const cssH = Math.max(1, Math.round(vp?.result?.value?.h || 768));
+
       if (coordAligned) {
-        const vp = await cdpClient.evaluate(tabId, '({w: window.innerWidth, h: window.innerHeight})');
-        const w = Math.max(1, Math.round(vp?.result?.value?.w || 1024));
-        const h = Math.max(1, Math.round(vp?.result?.value?.h || 768));
+        // Pixel-accuracy mode: image pixels must equal CSS pixels so the
+        // planner can click by coordinate off the screenshot. Skip the
+        // token-budget resize — the whole point of this mode is fidelity.
+        // We DO still run the byte-ceiling fallback afterwards: if the
+        // CSS viewport happens to be huge, we'd rather lose some JPEG
+        // quality than overflow the provider's image cap.
         const shot = await cdpClient.sendCommand(tabId, 'Page.captureScreenshot', {
           format: 'jpeg',
           quality: 60,
-          clip: { x: 0, y: 0, width: w, height: h, scale: 1 },
+          clip: { x: 0, y: 0, width: cssW, height: cssH, scale: 1 },
         });
         if (!shot?.data) return null;
-        return {
-          dataUrl: `data:image/jpeg;base64,${shot.data}`,
-          width: w,
-          height: h,
-          coordAligned: true,
-        };
+        const rawDataUrl = `data:image/jpeg;base64,${shot.data}`;
+        const shrunk = await this._compressJpegToByteCeiling(rawDataUrl);
+        return { dataUrl: shrunk, width: cssW, height: cssH, coordAligned: true };
       }
+
+      // Non-coord-aligned mode: pre-compute target dims via the budget
+      // binary-search, then ask CDP to capture + scale in one pass. This
+      // avoids ever materializing a multi-MB native-DPR JPEG that we'd
+      // then have to decode and resize in the service worker.
+      const [targetW, targetH] = Agent._fitImageDimensions(cssW, cssH);
+      const scale = targetW < cssW ? targetW / cssW : 1;
       const shot = await cdpClient.sendCommand(tabId, 'Page.captureScreenshot', {
         format: 'jpeg',
-        quality: 60,
+        quality: Math.round(Agent.IMAGE_BUDGET.initialJpegQuality * 100),
         fromSurface: true,
+        clip: { x: 0, y: 0, width: cssW, height: cssH, scale },
       });
       if (!shot?.data) return null;
+      const rawDataUrl = `data:image/jpeg;base64,${shot.data}`;
+
+      // CDP-side resize + JPEG q=75 usually fits. Iterative quality
+      // downgrade is the safety net for high-DPR screens where the
+      // captured image can still exceed the base64 ceiling.
+      const shrunk = await this._compressJpegToByteCeiling(rawDataUrl);
       return {
-        dataUrl: `data:image/jpeg;base64,${shot.data}`,
+        dataUrl: shrunk,
+        width: targetW,
+        height: targetH,
         coordAligned: false,
       };
     } catch (e) {
@@ -1164,6 +1188,217 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
     try {
       await cdpClient.sendCommand(tabId, 'Page.bringToFront');
     } catch { /* ignore */ }
+  }
+
+  // ───────────── Image-budget (token-conscious screenshots) ─────────────
+  // Local vision models are cheap enough that a few thousand image tokens
+  // per screenshot doesn't sting, but the moment you point the dedicated
+  // vision model at a paid API (OpenAI, Anthropic, OpenRouter) every
+  // screenshot's pixel area translates directly into dollars. Anthropic's
+  // own "Claude for Chrome" extension solves this by:
+  //   (1) computing a target (w,h) that fits both a pixel-dimension cap
+  //       AND a token cap, via a binary search over the long side;
+  //   (2) capturing at that reduced size via CDP's clip.scale — and if
+  //       the resulting JPEG is still over a byte ceiling, iteratively
+  //       dropping JPEG quality (0.75 → 0.1 in 0.05 steps) until it fits.
+  //
+  // Defaults below match Anthropic's exactly (pxPerToken=28, 1568/1568,
+  // initial 0.75, step 0.05, min 0.1, ~1.4 MB base64 ceiling) — those
+  // are tuned to Claude's native vision encoder and happen to be
+  // reasonable for most other endpoints too. Override per-capture if you
+  // need sharper (coord_aligned) or looser (full_page) constraints.
+  static IMAGE_BUDGET = {
+    pxPerToken: 28,        // rough px² per vision token across providers
+    maxTargetPx: 1568,     // no dimension bigger than this
+    maxTargetTokens: 1568, // total image tokens budget
+    maxBase64Chars: 1398100, // ~1.4 MB base64, matches Anthropic's cap
+    initialJpegQuality: 0.75,
+    minJpegQuality: 0.10,
+    jpegQualityStep: 0.05,
+  };
+
+  /**
+   * Anthropic's token-cost approximation: ceil((w*h) / pxPerToken²).
+   * Good enough to compare two capture sizes under the same budget; not
+   * exact for any specific provider's tokenizer, but better than eyeballing.
+   */
+  static _estimateImageTokens(w, h, pxPerToken) {
+    return Math.ceil((w / pxPerToken) * (h / pxPerToken));
+  }
+
+  /**
+   * Largest (w, h) ≤ original that fits BOTH maxTargetPx per side AND
+   * maxTargetTokens total at the given pxPerToken. Aspect ratio preserved.
+   * Binary-searches over the long side; short side follows. Ported from
+   * Claude-for-Chrome's `C(w, h, params)` (same algorithm, clearer names).
+   */
+  static _fitImageDimensions(origW, origH, budget = Agent.IMAGE_BUDGET) {
+    const { pxPerToken, maxTargetPx, maxTargetTokens } = budget;
+    // Already fits — no work.
+    if (origW <= maxTargetPx && origH <= maxTargetPx &&
+        Agent._estimateImageTokens(origW, origH, pxPerToken) <= maxTargetTokens) {
+      return [origW, origH];
+    }
+    // Search the long side; the other follows from aspect ratio.
+    if (origH > origW) {
+      const [h, w] = Agent._fitImageDimensions(origH, origW, budget);
+      return [w, h];
+    }
+    const aspect = origW / origH;
+    let hi = origW, lo = 1;
+    // eslint-disable-next-line no-constant-condition
+    while (true) {
+      if (lo + 1 >= hi) {
+        return [lo, Math.max(Math.round(lo / aspect), 1)];
+      }
+      const mid = Math.floor((lo + hi) / 2);
+      const midH = Math.max(Math.round(mid / aspect), 1);
+      if (mid <= maxTargetPx &&
+          Agent._estimateImageTokens(mid, midH, pxPerToken) <= maxTargetTokens) {
+        lo = mid;
+      } else {
+        hi = mid;
+      }
+    }
+  }
+
+  /**
+   * Convert an ArrayBuffer of JPEG/PNG bytes to a base64 dataUrl, chunking
+   * through String.fromCharCode so we don't blow the call stack on
+   * multi-MB images. Pure helper, no state.
+   */
+  static _bufferToDataUrl(buf, mime) {
+    const bytes = new Uint8Array(buf);
+    let bin = '';
+    const chunk = 0x8000;
+    for (let i = 0; i < bytes.length; i += chunk) {
+      bin += String.fromCharCode.apply(null, bytes.subarray(i, i + chunk));
+    }
+    return `data:${mime};base64,${btoa(bin)}`;
+  }
+
+  /**
+   * If `dataUrl`'s base64 payload is already under `maxBase64Chars`, return
+   * it unchanged. Otherwise decode, draw to an OffscreenCanvas, and
+   * re-encode as JPEG, iteratively dropping quality from
+   * `initialJpegQuality` down to `minJpegQuality` in `jpegQualityStep`
+   * increments until the output fits — or until we hit `minJpegQuality`,
+   * in which case we return the min-quality version anyway (best-effort).
+   *
+   * Never throws: returns the original dataUrl on any decode/encode
+   * failure so screenshot paths don't take down the whole agent turn
+   * over a single bad capture.
+   */
+  async _compressJpegToByteCeiling(dataUrl, budget = Agent.IMAGE_BUDGET) {
+    try {
+      if (!dataUrl) return dataUrl;
+      const payloadStart = dataUrl.indexOf(',') + 1;
+      const payloadLen = payloadStart > 0 ? dataUrl.length - payloadStart : dataUrl.length;
+      if (payloadLen <= budget.maxBase64Chars) return dataUrl;
+
+      const resp = await fetch(dataUrl);
+      const blob = await resp.blob();
+      const bmp = await createImageBitmap(blob);
+      const canvas = new OffscreenCanvas(bmp.width, bmp.height);
+      const ctx = canvas.getContext('2d');
+      ctx.drawImage(bmp, 0, 0);
+
+      let quality = budget.initialJpegQuality;
+      let lastBuf = null;
+      while (quality >= budget.minJpegQuality - 1e-9) {
+        const outBlob = await canvas.convertToBlob({ type: 'image/jpeg', quality });
+        const buf = await outBlob.arrayBuffer();
+        lastBuf = buf;
+        // Base64 length ≈ 4/3 × byte count (plus rounding). Cheap estimate
+        // avoids the base64 encode cost per iteration.
+        if (Math.ceil(buf.byteLength * 4 / 3) <= budget.maxBase64Chars) {
+          return Agent._bufferToDataUrl(buf, 'image/jpeg');
+        }
+        quality -= budget.jpegQualityStep;
+      }
+      // Floor quality reached and still over budget — send it anyway.
+      return lastBuf ? Agent._bufferToDataUrl(lastBuf, 'image/jpeg') : dataUrl;
+    } catch {
+      return dataUrl;
+    }
+  }
+
+  /**
+   * End-to-end "shrink this screenshot to fit the vision budget" pass.
+   * Decodes, resizes to the target dims picked by `_fitImageDimensions`,
+   * and runs JPEG iterative-quality fallback if bytes are still too large.
+   *
+   * Returns { dataUrl, width, height } — width/height are the actual
+   * pixel dimensions of the returned image (useful for callers that want
+   * to report what the model will see).
+   *
+   * `origW`/`origH` should be the decoded image's natural dimensions.
+   * Pass them in rather than relying on createImageBitmap twice; callers
+   * that captured via CDP already know the viewport dims and can feed
+   * them here.
+   */
+  async _shrinkImageForBudget(dataUrl, origW, origH, budget = Agent.IMAGE_BUDGET) {
+    try {
+      if (!dataUrl) return { dataUrl, width: origW, height: origH };
+
+      // If caller passed dims, check the fast-exit path up front (no decode).
+      if (origW && origH) {
+        const [targetW, targetH] = Agent._fitImageDimensions(origW, origH, budget);
+        const payloadStart = dataUrl.indexOf(',') + 1;
+        const payloadLen = payloadStart > 0 ? dataUrl.length - payloadStart : dataUrl.length;
+        if (targetW === origW && targetH === origH && payloadLen <= budget.maxBase64Chars) {
+          return { dataUrl, width: origW, height: origH };
+        }
+      }
+
+      const resp = await fetch(dataUrl);
+      const blob = await resp.blob();
+      const bmp = await createImageBitmap(blob);
+
+      // If dims weren't passed (e.g. full_page_screenshot where we don't
+      // know the document height up front), use the decoded bitmap's.
+      if (!origW || !origH) {
+        origW = bmp.width;
+        origH = bmp.height;
+      }
+      const [targetW, targetH] = Agent._fitImageDimensions(origW, origH, budget);
+
+      // If the decoded bitmap is already smaller than our target (e.g. CDP
+      // pre-scaled it for us via clip.scale), use the bitmap's own dims.
+      const finalW = Math.min(targetW, bmp.width);
+      const finalH = Math.min(targetH, bmp.height);
+
+      const canvas = new OffscreenCanvas(finalW, finalH);
+      const ctx = canvas.getContext('2d');
+      // High-quality downscale — matters at 2-4× ratios we often hit.
+      ctx.imageSmoothingEnabled = true;
+      ctx.imageSmoothingQuality = 'high';
+      ctx.drawImage(bmp, 0, 0, bmp.width, bmp.height, 0, 0, finalW, finalH);
+
+      // Iterative JPEG quality until bytes fit.
+      let quality = budget.initialJpegQuality;
+      let lastBuf = null;
+      while (quality >= budget.minJpegQuality - 1e-9) {
+        const outBlob = await canvas.convertToBlob({ type: 'image/jpeg', quality });
+        const buf = await outBlob.arrayBuffer();
+        lastBuf = buf;
+        if (Math.ceil(buf.byteLength * 4 / 3) <= budget.maxBase64Chars) {
+          return {
+            dataUrl: Agent._bufferToDataUrl(buf, 'image/jpeg'),
+            width: finalW,
+            height: finalH,
+          };
+        }
+        quality -= budget.jpegQualityStep;
+      }
+      return {
+        dataUrl: lastBuf ? Agent._bufferToDataUrl(lastBuf, 'image/jpeg') : dataUrl,
+        width: finalW,
+        height: finalH,
+      };
+    } catch {
+      return { dataUrl, width: origW, height: origH };
+    }
   }
 
   /**
@@ -1941,15 +2176,39 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
           probe = await this._captureViewportProbe(tabId);
           await this._bringToFrontForCapture(tabId);
           coordAligned = !!(args && args.coord_aligned);
-          const capArgs = { format: 'png', fromSurface: true };
+          const cssW = Math.max(1, Math.round(probe?.innerWidth || 1024));
+          const cssH = Math.max(1, Math.round(probe?.innerHeight || 768));
+
           if (coordAligned) {
-            const w = Math.max(1, Math.round(probe?.innerWidth || 1024));
-            const h = Math.max(1, Math.round(probe?.innerHeight || 768));
-            capArgs.clip = { x: 0, y: 0, width: w, height: h, scale: 1 };
+            // Pixel-accuracy mode: image pixels must equal CSS pixels so
+            // click({x,y}) off the screenshot lands on the real element.
+            // PNG (lossless, no quality knob) so no artifacts at glyph edges.
+            const screenshot = await cdpClient.sendCommand(tabId, 'Page.captureScreenshot', {
+              format: 'png',
+              fromSurface: true,
+              clip: { x: 0, y: 0, width: cssW, height: cssH, scale: 1 },
+            });
+            dataUrl = `data:image/png;base64,${screenshot.data}`;
+            description = `Screenshot captured via CDP (${screenshot.data.length} bytes, CSS-pixel aligned for pixel clicks)`;
+            // Byte-ceiling fallback only — we don't resize in coord mode.
+            dataUrl = await this._compressJpegToByteCeiling(dataUrl);
+          } else {
+            // Budget-aware mode (default): pick target dims via binary
+            // search, ask CDP to capture + scale in one pass, then run
+            // the iterative-quality fallback if bytes are still over.
+            const [targetW, targetH] = Agent._fitImageDimensions(cssW, cssH);
+            const scale = targetW < cssW ? targetW / cssW : 1;
+            const screenshot = await cdpClient.sendCommand(tabId, 'Page.captureScreenshot', {
+              format: 'jpeg',
+              quality: Math.round(Agent.IMAGE_BUDGET.initialJpegQuality * 100),
+              fromSurface: true,
+              clip: { x: 0, y: 0, width: cssW, height: cssH, scale },
+            });
+            const rawUrl = `data:image/jpeg;base64,${screenshot.data}`;
+            dataUrl = await this._compressJpegToByteCeiling(rawUrl);
+            const resized = scale < 1 ? ` (resized ${cssW}×${cssH} → ${targetW}×${targetH} for vision-token budget)` : '';
+            description = `Screenshot captured via CDP (${screenshot.data.length} bytes, JPEG)${resized}`;
           }
-          const screenshot = await cdpClient.sendCommand(tabId, 'Page.captureScreenshot', capArgs);
-          dataUrl = `data:image/png;base64,${screenshot.data}`;
-          description = `Screenshot captured via CDP (${screenshot.data.length} bytes, ${coordAligned ? 'CSS-pixel aligned for pixel clicks' : 'native resolution'})`;
         } catch {
           const tab = await chrome.tabs.get(tabId);
           if (!tab?.active) {
@@ -1958,8 +2217,19 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
               error: 'Cannot capture screenshot: this tab is not the active tab in its window. Switch to the tab to take a screenshot, or use a different tool.',
             };
           }
-          dataUrl = await chrome.tabs.captureVisibleTab(tab.windowId, { format: 'png', quality: 80 });
-          description = `Screenshot captured (${dataUrl.length} bytes base64 PNG)`;
+          // Tabs API fallback: no clip/scale available. Capture full, then
+          // decode + resize + recompress via OffscreenCanvas to fit budget.
+          const rawUrl = await chrome.tabs.captureVisibleTab(tab.windowId, { format: 'png', quality: 80 });
+          if (!coordAligned) {
+            const cssW = Math.max(1, Math.round(probe?.innerWidth || 1024));
+            const cssH = Math.max(1, Math.round(probe?.innerHeight || 768));
+            const shrunk = await this._shrinkImageForBudget(rawUrl, cssW, cssH);
+            dataUrl = shrunk.dataUrl;
+            description = `Screenshot captured via tabs API (${dataUrl.length} bytes base64, resized to ${shrunk.width}×${shrunk.height})`;
+          } else {
+            dataUrl = await this._compressJpegToByteCeiling(rawUrl);
+            description = `Screenshot captured via tabs API (${dataUrl.length} bytes base64)`;
+          }
         }
 
         // Pick the presentation path based on what the active providers can
@@ -2172,10 +2442,41 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
         await cdpClient.attach(tabId);
         await this._bringToFrontForCapture(tabId);
         const imageData = await cdpClient.captureFullPageScreenshot(tabId);
+        const rawUrl = `data:image/png;base64,${imageData}`;
+
+        // Full-page captures are the worst case for size — a 1920×8000
+        // document at native DPR easily blows past any provider's image
+        // budget. Always shrink to the token/byte budget. Dimensions come
+        // from decoding the bitmap (we don't know the real doc size up
+        // front the way we do for viewport captures).
+        const shrunk = await this._shrinkImageForBudget(rawUrl, 0, 0);
+
+        // Check the planner/vision setup. A text-only model with no
+        // vision sub-call can't consume this at all — refuse rather
+        // than hand over a huge useless payload.
+        const provider = this.providerManager.getActive();
+        const visionProvider = await this.providerManager.getVisionProvider();
+        if (visionProvider) {
+          const desc = await this._describeScreenshot(tabId, shrunk.dataUrl, 'full_page_screenshot');
+          if (desc) {
+            return {
+              success: true,
+              method: 'vision_describe',
+              description: `[Full-page screenshot described by vision model ${desc.model}, ${shrunk.width}×${shrunk.height} after budget fit]\n${desc.text}`,
+            };
+          }
+        }
+        if (provider?.supportsVision) {
+          return {
+            success: true,
+            method: 'image_attach',
+            description: `Full page screenshot captured and fit to vision budget (${shrunk.width}×${shrunk.height}, ${shrunk.dataUrl.length} base64 chars)`,
+            _attachImage: shrunk.dataUrl,
+          };
+        }
         return {
-          success: true,
-          image: `data:image/png;base64,${imageData}`,
-          description: `Full page screenshot captured (${imageData.length} bytes)`,
+          success: false,
+          error: 'This model cannot see images. Enable "Model supports vision" for the active provider or configure a dedicated vision model.',
         };
       } catch (e) {
         return { success: false, error: `Full page screenshot failed: ${e.message}` };

--- a/src/firefox/src/agent/agent.js
+++ b/src/firefox/src/agent/agent.js
@@ -480,6 +480,182 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
     return { action: 'continue' };
   }
 
+  // ───────────── Image-budget (token-conscious screenshots) ─────────────
+  // See src/chrome/src/agent/agent.js for the full rationale. Firefox MV2
+  // runs in a background PAGE (not a worker) so we have a real `document`
+  // and can use regular <canvas> / toBlob instead of OffscreenCanvas.
+  // Constants match Anthropic's Claude-for-Chrome defaults and the Chrome
+  // Agent's IMAGE_BUDGET — keep them in sync.
+  static IMAGE_BUDGET = {
+    pxPerToken: 28,
+    maxTargetPx: 1568,
+    maxTargetTokens: 1568,
+    maxBase64Chars: 1398100,
+    initialJpegQuality: 0.75,
+    minJpegQuality: 0.10,
+    jpegQualityStep: 0.05,
+  };
+
+  static _estimateImageTokens(w, h, pxPerToken) {
+    return Math.ceil((w / pxPerToken) * (h / pxPerToken));
+  }
+
+  static _fitImageDimensions(origW, origH, budget = Agent.IMAGE_BUDGET) {
+    const { pxPerToken, maxTargetPx, maxTargetTokens } = budget;
+    if (origW <= maxTargetPx && origH <= maxTargetPx &&
+        Agent._estimateImageTokens(origW, origH, pxPerToken) <= maxTargetTokens) {
+      return [origW, origH];
+    }
+    if (origH > origW) {
+      const [h, w] = Agent._fitImageDimensions(origH, origW, budget);
+      return [w, h];
+    }
+    const aspect = origW / origH;
+    let hi = origW, lo = 1;
+    // eslint-disable-next-line no-constant-condition
+    while (true) {
+      if (lo + 1 >= hi) return [lo, Math.max(Math.round(lo / aspect), 1)];
+      const mid = Math.floor((lo + hi) / 2);
+      const midH = Math.max(Math.round(mid / aspect), 1);
+      if (mid <= maxTargetPx &&
+          Agent._estimateImageTokens(mid, midH, pxPerToken) <= maxTargetTokens) {
+        lo = mid;
+      } else {
+        hi = mid;
+      }
+    }
+  }
+
+  /**
+   * Load a dataUrl into an <img>, returning it after `load`. Used by the
+   * budget helpers since Firefox MV2's background page has DOM.
+   */
+  _loadImageFromDataUrl(dataUrl) {
+    return new Promise((resolve, reject) => {
+      const img = new Image();
+      img.onload = () => resolve(img);
+      img.onerror = () => reject(new Error('Failed to load image'));
+      img.src = dataUrl;
+    });
+  }
+
+  _canvasToBlob(canvas, type, quality) {
+    return new Promise((resolve, reject) => {
+      canvas.toBlob((blob) => {
+        if (blob) resolve(blob);
+        else reject(new Error('Failed to encode canvas'));
+      }, type, quality);
+    });
+  }
+
+  static _bufferToDataUrl(buf, mime) {
+    const bytes = new Uint8Array(buf);
+    let bin = '';
+    const chunk = 0x8000;
+    for (let i = 0; i < bytes.length; i += chunk) {
+      bin += String.fromCharCode.apply(null, bytes.subarray(i, i + chunk));
+    }
+    return `data:${mime};base64,${btoa(bin)}`;
+  }
+
+  /**
+   * Decode, resize to the budget target dims, and JPEG-quality-iterate
+   * until the base64 fits. DOM-based (not OffscreenCanvas) because MV2's
+   * background page has a real document. Returns { dataUrl, width, height }.
+   */
+  async _shrinkImageForBudget(dataUrl, origW, origH, budget = Agent.IMAGE_BUDGET) {
+    try {
+      if (!dataUrl) return { dataUrl, width: origW, height: origH };
+
+      if (origW && origH) {
+        const [targetW, targetH] = Agent._fitImageDimensions(origW, origH, budget);
+        const payloadStart = dataUrl.indexOf(',') + 1;
+        const payloadLen = payloadStart > 0 ? dataUrl.length - payloadStart : dataUrl.length;
+        if (targetW === origW && targetH === origH && payloadLen <= budget.maxBase64Chars) {
+          return { dataUrl, width: origW, height: origH };
+        }
+      }
+
+      const img = await this._loadImageFromDataUrl(dataUrl);
+      if (!origW || !origH) {
+        origW = img.naturalWidth || img.width;
+        origH = img.naturalHeight || img.height;
+      }
+      const [targetW, targetH] = Agent._fitImageDimensions(origW, origH, budget);
+      const finalW = Math.min(targetW, origW);
+      const finalH = Math.min(targetH, origH);
+
+      const canvas = document.createElement('canvas');
+      canvas.width = finalW;
+      canvas.height = finalH;
+      const ctx = canvas.getContext('2d');
+      ctx.imageSmoothingEnabled = true;
+      ctx.imageSmoothingQuality = 'high';
+      ctx.drawImage(img, 0, 0, origW, origH, 0, 0, finalW, finalH);
+
+      let quality = budget.initialJpegQuality;
+      let lastBuf = null;
+      while (quality >= budget.minJpegQuality - 1e-9) {
+        const outBlob = await this._canvasToBlob(canvas, 'image/jpeg', quality);
+        const buf = await outBlob.arrayBuffer();
+        lastBuf = buf;
+        if (Math.ceil(buf.byteLength * 4 / 3) <= budget.maxBase64Chars) {
+          return {
+            dataUrl: Agent._bufferToDataUrl(buf, 'image/jpeg'),
+            width: finalW,
+            height: finalH,
+          };
+        }
+        quality -= budget.jpegQualityStep;
+      }
+      return {
+        dataUrl: lastBuf ? Agent._bufferToDataUrl(lastBuf, 'image/jpeg') : dataUrl,
+        width: finalW,
+        height: finalH,
+      };
+    } catch {
+      return { dataUrl, width: origW, height: origH };
+    }
+  }
+
+  /**
+   * Byte-ceiling-only re-encode: preserves dimensions, just drops JPEG
+   * quality until bytes fit. Useful when you've already decided the
+   * dims are correct (e.g. coord-aligned captures) but the payload
+   * happens to exceed the provider's image cap.
+   */
+  async _compressJpegToByteCeiling(dataUrl, budget = Agent.IMAGE_BUDGET) {
+    try {
+      if (!dataUrl) return dataUrl;
+      const payloadStart = dataUrl.indexOf(',') + 1;
+      const payloadLen = payloadStart > 0 ? dataUrl.length - payloadStart : dataUrl.length;
+      if (payloadLen <= budget.maxBase64Chars) return dataUrl;
+
+      const img = await this._loadImageFromDataUrl(dataUrl);
+      const w = img.naturalWidth || img.width;
+      const h = img.naturalHeight || img.height;
+      const canvas = document.createElement('canvas');
+      canvas.width = w;
+      canvas.height = h;
+      canvas.getContext('2d').drawImage(img, 0, 0);
+
+      let quality = budget.initialJpegQuality;
+      let lastBuf = null;
+      while (quality >= budget.minJpegQuality - 1e-9) {
+        const outBlob = await this._canvasToBlob(canvas, 'image/jpeg', quality);
+        const buf = await outBlob.arrayBuffer();
+        lastBuf = buf;
+        if (Math.ceil(buf.byteLength * 4 / 3) <= budget.maxBase64Chars) {
+          return Agent._bufferToDataUrl(buf, 'image/jpeg');
+        }
+        quality -= budget.jpegQualityStep;
+      }
+      return lastBuf ? Agent._bufferToDataUrl(lastBuf, 'image/jpeg') : dataUrl;
+    } catch {
+      return dataUrl;
+    }
+  }
+
   /**
    * Capture a viewport screenshot via the WebExtension tabs API. Firefox
    * supports `scale: 1` on captureVisibleTab to force a CSS-pixel-aligned
@@ -512,13 +688,19 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
       } catch (e) { /* fall back to defaults */ }
       // scale: 1 forces 1 image pixel per CSS pixel (Firefox-specific option,
       // ignored by Chrome but Chrome path uses CDP anyway).
-      const dataUrl = await browser.tabs.captureVisibleTab(tab.windowId, {
+      const rawDataUrl = await browser.tabs.captureVisibleTab(tab.windowId, {
         format: 'jpeg',
         quality: 60,
         scale: 1,
       });
-      if (!dataUrl) return null;
-      return { dataUrl, width: w, height: h };
+      if (!rawDataUrl) return null;
+
+      // Firefox's captureVisibleTab doesn't take a clip/scale in a way that
+      // lets us downsize during capture (scale:1 is viewport-lock, not a
+      // factor). So we capture at CSS size and shrink via DOM canvas to
+      // the token budget. On small viewports this is a no-op fast-exit.
+      const shrunk = await this._shrinkImageForBudget(rawDataUrl, w, h);
+      return { dataUrl: shrunk.dataUrl, width: shrunk.width, height: shrunk.height };
     } catch (e) {
       return null;
     }
@@ -960,11 +1142,16 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
             error: 'Cannot capture screenshot: this tab is not the active tab in its window. Switch to the tab to take a screenshot, or use a different tool.',
           };
         }
-        const dataUrl = await browser.tabs.captureVisibleTab(tab.windowId, {
+        const rawUrl = await browser.tabs.captureVisibleTab(tab.windowId, {
           format: 'png',
           quality: 80,
         });
-        const description = `Screenshot captured (${dataUrl.length} bytes base64 PNG)`;
+        // Shrink to the vision budget before handing the image to the
+        // model. Same two-stage dance as Chrome: decode → pick target dims
+        // → draw at target → iterative JPEG quality until bytes fit.
+        const shrunk = await this._shrinkImageForBudget(rawUrl, 0, 0);
+        const dataUrl = shrunk.dataUrl;
+        const description = `Screenshot captured (${dataUrl.length} base64 chars, ${shrunk.width}×${shrunk.height})`;
 
         // Route the image through whichever vision path is actually wired up.
         // Returning a bare `{image: dataUrl}` blob looks like success but

--- a/test/run.js
+++ b/test/run.js
@@ -409,4 +409,137 @@ test('window of 6 means a loop can fall out of the window', () => {
   assert.equal(result.kind, 'none');
 });
 
+// ────────────────────────────────────────────────────────────────────────
+// Image budget (token-conscious screenshots)
+//
+// These mirror the static helpers on Agent exactly — keep them in sync
+// with src/chrome/src/agent/agent.js `_estimateImageTokens` and
+// `_fitImageDimensions`. We shim rather than import because agent.js
+// pulls in chrome.* and cdp-client.
+// ────────────────────────────────────────────────────────────────────────
+
+const IMAGE_BUDGET_DEFAULT = {
+  pxPerToken: 28,
+  maxTargetPx: 1568,
+  maxTargetTokens: 1568,
+};
+
+function estimateImageTokens(w, h, pxPerToken) {
+  return Math.ceil((w / pxPerToken) * (h / pxPerToken));
+}
+
+function fitImageDimensions(origW, origH, budget = IMAGE_BUDGET_DEFAULT) {
+  const { pxPerToken, maxTargetPx, maxTargetTokens } = budget;
+  if (origW <= maxTargetPx && origH <= maxTargetPx &&
+      estimateImageTokens(origW, origH, pxPerToken) <= maxTargetTokens) {
+    return [origW, origH];
+  }
+  if (origH > origW) {
+    const [h, w] = fitImageDimensions(origH, origW, budget);
+    return [w, h];
+  }
+  const aspect = origW / origH;
+  let hi = origW, lo = 1;
+  while (true) {
+    if (lo + 1 >= hi) return [lo, Math.max(Math.round(lo / aspect), 1)];
+    const mid = Math.floor((lo + hi) / 2);
+    const midH = Math.max(Math.round(mid / aspect), 1);
+    if (mid <= maxTargetPx &&
+        estimateImageTokens(mid, midH, pxPerToken) <= maxTargetTokens) {
+      lo = mid;
+    } else {
+      hi = mid;
+    }
+  }
+}
+
+console.log('\nimage budget');
+
+test('small viewport passes through unchanged (fast path)', () => {
+  // 1280×800 at pxPerToken=28 → 1307 tokens < 1568 — no resize.
+  const [w, h] = fitImageDimensions(1280, 800);
+  assert.equal(w, 1280);
+  assert.equal(h, 800);
+});
+
+test('1080p shrinks to fit the token cap', () => {
+  // 1920×1080 → 2645 tokens (over). Target keeps aspect at ~1.78.
+  const [w, h] = fitImageDimensions(1920, 1080);
+  assert.ok(w <= 1568, `width ${w} > 1568`);
+  assert.ok(h <= 1568, `height ${h} > 1568`);
+  assert.ok(estimateImageTokens(w, h, 28) <= 1568, `tokens over cap: ${estimateImageTokens(w, h, 28)}`);
+  // Aspect ratio preserved within 1 pixel (rounding).
+  const origAspect = 1920 / 1080;
+  const newAspect = w / h;
+  assert.ok(Math.abs(origAspect - newAspect) < 0.01, `aspect drift ${newAspect} vs ${origAspect}`);
+});
+
+test('4K and 1440p converge to the same max-budget dims', () => {
+  // Any input with the same 16:9 aspect ratio should produce the same
+  // largest-that-fits output. Catches off-by-one regressions in the
+  // binary search.
+  const [w1440, h1440] = fitImageDimensions(2560, 1440);
+  const [w4k, h4k] = fitImageDimensions(3840, 2160);
+  assert.equal(w1440, w4k);
+  assert.equal(h1440, h4k);
+});
+
+test('tall portrait caps the long side at maxTargetPx', () => {
+  // A 1920×8000 full-page capture — the long side here is height.
+  const [w, h] = fitImageDimensions(1920, 8000);
+  assert.ok(h <= 1568, `height ${h} > 1568`);
+  assert.ok(w > 0, 'width should be positive');
+  assert.ok(estimateImageTokens(w, h, 28) <= 1568);
+});
+
+test('high-DPR 5K viewport stays within budget', () => {
+  // 5120×2880 (retina 5K). Should fit token cap after resize.
+  const [w, h] = fitImageDimensions(5120, 2880);
+  assert.ok(w <= 1568);
+  assert.ok(h <= 1568);
+  assert.ok(estimateImageTokens(w, h, 28) <= 1568);
+});
+
+test('square input returns a square that fits', () => {
+  const [w, h] = fitImageDimensions(3000, 3000);
+  assert.ok(w <= 1568);
+  assert.ok(h <= 1568);
+  // Square in, square (within 1 px) out.
+  assert.ok(Math.abs(w - h) <= 1);
+});
+
+test('pathological 1×100000 strip does not blow up', () => {
+  // Edge case: an extremely thin strip. The binary search used to have
+  // a termination bug when origH >> origW; this locks in that fix.
+  const [w, h] = fitImageDimensions(1, 100000);
+  assert.ok(h <= 1568);
+  assert.ok(w >= 1);
+  assert.ok(estimateImageTokens(w, h, 28) <= 1568);
+});
+
+test('custom budget is honored', () => {
+  // Shrink to a tight 400 token / 400 px budget — no dimension should exceed.
+  const [w, h] = fitImageDimensions(1920, 1080, {
+    pxPerToken: 28, maxTargetPx: 400, maxTargetTokens: 400,
+  });
+  assert.ok(w <= 400);
+  assert.ok(h <= 400);
+  assert.ok(estimateImageTokens(w, h, 28) <= 400);
+});
+
+test('existing dims under caps stay within the monotonic bound', () => {
+  // Fuzz a range of common viewport sizes; invariant: output ≤ input on
+  // every dimension, and output token count ≤ maxTargetTokens.
+  const inputs = [
+    [1366, 768], [1440, 900], [1680, 1050], [1600, 900], [1920, 1200],
+    [2048, 1152], [2304, 1440], [2560, 1600], [2880, 1800],
+  ];
+  for (const [iw, ih] of inputs) {
+    const [ow, oh] = fitImageDimensions(iw, ih);
+    assert.ok(ow <= iw, `w grew: ${iw}→${ow}`);
+    assert.ok(oh <= ih, `h grew: ${ih}→${oh}`);
+    assert.ok(estimateImageTokens(ow, oh, 28) <= 1568, `tokens over cap for ${iw}×${ih} → ${ow}×${oh}`);
+  }
+});
+
 await run();


### PR DESCRIPTION
## Summary

Ports the two image-sizing ideas from Anthropic's [Claude-for-Chrome](https://webbrain.one/blog/vision-model-shootout) extension into our screenshot pipeline, so every screenshot is cheap enough to throw at any vision endpoint — local or paid — without cost-per-image anxiety.

Two helpers on `Agent` (Chrome + Firefox parity):

- **`_fitImageDimensions(w, h, budget)`** — binary-search on the long side for the largest (w, h) that fits both a per-dimension pixel cap and a total-token cap (default 1568 / 1568 at 28 px per token). Preserves aspect ratio. Port of their `C(w, h, params)` with clearer names.
- **`_shrinkImageForBudget(dataUrl, origW, origH)`** — end-to-end pass: decode → draw at target dims → iteratively drop JPEG quality (0.75 → 0.10 in 0.05 steps) until base64 fits under `maxBase64Chars` (~1.4 MB). Best-effort, falls back to original on any failure.
- **`_compressJpegToByteCeiling(dataUrl)`** — dim-preserving variant for coord-aligned captures that can't be resized.

## Wired into

1. **`_captureAutoScreenshot`** — probes CSS viewport, asks CDP to capture at a pre-scaled resolution via `clip.scale` (so we never materialize a multi-MB native-DPR JPEG just to throw away). Byte-ceiling fallback runs afterwards as a safety net. `coord_aligned` mode skips the resize — fidelity > tokens for pixel clicks.
2. **`screenshot` tool** — same treatment. JPEG + budget-aware clip in the default path; PNG + `scale:1` in coord_aligned mode. Description string reports resized dimensions so the planner knows what it's looking at.
3. **`full_page_screenshot`** — was returning raw base64 via `{image: …}` which hit `_limitToolResult`'s 8 KB chop and mangled the payload, AND had no size ceiling. Now shrinks via the budget pass (using the decoded bitmap's dims since we don't know doc height up front) and ships through `_attachImage`.

Firefox side: MV2 background page has a real DOM so it uses regular `<canvas>` + `toBlob` instead of `OffscreenCanvas`. `captureVisibleTab` doesn't accept `clip/scale` so we always decode + resize post-capture (marginally slower than Chrome's CDP pre-scale but identical output).

## Bench (from the quick binary-search sanity check)

| Source viewport | After fit | Tokens before → after |
|---|---|---|
| 1280×800 | 1280×800 | 1307 → 1307 (no-op) |
| 1920×1080 | 1478×831 | 2645 → 1567 |
| 2560×1440 | 1478×831 | 4703 → 1567 |
| 3840×2160 | 1478×831 | 10580 → 1567 |
| 1920×8000 (full-page) | 376×1568 | **19592 → 752** |

26× cost reduction on a pathological full-page capture, always within the provider's image cap.

## Intentionally left alone

- **`done` verification screenshot.** It annotates a red outline around the last ax-interacted element and fires once per task — annotation legibility matters more than per-image cost.

## Test plan

- [ ] Load extension, run `auto_screenshot` path on a 1920×1080 viewport, confirm captured image is 1478×831 JPEG and under ~1 MB base64.
- [ ] Call `screenshot` tool explicitly with `coord_aligned: true`, confirm image is CSS-pixel-aligned PNG (no resize).
- [ ] Call `screenshot` tool with default args, confirm resize happens and description string reports the new dims.
- [ ] Call `full_page_screenshot` on a long-scroll page, confirm it no longer truncates and the image reaches the planner.
- [ ] Sanity-check Firefox parity: load Firefox MV2 build, confirm auto-screenshot + screenshot tool both produce budget-fit JPEGs.
- [ ] Run `test/vision-probe.mjs` against a post-change screenshot to confirm vision model output quality is still acceptable on a downscaled image.