### PR TITLE
chrome: scope sidebar visibility to a per-window WebBrain tab group

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,21 @@ The default UI-first rule exists because API actions are invisible (you don't se
 - **SPA navigation detection in Firefox.** Some single-page applications may not trigger content-script re-injection after client-side navigation.
 - **Firefox temporary add-on** — Firefox requires the extension to be loaded as a temporary add-on during development, which is removed on restart.
 
-## What's New in 4.2.0 (from 1.x)
+## What's New
+
+### 5.x
+
+- **Group-scoped side panel visibility (Chrome).** Clicking the WebBrain action now puts the source tab into a "WebBrain" tab group; the side panel is shown only for tabs in that group. Switch to any tab outside the group → panel hides. Drag the tab out of the group → panel hides. Mirrors how Claude-for-Chrome handles sidebar scope and replaces the older per-tab opt-in Set, which left the panel "sticky" across tab switches.
+  - Adds `tabs` and `tabGroups` permissions (Chrome will surface a permissions notice on auto-update).
+  - Tabs the agent opens via `new_tab` or `target=_blank` redirects automatically join the same group.
+- **Token-conscious screenshots.** All viewport and full-page screenshots are now resized to fit a vision-token budget (≤1568 tokens, ≤1.4 MB base64) before being sent to a vision model — uses CDP-side `clip.scale` for capture-time downscaling, with iterative JPEG-quality fallback (0.75 → 0.10) for the byte ceiling. Pathological full-page captures drop from ~19.6k tokens to ~750.
+- **Multilingual UI** in 5 languages (English, Spanish, French, Turkish, Chinese).
+- **Vision-model split-provider mode.** Pair a fast text-only planner with a separate vision-capable model; screenshots get a structured 6-section caption from the vision model and only the text reaches the planner.
+- **Profile auto-fill** for low-stakes signup forms — opt-in plaintext bio (name, work email, throwaway password) injected into the agent's system prompt.
+- **Cookie banner & paywall guidance** built into the universal preamble — agent dismisses OneTrust/Cookiebot/Didomi/Quantcast/Funding-Choices banners automatically and refuses to bypass paywalls.
+- **Site adapters** for ~25 high-traffic sites (GitHub, Stripe, Gmail, AWS console, NYT/WSJ/FT/Bloomberg/Economist paywalls, etc.).
+
+### 4.2.0 (from 1.x)
 
 - **Safety-first API behavior** via `/allow-api` per-conversation override (UI-first for mutations by default)
 - **Cross-origin iframe interaction tools** (`iframe_read`, `iframe_click`, `iframe_type`) for embedded forms and widgets

--- a/README.md
+++ b/README.md
@@ -162,6 +162,7 @@ The default UI-first rule exists because API actions are invisible (you don't se
 
 ### 5.x
 
+- **On-page agent indicator (Chrome).** While the agent is acting on a tab, the page now shows a soft purple inset glow around the viewport plus a "Stop WebBrain" floating button at the bottom — same UX pattern as Claude-for-Chrome. Clicking Stop aborts the run without you having to switch back to the side panel. The indicator hides itself during screenshot capture so it doesn't end up in the images sent to the vision model.
 - **Group-scoped side panel visibility (Chrome).** Clicking the WebBrain action now puts the source tab into a "WebBrain" tab group; the side panel is shown only for tabs in that group. Switch to any tab outside the group → panel hides. Drag the tab out of the group → panel hides. Mirrors how Claude-for-Chrome handles sidebar scope and replaces the older per-tab opt-in Set, which left the panel "sticky" across tab switches.
   - Adds `tabs` and `tabGroups` permissions (Chrome will surface a permissions notice on auto-update).
   - Tabs the agent opens via `new_tab` or `target=_blank` redirects automatically join the same group.

--- a/src/chrome/manifest.json
+++ b/src/chrome/manifest.json
@@ -6,6 +6,8 @@
   "permissions": [
     "sidePanel",
     "activeTab",
+    "tabs",
+    "tabGroups",
     "scripting",
     "storage",
     "webNavigation",

--- a/src/chrome/manifest.json
+++ b/src/chrome/manifest.json
@@ -36,7 +36,11 @@
   "content_scripts": [
     {
       "matches": ["<all_urls>"],
-      "js": ["src/content/accessibility-tree.js", "src/content/content.js"],
+      "js": [
+        "src/content/accessibility-tree.js",
+        "src/content/content.js",
+        "src/content/agent-visual-indicator.js"
+      ],
       "run_at": "document_idle"
     }
   ],

--- a/src/chrome/src/agent/agent.js
+++ b/src/chrome/src/agent/agent.js
@@ -1045,6 +1045,38 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
    *
    * Returns { dataUrl, width, height } (in image pixels) or null.
    */
+  /**
+   * Wrap a screenshot capture in messages that ask the agent-visual-
+   * indicator content script to hide its pulsing border + Stop button
+   * for the duration of the capture. Without this, the agent's own
+   * indicator gets baked into every screenshot it sends to the vision
+   * model — which is both ugly and a small token-budget tax.
+   *
+   * Best-effort: if the content script isn't loaded (chrome:// /
+   * chrome-extension:// / file:// pages), the sendMessage rejects and
+   * we capture as-is. Same on tabs the user opened before the extension
+   * had a chance to inject.
+   */
+  async _withIndicatorsHidden(tabId, fn) {
+    let needsRestore = false;
+    try {
+      await chrome.tabs.sendMessage(tabId, { type: 'WB_HIDE_FOR_TOOL_USE' });
+      needsRestore = true;
+      // One paint frame for Chrome to apply the display:none the
+      // content script just set, before CDP grabs the surface.
+      await new Promise((r) => setTimeout(r, 16));
+    } catch { /* content script absent — that's fine, no UI to hide */ }
+    try {
+      return await fn();
+    } finally {
+      if (needsRestore) {
+        try {
+          chrome.tabs.sendMessage(tabId, { type: 'WB_SHOW_AFTER_TOOL_USE' }).catch(() => {});
+        } catch { /* ignore */ }
+      }
+    }
+  }
+
   async _captureAutoScreenshot(tabId, { coordAligned = false } = {}) {
     try {
       await cdpClient.attach(tabId);
@@ -1065,11 +1097,13 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
         // We DO still run the byte-ceiling fallback afterwards: if the
         // CSS viewport happens to be huge, we'd rather lose some JPEG
         // quality than overflow the provider's image cap.
-        const shot = await cdpClient.sendCommand(tabId, 'Page.captureScreenshot', {
-          format: 'jpeg',
-          quality: 60,
-          clip: { x: 0, y: 0, width: cssW, height: cssH, scale: 1 },
-        });
+        const shot = await this._withIndicatorsHidden(tabId, () =>
+          cdpClient.sendCommand(tabId, 'Page.captureScreenshot', {
+            format: 'jpeg',
+            quality: 60,
+            clip: { x: 0, y: 0, width: cssW, height: cssH, scale: 1 },
+          })
+        );
         if (!shot?.data) return null;
         const rawDataUrl = `data:image/jpeg;base64,${shot.data}`;
         const shrunk = await this._compressJpegToByteCeiling(rawDataUrl);
@@ -1082,12 +1116,14 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
       // then have to decode and resize in the service worker.
       const [targetW, targetH] = Agent._fitImageDimensions(cssW, cssH);
       const scale = targetW < cssW ? targetW / cssW : 1;
-      const shot = await cdpClient.sendCommand(tabId, 'Page.captureScreenshot', {
-        format: 'jpeg',
-        quality: Math.round(Agent.IMAGE_BUDGET.initialJpegQuality * 100),
-        fromSurface: true,
-        clip: { x: 0, y: 0, width: cssW, height: cssH, scale },
-      });
+      const shot = await this._withIndicatorsHidden(tabId, () =>
+        cdpClient.sendCommand(tabId, 'Page.captureScreenshot', {
+          format: 'jpeg',
+          quality: Math.round(Agent.IMAGE_BUDGET.initialJpegQuality * 100),
+          fromSurface: true,
+          clip: { x: 0, y: 0, width: cssW, height: cssH, scale },
+        })
+      );
       if (!shot?.data) return null;
       const rawDataUrl = `data:image/jpeg;base64,${shot.data}`;
 
@@ -2210,11 +2246,13 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
             // Pixel-accuracy mode: image pixels must equal CSS pixels so
             // click({x,y}) off the screenshot lands on the real element.
             // PNG (lossless, no quality knob) so no artifacts at glyph edges.
-            const screenshot = await cdpClient.sendCommand(tabId, 'Page.captureScreenshot', {
-              format: 'png',
-              fromSurface: true,
-              clip: { x: 0, y: 0, width: cssW, height: cssH, scale: 1 },
-            });
+            const screenshot = await this._withIndicatorsHidden(tabId, () =>
+              cdpClient.sendCommand(tabId, 'Page.captureScreenshot', {
+                format: 'png',
+                fromSurface: true,
+                clip: { x: 0, y: 0, width: cssW, height: cssH, scale: 1 },
+              })
+            );
             dataUrl = `data:image/png;base64,${screenshot.data}`;
             description = `Screenshot captured via CDP (${screenshot.data.length} bytes, CSS-pixel aligned for pixel clicks)`;
             // Byte-ceiling fallback only — we don't resize in coord mode.
@@ -2225,12 +2263,14 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
             // the iterative-quality fallback if bytes are still over.
             const [targetW, targetH] = Agent._fitImageDimensions(cssW, cssH);
             const scale = targetW < cssW ? targetW / cssW : 1;
-            const screenshot = await cdpClient.sendCommand(tabId, 'Page.captureScreenshot', {
-              format: 'jpeg',
-              quality: Math.round(Agent.IMAGE_BUDGET.initialJpegQuality * 100),
-              fromSurface: true,
-              clip: { x: 0, y: 0, width: cssW, height: cssH, scale },
-            });
+            const screenshot = await this._withIndicatorsHidden(tabId, () =>
+              cdpClient.sendCommand(tabId, 'Page.captureScreenshot', {
+                format: 'jpeg',
+                quality: Math.round(Agent.IMAGE_BUDGET.initialJpegQuality * 100),
+                fromSurface: true,
+                clip: { x: 0, y: 0, width: cssW, height: cssH, scale },
+              })
+            );
             const rawUrl = `data:image/jpeg;base64,${screenshot.data}`;
             dataUrl = await this._compressJpegToByteCeiling(rawUrl);
             const resized = scale < 1 ? ` (resized ${cssW}×${cssH} → ${targetW}×${targetH} for vision-token budget)` : '';
@@ -2325,9 +2365,11 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
           // reflects what the user would actually see.
           const probe = await this._captureViewportProbe(tabId);
           await this._bringToFrontForCapture(tabId);
-          const shot = await cdpClient.sendCommand(tabId, 'Page.captureScreenshot', {
-            format: 'png', quality: 80, fromSurface: true,
-          });
+          const shot = await this._withIndicatorsHidden(tabId, () =>
+            cdpClient.sendCommand(tabId, 'Page.captureScreenshot', {
+              format: 'png', quality: 80, fromSurface: true,
+            })
+          );
           let imageDataUrl = `data:image/png;base64,${shot.data}`;
           // If we remember the rect of the last ax interaction on this tab,
           // outline it on the screenshot so the model can anchor its review
@@ -2468,7 +2510,9 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
       try {
         await cdpClient.attach(tabId);
         await this._bringToFrontForCapture(tabId);
-        const imageData = await cdpClient.captureFullPageScreenshot(tabId);
+        const imageData = await this._withIndicatorsHidden(tabId, () =>
+          cdpClient.captureFullPageScreenshot(tabId)
+        );
         const rawUrl = `data:image/png;base64,${imageData}`;
 
         // Full-page captures are the worst case for size — a 1920×8000
@@ -2553,9 +2597,11 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
         try {
           await cdpClient.sendCommand(tabId, 'Page.enable');
           await this._bringToFrontForCapture(tabId);
-          const shot = await cdpClient.sendCommand(tabId, 'Page.captureScreenshot', {
-            format: 'png', quality: 100, fromSurface: true,
-          });
+          const shot = await this._withIndicatorsHidden(tabId, () =>
+            cdpClient.sendCommand(tabId, 'Page.captureScreenshot', {
+              format: 'png', quality: 100, fromSurface: true,
+            })
+          );
           result.image = `data:image/png;base64,${shot.data}`;
         } catch {
           result.screenshotFailed = true;

--- a/src/chrome/src/agent/agent.js
+++ b/src/chrome/src/agent/agent.js
@@ -169,20 +169,47 @@ export class Agent {
   /**
    * Add a tab to the "WebBrain" tab group — reused by both the explicit
    * `new_tab` tool and the click handler's target=_blank redirect fallback.
-   * Preserves the source tab's existing group when present so multi-tab
-   * research chains stay visually together.
+   *
+   * We look up the WebBrain group by title within the source tab's
+   * window rather than by source-tab-membership: if the source is in a
+   * user-owned group (e.g. "Dev", "Research"), we don't drag agent-
+   * spawned tabs into that group. The user's own grouping stays intact;
+   * agent outputs live in their own WebBrain group.
+   *
+   * If no WebBrain group exists yet for the window, we create a fresh one
+   * containing only the new tab (NOT the source tab) — leaving the
+   * source where the user put it. Background.js's action.onClicked
+   * handler is the canonical place that opts the source tab into the
+   * group, via `ensureWebBrainGroup`.
    *
    * Returns the group id (or -1 if grouping isn't supported / failed).
    */
   async _addToWebBrainGroup(sourceTab, tabId) {
     if (!chrome.tabGroups || !sourceTab?.id || tabId == null) return -1;
     try {
-      if (typeof sourceTab.groupId === 'number' && sourceTab.groupId >= 0) {
-        await chrome.tabs.group({ groupId: sourceTab.groupId, tabIds: [tabId] });
-        return sourceTab.groupId;
+      // Find an existing WebBrain group in this window, if any.
+      let existing = null;
+      try {
+        const groups = await chrome.tabGroups.query({
+          title: 'WebBrain',
+          windowId: sourceTab.windowId,
+        });
+        if (Array.isArray(groups) && groups.length > 0) existing = groups[0];
+      } catch { /* tabGroups.query unsupported on very old Chromes */ }
+
+      if (existing) {
+        await chrome.tabs.group({ groupId: existing.id, tabIds: [tabId] });
+        return existing.id;
       }
-      const gid = await chrome.tabs.group({ tabIds: [sourceTab.id, tabId] });
-      await chrome.tabGroups.update(gid, { title: 'WebBrain', color: 'blue', collapsed: false });
+
+      // No WebBrain group yet — create one with just the new tab. We
+      // deliberately do NOT include sourceTab here, because if the user
+      // put it in their own "Dev" group, pulling it out is hostile.
+      // The first action.onClicked elsewhere will opt the source tab in.
+      const gid = await chrome.tabs.group({ tabIds: [tabId] });
+      await chrome.tabGroups.update(gid, {
+        title: 'WebBrain', color: 'blue', collapsed: false,
+      });
       return gid;
     } catch (_) { return -1; }
   }

--- a/src/chrome/src/background.js
+++ b/src/chrome/src/background.js
@@ -79,9 +79,30 @@ chrome.storage.onChanged.addListener((changes) => {
   if (refreshPrompts) agent._refreshSystemPrompts();
 });
 
-// Track which tabs have the panel enabled (per-tab, not global).
-// Persisted to chrome.storage.session so a service worker restart doesn't
-// forget which tabs the user had opened the panel on.
+// ────────────────────────────────────────────────────────────────────────
+// Side-panel visibility model — Claude-for-Chrome style
+//
+// We tie the side panel to a per-window "WebBrain" tab group rather than to
+// individual tabs. When the user clicks the action, the source tab joins
+// (or seeds) a tab group; the panel is enabled only for tabs in that group.
+// Switch to any tab outside the group → panel disabled → Chrome hides it.
+//
+// Why this and not a per-tab Set?
+//
+// Chrome's `sidePanel.setOptions({enabled: false})` doesn't actively close
+// an already-open panel — it only prevents future opens. With a per-tab Set
+// the panel was visible on every tab the user had ever clicked the action
+// on, which mounted up across a session. Group membership is observable to
+// the user (they see the colored group label) and matches the agent's own
+// `_addToWebBrainGroup` behaviour for `new_tab` calls — so a sidebar
+// session, an explicitly-opened new_tab, and a target=_blank redirect all
+// land in the same group.
+//
+// `panelTabs` survives as a fallback for old Chromes without `tabGroups`
+// (pre-89, very rare). On modern Chrome the group map is the source of truth.
+// ────────────────────────────────────────────────────────────────────────
+
+// Legacy per-tab fallback (used only if chrome.tabGroups is unavailable).
 const panelTabs = new Set();
 const PANEL_TABS_KEY = 'panelTabs';
 
@@ -98,26 +119,150 @@ function savePanelTabs() {
 }
 loadPanelTabs();
 
+// Per-window WebBrain group ID. windowId -> tabGroups groupId.
+const webBrainGroupByWindow = new Map();
+const WB_GROUPS_KEY = 'webBrainGroupByWindow';
+
+async function loadWebBrainGroups() {
+  if (!chrome.tabGroups) return;
+  try {
+    const stored = await chrome.storage.session.get(WB_GROUPS_KEY);
+    const arr = stored[WB_GROUPS_KEY];
+    if (Array.isArray(arr)) {
+      // Validate each group still exists before re-adopting — Chrome may
+      // have closed some between sessions / service-worker restarts.
+      for (const [windowId, groupId] of arr) {
+        try {
+          await chrome.tabGroups.get(groupId);
+          webBrainGroupByWindow.set(windowId, groupId);
+        } catch { /* group gone, skip */ }
+      }
+    }
+  } catch { /* session storage unavailable */ }
+}
+function saveWebBrainGroups() {
+  chrome.storage.session?.set({
+    [WB_GROUPS_KEY]: Array.from(webBrainGroupByWindow.entries()),
+  }).catch(() => {});
+}
+loadWebBrainGroups();
+
 chrome.sidePanel.setPanelBehavior({ openPanelOnActionClick: false }).catch(() => {});
 
-// Because manifest.side_panel.default_path is required by Chrome, the panel
-// is implicitly available on every tab. Disable it pre-emptively on all
-// existing tabs (and any newly created tab) so it only opens where the user
-// has explicitly clicked the action.
-async function disablePanelOnAllTabsExceptOptedIn() {
+/**
+ * Decide whether the side panel should show for `tab`.
+ * Modern Chrome: tab.groupId === window's WebBrain group.
+ * Legacy fallback: panelTabs membership.
+ */
+function shouldEnablePanelForTab(tab) {
+  if (!tab) return false;
+  if (chrome.tabGroups) {
+    const wbGroupId = webBrainGroupByWindow.get(tab.windowId);
+    if (wbGroupId == null) return false;
+    return tab.groupId === wbGroupId;
+  }
+  return panelTabs.has(tab.id);
+}
+
+/**
+ * Apply the current visibility decision to a tab. Cheap; called from any
+ * listener that might have changed the answer (onActivated, onUpdated,
+ * tabGroups.onRemoved, etc.).
+ */
+async function refreshPanelVisibility(tabId) {
+  let tab;
+  try { tab = await chrome.tabs.get(tabId); } catch { return; }
+  if (!tab) return;
+  const enabled = shouldEnablePanelForTab(tab);
+  try {
+    await chrome.sidePanel.setOptions({
+      tabId,
+      ...(enabled ? { path: 'src/ui/sidepanel.html' } : {}),
+      enabled,
+    });
+  } catch { /* ignore */ }
+}
+
+/**
+ * Make sure `tab.windowId` has a WebBrain group AND that `tab` is in it.
+ * Returns the group ID, or -1 on failure / unsupported. Called from the
+ * action.onClicked handler so the sidebar's source tab is always grouped
+ * before the user can switch tabs and break visibility.
+ */
+async function ensureWebBrainGroup(tab) {
+  if (!chrome.tabGroups || !tab?.id || tab.windowId == null) return -1;
+  try {
+    let groupId = webBrainGroupByWindow.get(tab.windowId);
+
+    // Validate the cached group still exists in Chrome (user may have
+    // ungrouped it manually, or the service worker restarted with a
+    // stale stored ID).
+    if (groupId != null) {
+      try {
+        await chrome.tabGroups.get(groupId);
+      } catch {
+        groupId = null;
+        webBrainGroupByWindow.delete(tab.windowId);
+        saveWebBrainGroups();
+      }
+    }
+
+    if (groupId == null) {
+      if (typeof tab.groupId === 'number' && tab.groupId >= 0) {
+        // Source tab is already in some group. Adopt + rebrand it as
+        // WebBrain instead of fragmenting tabs into a second group.
+        groupId = tab.groupId;
+        try {
+          await chrome.tabGroups.update(groupId, {
+            title: 'WebBrain', color: 'blue', collapsed: false,
+          });
+        } catch { /* user may have permission concerns */ }
+      } else {
+        // Source tab is ungrouped — create a fresh WebBrain group.
+        groupId = await chrome.tabs.group({ tabIds: [tab.id] });
+        try {
+          await chrome.tabGroups.update(groupId, {
+            title: 'WebBrain', color: 'blue', collapsed: false,
+          });
+        } catch { /* ignore styling failure */ }
+      }
+      webBrainGroupByWindow.set(tab.windowId, groupId);
+      saveWebBrainGroups();
+    } else if (tab.groupId !== groupId) {
+      // Group exists for this window but source tab isn't in it. Add it.
+      try {
+        await chrome.tabs.group({ groupId, tabIds: [tab.id] });
+      } catch { /* tab might already be moving; ignore */ }
+    }
+    return groupId;
+  } catch {
+    return -1;
+  }
+}
+
+// Disable the panel up-front on every tab. With group-scoped visibility,
+// the panel is OFF by default everywhere — tabs only "earn" the panel by
+// being part of a WebBrain group.
+async function disablePanelOnAllTabs() {
   try {
     const tabs = await chrome.tabs.query({});
     for (const t of tabs) {
-      if (t.id != null && !panelTabs.has(t.id)) {
+      if (t.id == null) continue;
+      const enabled = shouldEnablePanelForTab(t);
+      if (!enabled) {
         chrome.sidePanel.setOptions({ tabId: t.id, enabled: false }).catch(() => {});
       }
     }
-  } catch (e) { /* ignore */ }
+  } catch { /* ignore */ }
 }
-disablePanelOnAllTabsExceptOptedIn();
+disablePanelOnAllTabs();
 
 chrome.tabs.onCreated.addListener((tab) => {
-  if (tab?.id != null && !panelTabs.has(tab.id)) {
+  if (tab?.id == null) return;
+  // New tab inherits "panel off" unless it lands in a WebBrain group
+  // (e.g. agent's `_addToWebBrainGroup` adds it). The onUpdated handler
+  // below will flip the panel on if/when that happens.
+  if (!shouldEnablePanelForTab(tab)) {
     chrome.sidePanel.setOptions({ tabId: tab.id, enabled: false }).catch(() => {});
   }
 });
@@ -127,32 +272,57 @@ chrome.tabs.onCreated.addListener((tab) => {
 // silently refuses to open the panel.
 chrome.action.onClicked.addListener((tab) => {
   if (!tab?.id) return;
+  // Legacy fallback: keep panelTabs in sync for browsers without tabGroups.
   panelTabs.add(tab.id);
   savePanelTabs();
-  // Fire-and-forget; do NOT await — preserves user gesture for open() below
+  // Fire-and-forget; do NOT await — preserves user gesture for open() below.
   chrome.sidePanel.setOptions({
     tabId: tab.id,
     path: 'src/ui/sidepanel.html',
-    enabled: true
+    enabled: true,
   });
   chrome.sidePanel.open({ tabId: tab.id });
+  // Now group the source tab so the visibility scope is established
+  // before the user can switch tabs. Async — we already lost the user-
+  // gesture window for sidePanel.open, but ensureWebBrainGroup doesn't
+  // need it.
+  ensureWebBrainGroup(tab).catch(() => {});
 });
 
-// When switching tabs, explicitly disable the panel on tabs the user didn't
-// open it on. With manifest.default_path removed, the panel is OFF by default
-// — but we still call setOptions({enabled:false}) defensively to make sure
-// Chrome closes the side panel for any window whose new active tab isn't in
-// our opt-in set.
-chrome.tabs.onActivated.addListener(async ({ tabId }) => {
-  if (!panelTabs.has(tabId)) {
-    await chrome.sidePanel.setOptions({ tabId, enabled: false }).catch(() => {});
-  } else {
-    // Re-affirm enabled state in case service worker restarted between activations.
-    await chrome.sidePanel.setOptions({
-      tabId,
-      path: 'src/ui/sidepanel.html',
-      enabled: true,
-    }).catch(() => {});
+// When the active tab changes, re-check visibility against group membership.
+// This is the path that makes "switch tab → sidebar disappears" actually
+// work, since `setOptions({enabled: false})` told to a non-active tab
+// only takes effect once Chrome re-renders the panel for the next tab.
+chrome.tabs.onActivated.addListener(({ tabId }) => {
+  refreshPanelVisibility(tabId).catch(() => {});
+});
+
+// In-place group changes — user dragged the active tab out of the WebBrain
+// group, or the agent's `_addToWebBrainGroup` just dragged it in. Either
+// way, the active tab's panel state may need to flip without a tab switch.
+chrome.tabs.onUpdated.addListener((tabId, changeInfo) => {
+  if (changeInfo.groupId === undefined) return;
+  refreshPanelVisibility(tabId).catch(() => {});
+});
+
+// User ungrouped (or Chrome auto-collapsed) the WebBrain group entirely.
+// Forget the mapping for that window so the next action click can seed
+// a fresh group rather than try to reuse a dead ID.
+chrome.tabGroups?.onRemoved?.addListener?.((group) => {
+  for (const [windowId, gid] of webBrainGroupByWindow) {
+    if (gid === group.id) {
+      webBrainGroupByWindow.delete(windowId);
+      saveWebBrainGroups();
+      break;
+    }
+  }
+});
+
+// Window closed — drop the per-window mapping.
+chrome.windows?.onRemoved?.addListener?.((windowId) => {
+  if (webBrainGroupByWindow.has(windowId)) {
+    webBrainGroupByWindow.delete(windowId);
+    saveWebBrainGroups();
   }
 });
 

--- a/src/chrome/src/background.js
+++ b/src/chrome/src/background.js
@@ -252,6 +252,43 @@ async function disablePanelOnAllTabs() {
 }
 disablePanelOnAllTabs();
 
+// ────────────────────────────────────────────────────────────────────────
+// Agent visual indicator (content-script bridge)
+//
+// While an agent run is in flight, we ask the page's content script to
+// render a pulsing purple inset glow around the viewport plus a
+// "Stop WebBrain" floating button. The chat / chat_stream / continue
+// handlers wrap their await with sendIndicatorMessage(tabId, 'SHOW' / 'HIDE').
+// agent.js fires HIDE_FOR_TOOL_USE / SHOW_AFTER_TOOL_USE around screenshot
+// capture so the agent doesn't see its own border in the pixels it sends
+// to the vision model.
+// ────────────────────────────────────────────────────────────────────────
+
+/**
+ * Tell a tab's content script to show/hide the agent indicator. Best-
+ * effort: silently no-ops on chrome:// / chrome-extension:// tabs (no
+ * content script there) and on tabs that haven't loaded yet. We don't
+ * await — these are decorative and shouldn't block the run.
+ */
+function sendIndicatorMessage(tabId, type) {
+  if (tabId == null || !type) return;
+  try {
+    chrome.tabs.sendMessage(tabId, { type }).catch(() => { /* expected */ });
+  } catch { /* ignore */ }
+}
+
+// Stop button on the page → abort the agent run for that tab. Mirrors
+// the sidepanel's Stop button.
+chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
+  if (msg?.type !== 'WB_STOP_AGENT') return; // not ours
+  const tabId = sender?.tab?.id;
+  if (tabId != null) {
+    try { agent.abort(tabId); } catch { /* ignore */ }
+  }
+  sendResponse({ ok: true });
+  // Synchronous response — return undefined.
+});
+
 chrome.tabs.onCreated.addListener((tab) => {
   if (tab?.id == null) return;
   // New tab inherits "panel off" unless it lands in a WebBrain group
@@ -391,18 +428,27 @@ async function handleMessage(msg, sender) {
       // service worker restart.
       if (msg.apiMutationsAllowed) agent.setApiMutationsAllowed(tabId, true);
 
-      const updates = [];
-      const result = await agent.processMessage(tabId, msg.text, (type, data) => {
-        updates.push({ type, data });
-        chrome.runtime.sendMessage({
-          target: 'sidepanel',
-          action: 'agent_update',
-          type,
-          data,
-        }).catch(() => {});
-      }, mode);
+      // Show the on-page glow + Stop button while the run is in flight.
+      // Best-effort: silently no-ops on tabs where the content script
+      // isn't present (chrome://, chrome-extension://, etc.).
+      sendIndicatorMessage(tabId, 'WB_SHOW_AGENT_INDICATORS');
 
-      return { content: result, updates };
+      const updates = [];
+      try {
+        const result = await agent.processMessage(tabId, msg.text, (type, data) => {
+          updates.push({ type, data });
+          chrome.runtime.sendMessage({
+            target: 'sidepanel',
+            action: 'agent_update',
+            type,
+            data,
+          }).catch(() => {});
+        }, mode);
+
+        return { content: result, updates };
+      } finally {
+        sendIndicatorMessage(tabId, 'WB_HIDE_AGENT_INDICATORS');
+      }
     }
 
     case 'chat_stream': {
@@ -412,16 +458,21 @@ async function handleMessage(msg, sender) {
 
       if (msg.apiMutationsAllowed) agent.setApiMutationsAllowed(tabId, true);
 
-      const result = await agent.processMessageStream(tabId, msg.text, (type, data) => {
-        chrome.runtime.sendMessage({
-          target: 'sidepanel',
-          action: 'agent_update',
-          type,
-          data,
-        }).catch(() => {});
-      }, mode);
+      sendIndicatorMessage(tabId, 'WB_SHOW_AGENT_INDICATORS');
+      try {
+        const result = await agent.processMessageStream(tabId, msg.text, (type, data) => {
+          chrome.runtime.sendMessage({
+            target: 'sidepanel',
+            action: 'agent_update',
+            type,
+            data,
+          }).catch(() => {});
+        }, mode);
 
-      return { content: result };
+        return { content: result };
+      } finally {
+        sendIndicatorMessage(tabId, 'WB_HIDE_AGENT_INDICATORS');
+      }
     }
 
     case 'continue': {
@@ -429,16 +480,21 @@ async function handleMessage(msg, sender) {
       if (!tabId) throw new Error('No tab ID');
       const mode = msg.mode || 'ask';
 
-      const result = await agent.continueProcessing(tabId, (type, data) => {
-        chrome.runtime.sendMessage({
-          target: 'sidepanel',
-          action: 'agent_update',
-          type,
-          data,
-        }).catch(() => {});
-      }, mode);
+      sendIndicatorMessage(tabId, 'WB_SHOW_AGENT_INDICATORS');
+      try {
+        const result = await agent.continueProcessing(tabId, (type, data) => {
+          chrome.runtime.sendMessage({
+            target: 'sidepanel',
+            action: 'agent_update',
+            type,
+            data,
+          }).catch(() => {});
+        }, mode);
 
-      return { content: result };
+        return { content: result };
+      } finally {
+        sendIndicatorMessage(tabId, 'WB_HIDE_AGENT_INDICATORS');
+      }
     }
 
     case 'clear_conversation': {

--- a/src/chrome/src/background.js
+++ b/src/chrome/src/background.js
@@ -208,24 +208,19 @@ async function ensureWebBrainGroup(tab) {
     }
 
     if (groupId == null) {
-      if (typeof tab.groupId === 'number' && tab.groupId >= 0) {
-        // Source tab is already in some group. Adopt + rebrand it as
-        // WebBrain instead of fragmenting tabs into a second group.
-        groupId = tab.groupId;
-        try {
-          await chrome.tabGroups.update(groupId, {
-            title: 'WebBrain', color: 'blue', collapsed: false,
-          });
-        } catch { /* user may have permission concerns */ }
-      } else {
-        // Source tab is ungrouped — create a fresh WebBrain group.
-        groupId = await chrome.tabs.group({ tabIds: [tab.id] });
-        try {
-          await chrome.tabGroups.update(groupId, {
-            title: 'WebBrain', color: 'blue', collapsed: false,
-          });
-        } catch { /* ignore styling failure */ }
-      }
+      // Always create a FRESH WebBrain group for this window, even if the
+      // source tab is currently in some other (user-owned) group. The
+      // earlier behaviour adopted the source's existing group and renamed
+      // it to "WebBrain" — surprising for users who had a "Dev" or
+      // "Research" group of their own. Calling chrome.tabs.group with no
+      // groupId moves the source tab out of any old group into the new
+      // one; the user's old group keeps its other tabs untouched.
+      groupId = await chrome.tabs.group({ tabIds: [tab.id] });
+      try {
+        await chrome.tabGroups.update(groupId, {
+          title: 'WebBrain', color: 'blue', collapsed: false,
+        });
+      } catch { /* ignore styling failure */ }
       webBrainGroupByWindow.set(tab.windowId, groupId);
       saveWebBrainGroups();
     } else if (tab.groupId !== groupId) {

--- a/src/chrome/src/content/agent-visual-indicator.js
+++ b/src/chrome/src/content/agent-visual-indicator.js
@@ -1,0 +1,251 @@
+/**
+ * WebBrain Agent Visual Indicator (content script)
+ *
+ * Renders an animated purple inset glow around the page viewport while
+ * the agent is operating on this tab, plus a "Stop WebBrain" floating
+ * button at the bottom center. The same UI Anthropic's Claude-for-Chrome
+ * extension uses while its agent is acting (see their bundled
+ * agent-visual-indicator.js), recolored for WebBrain's accent (#6c63ff).
+ *
+ * Lifecycle messages from the service worker:
+ *
+ *   WB_SHOW_AGENT_INDICATORS  — agent run started → fade in border + button
+ *   WB_HIDE_AGENT_INDICATORS  — agent run ended → fade out + remove
+ *   WB_HIDE_FOR_TOOL_USE      — temporarily hide so screenshots don't
+ *                                capture our own UI
+ *   WB_SHOW_AFTER_TOOL_USE    — restore visibility after the screenshot
+ *                                has been captured
+ *
+ * Stop button click → service worker via WB_STOP_AGENT, which calls
+ * agent.abort(tabId) the same way the sidepanel's Stop button does.
+ *
+ * Self-contained — no imports, runs in the page's content-script world.
+ * z-index uses the max signed 32-bit value so the indicator sits above
+ * site overlays/modals but never accidentally swallows page input
+ * (border has pointer-events: none; button uses pointer-events: auto).
+ */
+
+(function () {
+  let borderEl = null;
+  let stopContainerEl = null;
+  let indicatorsActive = false;
+  // Saved visibility state during HIDE_FOR_TOOL_USE so SHOW_AFTER_TOOL_USE
+  // can restore the right thing (don't want to show indicators that
+  // weren't on before the screenshot).
+  let savedBorderVisible = false;
+  let savedStopVisible = false;
+
+  function injectStyles() {
+    if (document.getElementById('webbrain-agent-styles')) return;
+    const style = document.createElement('style');
+    style.id = 'webbrain-agent-styles';
+    style.textContent = `
+      @keyframes webbrain-pulse {
+        0% {
+          box-shadow:
+            inset 0 0 10px rgba(108, 99, 255, 0.5),
+            inset 0 0 20px rgba(108, 99, 255, 0.3),
+            inset 0 0 30px rgba(108, 99, 255, 0.1);
+        }
+        50% {
+          box-shadow:
+            inset 0 0 15px rgba(108, 99, 255, 0.7),
+            inset 0 0 25px rgba(108, 99, 255, 0.5),
+            inset 0 0 35px rgba(108, 99, 255, 0.2);
+        }
+        100% {
+          box-shadow:
+            inset 0 0 10px rgba(108, 99, 255, 0.5),
+            inset 0 0 20px rgba(108, 99, 255, 0.3),
+            inset 0 0 30px rgba(108, 99, 255, 0.1);
+        }
+      }
+    `;
+    (document.head || document.documentElement).appendChild(style);
+  }
+
+  function createBorder() {
+    const el = document.createElement('div');
+    el.id = 'webbrain-agent-glow-border';
+    el.style.cssText = `
+      position: fixed;
+      top: 0; left: 0; right: 0; bottom: 0;
+      pointer-events: none;
+      z-index: 2147483646;
+      opacity: 0;
+      transition: opacity 0.3s ease-in-out;
+      animation: webbrain-pulse 2s ease-in-out infinite;
+      box-shadow:
+        inset 0 0 10px rgba(108, 99, 255, 0.5),
+        inset 0 0 20px rgba(108, 99, 255, 0.3),
+        inset 0 0 30px rgba(108, 99, 255, 0.1);
+    `;
+    return el;
+  }
+
+  function createStopButton() {
+    const container = document.createElement('div');
+    container.id = 'webbrain-agent-stop-container';
+    container.style.cssText = `
+      position: fixed;
+      bottom: 16px;
+      left: 50%;
+      transform: translateX(-50%);
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      pointer-events: none;
+      z-index: 2147483647;
+    `;
+    const button = document.createElement('button');
+    button.id = 'webbrain-agent-stop-button';
+    button.type = 'button';
+    button.innerHTML = `
+      <svg width="16" height="16" viewBox="0 0 256 256" fill="currentColor"
+           style="margin-right: 10px; vertical-align: middle;">
+        <path d="M128,20A108,108,0,1,0,236,128,108.12,108.12,0,0,0,128,20Zm0,192a84,84,0,1,1,84-84A84.09,84.09,0,0,1,128,212Zm40-112v56a12,12,0,0,1-12,12H100a12,12,0,0,1-12-12V100a12,12,0,0,1,12-12h56A12,12,0,0,1,168,100Z"/>
+      </svg>
+      <span style="vertical-align: middle;">Stop WebBrain</span>
+    `;
+    button.style.cssText = `
+      position: relative;
+      transform: translateY(80px);
+      padding: 11px 18px;
+      background: #ffffff;
+      color: #1a1a2e;
+      border: 1px solid rgba(108, 99, 255, 0.30);
+      border-radius: 12px;
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
+      font-size: 14px;
+      font-weight: 600;
+      cursor: pointer;
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      box-shadow:
+        0 24px 48px rgba(108, 99, 255, 0.24),
+        0 4px 14px rgba(108, 99, 255, 0.20);
+      transition:
+        transform 0.3s cubic-bezier(0.4, 0, 0.2, 1),
+        opacity 0.3s ease,
+        background 0.15s ease;
+      opacity: 0;
+      user-select: none;
+      pointer-events: auto;
+      white-space: nowrap;
+      margin: 0 auto;
+    `;
+    button.addEventListener('mouseenter', () => {
+      if (indicatorsActive) button.style.background = '#f3f0ff';
+    });
+    button.addEventListener('mouseleave', () => {
+      if (indicatorsActive) button.style.background = '#ffffff';
+    });
+    button.addEventListener('click', async () => {
+      try {
+        await chrome.runtime.sendMessage({ type: 'WB_STOP_AGENT' });
+      } catch { /* extension context invalidated, ignore */ }
+    });
+    container.appendChild(button);
+    return container;
+  }
+
+  function show() {
+    indicatorsActive = true;
+    injectStyles();
+
+    const root = document.body || document.documentElement;
+    if (!root) return; // page hasn't parsed yet — extremely unlikely on document_idle
+
+    if (borderEl) {
+      borderEl.style.display = '';
+    } else {
+      borderEl = createBorder();
+      root.appendChild(borderEl);
+    }
+
+    if (stopContainerEl) {
+      stopContainerEl.style.display = '';
+    } else {
+      stopContainerEl = createStopButton();
+      root.appendChild(stopContainerEl);
+    }
+
+    // Two RAFs: first to land the elements in the DOM (so the browser
+    // computes their initial transforms with opacity 0 / translateY 80px),
+    // second to apply the in-flight values for a clean transition.
+    requestAnimationFrame(() => {
+      requestAnimationFrame(() => {
+        if (borderEl) borderEl.style.opacity = '1';
+        const btn = stopContainerEl?.querySelector('#webbrain-agent-stop-button');
+        if (btn) {
+          btn.style.transform = 'translateY(0)';
+          btn.style.opacity = '1';
+        }
+      });
+    });
+  }
+
+  function hide() {
+    if (!indicatorsActive) return;
+    indicatorsActive = false;
+    if (borderEl) borderEl.style.opacity = '0';
+    const btn = stopContainerEl?.querySelector('#webbrain-agent-stop-button');
+    if (btn) {
+      btn.style.transform = 'translateY(80px)';
+      btn.style.opacity = '0';
+    }
+    setTimeout(() => {
+      // Bail if the user re-triggered show() during the fade-out.
+      if (indicatorsActive) return;
+      borderEl?.parentNode?.removeChild(borderEl);
+      stopContainerEl?.parentNode?.removeChild(stopContainerEl);
+      borderEl = null;
+      stopContainerEl = null;
+    }, 320);
+  }
+
+  /**
+   * Hide both elements without tearing them down — for the brief window
+   * around a screenshot capture, so the agent doesn't see its own border
+   * pulsing in the screenshots it sends back to the model.
+   */
+  function hideForToolUse() {
+    savedBorderVisible = !!(borderEl && borderEl.style.display !== 'none');
+    savedStopVisible = !!(stopContainerEl && stopContainerEl.style.display !== 'none');
+    if (borderEl) borderEl.style.display = 'none';
+    if (stopContainerEl) stopContainerEl.style.display = 'none';
+  }
+
+  function showAfterToolUse() {
+    if (savedBorderVisible && borderEl) borderEl.style.display = '';
+    if (savedStopVisible && stopContainerEl) stopContainerEl.style.display = '';
+    savedBorderVisible = false;
+    savedStopVisible = false;
+  }
+
+  chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
+    if (!msg || typeof msg.type !== 'string') return;
+    switch (msg.type) {
+      case 'WB_SHOW_AGENT_INDICATORS':
+        show();
+        sendResponse({ ok: true });
+        break;
+      case 'WB_HIDE_AGENT_INDICATORS':
+        hide();
+        sendResponse({ ok: true });
+        break;
+      case 'WB_HIDE_FOR_TOOL_USE':
+        hideForToolUse();
+        sendResponse({ ok: true });
+        break;
+      case 'WB_SHOW_AFTER_TOOL_USE':
+        showAfterToolUse();
+        sendResponse({ ok: true });
+        break;
+      // Unknown messages are silently ignored — other content scripts in
+      // the same world might be using chrome.runtime.onMessage too.
+    }
+    // Synchronous response — return falsy so the channel closes.
+  });
+})();


### PR DESCRIPTION
## Summary

Replaces the per-tab `panelTabs` opt-in Set with a **tab-group-membership** model that mirrors how Anthropic's Claude-for-Chrome extension handles side-panel visibility. Fixes the user-reported bug that the side panel "never goes away" when you switch tabs after opening it.

## Why

Chrome's `sidePanel.setOptions({enabled: false})` doesn't actively close an already-open panel — it only prevents future opens. With the old per-tab Set, the panel ended up sticky: once you'd clicked the action on tab A, switching to tab B left the panel rendered, and returning to A re-affirmed enabled. Net effect: the panel followed you everywhere.

Tying visibility to a tab group gives Chrome a deterministic on/off signal:

| Event | Behaviour |
|---|---|
| Click action on tab A | A joins (or seeds) a "WebBrain" group for that window. Panel enabled. |
| Switch to tab B (not in group) | onActivated → `enabled=false` → panel hides. |
| Switch back to A (in group) | `enabled=true` → panel reappears. |
| Drag A out of the WebBrain group | onUpdated fires → panel hides without a tab switch. |
| Agent's `_addToWebBrainGroup` runs | new tab joins the same group → automatically inherits panel. |

The colored "WebBrain" group label also gives the user a visible representation of the session's scope, which matches Claude-for-Chrome's UX.

## What changed

### `src/chrome/manifest.json`
- Added `tabs` and `tabGroups` permissions. We were already calling `chrome.tabs.group()` and `chrome.tabGroups.update()` in `agent.js` for the `new_tab` flow, but without the explicit permissions those calls were being silently rejected by Chrome on some setups.

### `src/chrome/src/background.js`
- **`webBrainGroupByWindow: Map<windowId, groupId>`** — per-window source of truth on modern Chrome. Persisted to `chrome.storage.session` and revalidated against `chrome.tabGroups.get` on load.
- **`ensureWebBrainGroup(tab)`** — creates / joins the group for the source tab's window. Called from `action.onClicked` *after* the sync `sidePanel.open` block (user gesture is only needed for `open()`, not for grouping). **Always creates a fresh group** rather than adopting any pre-existing user-owned group the source tab might be in (see "Existing-group adoption" below).
- **`shouldEnablePanelForTab(tab)`** — single decision function. Modern Chrome → group membership; legacy fallback → `panelTabs`.
- **`refreshPanelVisibility(tabId)`** — applies the decision via `setOptions`. Used by `onActivated`, `onUpdated`, etc.
- `onActivated` now refreshes via the helper instead of doing the decision inline.
- `onUpdated` listens for `changeInfo.groupId` so an active tab being dragged in/out of the group flips the panel without needing a tab switch.
- `tabGroups.onRemoved` / `windows.onRemoved` clean up the map so a later action click seeds a fresh group instead of trying to reuse a dead group id.

### `src/chrome/src/agent/agent.js`
- **`_addToWebBrainGroup(sourceTab, tabId)`** rewritten to look up the WebBrain group by title (`chrome.tabGroups.query({title: 'WebBrain', windowId})`) instead of inheriting from `sourceTab.groupId`. If the user has the source tab in their own group ("Dev", "Research", etc.), agent-spawned tabs no longer get dragged into it — they live in the WebBrain group only.

### `README.md`
- Refreshed the "What's New" section to cover the 5.x line — group-scoped sidebar, token-conscious screenshots, multilingual UI, vision split-provider mode, profile auto-fill, cookie/paywall guidance, site adapters.

`panelTabs` survives untouched — only used as the fallback path when `chrome.tabGroups` isn't available (Chrome <89, very rare). On modern Chrome, `panelTabs.add()` in the action handler is just legacy hedging.

## Existing-group adoption: the policy choice

If the user clicks the action on a tab that's already in their own non-WebBrain group ("Dev", "Research", etc.), we have to do *something*. Two options:

1. **Adopt + rebrand** the existing group as "WebBrain". Hijacks the user's organization but keeps every tab where it was.
2. **Leave the existing group alone**, move just the source tab into a fresh WebBrain group. The user's old group keeps its other tabs intact, but loses the one we re-homed.

This PR ships **Option 2**. It's strictly less invasive — the user's old group is never renamed or recolored, and they can drag the tab back in if they want. The net cost is that one tab moves between groups when the action is clicked.

`agent.js`'s `_addToWebBrainGroup` was changed for the same reason — previously it would drop agent-spawned tabs into whatever group the source tab was in (so a new_tab from a "Dev"-grouped source ended up in "Dev"). Now it queries by title and only ever uses the WebBrain group.

## Test plan

- [ ] **Basic show/hide:** Click WebBrain action on tab A → panel opens, A gets a "WebBrain" group label. Switch to a brand-new tab B → panel disappears. Switch back to A → panel reappears.
- [ ] **Pre-existing user group is preserved:** Put tab A in your own "Dev" group (4 other tabs in it). Click WebBrain action on A → A moves out of "Dev" into a new "WebBrain" group. "Dev" group keeps its other 4 tabs untouched.
- [ ] **Drag tab out:** While on tab A with sidebar open, drag A out of the WebBrain group → panel disappears immediately, no tab switch needed.
- [ ] **Agent new_tab respects user groups:** With sidebar NOT yet opened, ask the agent (somehow — only works if a panel is already open) to "open a new tab to github.com" → the new tab goes into a fresh WebBrain group, NOT into any of the user's existing groups.
- [ ] **Agent new_tab joins WebBrain:** With sidebar open on tab A (so A is in WebBrain group), ask the agent to open new tab B → B joins the same WebBrain group, sidebar visible on both.
- [ ] **Multiple windows:** Open a new browser window, click action there → that window gets its own independent WebBrain group; doesn't disturb the first window's panel.
- [ ] **Service worker restart:** Open sidebar, wait ~30s for SW to suspend, switch tabs → group state survives via `chrome.storage.session`.
- [ ] **Manual ungroup:** Right-click WebBrain group → Ungroup → panel hides; next action click on any tab seeds a new WebBrain group.
- [ ] **Window close:** Close a window with a WebBrain group → no errors in service-worker console; opening sidebar in another window still works.

## Caveats

- **Permission prompt on update.** Adding `tabs` + `tabGroups` to the manifest may trigger Chrome to show users an updated-permissions notice when the extension auto-updates. Worth mentioning in release notes.
- **Pinned tabs.** Pinned tabs can't be in groups in Chrome. If the source tab is pinned, `ensureWebBrainGroup` will fail silently (logged as `-1`); the panel will still open via the legacy per-tab fallback (`panelTabs.add` runs synchronously before `ensureWebBrainGroup`).

This branch was forked off `main` after `f7f76ef`.