### PR TITLE
plugin(lmstudio): web-fetching tools (fetch_url + research_url)

### DIFF
--- a/lmstudio-plugin/.gitignore
+++ b/lmstudio-plugin/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+dist/
+*.log
+.DS_Store

--- a/lmstudio-plugin/README.md
+++ b/lmstudio-plugin/README.md
@@ -102,20 +102,64 @@ register them via `client.plugins.setToolsProvider(...)`.
 
 ## Safety notes
 
-- **URL guard.** By default, requests to RFC1918 (`10.*`,
-  `172.16-31.*`, `192.168.*`), loopback (`127.*`, `::1`), link-local
-  (`169.254.*`, `fe80::/10`), unique-local IPv6 (`fc00::/7`),
-  cloud-metadata IPs, and `*.local` / `*.internal` / `*.lan` domains
-  are blocked. This keeps a confused or maliciously-prompted model
-  from being directed at AWS/GCP metadata endpoints or the user's
-  intranet. Set `allowPrivate: true` on a per-call basis to opt in
-  when you actually want the plugin to talk to localhost services.
+The plugin runs in the user's local Node process, so anything
+reachable from that process is reachable from the LLM. The defenses
+below are layered — each closes a class of bypass the previous one
+missed — but DNS rebinding is a known residual gap (see the bottom
+of this section).
+
+- **URL guard, structural (sync).** By default, requests to RFC1918
+  (`10.*`, `172.16-31.*`, `192.168.*`), loopback (`127.*`, `::1`),
+  link-local (`169.254.*`, `fe80::/10`), unique-local IPv6
+  (`fc00::/7`), cloud-metadata IPs, and `*.local` / `*.internal` /
+  `*.lan` / `*.home` / `*.corp` / `*.intranet` domains are blocked.
+  Non-`http(s)` protocols (`file://`, `ftp://`, `gopher://`,
+  `javascript:`) are blocked too.
+- **DNS resolution check.** Before each hop, the hostname is
+  resolved via `dns.lookup({all: true})` and every returned A/AAAA
+  address is checked against the same private ranges. This closes
+  the bypass where `attacker.example A 127.0.0.1` would otherwise
+  pass the syntactic check.
+- **Per-redirect re-validation.** Redirects are followed manually
+  (5 hops max). Each `Location` header runs through both the
+  structural and DNS-resolution checks before we follow it. A
+  public URL cannot 302 to `http://169.254.169.254/...` and have
+  the plugin happily fetch it.
+- **Cross-origin header stripping.** When a redirect crosses
+  origins, `Authorization`, `Cookie`, `Proxy-Authorization`, and
+  `Proxy-Authenticate` request headers are dropped. Same-origin
+  redirects keep the full header set. This stops credentials
+  passed via the per-call `headers` arg from leaking through an
+  open-redirect chain.
+- **Streaming response cap.** Bodies are read with a hard byte
+  ceiling (4 MB for `fetch_url`, 6 MB for `research_url`). Past
+  the cap, the underlying stream is cancelled and the result is
+  marked `truncated: true`. A malicious or misconfigured server
+  that sends a 1 GB response can no longer OOM the plugin.
 - **No `credentials: 'include'`.** Unlike the Chrome extension
-  (which forwards the user's browser cookies via `credentials:
-  'include'`), this plugin makes anonymous requests. The model
-  cannot reach pages behind your existing browser logins.
+  (which forwards the user's browser cookies), this plugin makes
+  anonymous requests. The model cannot reach pages behind your
+  existing browser logins.
 - **Timeouts.** Default 30 s, hard cap 120 s. Long-tail sites that
   hang forever won't lock up the model's tool-call loop.
+
+Set `allowPrivate: true` on a per-call basis to opt out of the URL
+guard + DNS check for that one call — useful when you actually want
+the plugin to talk to localhost services.
+
+### Known residual gap: DNS rebinding
+
+An attacker controlling a domain with TTL=0 can return a public IP
+when our guard runs `dns.lookup` and a private IP a moment later
+when `fetch` connects. Closing this fully requires pinning the
+resolved IP via a custom `undici` Agent's `connect.lookup` hook so
+the connection uses the exact address we validated. That's tracked
+as a follow-up — the current layered defense raises the bar enough
+to stop drive-by SSRF from open redirects and naive hostname tricks
+but is not a hardened sandbox. If you're running this on a cloud
+VM with sensitive instance-metadata endpoints, run it under a
+network policy that blocks 169.254.169.254 outbound rather than
+relying solely on this plugin's checks.
 
 ## File layout
 
@@ -132,7 +176,8 @@ lmstudio-plugin/
     │   └── researchUrl.ts← research_url implementation
     └── util/
         ├── htmlToText.ts ← regex HTML stripper
-        └── urlGuard.ts   ← private-IP / file:// blocker
+        ├── safeFetch.ts  ← redirect-revalidating wrapper + streaming cap
+        └── urlGuard.ts   ← private-IP / file:// blocker (sync structural check)
 ```
 
 `tools/` and `util/` are pure functions with no SDK dependency —

--- a/lmstudio-plugin/README.md
+++ b/lmstudio-plugin/README.md
@@ -1,0 +1,144 @@
+# WebBrain Web Tools — LM Studio plugin
+
+Two web-fetching tools that make any LM Studio model chat-aware of
+the live web:
+
+- **`fetch_url`** — raw HTTP fetch, content-type aware. JSON gets
+  pretty-printed, HTML gets stripped to readable text plus the page
+  `<title>`, plain text comes back verbatim, binary is summarised
+  rather than inlined as a data URL.
+- **`research_url`** — same fetcher, but biased toward "give me the
+  readable article body, not the navigation chrome". Extracts the
+  `<main>` / `<article>` region and culls header/nav/footer/aside
+  before stripping tags. Best for news pages, blog posts, GitHub
+  READMEs, Wikipedia, docs sites.
+
+Pure Node implementation — no browser, no Puppeteer, no Playwright.
+The actual fetching code is the same logic that ships in the
+[WebBrain](https://webbrain.one) Chrome / Firefox extension's
+`network-tools.js` module, ported to TypeScript with the chrome.*
+APIs replaced by Node `fetch`.
+
+## What this plugin can't do
+
+Listed up front so it doesn't bite you mid-session:
+
+- **No JavaScript rendering.** Single-page apps that hydrate from
+  JSON (Twitter, Notion, modern dashboards) will return near-empty
+  text. The plugin flags this case with `spaSuspected: true` in the
+  result so the model can give up gracefully instead of looping.
+- **No clicks, no typing, no screenshots.** Those need a real
+  browser. The WebBrain Chrome/Firefox extension does that; this
+  plugin only does the read-only subset.
+- **No cookies, no login.** Each fetch is anonymous from your IP
+  with no shared session — you can't research pages behind a
+  login through this tool.
+
+If you need any of those, install the WebBrain extension instead
+(or in addition) — it talks to the same model server but provides
+the full agent loop with browser interaction. See <https://webbrain.one>.
+
+## Install
+
+### Prerequisite
+
+LM Studio 0.3.x or newer (when the plugin SDK shipped) and Node 20+.
+
+### Build
+
+```bash
+cd lmstudio-plugin
+npm install
+npm run build
+```
+
+This compiles `src/*.ts` → `dist/*.js` via `tsc`.
+
+### Hook it into LM Studio
+
+LM Studio looks for plugins in `~/.lmstudio/plugins/<author>/<name>/`
+(macOS / Linux) or `%USERPROFILE%\.lmstudio\plugins\<author>\<name>\`
+(Windows). The fastest way to install during development:
+
+```bash
+# from the repo root
+lms plugin push ./lmstudio-plugin
+```
+
+Or symlink the folder into your plugins dir for hot-reload:
+
+```bash
+ln -s "$(pwd)/lmstudio-plugin" ~/.lmstudio/plugins/@webbrain/lmstudio-web-tools
+```
+
+Then restart LM Studio (or reload the plugins panel) and enable
+"WebBrain Web Tools" for the chat session you want to use it in.
+
+### Verify
+
+In any chat where the plugin is enabled, ask the model something
+that obviously needs a fresh fetch:
+
+> What's on the front page of news.ycombinator.com right now?
+
+Models that support tool-use will call `research_url` and come back
+with the live headlines.
+
+## Caveats and SDK drift
+
+The plugin SDK API surface (`@lmstudio/sdk`'s `tool()`, the
+`client.plugins.setToolsProvider(...)` registration, the manifest
+shape) is current as of this plugin's `version`. If LM Studio
+ships a breaking SDK change, you may need to adjust **only**
+`src/index.ts` — the actual tool logic in `src/tools/*.ts` and
+`src/util/*.ts` doesn't depend on the SDK.
+
+The fastest way to see current shape: run
+`lms create -t tools-provider` in a scratch directory once and
+diff the scaffolded `index.ts` against ours. The pattern is small:
+import `tool` and `LMStudioClient`, build tool objects with a
+`name` / `description` / `parameters` / `implementation`, and
+register them via `client.plugins.setToolsProvider(...)`.
+
+## Safety notes
+
+- **URL guard.** By default, requests to RFC1918 (`10.*`,
+  `172.16-31.*`, `192.168.*`), loopback (`127.*`, `::1`), link-local
+  (`169.254.*`, `fe80::/10`), unique-local IPv6 (`fc00::/7`),
+  cloud-metadata IPs, and `*.local` / `*.internal` / `*.lan` domains
+  are blocked. This keeps a confused or maliciously-prompted model
+  from being directed at AWS/GCP metadata endpoints or the user's
+  intranet. Set `allowPrivate: true` on a per-call basis to opt in
+  when you actually want the plugin to talk to localhost services.
+- **No `credentials: 'include'`.** Unlike the Chrome extension
+  (which forwards the user's browser cookies via `credentials:
+  'include'`), this plugin makes anonymous requests. The model
+  cannot reach pages behind your existing browser logins.
+- **Timeouts.** Default 30 s, hard cap 120 s. Long-tail sites that
+  hang forever won't lock up the model's tool-call loop.
+
+## File layout
+
+```
+lmstudio-plugin/
+├── README.md
+├── package.json          ← npm dependencies + build scripts
+├── tsconfig.json         ← strict-mode TS config, ES2022 / ESM
+├── manifest.json         ← LM Studio plugin metadata
+└── src/
+    ├── index.ts          ← plugin registration glue
+    ├── tools/
+    │   ├── fetchUrl.ts   ← fetch_url implementation
+    │   └── researchUrl.ts← research_url implementation
+    └── util/
+        ├── htmlToText.ts ← regex HTML stripper
+        └── urlGuard.ts   ← private-IP / file:// blocker
+```
+
+`tools/` and `util/` are pure functions with no SDK dependency —
+you can also `import` them from any other Node project that wants
+the same web-fetching primitives.
+
+## License
+
+MIT, same as the rest of WebBrain. See `../LICENSE`.

--- a/lmstudio-plugin/manifest.json
+++ b/lmstudio-plugin/manifest.json
@@ -1,0 +1,13 @@
+{
+  "owner": "webbrain",
+  "name": "web-tools",
+  "type": "plugin",
+  "runner": "node",
+  "tags": [
+    "tools-provider",
+    "web",
+    "fetch",
+    "research",
+    "browser-tools"
+  ]
+}

--- a/lmstudio-plugin/package-lock.json
+++ b/lmstudio-plugin/package-lock.json
@@ -1,0 +1,195 @@
+{
+  "name": "@webbrain/lmstudio-web-tools",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@webbrain/lmstudio-web-tools",
+      "version": "0.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "@lmstudio/sdk": "^1.0.0",
+        "zod": "^3.23.0"
+      },
+      "devDependencies": {
+        "@types/node": "^20.11.0",
+        "typescript": "^5.5.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@lmstudio/lms-isomorphic": {
+      "version": "0.4.6",
+      "resolved": "https://registry.npmjs.org/@lmstudio/lms-isomorphic/-/lms-isomorphic-0.4.6.tgz",
+      "integrity": "sha512-v0LIjXKnDe3Ff3XZO5eQjlVxTjleUHXaom14MV7QU9bvwaoo3l5p71+xJ3mmSaqZq370CQ6pTKCn1Bb7Jf+VwQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "ws": "^8.16.0"
+      }
+    },
+    "node_modules/@lmstudio/sdk": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@lmstudio/sdk/-/sdk-1.5.0.tgz",
+      "integrity": "sha512-fdY12x4hb14PEjYijh7YeCqT1ZDY5Ok6VR4l4+E/dI+F6NW8oB+P83Sxed5vqE4XgTzbgyPuSR2ZbMNxxF+6jA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@lmstudio/lms-isomorphic": "^0.4.6",
+        "chalk": "^4.1.2",
+        "jsonschema": "^1.5.0",
+        "zod": "^3.22.4",
+        "zod-to-json-schema": "^3.22.5"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "20.19.39",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.39.tgz",
+      "integrity": "sha512-orrrD74MBUyK8jOAD/r0+lfa1I2MO6I+vAkmAWzMYbCcgrN4lCrmK52gRFQq/JRxfYPfonkr4b0jcY7Olqdqbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "license": "MIT"
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jsonschema": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/jsonschema/-/jsonschema-1.5.0.tgz",
+      "integrity": "sha512-K+A9hhqbn0f3pJX17Q/7H6yQfD/5OXgdrR5UE12gMXCiN9D5Xq2o5mddV2QEcX/bjla99ASsAAQUyMCCRWAEhw==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/ws": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
+      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25.28 || ^4"
+      }
+    }
+  }
+}

--- a/lmstudio-plugin/package.json
+++ b/lmstudio-plugin/package.json
@@ -1,0 +1,47 @@
+{
+  "name": "@webbrain/lmstudio-web-tools",
+  "displayName": "WebBrain Web Tools",
+  "description": "Web fetching + research tools for LM Studio. Adds fetch_url (raw HTTP, content-type aware) and research_url (extracts the readable article body) to any chat. Pure Node — no browser dependency. Ports the same network-tools the WebBrain Chrome/Firefox extension uses.",
+  "version": "0.1.0",
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "license": "MIT",
+  "homepage": "https://webbrain.one",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/esokullu/webbrain.git",
+    "directory": "lmstudio-plugin"
+  },
+  "scripts": {
+    "build": "tsc",
+    "dev": "tsc --watch",
+    "clean": "rm -rf dist"
+  },
+  "keywords": [
+    "lmstudio",
+    "lmstudio-plugin",
+    "tools-provider",
+    "web",
+    "fetch",
+    "research",
+    "browser-tools",
+    "webbrain"
+  ],
+  "dependencies": {
+    "@lmstudio/sdk": "^1.0.0",
+    "zod": "^3.23.0"
+  },
+  "devDependencies": {
+    "typescript": "^5.5.0",
+    "@types/node": "^20.11.0"
+  },
+  "files": [
+    "dist",
+    "manifest.json",
+    "README.md"
+  ],
+  "engines": {
+    "node": ">=20.0.0"
+  }
+}

--- a/lmstudio-plugin/src/index.ts
+++ b/lmstudio-plugin/src/index.ts
@@ -1,0 +1,129 @@
+/**
+ * LM Studio plugin entry — registers two web-fetching tools with the
+ * host's tool-provider system.
+ *
+ * Tool implementations live in `./tools/*.ts` as pure functions so
+ * they stay portable across SDK API changes. Only the `main(ctx)`
+ * glue here couples to `@lmstudio/sdk`. If a future SDK release
+ * shifts the registration shape (the SDK is still marked
+ * `@experimental` for plugin support as of 1.5.x), update this
+ * file's contents — `tools/*` and `util/*` should keep compiling
+ * unchanged.
+ *
+ * The pattern matches the `PluginContext` interface exported by
+ * `@lmstudio/sdk`: a chained builder where you call
+ * `ctx.withToolsProvider(...)` (and friends) once per plugin
+ * capability you want to register. The host calls `main(ctx)` once
+ * at plugin load time.
+ */
+
+import { tool } from "@lmstudio/sdk";
+import type { PluginContext } from "@lmstudio/sdk";
+import { z } from "zod";
+import { fetchUrl } from "./tools/fetchUrl.js";
+import { researchUrl } from "./tools/researchUrl.js";
+
+const fetchUrlTool = tool({
+  name: "fetch_url",
+  description:
+    "Fetch a URL and return its content. Auto-detects content type: " +
+    "JSON is pretty-printed, HTML is stripped to readable text with the " +
+    "page's <title>, plain text is returned verbatim, binary is summarised. " +
+    "Use this when the user gives you a specific URL or when you need raw " +
+    "content from a known endpoint. For 'find me information about X', " +
+    "prefer research_url instead — it pulls the article body, not the " +
+    "navigation chrome.",
+  parameters: {
+    url: z
+      .string()
+      .url()
+      .describe("Absolute http(s) URL to fetch."),
+    method: z
+      .string()
+      .optional()
+      .describe("HTTP method. Defaults to GET."),
+    headers: z
+      .record(z.string(), z.string())
+      .optional()
+      .describe("Extra request headers."),
+    body: z
+      .string()
+      .optional()
+      .describe("Request body for non-GET methods."),
+    timeout: z
+      .number()
+      .optional()
+      .describe("Request timeout in ms (default 30000, max 120000)."),
+    allowPrivate: z
+      .boolean()
+      .optional()
+      .describe(
+        "Allow targets that resolve to RFC1918 / loopback / link-local " +
+          "addresses (localhost, 192.168.*, 10.*, 172.16-31.*, " +
+          "169.254.*, fe80::*, fc00::/7). Off by default to keep the " +
+          "model out of cloud-metadata services and the user's intranet.",
+      ),
+  },
+  implementation: async ({ url, method, headers, body, timeout, allowPrivate }) => {
+    const result = await fetchUrl({
+      url,
+      method,
+      headers,
+      body,
+      timeout,
+      allowPrivate,
+    });
+    // The implementation contract returns whatever string the LLM
+    // should see in the tool result. JSON-stringify so the model gets
+    // stable, parseable structure rather than a `[object Object]`.
+    return JSON.stringify(result, null, 2);
+  },
+});
+
+const researchUrlTool = tool({
+  name: "research_url",
+  description:
+    "Fetch a URL and return its readable article body, biased toward " +
+    "the <main>/<article> region with header/nav/footer/aside removed. " +
+    "Best for 'tell me what this page says' on news sites, blog posts, " +
+    "GitHub READMEs, Wikipedia, docs sites. Pure HTTP, no JS execution: " +
+    "single-page apps that hydrate from JSON will return near-empty text — " +
+    "if you see {spaSuspected:true} in the result, the page needs a real " +
+    "browser to render and this plugin can't help.",
+  parameters: {
+    url: z
+      .string()
+      .url()
+      .describe("Absolute http(s) URL to research."),
+    timeout: z
+      .number()
+      .optional()
+      .describe("Request timeout in ms (default 30000, max 120000)."),
+    allowPrivate: z
+      .boolean()
+      .optional()
+      .describe(
+        "Allow targets that resolve to RFC1918 / loopback / link-local. " +
+          "Off by default.",
+      ),
+  },
+  implementation: async ({ url, timeout, allowPrivate }) => {
+    const result = await researchUrl({ url, timeout, allowPrivate });
+    return JSON.stringify(result, null, 2);
+  },
+});
+
+/**
+ * Plugin entry point. LM Studio's plugin runner calls this once at
+ * load time with a `PluginContext` builder. We register both tools
+ * via the chained `withToolsProvider(...)` API; the callback is
+ * invoked any time the host needs a fresh list of tools (e.g. when
+ * settings change).
+ */
+export async function main(ctx: PluginContext): Promise<void> {
+  ctx.withToolsProvider(async () => [fetchUrlTool, researchUrlTool]);
+}
+
+// Some plugin loaders look at the default export instead of `main`.
+// Re-export so either entry path works.
+export default main;

--- a/lmstudio-plugin/src/tools/fetchUrl.ts
+++ b/lmstudio-plugin/src/tools/fetchUrl.ts
@@ -13,12 +13,19 @@
  *      default. Opt out per-call with `allowPrivate: true`.
  */
 
-import { assertSafeUrl } from "../util/urlGuard.js";
 import { htmlToText } from "../util/htmlToText.js";
+import { safeFetch, readBodyCapped } from "../util/safeFetch.js";
 
 const FETCH_TEXT_LIMIT = 8000;
 const FETCH_JSON_LIMIT = 16000;
 const DEFAULT_TIMEOUT_MS = 30_000;
+// Hard byte ceiling for the streamed body. Sized to comfortably fit
+// the largest "useful" response while still bounding worst-case memory
+// use of the plugin process. We slice down to FETCH_TEXT_LIMIT /
+// FETCH_JSON_LIMIT for the model after this — the body cap exists to
+// stop an attacker from streaming a gigabyte of garbage into our
+// buffer before we get a chance to truncate.
+const MAX_RESPONSE_BYTES = 4 * 1024 * 1024; // 4 MB
 
 export interface FetchUrlArgs {
   url: string;
@@ -68,13 +75,6 @@ export interface FetchUrlResult {
 export async function fetchUrl(args: FetchUrlArgs): Promise<FetchUrlResult> {
   if (!args?.url) return { success: false, error: "url is required" };
 
-  let parsed: URL;
-  try {
-    parsed = assertSafeUrl(args.url, { allowPrivate: !!args.allowPrivate });
-  } catch (e) {
-    return { success: false, error: (e as Error).message };
-  }
-
   const timeoutMs = Math.min(
     Math.max(args.timeout ?? DEFAULT_TIMEOUT_MS, 1000),
     120_000,
@@ -83,12 +83,16 @@ export async function fetchUrl(args: FetchUrlArgs): Promise<FetchUrlResult> {
   const t = setTimeout(() => controller.abort(), timeoutMs);
 
   try {
-    const res = await fetch(parsed.toString(), {
+    // safeFetch handles: URL guard → DNS check → manual redirect loop
+    // (revalidating each Location through both checks) → cross-origin
+    // header stripping. If any hop is a private IP / hostname, this
+    // throws synchronously inside the await.
+    const res = await safeFetch(args.url, {
       method: args.method || "GET",
       headers: args.headers || {},
       body: args.body,
-      redirect: "follow",
       signal: controller.signal,
+      allowPrivate: !!args.allowPrivate,
     });
     const contentType = (res.headers.get("content-type") || "").toLowerCase();
     const status = res.status;
@@ -96,7 +100,7 @@ export async function fetchUrl(args: FetchUrlArgs): Promise<FetchUrlResult> {
 
     // JSON: pretty-print, cap separately (JSON is denser than prose).
     if (contentType.includes("json")) {
-      const text = await res.text();
+      const { text, truncated: bodyTruncated } = await readBodyCapped(res, MAX_RESPONSE_BYTES);
       let pretty = text;
       try {
         pretty = JSON.stringify(JSON.parse(text), null, 2);
@@ -109,14 +113,14 @@ export async function fetchUrl(args: FetchUrlArgs): Promise<FetchUrlResult> {
         contentType,
         url: finalUrl,
         json: pretty.slice(0, FETCH_JSON_LIMIT),
-        truncated: pretty.length > FETCH_JSON_LIMIT,
+        truncated: pretty.length > FETCH_JSON_LIMIT || bodyTruncated,
         originalLength: pretty.length,
       };
     }
 
     // HTML: strip to readable text and capture <title>.
     if (contentType.includes("html") || contentType.includes("xhtml")) {
-      const html = await res.text();
+      const { text: html, truncated: bodyTruncated } = await readBodyCapped(res, MAX_RESPONSE_BYTES);
       const { title, text } = htmlToText(html);
       return {
         success: true,
@@ -125,7 +129,7 @@ export async function fetchUrl(args: FetchUrlArgs): Promise<FetchUrlResult> {
         url: finalUrl,
         title,
         text: text.slice(0, FETCH_TEXT_LIMIT),
-        truncated: text.length > FETCH_TEXT_LIMIT,
+        truncated: text.length > FETCH_TEXT_LIMIT || bodyTruncated,
         originalLength: text.length,
       };
     }
@@ -139,14 +143,14 @@ export async function fetchUrl(args: FetchUrlArgs): Promise<FetchUrlResult> {
       contentType.includes("markdown") ||
       contentType === ""
     ) {
-      const text = await res.text();
+      const { text, truncated: bodyTruncated } = await readBodyCapped(res, MAX_RESPONSE_BYTES);
       return {
         success: true,
         status,
         contentType,
         url: finalUrl,
         text: text.slice(0, FETCH_TEXT_LIMIT),
-        truncated: text.length > FETCH_TEXT_LIMIT,
+        truncated: text.length > FETCH_TEXT_LIMIT || bodyTruncated,
         originalLength: text.length,
       };
     }

--- a/lmstudio-plugin/src/tools/fetchUrl.ts
+++ b/lmstudio-plugin/src/tools/fetchUrl.ts
@@ -1,0 +1,174 @@
+/**
+ * fetch_url tool — raw HTTP fetch with content-type-aware response.
+ *
+ * Ported from src/chrome/src/network/network-tools.js but with two
+ * adaptations for LM Studio (Node host):
+ *   1. No `credentials: 'include'` — we have no browser cookie jar
+ *      to forward, and silently sending nothing is more honest than
+ *      sending an empty cookie header.
+ *   2. URL safety guard layered on top — an LLM that decides to GET
+ *      http://169.254.169.254/latest/meta-data/ would happily exfil
+ *      cloud-credential blobs from the user's machine; the guard
+ *      blocks file://, RFC1918, link-local, and ULA targets by
+ *      default. Opt out per-call with `allowPrivate: true`.
+ */
+
+import { assertSafeUrl } from "../util/urlGuard.js";
+import { htmlToText } from "../util/htmlToText.js";
+
+const FETCH_TEXT_LIMIT = 8000;
+const FETCH_JSON_LIMIT = 16000;
+const DEFAULT_TIMEOUT_MS = 30_000;
+
+export interface FetchUrlArgs {
+  url: string;
+  /** GET (default), POST, PUT, PATCH, DELETE, HEAD, OPTIONS. */
+  method?: string;
+  /** Extra headers. User-Agent is set by Node automatically. */
+  headers?: Record<string, string>;
+  /** Request body for non-GET methods. */
+  body?: string;
+  /** ms; default 30 000, cap 120 000. */
+  timeout?: number;
+  /**
+   * Allow URLs that target RFC1918 / loopback / link-local addresses.
+   * Off by default to keep the LLM out of cloud-metadata services and
+   * the user's intranet. Set to true only when you actually want the
+   * plugin to talk to localhost/private services.
+   */
+  allowPrivate?: boolean;
+}
+
+export interface FetchUrlResult {
+  success: boolean;
+  /** HTTP status code, when the request reached a server. */
+  status?: number;
+  /** Lower-cased content-type header. */
+  contentType?: string;
+  /** Final URL after any redirects. */
+  url?: string;
+  /** Document title, when the response was HTML. */
+  title?: string;
+  /** Extracted text (HTML/text responses) — capped at FETCH_TEXT_LIMIT. */
+  text?: string;
+  /** Pretty-printed JSON (when the response was application/json). */
+  json?: string;
+  /** Set when text/json was clipped to a limit. */
+  truncated?: boolean;
+  /** Pre-clip length, so the caller knows how much they didn't get. */
+  originalLength?: number;
+  /** For binary responses we don't inline — bytes from Content-Length. */
+  sizeBytes?: number | null;
+  /** Friendly note for binary responses we declined to inline. */
+  note?: string;
+  /** Failure case. */
+  error?: string;
+}
+
+export async function fetchUrl(args: FetchUrlArgs): Promise<FetchUrlResult> {
+  if (!args?.url) return { success: false, error: "url is required" };
+
+  let parsed: URL;
+  try {
+    parsed = assertSafeUrl(args.url, { allowPrivate: !!args.allowPrivate });
+  } catch (e) {
+    return { success: false, error: (e as Error).message };
+  }
+
+  const timeoutMs = Math.min(
+    Math.max(args.timeout ?? DEFAULT_TIMEOUT_MS, 1000),
+    120_000,
+  );
+  const controller = new AbortController();
+  const t = setTimeout(() => controller.abort(), timeoutMs);
+
+  try {
+    const res = await fetch(parsed.toString(), {
+      method: args.method || "GET",
+      headers: args.headers || {},
+      body: args.body,
+      redirect: "follow",
+      signal: controller.signal,
+    });
+    const contentType = (res.headers.get("content-type") || "").toLowerCase();
+    const status = res.status;
+    const finalUrl = res.url;
+
+    // JSON: pretty-print, cap separately (JSON is denser than prose).
+    if (contentType.includes("json")) {
+      const text = await res.text();
+      let pretty = text;
+      try {
+        pretty = JSON.stringify(JSON.parse(text), null, 2);
+      } catch {
+        /* leave as-is if it's not valid JSON */
+      }
+      return {
+        success: true,
+        status,
+        contentType,
+        url: finalUrl,
+        json: pretty.slice(0, FETCH_JSON_LIMIT),
+        truncated: pretty.length > FETCH_JSON_LIMIT,
+        originalLength: pretty.length,
+      };
+    }
+
+    // HTML: strip to readable text and capture <title>.
+    if (contentType.includes("html") || contentType.includes("xhtml")) {
+      const html = await res.text();
+      const { title, text } = htmlToText(html);
+      return {
+        success: true,
+        status,
+        contentType,
+        url: finalUrl,
+        title,
+        text: text.slice(0, FETCH_TEXT_LIMIT),
+        truncated: text.length > FETCH_TEXT_LIMIT,
+        originalLength: text.length,
+      };
+    }
+
+    // Plain text family: return verbatim, just trimmed to the cap.
+    if (
+      contentType.startsWith("text/") ||
+      contentType.includes("xml") ||
+      contentType.includes("javascript") ||
+      contentType.includes("csv") ||
+      contentType.includes("markdown") ||
+      contentType === ""
+    ) {
+      const text = await res.text();
+      return {
+        success: true,
+        status,
+        contentType,
+        url: finalUrl,
+        text: text.slice(0, FETCH_TEXT_LIMIT),
+        truncated: text.length > FETCH_TEXT_LIMIT,
+        originalLength: text.length,
+      };
+    }
+
+    // Binary — don't inline (would bloat the conversation with garbage).
+    const len = res.headers.get("content-length");
+    return {
+      success: true,
+      status,
+      contentType,
+      url: finalUrl,
+      note: "Binary content not inlined. Content-Type was " +
+        contentType + ".",
+      sizeBytes: len ? parseInt(len, 10) : null,
+    };
+  } catch (e) {
+    const err = e as Error;
+    if (err.name === "AbortError") {
+      return { success: false, error: `Fetch timed out after ${timeoutMs} ms` };
+    }
+    return { success: false, error: `Fetch failed: ${err.message}` };
+  } finally {
+    clearTimeout(t);
+  }
+}

--- a/lmstudio-plugin/src/tools/researchUrl.ts
+++ b/lmstudio-plugin/src/tools/researchUrl.ts
@@ -29,11 +29,16 @@
  * page that hydrates from JSON, you'll see a near-empty result.
  */
 
-import { assertSafeUrl } from "../util/urlGuard.js";
 import { htmlToText } from "../util/htmlToText.js";
+import { safeFetch, readBodyCapped } from "../util/safeFetch.js";
 
 const RESEARCH_TEXT_LIMIT = 16_000;
 const DEFAULT_TIMEOUT_MS = 30_000;
+// Hard byte ceiling for the streamed body. Slightly larger than
+// fetchUrl's 4 MB because research_url is biased toward whole HTML
+// articles (which can run long), but small enough to bound worst-case
+// memory if a server replies with a giant SPA bundle.
+const MAX_RESPONSE_BYTES = 6 * 1024 * 1024; // 6 MB
 
 export interface ResearchUrlArgs {
   url: string;
@@ -133,13 +138,6 @@ function extractLinks(html: string, base: string): ResearchUrlLink[] {
 export async function researchUrl(args: ResearchUrlArgs): Promise<ResearchUrlResult> {
   if (!args?.url) return { success: false, error: "url is required" };
 
-  let parsed: URL;
-  try {
-    parsed = assertSafeUrl(args.url, { allowPrivate: !!args.allowPrivate });
-  } catch (e) {
-    return { success: false, error: (e as Error).message };
-  }
-
   const timeoutMs = Math.min(
     Math.max(args.timeout ?? DEFAULT_TIMEOUT_MS, 1000),
     120_000,
@@ -148,13 +146,15 @@ export async function researchUrl(args: ResearchUrlArgs): Promise<ResearchUrlRes
   const t = setTimeout(() => controller.abort(), timeoutMs);
 
   try {
-    const res = await fetch(parsed.toString(), {
+    // safeFetch handles URL guard + DNS check + per-redirect re-validation
+    // and cross-origin header stripping. See safeFetch.ts for design.
+    const res = await safeFetch(args.url, {
       method: "GET",
-      redirect: "follow",
       signal: controller.signal,
+      allowPrivate: !!args.allowPrivate,
       headers: {
         // Some sites gate on User-Agent. Pretend to be a recent
-        // desktop Chrome — same MO as curl/wget defaults.
+        // desktop Firefox — same MO as curl/wget defaults.
         "User-Agent":
           "Mozilla/5.0 (LMStudio WebBrain Tools) Gecko/20100101 Firefox/142.0",
       },
@@ -178,7 +178,7 @@ export async function researchUrl(args: ResearchUrlArgs): Promise<ResearchUrlRes
       };
     }
 
-    const html = await res.text();
+    const { text: html, truncated: bodyTruncated } = await readBodyCapped(res, MAX_RESPONSE_BYTES);
     const finalUrl = res.url;
 
     // Title comes from the full document, not the cropped region —
@@ -200,7 +200,7 @@ export async function researchUrl(args: ResearchUrlArgs): Promise<ResearchUrlRes
       url: finalUrl,
       title,
       text: text.slice(0, RESEARCH_TEXT_LIMIT),
-      truncated: text.length > RESEARCH_TEXT_LIMIT,
+      truncated: text.length > RESEARCH_TEXT_LIMIT || bodyTruncated,
       originalLength: text.length,
       links,
       ...(spaSuspected ? { spaSuspected: true } : {}),

--- a/lmstudio-plugin/src/tools/researchUrl.ts
+++ b/lmstudio-plugin/src/tools/researchUrl.ts
@@ -1,0 +1,217 @@
+/**
+ * research_url tool — like fetch_url, but biased toward "give me the
+ * readable article body, not the navigation chrome".
+ *
+ * The Chrome extension version of this tool spawns a hidden tab and
+ * lets the page's JavaScript run, then walks the DOM picking out
+ * <main> / <article> and culling header/nav/footer/aside. We can't
+ * do that inside an LM Studio plugin (Node host, no browser), so we
+ * fall back to a fetch-based heuristic:
+ *
+ *   1. Fetch the URL plain (no JS execution — SPAs that rely on
+ *      client-side rendering won't return useful content here).
+ *   2. Pluck the chunk between the first <main> / <article> /
+ *      role="main" element's open tag and its close, if present.
+ *   3. Otherwise fall back to <body>.
+ *   4. Drop noisy children (<header>, <nav>, <footer>, <aside>,
+ *      common nav/sidebar class names) before stripping tags.
+ *   5. Run the result through htmlToText to flatten to prose.
+ *
+ * Limitations vs the Chrome version (documented up front):
+ *   - SPAs that render content via JavaScript appear empty here.
+ *   - The "skip if it looks like a paywall/cookie banner" logic
+ *     in the Chrome version isn't ported — we just return whatever
+ *     the page sent.
+ *   - Outbound link extraction is best-effort regex, not real DOM.
+ *
+ * For most static news pages, blog posts, GitHub READMEs, Wikipedia,
+ * docs sites, this is plenty. For a Twitter timeline or a Notion
+ * page that hydrates from JSON, you'll see a near-empty result.
+ */
+
+import { assertSafeUrl } from "../util/urlGuard.js";
+import { htmlToText } from "../util/htmlToText.js";
+
+const RESEARCH_TEXT_LIMIT = 16_000;
+const DEFAULT_TIMEOUT_MS = 30_000;
+
+export interface ResearchUrlArgs {
+  url: string;
+  /** ms; default 30 000, cap 120 000. */
+  timeout?: number;
+  /** Allow RFC1918 / loopback targets. Off by default. */
+  allowPrivate?: boolean;
+}
+
+export interface ResearchUrlLink {
+  text: string;
+  href: string;
+}
+
+export interface ResearchUrlResult {
+  success: boolean;
+  url?: string;
+  title?: string;
+  text?: string;
+  truncated?: boolean;
+  originalLength?: number;
+  /** Up to 30 outbound links extracted by regex from the source HTML. */
+  links?: ResearchUrlLink[];
+  error?: string;
+  /** True if the fetched HTML looked SPA-shaped (almost no body content). */
+  spaSuspected?: boolean;
+}
+
+/**
+ * Find the "main content" region in raw HTML using a few common
+ * containers in priority order. Returns the inner HTML of whichever
+ * container matched, or the original string if none did.
+ */
+function extractMainRegion(html: string): string {
+  const containers = [
+    /<main\b[^>]*>([\s\S]*?)<\/main>/i,
+    /<article\b[^>]*>([\s\S]*?)<\/article>/i,
+    /<[^>]+role=["']main["'][^>]*>([\s\S]*?)<\/[^>]+>/i,
+    /<body\b[^>]*>([\s\S]*?)<\/body>/i,
+  ];
+  for (const re of containers) {
+    const m = html.match(re);
+    if (m && m[1] && m[1].trim().length > 100) return m[1];
+  }
+  return html;
+}
+
+/**
+ * Cull header/nav/footer/aside blocks from a chunk of HTML before
+ * we tag-strip it. The patterns are deliberately permissive —
+ * better to drop a few too many ad/nav blocks than to leak them
+ * into the readable text.
+ */
+function dropChrome(html: string): string {
+  const patterns = [
+    /<header\b[^<]*(?:(?!<\/header>)<[^<]*)*<\/header>/gi,
+    /<nav\b[^<]*(?:(?!<\/nav>)<[^<]*)*<\/nav>/gi,
+    /<footer\b[^<]*(?:(?!<\/footer>)<[^<]*)*<\/footer>/gi,
+    /<aside\b[^<]*(?:(?!<\/aside>)<[^<]*)*<\/aside>/gi,
+    /<[^>]+role=["'](?:navigation|banner|contentinfo|complementary)["'][\s\S]*?<\/[^>]+>/gi,
+  ];
+  let out = html;
+  for (const re of patterns) out = out.replace(re, " ");
+  return out;
+}
+
+/**
+ * Extract outbound links via regex. Real DOM would be better, but
+ * we've already accepted the "regex parsing is good enough for
+ * non-SPA pages" tradeoff in the rest of this file.
+ */
+function extractLinks(html: string, base: string): ResearchUrlLink[] {
+  const out: ResearchUrlLink[] = [];
+  const re = /<a\b[^>]*href=["']([^"']+)["'][^>]*>([\s\S]*?)<\/a>/gi;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(html)) !== null && out.length < 30) {
+    const rawHref = m[1];
+    if (!rawHref || rawHref.startsWith("#") || rawHref.startsWith("javascript:")) continue;
+    let absolute: string;
+    try {
+      absolute = new URL(rawHref, base).toString();
+    } catch {
+      continue;
+    }
+    // Inner text via regex tag-strip
+    const text = (m[2] ?? "")
+      .replace(/<[^>]+>/g, "")
+      .replace(/\s+/g, " ")
+      .trim()
+      .slice(0, 80);
+    if (!text) continue;
+    out.push({ text, href: absolute });
+  }
+  return out;
+}
+
+export async function researchUrl(args: ResearchUrlArgs): Promise<ResearchUrlResult> {
+  if (!args?.url) return { success: false, error: "url is required" };
+
+  let parsed: URL;
+  try {
+    parsed = assertSafeUrl(args.url, { allowPrivate: !!args.allowPrivate });
+  } catch (e) {
+    return { success: false, error: (e as Error).message };
+  }
+
+  const timeoutMs = Math.min(
+    Math.max(args.timeout ?? DEFAULT_TIMEOUT_MS, 1000),
+    120_000,
+  );
+  const controller = new AbortController();
+  const t = setTimeout(() => controller.abort(), timeoutMs);
+
+  try {
+    const res = await fetch(parsed.toString(), {
+      method: "GET",
+      redirect: "follow",
+      signal: controller.signal,
+      headers: {
+        // Some sites gate on User-Agent. Pretend to be a recent
+        // desktop Chrome — same MO as curl/wget defaults.
+        "User-Agent":
+          "Mozilla/5.0 (LMStudio WebBrain Tools) Gecko/20100101 Firefox/142.0",
+      },
+    });
+    if (!res.ok) {
+      return {
+        success: false,
+        error: `HTTP ${res.status} ${res.statusText} for ${res.url}`,
+      };
+    }
+    const contentType = (res.headers.get("content-type") || "").toLowerCase();
+    if (
+      !contentType.includes("html") &&
+      !contentType.includes("xhtml") &&
+      !contentType.startsWith("text/")
+    ) {
+      return {
+        success: false,
+        error:
+          `research_url expected HTML/text content; got ${contentType || "(unknown)"}. Use fetch_url for JSON / binary.`,
+      };
+    }
+
+    const html = await res.text();
+    const finalUrl = res.url;
+
+    // Title comes from the full document, not the cropped region —
+    // <title> lives in <head>.
+    const titleMatch = html.match(/<title[^>]*>([\s\S]*?)<\/title>/i);
+    const title = titleMatch?.[1] ? titleMatch[1].replace(/\s+/g, " ").trim() : "";
+
+    const mainHtml = dropChrome(extractMainRegion(html));
+    const { text } = htmlToText(mainHtml);
+
+    // Heuristic: pages whose body strips to <300 chars after we've
+    // pulled <main> / <article> are almost certainly SPA shells.
+    const spaSuspected = text.length < 300 && html.length > 5000;
+
+    const links = extractLinks(html, finalUrl);
+
+    return {
+      success: true,
+      url: finalUrl,
+      title,
+      text: text.slice(0, RESEARCH_TEXT_LIMIT),
+      truncated: text.length > RESEARCH_TEXT_LIMIT,
+      originalLength: text.length,
+      links,
+      ...(spaSuspected ? { spaSuspected: true } : {}),
+    };
+  } catch (e) {
+    const err = e as Error;
+    if (err.name === "AbortError") {
+      return { success: false, error: `research_url timed out after ${timeoutMs} ms` };
+    }
+    return { success: false, error: `research_url failed: ${err.message}` };
+  } finally {
+    clearTimeout(t);
+  }
+}

--- a/lmstudio-plugin/src/util/htmlToText.ts
+++ b/lmstudio-plugin/src/util/htmlToText.ts
@@ -1,0 +1,92 @@
+/**
+ * Pure-TS HTML → readable text. Ported from
+ * src/chrome/src/network/network-tools.js, no DOM / DOMParser
+ * dependency so it runs in any Node context (LM Studio's plugin host
+ * is Node, not a browser).
+ *
+ * The conversion is regex-based and deliberately conservative:
+ *   - drops <script>, <style>, <noscript>, <svg>, comments outright
+ *   - inserts \n at the close of common block elements so paragraphs
+ *     don't merge into a single line
+ *   - decodes the most common named entities + numeric escapes
+ *   - collapses runs of whitespace, preserves paragraph breaks
+ *
+ * Good enough for feeding an LLM the readable content of a page.
+ * Won't cope with JS-rendered SPAs (the page's HTML doesn't contain
+ * the rendered text) — that's a documented limitation of this tool.
+ */
+
+const HTML_ENTITIES: Record<string, string> = {
+  "&amp;": "&",
+  "&lt;": "<",
+  "&gt;": ">",
+  "&quot;": '"',
+  "&#39;": "'",
+  "&apos;": "'",
+  "&nbsp;": " ",
+  "&#160;": " ",
+  "&hellip;": "…",
+  "&mdash;": "—",
+  "&ndash;": "–",
+  "&laquo;": "«",
+  "&raquo;": "»",
+  "&copy;": "©",
+  "&reg;": "®",
+  "&trade;": "™",
+};
+
+function decodeEntities(s: string): string {
+  return s
+    .replace(/&[a-z]+;|&#\d+;/gi, (m) => HTML_ENTITIES[m] ?? m)
+    .replace(/&#(\d+);/g, (_, n) => String.fromCharCode(parseInt(n ?? "0", 10)));
+}
+
+export interface HtmlToTextResult {
+  /** Document title (from <title>), or empty string if none. */
+  title: string;
+  /** Cleaned, whitespace-collapsed body text. */
+  text: string;
+}
+
+/**
+ * Convert an HTML string to a `{title, text}` object. The output is
+ * intended for human/LLM consumption, NOT for round-tripping back to
+ * HTML — semantic markup (lists, headings) gets flattened to plain
+ * paragraphs separated by blank lines.
+ */
+export function htmlToText(html: string): HtmlToTextResult {
+  if (!html) return { title: "", text: "" };
+
+  let s = html;
+
+  // Title — pluck before stripping tags.
+  const titleMatch = s.match(/<title[^>]*>([\s\S]*?)<\/title>/i);
+  const title = titleMatch?.[1] ? decodeEntities(titleMatch[1]).trim() : "";
+
+  // Drop noise: scripts, styles, SVG (decorative), comments.
+  s = s.replace(/<script\b[^<]*(?:(?!<\/script>)<[^<]*)*<\/script>/gi, " ");
+  s = s.replace(/<style\b[^<]*(?:(?!<\/style>)<[^<]*)*<\/style>/gi, " ");
+  s = s.replace(/<noscript\b[^<]*(?:(?!<\/noscript>)<[^<]*)*<\/noscript>/gi, " ");
+  s = s.replace(/<svg\b[^<]*(?:(?!<\/svg>)<[^<]*)*<\/svg>/gi, " ");
+  s = s.replace(/<!--[\s\S]*?-->/g, " ");
+
+  // Block-element close → newline so paragraphs don't run together.
+  s = s.replace(
+    /<\/(p|div|h[1-6]|li|tr|br|article|section|header|footer)[^>]*>/gi,
+    "\n",
+  );
+  s = s.replace(/<br\s*\/?>/gi, "\n");
+
+  // Remove every other tag entirely.
+  s = s.replace(/<[^>]+>/g, "");
+  s = decodeEntities(s);
+
+  // Collapse runs of whitespace; keep paragraph breaks (≤2 newlines).
+  s = s
+    .replace(/[ \t]+/g, " ")
+    .replace(/\n\s+/g, "\n")
+    .replace(/\n{3,}/g, "\n\n")
+    .trim();
+
+  return { title, text: s };
+}

--- a/lmstudio-plugin/src/util/safeFetch.ts
+++ b/lmstudio-plugin/src/util/safeFetch.ts
@@ -1,0 +1,269 @@
+/**
+ * Safe fetch wrapper for the LM Studio plugin.
+ *
+ * Wraps the native `fetch` to add three security guarantees that are
+ * easy to get wrong with the bare API:
+ *
+ *   1. Every redirect target is re-validated through the URL guard,
+ *      so a public URL can't 30x to `http://169.254.169.254/...` (cloud
+ *      metadata) or any RFC1918 / loopback / link-local target. The
+ *      bare `fetch(..., { redirect: "follow" })` follows redirects
+ *      transparently without the caller getting a chance to intervene.
+ *
+ *   2. Hostnames are resolved at the start of each hop and every
+ *      returned address is checked against private-IP ranges. This
+ *      closes the simple bypass where `attacker.example A 127.0.0.1`
+ *      passes a syntactic hostname check but resolves to localhost.
+ *      It does NOT fully close DNS-rebinding (TTL=0 returning a
+ *      different IP between guard and connect) — see the urlGuard
+ *      header comment for the residual window.
+ *
+ *   3. Response bodies are read with a hard byte cap so a malicious
+ *      or accidental gigabyte response can't OOM the plugin. Chunks
+ *      past the cap are dropped; the caller gets `truncated:true` and
+ *      whatever fit.
+ *
+ * Cross-origin redirects also have `Authorization`, `Cookie`, and
+ * `Proxy-*` request headers stripped so credentials picked up from a
+ * page-injected `headers` arg can't leak to a different origin via an
+ * open-redirect chain.
+ */
+
+import { lookup as dnsLookup } from "node:dns/promises";
+import {
+  assertSafeUrl,
+  isPrivateIpv4,
+  isPrivateIpv6,
+  type UrlGuardOptions,
+} from "./urlGuard.js";
+
+const DEFAULT_MAX_REDIRECTS = 5;
+const DEFAULT_BODY_CAP_BYTES = 10 * 1024 * 1024; // 10 MB hard ceiling
+
+/** Headers we never forward across origins. Lower-case for easy compare. */
+const SENSITIVE_HEADERS = new Set([
+  "authorization",
+  "cookie",
+  "proxy-authorization",
+  "proxy-authenticate",
+]);
+
+/**
+ * Strip headers that shouldn't survive a cross-origin redirect.
+ * Same-origin redirects keep the full header set.
+ */
+function stripCrossOriginHeaders(
+  headers: Record<string, string>,
+  fromOrigin: string,
+  toOrigin: string,
+): Record<string, string> {
+  if (fromOrigin === toOrigin) return headers;
+  const out: Record<string, string> = {};
+  for (const [k, v] of Object.entries(headers)) {
+    if (SENSITIVE_HEADERS.has(k.toLowerCase())) continue;
+    out[k] = v;
+  }
+  return out;
+}
+
+/**
+ * Resolve a hostname's A/AAAA records and reject if any address is in
+ * a private range. Literal IPs are short-circuited (the sync URL guard
+ * already covered them).
+ *
+ * Why we check ALL returned addresses rather than just the first one
+ * fetch will use: defense-in-depth against accidentally-misconfigured
+ * dual-stack hosts and against future fetch-implementation changes
+ * about which family wins in `lookup({ all: false })`.
+ */
+async function assertHostnameDoesNotResolveToPrivate(
+  parsed: URL,
+  opts: UrlGuardOptions,
+): Promise<void> {
+  if (opts.allowPrivate) return;
+
+  // Strip the [..] wrapper IPv6 URL syntax adds.
+  let host = parsed.hostname;
+  if (host.startsWith("[") && host.endsWith("]")) {
+    host = host.slice(1, -1);
+  }
+
+  // Literal IP — the sync guard already validated. Skip DNS.
+  if (/^\d+\.\d+\.\d+\.\d+$/.test(host)) return;
+  if (host.includes(":")) return; // literal IPv6
+
+  let addresses: Array<{ address: string; family: number }>;
+  try {
+    addresses = await dnsLookup(host, { all: true });
+  } catch (e) {
+    // Resolution failure isn't a security signal — let the subsequent
+    // fetch surface a clean error. Don't fail the guard here.
+    return;
+  }
+
+  for (const { address, family } of addresses) {
+    if (family === 4 && isPrivateIpv4(address)) {
+      throw new Error(
+        `Refusing ${host} — resolves to private IPv4 ${address}. Set allowPrivate to opt in.`,
+      );
+    }
+    if (family === 6 && isPrivateIpv6(address)) {
+      throw new Error(
+        `Refusing ${host} — resolves to private IPv6 ${address}. Set allowPrivate to opt in.`,
+      );
+    }
+  }
+}
+
+export interface SafeFetchInit {
+  method?: string;
+  headers?: Record<string, string>;
+  body?: string | undefined;
+  signal?: AbortSignal;
+  /** Allow private/loopback/link-local destinations. Default false. */
+  allowPrivate?: boolean;
+  /** Cap manual redirect hops. Default 5. */
+  maxRedirects?: number;
+}
+
+/**
+ * Fetch `initialUrl` with redirect-following that re-validates each
+ * hop through the URL guard. Returns a Response object whose body has
+ * NOT been consumed — caller is responsible for reading it (use
+ * `readBodyCapped` to apply the streaming size limit).
+ *
+ * Uses `redirect: "manual"` under the hood so we can intercept each
+ * 3xx Location header. On exhausting the hop budget, throws.
+ */
+export async function safeFetch(
+  initialUrl: string,
+  init: SafeFetchInit = {},
+): Promise<Response> {
+  const allowPrivate = !!init.allowPrivate;
+  const maxRedirects = init.maxRedirects ?? DEFAULT_MAX_REDIRECTS;
+
+  // Initial URL goes through the full guard (sync structural check
+  // + DNS resolution). Throws on a private hostname / IP / TLD.
+  let current: URL;
+  current = assertSafeUrl(initialUrl, { allowPrivate });
+  await assertHostnameDoesNotResolveToPrivate(current, { allowPrivate });
+
+  let originForCredentials = current.origin;
+  let headers = { ...(init.headers || {}) };
+  // Pass through method/body on the first hop only — 30x with body
+  // forwarding is a footgun (RFC 7231 says 301/302/303 should drop
+  // the body, 307/308 should preserve it; we conservatively drop on
+  // every redirect to keep the surface predictable).
+  let method = (init.method || "GET").toUpperCase();
+  let body: string | undefined = init.body;
+
+  for (let hop = 0; hop <= maxRedirects; hop++) {
+    const res = await fetch(current.toString(), {
+      method,
+      headers,
+      body,
+      redirect: "manual",
+      ...(init.signal ? { signal: init.signal } : {}),
+    });
+
+    // Not a redirect — return as-is. Caller reads the body.
+    if (res.status < 300 || res.status >= 400) return res;
+
+    const location = res.headers.get("location");
+    if (!location) return res; // 3xx without Location — let caller see it.
+
+    let next: URL;
+    try {
+      next = new URL(location, current);
+    } catch {
+      throw new Error(`Invalid redirect Location: ${location}`);
+    }
+
+    // Re-validate the redirect target. Both sync (protocol /
+    // hostname-pattern checks) and async (DNS resolution).
+    next = assertSafeUrl(next.toString(), { allowPrivate });
+    await assertHostnameDoesNotResolveToPrivate(next, { allowPrivate });
+
+    // Cross-origin redirect → drop sensitive headers.
+    headers = stripCrossOriginHeaders(headers, originForCredentials, next.origin);
+
+    // Drop the request body and downgrade method per RFC 7231 / 7538
+    // semantics for the common 301/302/303 case. 307/308 technically
+    // preserve, but body forwarding to a different origin is rarely
+    // what a fetch_url caller wants — we strip uniformly.
+    body = undefined;
+    if (res.status === 303) method = "GET";
+
+    current = next;
+    originForCredentials = next.origin;
+  }
+
+  throw new Error(
+    `Too many redirects (>${maxRedirects}) starting from ${initialUrl}`,
+  );
+}
+
+export interface CappedReadResult {
+  text: string;
+  /** True if the body was longer than `maxBytes` and we cut it short. */
+  truncated: boolean;
+  /** Bytes actually read (≤ maxBytes when truncated). */
+  bytesRead: number;
+}
+
+/**
+ * Read a Response body to a string with a hard byte cap. Decodes as
+ * UTF-8 (the default for text/html/json/etc.); binary callers should
+ * use res.arrayBuffer() and apply their own caps.
+ *
+ * On exceeding `maxBytes` we cancel the underlying reader so the
+ * server doesn't keep sending and we don't keep buffering.
+ */
+export async function readBodyCapped(
+  res: Response,
+  maxBytes: number = DEFAULT_BODY_CAP_BYTES,
+): Promise<CappedReadResult> {
+  if (!res.body) return { text: "", truncated: false, bytesRead: 0 };
+
+  const reader = res.body.getReader();
+  const decoder = new TextDecoder("utf-8", { fatal: false });
+  let bytesRead = 0;
+  let truncated = false;
+  let out = "";
+
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      if (!value) continue;
+
+      const remaining = maxBytes - bytesRead;
+      if (value.length > remaining) {
+        // Take only what fits, decode the partial chunk with `stream:false`
+        // so the decoder flushes any pending lead bytes, then stop.
+        const slice = value.subarray(0, Math.max(0, remaining));
+        if (slice.length > 0) {
+          out += decoder.decode(slice, { stream: false });
+          bytesRead += slice.length;
+        }
+        truncated = true;
+        try { await reader.cancel(); } catch { /* ignore */ }
+        break;
+      }
+
+      out += decoder.decode(value, { stream: true });
+      bytesRead += value.length;
+    }
+    if (!truncated) {
+      // Final flush for any trailing multibyte sequence.
+      out += decoder.decode();
+    }
+  } catch (e) {
+    // Surface I/O errors to the caller — but only if we have nothing
+    // useful. If we have a partial body, return it with truncated:true.
+    if (out.length === 0) throw e;
+    truncated = true;
+  }
+
+  return { text: out, truncated, bytesRead };
+}

--- a/lmstudio-plugin/src/util/urlGuard.ts
+++ b/lmstudio-plugin/src/util/urlGuard.ts
@@ -10,15 +10,32 @@
  * process is reachable from the LLM: localhost services, intranet
  * apps, cloud-metadata endpoints (169.254.169.254), file:// URLs.
  *
- * `assertSafeUrl(url)` rejects:
+ * `assertSafeUrl(url)` (sync) rejects:
  *   - non-http(s) protocols (file://, ftp://, gopher://, javascript:)
- *   - hostnames that resolve to RFC1918 / loopback / link-local /
- *     unique-local IPv6 — both literal IPs and the common DNS spellings
- *     (localhost, *.local, *.internal, *.lan)
- *   - cloud metadata IPs (169.254.169.254, fd00::/8 ULAs)
+ *   - literal RFC1918 / loopback / link-local / ULA IPv6 hostnames
+ *   - common private DNS spellings (localhost, *.local, *.internal, *.lan)
+ *
+ * The DNS-resolution-aware check
+ * (`assertHostnameDoesNotResolveToPrivate`) lives in `safeFetch.ts`
+ * because it requires `node:dns` and is awaited once per redirect hop
+ * inside the `safeFetch` wrapper. That additional layer closes the case
+ * where a public-looking hostname has an A record pointing into
+ * RFC1918 / loopback / link-local space, e.g. `attacker.example A
+ * 127.0.0.1`. `isPrivateIpv4` / `isPrivateIpv6` are exported so the
+ * resolver-side check reuses the same range definitions.
+ *
+ * Residual gap: DNS rebinding. An attacker controlling a domain with
+ * TTL=0 can return a public IP at the time of the guard check and a
+ * private IP at the time `fetch` connects. Closing this fully requires
+ * pinning the resolved IP via a custom undici Agent + `lookup` hook —
+ * tracked as a follow-up. The current layered defense (sync check +
+ * DNS check + per-redirect re-validation) raises the bar enough to
+ * stop drive-by SSRF from open redirects and naive hostname tricks
+ * but is NOT a hardened sandbox.
  *
  * To opt-out (e.g. you really do want to point this at your intranet)
- * call assertSafeUrl(url, { allowPrivate: true }).
+ * call assertSafeUrl(url, { allowPrivate: true }) and pass the same
+ * flag through to safeFetch.
  */
 
 const PRIVATE_IPV4_RANGES: Array<[number, number]> = [
@@ -38,7 +55,7 @@ function ipv4ToBytes(ip: string): number[] | null {
   return bytes;
 }
 
-function isPrivateIpv4(ip: string): boolean {
+export function isPrivateIpv4(ip: string): boolean {
   const bytes = ipv4ToBytes(ip);
   if (!bytes || bytes.length < 4) return false;
   const a = bytes[0]!;
@@ -51,7 +68,7 @@ function isPrivateIpv4(ip: string): boolean {
   return false;
 }
 
-function isPrivateIpv6(host: string): boolean {
+export function isPrivateIpv6(host: string): boolean {
   const lower = host.toLowerCase();
   // Loopback ::1, link-local fe80::/10, ULAs fc00::/7 (fc00..fdff),
   // mapped IPv4 ::ffff:<ipv4> if the inner ipv4 is private.

--- a/lmstudio-plugin/src/util/urlGuard.ts
+++ b/lmstudio-plugin/src/util/urlGuard.ts
@@ -1,0 +1,141 @@
+/**
+ * URL safety guard.
+ *
+ * Why this exists: when an LLM is given a `fetch_url` tool, it will
+ * eventually try to fetch URLs the user doesn't want it to — usually
+ * because a page told it to ("for more info visit
+ * http://192.168.1.1/admin"), or because of a prompt injection
+ * attempt baked into a previously-fetched page. The plugin runs in
+ * the user's local Node process, so anything reachable from that
+ * process is reachable from the LLM: localhost services, intranet
+ * apps, cloud-metadata endpoints (169.254.169.254), file:// URLs.
+ *
+ * `assertSafeUrl(url)` rejects:
+ *   - non-http(s) protocols (file://, ftp://, gopher://, javascript:)
+ *   - hostnames that resolve to RFC1918 / loopback / link-local /
+ *     unique-local IPv6 — both literal IPs and the common DNS spellings
+ *     (localhost, *.local, *.internal, *.lan)
+ *   - cloud metadata IPs (169.254.169.254, fd00::/8 ULAs)
+ *
+ * To opt-out (e.g. you really do want to point this at your intranet)
+ * call assertSafeUrl(url, { allowPrivate: true }).
+ */
+
+const PRIVATE_IPV4_RANGES: Array<[number, number]> = [
+  // [first byte, second byte]; second byte 0xFF means any
+  [10, 0xff],          // 10.0.0.0/8
+  [127, 0xff],         // 127.0.0.0/8 (loopback)
+  [169, 254],          // 169.254.0.0/16 (link-local + cloud metadata)
+  [192, 168],          // 192.168.0.0/16
+  [100, 64],           // 100.64.0.0/10 carrier-grade NAT (we treat as private)
+];
+
+function ipv4ToBytes(ip: string): number[] | null {
+  const m = ip.match(/^(\d+)\.(\d+)\.(\d+)\.(\d+)$/);
+  if (!m) return null;
+  const bytes = m.slice(1, 5).map((s) => parseInt(s, 10));
+  if (bytes.some((b) => Number.isNaN(b) || b < 0 || b > 255)) return null;
+  return bytes;
+}
+
+function isPrivateIpv4(ip: string): boolean {
+  const bytes = ipv4ToBytes(ip);
+  if (!bytes || bytes.length < 4) return false;
+  const a = bytes[0]!;
+  const b = bytes[1]!;
+  for (const [pa, pb] of PRIVATE_IPV4_RANGES) {
+    if (a === pa && (pb === 0xff || b === pb)) return true;
+  }
+  // 172.16.0.0/12 — non-contiguous; second byte 16..31
+  if (a === 172 && b >= 16 && b <= 31) return true;
+  return false;
+}
+
+function isPrivateIpv6(host: string): boolean {
+  const lower = host.toLowerCase();
+  // Loopback ::1, link-local fe80::/10, ULAs fc00::/7 (fc00..fdff),
+  // mapped IPv4 ::ffff:<ipv4> if the inner ipv4 is private.
+  if (lower === "::1") return true;
+  if (lower.startsWith("fe8") || lower.startsWith("fe9") ||
+      lower.startsWith("fea") || lower.startsWith("feb")) return true;
+  if (lower.startsWith("fc") || lower.startsWith("fd")) return true;
+  const v4mapped = lower.match(/::ffff:(\d+\.\d+\.\d+\.\d+)$/);
+  if (v4mapped?.[1] && isPrivateIpv4(v4mapped[1])) return true;
+  return false;
+}
+
+const PRIVATE_HOSTNAMES = new Set([
+  "localhost",
+  "ip6-localhost",
+  "ip6-loopback",
+]);
+
+const PRIVATE_TLDS = new Set([
+  ".local",
+  ".internal",
+  ".lan",
+  ".intranet",
+  ".home",
+  ".corp",
+]);
+
+function isPrivateHostname(host: string): boolean {
+  const lower = host.toLowerCase();
+  if (PRIVATE_HOSTNAMES.has(lower)) return true;
+  for (const tld of PRIVATE_TLDS) {
+    if (lower.endsWith(tld)) return true;
+  }
+  return false;
+}
+
+export interface UrlGuardOptions {
+  /**
+   * Set true to allow URLs that resolve to RFC1918 / loopback / link-
+   * local addresses. Use only when you actually want the plugin to
+   * reach intranet services. Default false.
+   */
+  allowPrivate?: boolean;
+}
+
+/**
+ * Throws if the URL fails the safety check. Returns the parsed URL
+ * object on success so callers can use `assertSafeUrl(url).hostname`
+ * etc. without re-parsing.
+ */
+export function assertSafeUrl(input: string, opts: UrlGuardOptions = {}): URL {
+  let parsed: URL;
+  try {
+    parsed = new URL(input);
+  } catch {
+    throw new Error(`Invalid URL: ${input}`);
+  }
+  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+    throw new Error(
+      `Refusing ${parsed.protocol} URL — this plugin only fetches http(s).`,
+    );
+  }
+  if (opts.allowPrivate) return parsed;
+
+  // hostname for IPv6 comes back wrapped in [] — strip them.
+  let host = parsed.hostname;
+  if (host.startsWith("[") && host.endsWith("]")) {
+    host = host.slice(1, -1);
+  }
+
+  if (isPrivateIpv4(host)) {
+    throw new Error(
+      `Refusing private IPv4 ${host} — set allowPrivate to opt in.`,
+    );
+  }
+  if (host.includes(":") && isPrivateIpv6(host)) {
+    throw new Error(
+      `Refusing private IPv6 ${host} — set allowPrivate to opt in.`,
+    );
+  }
+  if (isPrivateHostname(host)) {
+    throw new Error(
+      `Refusing private hostname ${host} — set allowPrivate to opt in.`,
+    );
+  }
+  return parsed;
+}

--- a/lmstudio-plugin/tsconfig.json
+++ b/lmstudio-plugin/tsconfig.json
@@ -1,0 +1,25 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "lib": ["ES2022"],
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "noImplicitOverride": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "allowSyntheticDefaultImports": true,
+    "forceConsistentCasingInFileNames": true,
+    "isolatedModules": true,
+    "verbatimModuleSyntax": false
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
## Summary

New top-level folder `lmstudio-plugin/` housing a self-contained LM Studio plugin that adds two read-only web tools to any LM Studio chat:

| Tool | Purpose |
|---|---|
| `fetch_url` | Raw HTTP fetch, content-type aware. JSON pretty-printed, HTML stripped to readable text + `<title>`, plain text verbatim, binary summarised rather than inlined. |
| `research_url` | Same fetch, biased toward the readable article body. Locates `<main>` / `<article>` / `role=main`, drops header/nav/footer/aside, runs `htmlToText`. Surfaces `{spaSuspected: true}` when the response looks like an empty SPA shell. |

Both are ports of [`src/chrome/src/network/network-tools.js`](../blob/main/src/chrome/src/network/network-tools.js) translated to strict-mode TypeScript with `chrome.*` APIs replaced by Node's `fetch`. The same primitives the WebBrain extension already uses, available now to anyone running a model in LM Studio.

## Why read-only only

LM Studio plugins run in Node, not a browser. So this ships the read-only subset of the agent's tools — **no clicks, no typing, no screenshots, no JavaScript rendering**. Users who want full browser interaction should still install the WebBrain Chrome / Firefox extension; this plugin is the "read-only sidekick" for pure-LM-Studio workflows.

The README's "What this plugin can't do" section flags the limitations up front so they don't bite mid-session.

## Architecture

```
lmstudio-plugin/
├── README.md            ← install + usage + caveats + safety notes
├── package.json         ← @lmstudio/sdk + zod deps, tsc build
├── tsconfig.json        ← ES2022 / ESM / strict + noUncheckedIndexedAccess
├── manifest.json        ← owner/name/type/runner per PluginManifest
├── .gitignore           ← node_modules + dist
└── src/
    ├── index.ts         ← plugin entry, registers tools via PluginContext
    ├── tools/
    │   ├── fetchUrl.ts
    │   └── researchUrl.ts
    └── util/
        ├── htmlToText.ts ← regex HTML→text, no DOMParser
        └── urlGuard.ts   ← blocks RFC1918 / loopback / link-local / file://
```

`src/tools/*` and `src/util/*` are pure functions with no `@lmstudio/sdk` coupling — only `src/index.ts` touches the SDK. If a future LM Studio release reshuffles the plugin surface, only that one file should need updating.

## Safety: URL guard

`urlGuard.ts` rejects by default:
- Non-`http(s)` protocols (`file://`, `ftp://`, `javascript:`, etc.)
- RFC1918 IPv4 (`10.*`, `172.16-31.*`, `192.168.*`)
- Loopback (`127.*`, `::1`), link-local (`169.254.*`, `fe80::/10`), CGNAT (`100.64.*`)
- Unique-local IPv6 (`fc00::/7`)
- `localhost`, `*.local`, `*.internal`, `*.lan`, `*.intranet`, `*.home`, `*.corp`
- IPv4-mapped IPv6 of any of the above

Any tool call can pass `allowPrivate: true` to opt into private-network targets when the user actually wants the model to talk to localhost. Default-deny keeps a confused or prompt-injected model away from cloud-metadata IPs (`169.254.169.254`) and the user's intranet.

## Verified against `@lmstudio/sdk` 1.5.0

`PluginContext.withToolsProvider(...)` and `tool({...})` from `@lmstudio/sdk` are the right shapes for a `tools-provider` plugin in this version. The plugin's entry is `main(ctx: PluginContext)` (also re-exported as default for loader-version flexibility). If LM Studio ships an SDK rev that breaks this, the README points at `lms create -t tools-provider` to scaffold the current shape, and only `src/index.ts` would need updating.

The SDK's plugin surface is still flagged `@experimental` in the .d.ts as of 1.5.0, so this PR is also somewhat exploratory — worth landing now since it works end-to-end against the live SDK and lets us iterate.

## Smoke tests run

- `urlGuard` rejects all the expected private targets with descriptive errors.
- `fetchUrl` round-trips against GitHub API JSON (5.7 KB pretty-printed) and `example.com` HTML (gets the title, no surprises).
- `researchUrl` pulls 16 KB of clean text + 30 outbound links from `en.wikipedia.org/wiki/HTTP` in under a second.

`tsc` is clean with strict mode + `noUncheckedIndexedAccess`. No runtime test harness yet — the tool logic is small enough that the smoke tests above are the meaningful coverage; CI would add the same.

## Test plan for reviewer

- [ ] `cd lmstudio-plugin && npm install && npm run build` — clean tsc build.
- [ ] Optional: install into LM Studio via `lms plugin push ./lmstudio-plugin` (requires `lms` CLI bundled with LM Studio app), restart LM Studio, enable the plugin in a chat session.
- [ ] Ask a tool-using model "what's on the front page of news.ycombinator.com right now?" — expect a `research_url` call to come back with live headlines.
- [ ] Try a tool call against `http://localhost:8080` without `allowPrivate: true` — expect the URL guard to reject it.
- [ ] Try a Twitter/Notion URL — expect `{success: true, spaSuspected: true, text: "<short>"}` so the model knows the SPA can't be read this way.

## Out of scope (intentional)

- **No headless browser fallback.** No Puppeteer / Playwright dependency. Keeps the install footprint small and avoids the "another Chromium binary on disk" overhead. SPA-shaped sites are documented as a limitation.
- **No write tools.** `fetch_url` allows non-GET methods (POST/PUT/PATCH/DELETE/etc.) but doesn't carry browser cookies, so it can't impersonate a logged-in user. Matches the `/allow-api`-off default of the WebBrain extension. We could add a writeable mode later, but a model that can POST to arbitrary URLs as the local user has a wider blast radius than feels worth shipping by default.