### PR TITLE
Add Spanish, French, Turkish, and Chinese localized landing pages

### DIFF
--- a/web/es/index.html
+++ b/web/es/index.html
@@ -1,0 +1,61 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>WebBrain — Agente de navegador con IA de código abierto para Chrome y Firefox</title>
+  <meta name="description" content="WebBrain es un agente de navegador con IA, gratuito y de código abierto para Chrome y Firefox. Lee páginas, extrae datos y automatiza tareas con modelos locales o en la nube.">
+  <link rel="icon" type="image/svg+xml" href="/favicon.svg">
+  <style>
+    :root { --bg:#0b0e17; --card:#111827; --text:#e4e4ec; --muted:#8b8fa4; --accent:#6c63ff; --accent2:#a78bfa; --border:rgba(255,255,255,.08); }
+    * { box-sizing: border-box; }
+    body { margin:0; font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Inter,Roboto,sans-serif; background:var(--bg); color:var(--text); line-height:1.6; }
+    .wrap { max-width:980px; margin:0 auto; padding:24px; }
+    .top { display:flex; justify-content:space-between; align-items:center; gap:16px; }
+    .brand { font-weight:800; font-size:24px; background:linear-gradient(135deg,var(--accent),var(--accent2)); -webkit-background-clip:text; -webkit-text-fill-color:transparent; }
+    .langs a { color:var(--muted); margin-left:10px; text-decoration:none; }
+    .langs a:hover, .langs a.active { color:var(--text); }
+    .hero { background:linear-gradient(180deg, rgba(108,99,255,.15), transparent); border:1px solid var(--border); border-radius:16px; padding:28px; margin-top:24px; }
+    h1 { margin:0 0 10px; font-size:38px; line-height:1.15; }
+    p { color:var(--muted); }
+    .cta { display:flex; flex-wrap:wrap; gap:12px; margin-top:18px; }
+    .btn { display:inline-block; padding:10px 16px; border-radius:10px; text-decoration:none; font-weight:600; }
+    .btn.primary { background:var(--accent); color:white; }
+    .btn.secondary { border:1px solid var(--border); color:var(--text); }
+    .grid { display:grid; grid-template-columns:repeat(auto-fit,minmax(220px,1fr)); gap:14px; margin-top:20px; }
+    .card { background:var(--card); border:1px solid var(--border); border-radius:12px; padding:16px; }
+    h3 { margin:0 0 6px; }
+    footer { margin:36px 0 20px; color:var(--muted); font-size:14px; }
+  </style>
+</head>
+<body>
+  <div class="wrap">
+    <div class="top">
+      <div class="brand">🧠 WebBrain</div>
+      <div class="langs">
+        <a href="/">English</a><a href="/es/" class="active">Español</a><a href="/fr/">Français</a><a href="/tr/">Türkçe</a><a href="/zh/">中文</a>
+      </div>
+    </div>
+
+    <section class="hero">
+      <h1>Automatización web con IA, gratis y de código abierto.</h1>
+      <p>WebBrain funciona en Chrome y Firefox. Puedes leer páginas, investigar información y ejecutar tareas con LLMs locales (llama.cpp) o proveedores en la nube (OpenAI, Claude, OpenRouter).</p>
+      <div class="cta">
+        <a class="btn primary" href="https://chromewebstore.google.com/detail/webbrain/ljhijonmfahplgbbacgcfnaihbjljhhb">Instalar en Chrome</a>
+        <a class="btn secondary" href="https://addons.mozilla.org/firefox/addon/webbrain/">Instalar en Firefox</a>
+        <a class="btn secondary" href="https://github.com/emres/webbrain">Ver en GitHub</a>
+      </div>
+    </section>
+
+    <section class="grid">
+      <article class="card"><h3>Privacidad primero</h3><p>Soporte para modelos locales: tus datos pueden quedarse en tu equipo.</p></article>
+      <article class="card"><h3>Extensible</h3><p>Compatible con múltiples proveedores y flujos de trabajo automatizados.</p></article>
+      <article class="card"><h3>100% abierto</h3><p>Licencia MIT y desarrollo público en GitHub.</p></article>
+    </section>
+
+    <footer>
+      Esta es la versión en español de la página principal. También puedes leer la <a href="/privacy.html">política de privacidad</a> o visitar el <a href="/blog/">blog</a> (en inglés).
+    </footer>
+  </div>
+</body>
+</html>

--- a/web/fr/index.html
+++ b/web/fr/index.html
@@ -1,0 +1,61 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>WebBrain — Agent navigateur IA open source pour Chrome et Firefox</title>
+  <meta name="description" content="WebBrain est un agent navigateur IA gratuit et open source pour Chrome et Firefox. Lisez des pages, extrayez des données et automatisez des tâches avec des modèles locaux ou cloud.">
+  <link rel="icon" type="image/svg+xml" href="/favicon.svg">
+  <style>
+    :root { --bg:#0b0e17; --card:#111827; --text:#e4e4ec; --muted:#8b8fa4; --accent:#6c63ff; --accent2:#a78bfa; --border:rgba(255,255,255,.08); }
+    * { box-sizing: border-box; }
+    body { margin:0; font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Inter,Roboto,sans-serif; background:var(--bg); color:var(--text); line-height:1.6; }
+    .wrap { max-width:980px; margin:0 auto; padding:24px; }
+    .top { display:flex; justify-content:space-between; align-items:center; gap:16px; }
+    .brand { font-weight:800; font-size:24px; background:linear-gradient(135deg,var(--accent),var(--accent2)); -webkit-background-clip:text; -webkit-text-fill-color:transparent; }
+    .langs a { color:var(--muted); margin-left:10px; text-decoration:none; }
+    .langs a:hover, .langs a.active { color:var(--text); }
+    .hero { background:linear-gradient(180deg, rgba(108,99,255,.15), transparent); border:1px solid var(--border); border-radius:16px; padding:28px; margin-top:24px; }
+    h1 { margin:0 0 10px; font-size:38px; line-height:1.15; }
+    p { color:var(--muted); }
+    .cta { display:flex; flex-wrap:wrap; gap:12px; margin-top:18px; }
+    .btn { display:inline-block; padding:10px 16px; border-radius:10px; text-decoration:none; font-weight:600; }
+    .btn.primary { background:var(--accent); color:white; }
+    .btn.secondary { border:1px solid var(--border); color:var(--text); }
+    .grid { display:grid; grid-template-columns:repeat(auto-fit,minmax(220px,1fr)); gap:14px; margin-top:20px; }
+    .card { background:var(--card); border:1px solid var(--border); border-radius:12px; padding:16px; }
+    h3 { margin:0 0 6px; }
+    footer { margin:36px 0 20px; color:var(--muted); font-size:14px; }
+  </style>
+</head>
+<body>
+  <div class="wrap">
+    <div class="top">
+      <div class="brand">🧠 WebBrain</div>
+      <div class="langs">
+        <a href="/">English</a><a href="/es/">Español</a><a href="/fr/" class="active">Français</a><a href="/tr/">Türkçe</a><a href="/zh/">中文</a>
+      </div>
+    </div>
+
+    <section class="hero">
+      <h1>Automatisation web avec IA, gratuite et open source.</h1>
+      <p>WebBrain fonctionne sur Chrome et Firefox. Vous pouvez lire des pages, faire de la recherche et automatiser des tâches avec des LLM locaux (llama.cpp) ou des fournisseurs cloud (OpenAI, Claude, OpenRouter).</p>
+      <div class="cta">
+        <a class="btn primary" href="https://chromewebstore.google.com/detail/webbrain/ljhijonmfahplgbbacgcfnaihbjljhhb">Installer sur Chrome</a>
+        <a class="btn secondary" href="https://addons.mozilla.org/firefox/addon/webbrain/">Installer sur Firefox</a>
+        <a class="btn secondary" href="https://github.com/emres/webbrain">Voir sur GitHub</a>
+      </div>
+    </section>
+
+    <section class="grid">
+      <article class="card"><h3>Confidentialité d'abord</h3><p>Support des modèles locaux : vos données peuvent rester sur votre machine.</p></article>
+      <article class="card"><h3>Extensible</h3><p>Compatible avec plusieurs fournisseurs et workflows d'automatisation.</p></article>
+      <article class="card"><h3>100% open source</h3><p>Licence MIT et développement public sur GitHub.</p></article>
+    </section>
+
+    <footer>
+      Ceci est la version française de la page d'accueil. Vous pouvez aussi consulter la <a href="/privacy.html">politique de confidentialité</a> ou le <a href="/blog/">blog</a> (en anglais).
+    </footer>
+  </div>
+</body>
+</html>

--- a/web/index.html
+++ b/web/index.html
@@ -880,6 +880,10 @@
       <a href="#download">Download</a>
       <a href="#faq">FAQ</a>
       <a href="/blog">Blog</a>
+      <a href="/es/" title="Spanish version">ES</a>
+      <a href="/fr/" title="French version">FR</a>
+      <a href="/tr/" title="Turkish version">TR</a>
+      <a href="/zh/" title="Chinese version">中文</a>
       <a href="https://github.com/esokullu/webbrain" class="nav-cta" target="_blank">GitHub</a>
     </div>
   </div>

--- a/web/tr/index.html
+++ b/web/tr/index.html
@@ -1,0 +1,61 @@
+<!DOCTYPE html>
+<html lang="tr">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>WebBrain — Chrome ve Firefox için açık kaynak yapay zeka tarayıcı ajanı</title>
+  <meta name="description" content="WebBrain, Chrome ve Firefox için ücretsiz ve açık kaynak bir yapay zeka tarayıcı ajanıdır. Sayfaları okuyun, veri çıkarın ve görevleri yerel veya bulut modellerle otomatikleştirin.">
+  <link rel="icon" type="image/svg+xml" href="/favicon.svg">
+  <style>
+    :root { --bg:#0b0e17; --card:#111827; --text:#e4e4ec; --muted:#8b8fa4; --accent:#6c63ff; --accent2:#a78bfa; --border:rgba(255,255,255,.08); }
+    * { box-sizing: border-box; }
+    body { margin:0; font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Inter,Roboto,sans-serif; background:var(--bg); color:var(--text); line-height:1.6; }
+    .wrap { max-width:980px; margin:0 auto; padding:24px; }
+    .top { display:flex; justify-content:space-between; align-items:center; gap:16px; }
+    .brand { font-weight:800; font-size:24px; background:linear-gradient(135deg,var(--accent),var(--accent2)); -webkit-background-clip:text; -webkit-text-fill-color:transparent; }
+    .langs a { color:var(--muted); margin-left:10px; text-decoration:none; }
+    .langs a:hover, .langs a.active { color:var(--text); }
+    .hero { background:linear-gradient(180deg, rgba(108,99,255,.15), transparent); border:1px solid var(--border); border-radius:16px; padding:28px; margin-top:24px; }
+    h1 { margin:0 0 10px; font-size:38px; line-height:1.15; }
+    p { color:var(--muted); }
+    .cta { display:flex; flex-wrap:wrap; gap:12px; margin-top:18px; }
+    .btn { display:inline-block; padding:10px 16px; border-radius:10px; text-decoration:none; font-weight:600; }
+    .btn.primary { background:var(--accent); color:white; }
+    .btn.secondary { border:1px solid var(--border); color:var(--text); }
+    .grid { display:grid; grid-template-columns:repeat(auto-fit,minmax(220px,1fr)); gap:14px; margin-top:20px; }
+    .card { background:var(--card); border:1px solid var(--border); border-radius:12px; padding:16px; }
+    h3 { margin:0 0 6px; }
+    footer { margin:36px 0 20px; color:var(--muted); font-size:14px; }
+  </style>
+</head>
+<body>
+  <div class="wrap">
+    <div class="top">
+      <div class="brand">🧠 WebBrain</div>
+      <div class="langs">
+        <a href="/">English</a><a href="/es/">Español</a><a href="/fr/">Français</a><a href="/tr/" class="active">Türkçe</a><a href="/zh/">中文</a>
+      </div>
+    </div>
+
+    <section class="hero">
+      <h1>Ücretsiz ve açık kaynak yapay zeka destekli web otomasyonu.</h1>
+      <p>WebBrain, Chrome ve Firefox'ta çalışır. Sayfaları okuyabilir, araştırma yapabilir ve görevleri yerel LLM'lerle (llama.cpp) veya bulut sağlayıcılarıyla (OpenAI, Claude, OpenRouter) otomatikleştirebilirsiniz.</p>
+      <div class="cta">
+        <a class="btn primary" href="https://chromewebstore.google.com/detail/webbrain/ljhijonmfahplgbbacgcfnaihbjljhhb">Chrome'a Yükle</a>
+        <a class="btn secondary" href="https://addons.mozilla.org/firefox/addon/webbrain/">Firefox'a Yükle</a>
+        <a class="btn secondary" href="https://github.com/emres/webbrain">GitHub'da Gör</a>
+      </div>
+    </section>
+
+    <section class="grid">
+      <article class="card"><h3>Önce gizlilik</h3><p>Yerel model desteği sayesinde verileriniz bilgisayarınızda kalabilir.</p></article>
+      <article class="card"><h3>Genişletilebilir</h3><p>Birden fazla sağlayıcı ve otomasyon iş akışı ile uyumludur.</p></article>
+      <article class="card"><h3>%100 açık kaynak</h3><p>MIT lisansı ve GitHub üzerinde herkese açık geliştirme.</p></article>
+    </section>
+
+    <footer>
+      Bu sayfa ana sitenin Türkçe sürümüdür. Ayrıca <a href="/privacy.html">gizlilik politikasını</a> veya <a href="/blog/">blogu</a> (İngilizce) ziyaret edebilirsiniz.
+    </footer>
+  </div>
+</body>
+</html>

--- a/web/zh/index.html
+++ b/web/zh/index.html
@@ -1,0 +1,61 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>WebBrain — 适用于 Chrome 和 Firefox 的开源 AI 浏览器代理</title>
+  <meta name="description" content="WebBrain 是一款免费开源的 AI 浏览器代理，支持 Chrome 和 Firefox。可读取网页、提取数据，并用本地或云端模型自动化任务。">
+  <link rel="icon" type="image/svg+xml" href="/favicon.svg">
+  <style>
+    :root { --bg:#0b0e17; --card:#111827; --text:#e4e4ec; --muted:#8b8fa4; --accent:#6c63ff; --accent2:#a78bfa; --border:rgba(255,255,255,.08); }
+    * { box-sizing: border-box; }
+    body { margin:0; font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Inter,Roboto,'PingFang SC','Microsoft YaHei',sans-serif; background:var(--bg); color:var(--text); line-height:1.6; }
+    .wrap { max-width:980px; margin:0 auto; padding:24px; }
+    .top { display:flex; justify-content:space-between; align-items:center; gap:16px; }
+    .brand { font-weight:800; font-size:24px; background:linear-gradient(135deg,var(--accent),var(--accent2)); -webkit-background-clip:text; -webkit-text-fill-color:transparent; }
+    .langs a { color:var(--muted); margin-left:10px; text-decoration:none; }
+    .langs a:hover, .langs a.active { color:var(--text); }
+    .hero { background:linear-gradient(180deg, rgba(108,99,255,.15), transparent); border:1px solid var(--border); border-radius:16px; padding:28px; margin-top:24px; }
+    h1 { margin:0 0 10px; font-size:38px; line-height:1.15; }
+    p { color:var(--muted); }
+    .cta { display:flex; flex-wrap:wrap; gap:12px; margin-top:18px; }
+    .btn { display:inline-block; padding:10px 16px; border-radius:10px; text-decoration:none; font-weight:600; }
+    .btn.primary { background:var(--accent); color:white; }
+    .btn.secondary { border:1px solid var(--border); color:var(--text); }
+    .grid { display:grid; grid-template-columns:repeat(auto-fit,minmax(220px,1fr)); gap:14px; margin-top:20px; }
+    .card { background:var(--card); border:1px solid var(--border); border-radius:12px; padding:16px; }
+    h3 { margin:0 0 6px; }
+    footer { margin:36px 0 20px; color:var(--muted); font-size:14px; }
+  </style>
+</head>
+<body>
+  <div class="wrap">
+    <div class="top">
+      <div class="brand">🧠 WebBrain</div>
+      <div class="langs">
+        <a href="/">English</a><a href="/es/">Español</a><a href="/fr/">Français</a><a href="/tr/">Türkçe</a><a href="/zh/" class="active">中文</a>
+      </div>
+    </div>
+
+    <section class="hero">
+      <h1>免费、开源的 AI 网页自动化工具。</h1>
+      <p>WebBrain 可在 Chrome 与 Firefox 中运行。你可以读取网页、做信息研究，并使用本地 LLM（llama.cpp）或云服务（OpenAI、Claude、OpenRouter）自动执行任务。</p>
+      <div class="cta">
+        <a class="btn primary" href="https://chromewebstore.google.com/detail/webbrain/ljhijonmfahplgbbacgcfnaihbjljhhb">安装到 Chrome</a>
+        <a class="btn secondary" href="https://addons.mozilla.org/firefox/addon/webbrain/">安装到 Firefox</a>
+        <a class="btn secondary" href="https://github.com/emres/webbrain">查看 GitHub</a>
+      </div>
+    </section>
+
+    <section class="grid">
+      <article class="card"><h3>隐私优先</h3><p>支持本地模型，数据可保留在你的设备上。</p></article>
+      <article class="card"><h3>可扩展</h3><p>兼容多个模型提供商与自动化工作流。</p></article>
+      <article class="card"><h3>100% 开源</h3><p>MIT 许可证，GitHub 公开开发。</p></article>
+    </section>
+
+    <footer>
+      这是首页的中文版本。你也可以查看<a href="/privacy.html">隐私政策</a>或访问<a href="/blog/">博客</a>（英文）。
+    </footer>
+  </div>
+</body>
+</html>


### PR DESCRIPTION
### Motivation
- Provide localized homepages to make the site accessible to Spanish, French, Turkish, and Chinese readers. 
- Expose the localized pages from the main navigation so visitors can switch languages from the existing homepage.

### Description
- Added localized landing pages at `web/es/index.html`, `web/fr/index.html`, `web/tr/index.html`, and `web/zh/index.html` with translated headlines, descriptions, CTAs, and feature highlights while preserving the brand styling. 
- Updated the main `web/index.html` navigation to include links to `/es/`, `/fr/`, `/tr/`, and `/zh/`. 
- Localized pages currently link back to the existing English `privacy.html` and `/blog/` pages.

### Testing
- Ran the project test suite via `npm test -- --help`, which completed with `32 passed, 0 failed`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb5cba8bb08327a0b6326548de2e9a)