### PR TITLE
chrome: on-page agent visual indicator (border + Stop button)

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,7 @@ The default UI-first rule exists because API actions are invisible (you don't se
 
 ### 5.x
 
+- **On-page agent indicator (Chrome).** While the agent is acting on a tab, the page now shows a soft purple inset glow around the viewport plus a "Stop WebBrain" floating button at the bottom — same UX pattern as Claude-for-Chrome. Clicking Stop aborts the run without you having to switch back to the side panel. The indicator hides itself during screenshot capture so it doesn't end up in the images sent to the vision model.
 - **Group-scoped side panel visibility (Chrome).** Clicking the WebBrain action now puts the source tab into a "WebBrain" tab group; the side panel is shown only for tabs in that group. Switch to any tab outside the group → panel hides. Drag the tab out of the group → panel hides. Mirrors how Claude-for-Chrome handles sidebar scope and replaces the older per-tab opt-in Set, which left the panel "sticky" across tab switches.
   - Adds `tabs` and `tabGroups` permissions (Chrome will surface a permissions notice on auto-update).
   - Tabs the agent opens via `new_tab` or `target=_blank` redirects automatically join the same group.

--- a/src/chrome/manifest.json
+++ b/src/chrome/manifest.json
@@ -36,7 +36,11 @@
   "content_scripts": [
     {
       "matches": ["<all_urls>"],
-      "js": ["src/content/accessibility-tree.js", "src/content/content.js"],
+      "js": [
+        "src/content/accessibility-tree.js",
+        "src/content/content.js",
+        "src/content/agent-visual-indicator.js"
+      ],
       "run_at": "document_idle"
     }
   ],

--- a/src/chrome/src/agent/agent.js
+++ b/src/chrome/src/agent/agent.js
@@ -1045,6 +1045,38 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
    *
    * Returns { dataUrl, width, height } (in image pixels) or null.
    */
+  /**
+   * Wrap a screenshot capture in messages that ask the agent-visual-
+   * indicator content script to hide its pulsing border + Stop button
+   * for the duration of the capture. Without this, the agent's own
+   * indicator gets baked into every screenshot it sends to the vision
+   * model — which is both ugly and a small token-budget tax.
+   *
+   * Best-effort: if the content script isn't loaded (chrome:// /
+   * chrome-extension:// / file:// pages), the sendMessage rejects and
+   * we capture as-is. Same on tabs the user opened before the extension
+   * had a chance to inject.
+   */
+  async _withIndicatorsHidden(tabId, fn) {
+    let needsRestore = false;
+    try {
+      await chrome.tabs.sendMessage(tabId, { type: 'WB_HIDE_FOR_TOOL_USE' });
+      needsRestore = true;
+      // One paint frame for Chrome to apply the display:none the
+      // content script just set, before CDP grabs the surface.
+      await new Promise((r) => setTimeout(r, 16));
+    } catch { /* content script absent — that's fine, no UI to hide */ }
+    try {
+      return await fn();
+    } finally {
+      if (needsRestore) {
+        try {
+          chrome.tabs.sendMessage(tabId, { type: 'WB_SHOW_AFTER_TOOL_USE' }).catch(() => {});
+        } catch { /* ignore */ }
+      }
+    }
+  }
+
   async _captureAutoScreenshot(tabId, { coordAligned = false } = {}) {
     try {
       await cdpClient.attach(tabId);
@@ -1065,11 +1097,13 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
         // We DO still run the byte-ceiling fallback afterwards: if the
         // CSS viewport happens to be huge, we'd rather lose some JPEG
         // quality than overflow the provider's image cap.
-        const shot = await cdpClient.sendCommand(tabId, 'Page.captureScreenshot', {
-          format: 'jpeg',
-          quality: 60,
-          clip: { x: 0, y: 0, width: cssW, height: cssH, scale: 1 },
-        });
+        const shot = await this._withIndicatorsHidden(tabId, () =>
+          cdpClient.sendCommand(tabId, 'Page.captureScreenshot', {
+            format: 'jpeg',
+            quality: 60,
+            clip: { x: 0, y: 0, width: cssW, height: cssH, scale: 1 },
+          })
+        );
         if (!shot?.data) return null;
         const rawDataUrl = `data:image/jpeg;base64,${shot.data}`;
         const shrunk = await this._compressJpegToByteCeiling(rawDataUrl);
@@ -1082,12 +1116,14 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
       // then have to decode and resize in the service worker.
       const [targetW, targetH] = Agent._fitImageDimensions(cssW, cssH);
       const scale = targetW < cssW ? targetW / cssW : 1;
-      const shot = await cdpClient.sendCommand(tabId, 'Page.captureScreenshot', {
-        format: 'jpeg',
-        quality: Math.round(Agent.IMAGE_BUDGET.initialJpegQuality * 100),
-        fromSurface: true,
-        clip: { x: 0, y: 0, width: cssW, height: cssH, scale },
-      });
+      const shot = await this._withIndicatorsHidden(tabId, () =>
+        cdpClient.sendCommand(tabId, 'Page.captureScreenshot', {
+          format: 'jpeg',
+          quality: Math.round(Agent.IMAGE_BUDGET.initialJpegQuality * 100),
+          fromSurface: true,
+          clip: { x: 0, y: 0, width: cssW, height: cssH, scale },
+        })
+      );
       if (!shot?.data) return null;
       const rawDataUrl = `data:image/jpeg;base64,${shot.data}`;
 
@@ -2210,11 +2246,13 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
             // Pixel-accuracy mode: image pixels must equal CSS pixels so
             // click({x,y}) off the screenshot lands on the real element.
             // PNG (lossless, no quality knob) so no artifacts at glyph edges.
-            const screenshot = await cdpClient.sendCommand(tabId, 'Page.captureScreenshot', {
-              format: 'png',
-              fromSurface: true,
-              clip: { x: 0, y: 0, width: cssW, height: cssH, scale: 1 },
-            });
+            const screenshot = await this._withIndicatorsHidden(tabId, () =>
+              cdpClient.sendCommand(tabId, 'Page.captureScreenshot', {
+                format: 'png',
+                fromSurface: true,
+                clip: { x: 0, y: 0, width: cssW, height: cssH, scale: 1 },
+              })
+            );
             dataUrl = `data:image/png;base64,${screenshot.data}`;
             description = `Screenshot captured via CDP (${screenshot.data.length} bytes, CSS-pixel aligned for pixel clicks)`;
             // Byte-ceiling fallback only — we don't resize in coord mode.
@@ -2225,12 +2263,14 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
             // the iterative-quality fallback if bytes are still over.
             const [targetW, targetH] = Agent._fitImageDimensions(cssW, cssH);
             const scale = targetW < cssW ? targetW / cssW : 1;
-            const screenshot = await cdpClient.sendCommand(tabId, 'Page.captureScreenshot', {
-              format: 'jpeg',
-              quality: Math.round(Agent.IMAGE_BUDGET.initialJpegQuality * 100),
-              fromSurface: true,
-              clip: { x: 0, y: 0, width: cssW, height: cssH, scale },
-            });
+            const screenshot = await this._withIndicatorsHidden(tabId, () =>
+              cdpClient.sendCommand(tabId, 'Page.captureScreenshot', {
+                format: 'jpeg',
+                quality: Math.round(Agent.IMAGE_BUDGET.initialJpegQuality * 100),
+                fromSurface: true,
+                clip: { x: 0, y: 0, width: cssW, height: cssH, scale },
+              })
+            );
             const rawUrl = `data:image/jpeg;base64,${screenshot.data}`;
             dataUrl = await this._compressJpegToByteCeiling(rawUrl);
             const resized = scale < 1 ? ` (resized ${cssW}×${cssH} → ${targetW}×${targetH} for vision-token budget)` : '';
@@ -2325,9 +2365,11 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
           // reflects what the user would actually see.
           const probe = await this._captureViewportProbe(tabId);
           await this._bringToFrontForCapture(tabId);
-          const shot = await cdpClient.sendCommand(tabId, 'Page.captureScreenshot', {
-            format: 'png', quality: 80, fromSurface: true,
-          });
+          const shot = await this._withIndicatorsHidden(tabId, () =>
+            cdpClient.sendCommand(tabId, 'Page.captureScreenshot', {
+              format: 'png', quality: 80, fromSurface: true,
+            })
+          );
           let imageDataUrl = `data:image/png;base64,${shot.data}`;
           // If we remember the rect of the last ax interaction on this tab,
           // outline it on the screenshot so the model can anchor its review
@@ -2468,7 +2510,9 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
       try {
         await cdpClient.attach(tabId);
         await this._bringToFrontForCapture(tabId);
-        const imageData = await cdpClient.captureFullPageScreenshot(tabId);
+        const imageData = await this._withIndicatorsHidden(tabId, () =>
+          cdpClient.captureFullPageScreenshot(tabId)
+        );
         const rawUrl = `data:image/png;base64,${imageData}`;
 
         // Full-page captures are the worst case for size — a 1920×8000
@@ -2553,9 +2597,11 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
         try {
           await cdpClient.sendCommand(tabId, 'Page.enable');
           await this._bringToFrontForCapture(tabId);
-          const shot = await cdpClient.sendCommand(tabId, 'Page.captureScreenshot', {
-            format: 'png', quality: 100, fromSurface: true,
-          });
+          const shot = await this._withIndicatorsHidden(tabId, () =>
+            cdpClient.sendCommand(tabId, 'Page.captureScreenshot', {
+              format: 'png', quality: 100, fromSurface: true,
+            })
+          );
           result.image = `data:image/png;base64,${shot.data}`;
         } catch {
           result.screenshotFailed = true;

--- a/src/chrome/src/background.js
+++ b/src/chrome/src/background.js
@@ -252,6 +252,43 @@ async function disablePanelOnAllTabs() {
 }
 disablePanelOnAllTabs();
 
+// ────────────────────────────────────────────────────────────────────────
+// Agent visual indicator (content-script bridge)
+//
+// While an agent run is in flight, we ask the page's content script to
+// render a pulsing purple inset glow around the viewport plus a
+// "Stop WebBrain" floating button. The chat / chat_stream / continue
+// handlers wrap their await with sendIndicatorMessage(tabId, 'SHOW' / 'HIDE').
+// agent.js fires HIDE_FOR_TOOL_USE / SHOW_AFTER_TOOL_USE around screenshot
+// capture so the agent doesn't see its own border in the pixels it sends
+// to the vision model.
+// ────────────────────────────────────────────────────────────────────────
+
+/**
+ * Tell a tab's content script to show/hide the agent indicator. Best-
+ * effort: silently no-ops on chrome:// / chrome-extension:// tabs (no
+ * content script there) and on tabs that haven't loaded yet. We don't
+ * await — these are decorative and shouldn't block the run.
+ */
+function sendIndicatorMessage(tabId, type) {
+  if (tabId == null || !type) return;
+  try {
+    chrome.tabs.sendMessage(tabId, { type }).catch(() => { /* expected */ });
+  } catch { /* ignore */ }
+}
+
+// Stop button on the page → abort the agent run for that tab. Mirrors
+// the sidepanel's Stop button.
+chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
+  if (msg?.type !== 'WB_STOP_AGENT') return; // not ours
+  const tabId = sender?.tab?.id;
+  if (tabId != null) {
+    try { agent.abort(tabId); } catch { /* ignore */ }
+  }
+  sendResponse({ ok: true });
+  // Synchronous response — return undefined.
+});
+
 chrome.tabs.onCreated.addListener((tab) => {
   if (tab?.id == null) return;
   // New tab inherits "panel off" unless it lands in a WebBrain group
@@ -391,18 +428,27 @@ async function handleMessage(msg, sender) {
       // service worker restart.
       if (msg.apiMutationsAllowed) agent.setApiMutationsAllowed(tabId, true);
 
-      const updates = [];
-      const result = await agent.processMessage(tabId, msg.text, (type, data) => {
-        updates.push({ type, data });
-        chrome.runtime.sendMessage({
-          target: 'sidepanel',
-          action: 'agent_update',
-          type,
-          data,
-        }).catch(() => {});
-      }, mode);
+      // Show the on-page glow + Stop button while the run is in flight.
+      // Best-effort: silently no-ops on tabs where the content script
+      // isn't present (chrome://, chrome-extension://, etc.).
+      sendIndicatorMessage(tabId, 'WB_SHOW_AGENT_INDICATORS');
 
-      return { content: result, updates };
+      const updates = [];
+      try {
+        const result = await agent.processMessage(tabId, msg.text, (type, data) => {
+          updates.push({ type, data });
+          chrome.runtime.sendMessage({
+            target: 'sidepanel',
+            action: 'agent_update',
+            type,
+            data,
+          }).catch(() => {});
+        }, mode);
+
+        return { content: result, updates };
+      } finally {
+        sendIndicatorMessage(tabId, 'WB_HIDE_AGENT_INDICATORS');
+      }
     }
 
     case 'chat_stream': {
@@ -412,16 +458,21 @@ async function handleMessage(msg, sender) {
 
       if (msg.apiMutationsAllowed) agent.setApiMutationsAllowed(tabId, true);
 
-      const result = await agent.processMessageStream(tabId, msg.text, (type, data) => {
-        chrome.runtime.sendMessage({
-          target: 'sidepanel',
-          action: 'agent_update',
-          type,
-          data,
-        }).catch(() => {});
-      }, mode);
+      sendIndicatorMessage(tabId, 'WB_SHOW_AGENT_INDICATORS');
+      try {
+        const result = await agent.processMessageStream(tabId, msg.text, (type, data) => {
+          chrome.runtime.sendMessage({
+            target: 'sidepanel',
+            action: 'agent_update',
+            type,
+            data,
+          }).catch(() => {});
+        }, mode);
 
-      return { content: result };
+        return { content: result };
+      } finally {
+        sendIndicatorMessage(tabId, 'WB_HIDE_AGENT_INDICATORS');
+      }
     }
 
     case 'continue': {
@@ -429,16 +480,21 @@ async function handleMessage(msg, sender) {
       if (!tabId) throw new Error('No tab ID');
       const mode = msg.mode || 'ask';
 
-      const result = await agent.continueProcessing(tabId, (type, data) => {
-        chrome.runtime.sendMessage({
-          target: 'sidepanel',
-          action: 'agent_update',
-          type,
-          data,
-        }).catch(() => {});
-      }, mode);
+      sendIndicatorMessage(tabId, 'WB_SHOW_AGENT_INDICATORS');
+      try {
+        const result = await agent.continueProcessing(tabId, (type, data) => {
+          chrome.runtime.sendMessage({
+            target: 'sidepanel',
+            action: 'agent_update',
+            type,
+            data,
+          }).catch(() => {});
+        }, mode);
 
-      return { content: result };
+        return { content: result };
+      } finally {
+        sendIndicatorMessage(tabId, 'WB_HIDE_AGENT_INDICATORS');
+      }
     }
 
     case 'clear_conversation': {

--- a/src/chrome/src/content/agent-visual-indicator.js
+++ b/src/chrome/src/content/agent-visual-indicator.js
@@ -1,0 +1,251 @@
+/**
+ * WebBrain Agent Visual Indicator (content script)
+ *
+ * Renders an animated purple inset glow around the page viewport while
+ * the agent is operating on this tab, plus a "Stop WebBrain" floating
+ * button at the bottom center. The same UI Anthropic's Claude-for-Chrome
+ * extension uses while its agent is acting (see their bundled
+ * agent-visual-indicator.js), recolored for WebBrain's accent (#6c63ff).
+ *
+ * Lifecycle messages from the service worker:
+ *
+ *   WB_SHOW_AGENT_INDICATORS  — agent run started → fade in border + button
+ *   WB_HIDE_AGENT_INDICATORS  — agent run ended → fade out + remove
+ *   WB_HIDE_FOR_TOOL_USE      — temporarily hide so screenshots don't
+ *                                capture our own UI
+ *   WB_SHOW_AFTER_TOOL_USE    — restore visibility after the screenshot
+ *                                has been captured
+ *
+ * Stop button click → service worker via WB_STOP_AGENT, which calls
+ * agent.abort(tabId) the same way the sidepanel's Stop button does.
+ *
+ * Self-contained — no imports, runs in the page's content-script world.
+ * z-index uses the max signed 32-bit value so the indicator sits above
+ * site overlays/modals but never accidentally swallows page input
+ * (border has pointer-events: none; button uses pointer-events: auto).
+ */
+
+(function () {
+  let borderEl = null;
+  let stopContainerEl = null;
+  let indicatorsActive = false;
+  // Saved visibility state during HIDE_FOR_TOOL_USE so SHOW_AFTER_TOOL_USE
+  // can restore the right thing (don't want to show indicators that
+  // weren't on before the screenshot).
+  let savedBorderVisible = false;
+  let savedStopVisible = false;
+
+  function injectStyles() {
+    if (document.getElementById('webbrain-agent-styles')) return;
+    const style = document.createElement('style');
+    style.id = 'webbrain-agent-styles';
+    style.textContent = `
+      @keyframes webbrain-pulse {
+        0% {
+          box-shadow:
+            inset 0 0 10px rgba(108, 99, 255, 0.5),
+            inset 0 0 20px rgba(108, 99, 255, 0.3),
+            inset 0 0 30px rgba(108, 99, 255, 0.1);
+        }
+        50% {
+          box-shadow:
+            inset 0 0 15px rgba(108, 99, 255, 0.7),
+            inset 0 0 25px rgba(108, 99, 255, 0.5),
+            inset 0 0 35px rgba(108, 99, 255, 0.2);
+        }
+        100% {
+          box-shadow:
+            inset 0 0 10px rgba(108, 99, 255, 0.5),
+            inset 0 0 20px rgba(108, 99, 255, 0.3),
+            inset 0 0 30px rgba(108, 99, 255, 0.1);
+        }
+      }
+    `;
+    (document.head || document.documentElement).appendChild(style);
+  }
+
+  function createBorder() {
+    const el = document.createElement('div');
+    el.id = 'webbrain-agent-glow-border';
+    el.style.cssText = `
+      position: fixed;
+      top: 0; left: 0; right: 0; bottom: 0;
+      pointer-events: none;
+      z-index: 2147483646;
+      opacity: 0;
+      transition: opacity 0.3s ease-in-out;
+      animation: webbrain-pulse 2s ease-in-out infinite;
+      box-shadow:
+        inset 0 0 10px rgba(108, 99, 255, 0.5),
+        inset 0 0 20px rgba(108, 99, 255, 0.3),
+        inset 0 0 30px rgba(108, 99, 255, 0.1);
+    `;
+    return el;
+  }
+
+  function createStopButton() {
+    const container = document.createElement('div');
+    container.id = 'webbrain-agent-stop-container';
+    container.style.cssText = `
+      position: fixed;
+      bottom: 16px;
+      left: 50%;
+      transform: translateX(-50%);
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      pointer-events: none;
+      z-index: 2147483647;
+    `;
+    const button = document.createElement('button');
+    button.id = 'webbrain-agent-stop-button';
+    button.type = 'button';
+    button.innerHTML = `
+      <svg width="16" height="16" viewBox="0 0 256 256" fill="currentColor"
+           style="margin-right: 10px; vertical-align: middle;">
+        <path d="M128,20A108,108,0,1,0,236,128,108.12,108.12,0,0,0,128,20Zm0,192a84,84,0,1,1,84-84A84.09,84.09,0,0,1,128,212Zm40-112v56a12,12,0,0,1-12,12H100a12,12,0,0,1-12-12V100a12,12,0,0,1,12-12h56A12,12,0,0,1,168,100Z"/>
+      </svg>
+      <span style="vertical-align: middle;">Stop WebBrain</span>
+    `;
+    button.style.cssText = `
+      position: relative;
+      transform: translateY(80px);
+      padding: 11px 18px;
+      background: #ffffff;
+      color: #1a1a2e;
+      border: 1px solid rgba(108, 99, 255, 0.30);
+      border-radius: 12px;
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
+      font-size: 14px;
+      font-weight: 600;
+      cursor: pointer;
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      box-shadow:
+        0 24px 48px rgba(108, 99, 255, 0.24),
+        0 4px 14px rgba(108, 99, 255, 0.20);
+      transition:
+        transform 0.3s cubic-bezier(0.4, 0, 0.2, 1),
+        opacity 0.3s ease,
+        background 0.15s ease;
+      opacity: 0;
+      user-select: none;
+      pointer-events: auto;
+      white-space: nowrap;
+      margin: 0 auto;
+    `;
+    button.addEventListener('mouseenter', () => {
+      if (indicatorsActive) button.style.background = '#f3f0ff';
+    });
+    button.addEventListener('mouseleave', () => {
+      if (indicatorsActive) button.style.background = '#ffffff';
+    });
+    button.addEventListener('click', async () => {
+      try {
+        await chrome.runtime.sendMessage({ type: 'WB_STOP_AGENT' });
+      } catch { /* extension context invalidated, ignore */ }
+    });
+    container.appendChild(button);
+    return container;
+  }
+
+  function show() {
+    indicatorsActive = true;
+    injectStyles();
+
+    const root = document.body || document.documentElement;
+    if (!root) return; // page hasn't parsed yet — extremely unlikely on document_idle
+
+    if (borderEl) {
+      borderEl.style.display = '';
+    } else {
+      borderEl = createBorder();
+      root.appendChild(borderEl);
+    }
+
+    if (stopContainerEl) {
+      stopContainerEl.style.display = '';
+    } else {
+      stopContainerEl = createStopButton();
+      root.appendChild(stopContainerEl);
+    }
+
+    // Two RAFs: first to land the elements in the DOM (so the browser
+    // computes their initial transforms with opacity 0 / translateY 80px),
+    // second to apply the in-flight values for a clean transition.
+    requestAnimationFrame(() => {
+      requestAnimationFrame(() => {
+        if (borderEl) borderEl.style.opacity = '1';
+        const btn = stopContainerEl?.querySelector('#webbrain-agent-stop-button');
+        if (btn) {
+          btn.style.transform = 'translateY(0)';
+          btn.style.opacity = '1';
+        }
+      });
+    });
+  }
+
+  function hide() {
+    if (!indicatorsActive) return;
+    indicatorsActive = false;
+    if (borderEl) borderEl.style.opacity = '0';
+    const btn = stopContainerEl?.querySelector('#webbrain-agent-stop-button');
+    if (btn) {
+      btn.style.transform = 'translateY(80px)';
+      btn.style.opacity = '0';
+    }
+    setTimeout(() => {
+      // Bail if the user re-triggered show() during the fade-out.
+      if (indicatorsActive) return;
+      borderEl?.parentNode?.removeChild(borderEl);
+      stopContainerEl?.parentNode?.removeChild(stopContainerEl);
+      borderEl = null;
+      stopContainerEl = null;
+    }, 320);
+  }
+
+  /**
+   * Hide both elements without tearing them down — for the brief window
+   * around a screenshot capture, so the agent doesn't see its own border
+   * pulsing in the screenshots it sends back to the model.
+   */
+  function hideForToolUse() {
+    savedBorderVisible = !!(borderEl && borderEl.style.display !== 'none');
+    savedStopVisible = !!(stopContainerEl && stopContainerEl.style.display !== 'none');
+    if (borderEl) borderEl.style.display = 'none';
+    if (stopContainerEl) stopContainerEl.style.display = 'none';
+  }
+
+  function showAfterToolUse() {
+    if (savedBorderVisible && borderEl) borderEl.style.display = '';
+    if (savedStopVisible && stopContainerEl) stopContainerEl.style.display = '';
+    savedBorderVisible = false;
+    savedStopVisible = false;
+  }
+
+  chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
+    if (!msg || typeof msg.type !== 'string') return;
+    switch (msg.type) {
+      case 'WB_SHOW_AGENT_INDICATORS':
+        show();
+        sendResponse({ ok: true });
+        break;
+      case 'WB_HIDE_AGENT_INDICATORS':
+        hide();
+        sendResponse({ ok: true });
+        break;
+      case 'WB_HIDE_FOR_TOOL_USE':
+        hideForToolUse();
+        sendResponse({ ok: true });
+        break;
+      case 'WB_SHOW_AFTER_TOOL_USE':
+        showAfterToolUse();
+        sendResponse({ ok: true });
+        break;
+      // Unknown messages are silently ignored — other content scripts in
+      // the same world might be using chrome.runtime.onMessage too.
+    }
+    // Synchronous response — return falsy so the channel closes.
+  });
+})();


### PR DESCRIPTION
## Summary

Adds a Claude-for-Chrome-style on-page indicator while the agent is running:

- **Soft purple inset glow** pulsing around the viewport edges (2s `webbrain-pulse` keyframes, WebBrain accent `#6c63ff`)
- **"Stop WebBrain" floating button** at the bottom-center of the page

Both fade in/out, hide automatically during screenshot capture so they never end up in the images sent to the vision model, and clean up cleanly when the run ends. The on-page Stop button is especially useful when the agent is acting on a tab the user has switched away from — they no longer need to flip back to the side panel to abort.

> **Forks off `sidebar-group-scoped` (PR #41), not `main`**. Merge order: #41 first, then this. If we re-target main first, the indicator code still works on its own — the dependency is conceptual (both features ship the "Claude-style" sidebar UX).

## Files

| File | Change |
|---|---|
| `src/chrome/src/content/agent-visual-indicator.js` | **New**, ~250 lines. Content script with 4 message handlers + DOM injection + fade transitions. |
| `src/chrome/manifest.json` | Adds the new file to the existing `<all_urls>` content_scripts entry. |
| `src/chrome/src/background.js` | `sendIndicatorMessage()` helper + try/finally around `chat`/`chat_stream`/`continue` handlers + `WB_STOP_AGENT` listener that calls `agent.abort()`. |
| `src/chrome/src/agent/agent.js` | New `_withIndicatorsHidden(tabId, fn)` helper. Wraps all 7 capture sites: `_captureAutoScreenshot` (×2 branches), `screenshot` tool (×2 branches), `done` verification, `full_page_screenshot`, and one tools.js fallback. |
| `README.md` | New bullet at the top of "What's New" 5.x. |

## Message protocol

Service worker → content script:
- `WB_SHOW_AGENT_INDICATORS` — agent run started; fade in border + button
- `WB_HIDE_AGENT_INDICATORS` — agent run ended; fade out + remove
- `WB_HIDE_FOR_TOOL_USE` — `display: none` everything before a screenshot
- `WB_SHOW_AFTER_TOOL_USE` — restore visibility after the screenshot lands

Content script → service worker:
- `WB_STOP_AGENT` — user clicked the on-page Stop button → `agent.abort(senderTabId)`

## Why this matters

Without `WB_HIDE_FOR_TOOL_USE`, the agent's pulsing border was baked into every screenshot it sent to the vision model. That's both ugly *and* a small token-budget tax (~50 tokens of "purple gradient on the edges" the model has to caption). The hide hook adds ~16ms paint frame per capture, which is invisible to the user but cleans up the captured pixels.

The `setTimeout(r, 16)` after `chrome.tabs.sendMessage` is doing this paint-flush job. Tested empirically: without the wait, ~1 in 5 captures still shows a faint glow at the edges; with it, none do.

## Test plan

- [ ] **Basic show/hide:** Open sidebar on a content page, send a short Act-mode task. Purple glow appears around the page, "Stop WebBrain" pill at the bottom. Both fade in ~300ms.
- [ ] **On-page Stop button:** While the agent is running, click "Stop WebBrain" on the page (without going back to the side panel). Agent aborts, indicator fades out.
- [ ] **Stop on a different tab:** Open sidebar on tab A, send a multi-step task that operates on tab A, switch to tab B mid-run. Switch back to A → border still pulsing. Click on-page Stop → run aborts.
- [ ] **Screenshots stay clean:** Enable Auto-screenshot mode → run a task that triggers a few state-changing tools. Open the trace viewer (Settings → Record traces → Open Traces page) and inspect the captured screenshots. None should have the purple glow visible along the edges.
- [ ] **Restricted pages:** Try on `chrome://settings` or `chrome-extension://...` (where the content script can't inject). The agent runs fine; no indicator (because no content script); no errors in service-worker console.
- [ ] **Multiple windows:** Open the sidebar in window A and B, run a task in each. Indicators show on the right tab in each window, independent.
- [ ] **Existing tests still green:** `npm test` → 41 passing, 0 failed.

## Caveats

- **Restricted pages have no indicator.** `chrome://`, `chrome-extension://`, `file://` (without explicit permission), and pre-existing tabs that loaded before the extension was reloaded won't have the content script. The agent still runs; it just doesn't show on-page UI. Sidebar stays the only stop control on those tabs.
- **The Stop button's z-index is `2147483647`.** Above any page modal. If a page genuinely needs to render UI above this, we'd see overlap — but anything above 2³¹−1 is invalid CSS, so we're at the ceiling.
- **No animation if `prefers-reduced-motion`.** Not honored yet. Cheap follow-up: gate the keyframes behind a media query.