### PR TITLE
Add Press Releases link to website footer

### DIFF
--- a/web/build/locales/en.json
+++ b/web/build/locales/en.json
@@ -232,5 +232,6 @@
   "footer.link_safety": "Safety Notice",
   "footer.link_privacy": "Privacy Policy",
   "footer.link_report_bug": "Report Bug",
-  "footer.link_license": "MIT License"
+  "footer.link_license": "MIT License",
+  "footer.link_press_releases": "Press Releases"
 }

--- a/web/build/locales/es.json
+++ b/web/build/locales/es.json
@@ -232,5 +232,6 @@
   "footer.link_safety": "Aviso de seguridad",
   "footer.link_privacy": "Política de privacidad",
   "footer.link_report_bug": "Reportar un error",
-  "footer.link_license": "Licencia MIT"
+  "footer.link_license": "Licencia MIT",
+  "footer.link_press_releases": "Comunicados de prensa"
 }

--- a/web/build/locales/fr.json
+++ b/web/build/locales/fr.json
@@ -232,5 +232,6 @@
   "footer.link_safety": "Avertissement",
   "footer.link_privacy": "Politique de confidentialité",
   "footer.link_report_bug": "Signaler un bug",
-  "footer.link_license": "Licence MIT"
+  "footer.link_license": "Licence MIT",
+  "footer.link_press_releases": "Communiqués de presse"
 }

--- a/web/build/locales/tr.json
+++ b/web/build/locales/tr.json
@@ -232,5 +232,6 @@
   "footer.link_safety": "Güvenlik uyarısı",
   "footer.link_privacy": "Gizlilik politikası",
   "footer.link_report_bug": "Hata bildir",
-  "footer.link_license": "MIT Lisansı"
+  "footer.link_license": "MIT Lisansı",
+  "footer.link_press_releases": "Basın bültenleri"
 }

--- a/web/build/locales/zh.json
+++ b/web/build/locales/zh.json
@@ -232,5 +232,6 @@
   "footer.link_safety": "安全提示",
   "footer.link_privacy": "隐私政策",
   "footer.link_report_bug": "报告 Bug",
-  "footer.link_license": "MIT 许可"
+  "footer.link_license": "MIT 许可",
+  "footer.link_press_releases": "新闻稿"
 }

--- a/web/build/template.html
+++ b/web/build/template.html
@@ -1263,6 +1263,7 @@
       <a href="/privacy">{{t:footer.link_privacy}}</a>
       <a href="https://github.com/esokullu/webbrain/issues" target="_blank" rel="noopener">{{t:footer.link_report_bug}}</a>
       <a href="https://github.com/esokullu/webbrain/blob/main/LICENSE" target="_blank" rel="noopener">{{t:footer.link_license}}</a>
+      <a href="https://pressreleases.online/org/webbrain.one" target="_blank" rel="noopener">{{t:footer.link_press_releases}}</a>
     </div>
   </div>
 </footer>

--- a/web/es/index.html
+++ b/web/es/index.html
@@ -1426,6 +1426,7 @@
       <a href="/privacy">Política de privacidad</a>
       <a href="https://github.com/esokullu/webbrain/issues" target="_blank" rel="noopener">Reportar un error</a>
       <a href="https://github.com/esokullu/webbrain/blob/main/LICENSE" target="_blank" rel="noopener">Licencia MIT</a>
+      <a href="https://pressreleases.online/org/webbrain.one" target="_blank" rel="noopener">Comunicados de prensa</a>
     </div>
   </div>
 </footer>

--- a/web/fr/index.html
+++ b/web/fr/index.html
@@ -1426,6 +1426,7 @@
       <a href="/privacy">Politique de confidentialité</a>
       <a href="https://github.com/esokullu/webbrain/issues" target="_blank" rel="noopener">Signaler un bug</a>
       <a href="https://github.com/esokullu/webbrain/blob/main/LICENSE" target="_blank" rel="noopener">Licence MIT</a>
+      <a href="https://pressreleases.online/org/webbrain.one" target="_blank" rel="noopener">Communiqués de presse</a>
     </div>
   </div>
 </footer>

--- a/web/index.html
+++ b/web/index.html
@@ -1426,6 +1426,7 @@
       <a href="/privacy">Privacy Policy</a>
       <a href="https://github.com/esokullu/webbrain/issues" target="_blank" rel="noopener">Report Bug</a>
       <a href="https://github.com/esokullu/webbrain/blob/main/LICENSE" target="_blank" rel="noopener">MIT License</a>
+      <a href="https://pressreleases.online/org/webbrain.one" target="_blank" rel="noopener">Press Releases</a>
     </div>
   </div>
 </footer>

--- a/web/tr/index.html
+++ b/web/tr/index.html
@@ -1426,6 +1426,7 @@
       <a href="/privacy">Gizlilik politikası</a>
       <a href="https://github.com/esokullu/webbrain/issues" target="_blank" rel="noopener">Hata bildir</a>
       <a href="https://github.com/esokullu/webbrain/blob/main/LICENSE" target="_blank" rel="noopener">MIT Lisansı</a>
+      <a href="https://pressreleases.online/org/webbrain.one" target="_blank" rel="noopener">Basın bültenleri</a>
     </div>
   </div>
 </footer>

--- a/web/zh/index.html
+++ b/web/zh/index.html
@@ -1426,6 +1426,7 @@
       <a href="/privacy">隐私政策</a>
       <a href="https://github.com/esokullu/webbrain/issues" target="_blank" rel="noopener">报告 Bug</a>
       <a href="https://github.com/esokullu/webbrain/blob/main/LICENSE" target="_blank" rel="noopener">MIT 许可</a>
+      <a href="https://pressreleases.online/org/webbrain.one" target="_blank" rel="noopener">新闻稿</a>
     </div>
   </div>
 </footer>


### PR DESCRIPTION
### Motivation
- Expose a Press Releases entry in the site footer so visitors can easily find organization press materials across languages.
- Ensure the link is localizable and included in the template so future builds include it automatically.

### Description
- Added a new localized footer token `footer.link_press_releases` to `web/build/locales/{en,es,fr,tr,zh}.json` with translated labels. 
- Inserted the localized anchor pointing to `https://pressreleases.online/org/webbrain.one` into the footer template at `web/build/template.html`.
- Updated the generated HTML pages under `web/` (`index.html`, `es/index.html`, `fr/index.html`, `tr/index.html`, `zh/index.html`) so the new link appears in each language variant.

### Testing
- Verified all modified locale JSON files parse successfully with `python -m json.tool`.
- Confirmed the new localized label and the `https://pressreleases.online/org/webbrain.one` anchor are present in `web/build/template.html` and the generated `web/*.html` pages for `en`, `es`, `fr`, `tr`, and `zh`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f18b3454a483279ea4a06b7815c0fa)