### PR TITLE
web: hide stargazers button on narrow mobile nav

### DIFF
--- a/web/build/template.html
+++ b/web/build/template.html
@@ -924,8 +924,8 @@
       .browser-body { flex-direction: column; }
       .side-panel { width: 100%; border-left: none; border-top: 1px solid var(--border); min-height: 260px; }
       .modes-grid { grid-template-columns: 1fr; }
-      .nav-links a:not(.nav-cta):not(.gh-stars) { display: none; }
-      .gh-stars { padding: 4px 9px 4px 7px; font-size: 11px; }
+      .nav-links a:not(.nav-cta) { display: none; }
+      .gh-stars { display: none; }
       .provider-constellation { aspect-ratio: 4 / 5; max-width: 420px; }
       .pn-bubble { width: 46px; height: 46px; font-size: 18px; }
       .pn-label { font-size: 11px; }

--- a/web/es/index.html
+++ b/web/es/index.html
@@ -1087,8 +1087,8 @@
       .browser-body { flex-direction: column; }
       .side-panel { width: 100%; border-left: none; border-top: 1px solid var(--border); min-height: 260px; }
       .modes-grid { grid-template-columns: 1fr; }
-      .nav-links a:not(.nav-cta):not(.gh-stars) { display: none; }
-      .gh-stars { padding: 4px 9px 4px 7px; font-size: 11px; }
+      .nav-links a:not(.nav-cta) { display: none; }
+      .gh-stars { display: none; }
       .provider-constellation { aspect-ratio: 4 / 5; max-width: 420px; }
       .pn-bubble { width: 46px; height: 46px; font-size: 18px; }
       .pn-label { font-size: 11px; }

--- a/web/fr/index.html
+++ b/web/fr/index.html
@@ -1087,8 +1087,8 @@
       .browser-body { flex-direction: column; }
       .side-panel { width: 100%; border-left: none; border-top: 1px solid var(--border); min-height: 260px; }
       .modes-grid { grid-template-columns: 1fr; }
-      .nav-links a:not(.nav-cta):not(.gh-stars) { display: none; }
-      .gh-stars { padding: 4px 9px 4px 7px; font-size: 11px; }
+      .nav-links a:not(.nav-cta) { display: none; }
+      .gh-stars { display: none; }
       .provider-constellation { aspect-ratio: 4 / 5; max-width: 420px; }
       .pn-bubble { width: 46px; height: 46px; font-size: 18px; }
       .pn-label { font-size: 11px; }

--- a/web/index.html
+++ b/web/index.html
@@ -1087,8 +1087,8 @@
       .browser-body { flex-direction: column; }
       .side-panel { width: 100%; border-left: none; border-top: 1px solid var(--border); min-height: 260px; }
       .modes-grid { grid-template-columns: 1fr; }
-      .nav-links a:not(.nav-cta):not(.gh-stars) { display: none; }
-      .gh-stars { padding: 4px 9px 4px 7px; font-size: 11px; }
+      .nav-links a:not(.nav-cta) { display: none; }
+      .gh-stars { display: none; }
       .provider-constellation { aspect-ratio: 4 / 5; max-width: 420px; }
       .pn-bubble { width: 46px; height: 46px; font-size: 18px; }
       .pn-label { font-size: 11px; }

--- a/web/tr/index.html
+++ b/web/tr/index.html
@@ -1087,8 +1087,8 @@
       .browser-body { flex-direction: column; }
       .side-panel { width: 100%; border-left: none; border-top: 1px solid var(--border); min-height: 260px; }
       .modes-grid { grid-template-columns: 1fr; }
-      .nav-links a:not(.nav-cta):not(.gh-stars) { display: none; }
-      .gh-stars { padding: 4px 9px 4px 7px; font-size: 11px; }
+      .nav-links a:not(.nav-cta) { display: none; }
+      .gh-stars { display: none; }
       .provider-constellation { aspect-ratio: 4 / 5; max-width: 420px; }
       .pn-bubble { width: 46px; height: 46px; font-size: 18px; }
       .pn-label { font-size: 11px; }

--- a/web/zh/index.html
+++ b/web/zh/index.html
@@ -1087,8 +1087,8 @@
       .browser-body { flex-direction: column; }
       .side-panel { width: 100%; border-left: none; border-top: 1px solid var(--border); min-height: 260px; }
       .modes-grid { grid-template-columns: 1fr; }
-      .nav-links a:not(.nav-cta):not(.gh-stars) { display: none; }
-      .gh-stars { padding: 4px 9px 4px 7px; font-size: 11px; }
+      .nav-links a:not(.nav-cta) { display: none; }
+      .gh-stars { display: none; }
       .provider-constellation { aspect-ratio: 4 / 5; max-width: 420px; }
       .pn-bubble { width: 46px; height: 46px; font-size: 18px; }
       .pn-label { font-size: 11px; }


### PR DESCRIPTION
### Motivation
- On narrow/mobile view the navigation should show only the primary CTA and avoid clutter, so the GitHub stargazers pill needs to be hidden at the mobile breakpoint.

### Description
- Change the responsive selector in the `@media (max-width: 768px)` block so only non-CTA nav links are hidden and the stargazers pill is explicitly hidden by adding `.gh-stars { display: none; }`.
- Replace `.nav-links a:not(.nav-cta):not(.gh-stars) { display: none; }` / `.gh-stars { padding: ... }` with `.nav-links a:not(.nav-cta) { display: none; }` and `.gh-stars { display: none; }` in the CSS.
- Apply the same update across `web/index.html`, `web/es/index.html`, `web/fr/index.html`, `web/zh/index.html`, `web/tr/index.html`, and `web/build/template.html` so localized pages and the build template remain consistent.

### Testing
- Verified the updated mobile CSS selectors exist in all touched files using `rg` which returned the new rules successfully.
- Inspected the `@media (max-width: 768px)` blocks with `nl` to confirm the new `.gh-stars { display: none; }` rule is present in each modified file.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f378aabf688327bc7aae011e72b03d)