### PR TITLE
web: mention "Works with PDFs" on the Data Extraction feature card

### DIFF
--- a/web/build/locales/en.json
+++ b/web/build/locales/en.json
@@ -48,7 +48,7 @@
   "features.agent.title": "Full Browser Agent",
   "features.agent.desc": "Click, type, scroll, navigate, and interact with pages on your behalf. Automate repetitive tasks with natural language instructions.",
   "features.extraction.title": "Data Extraction",
-  "features.extraction.desc": "Extract structured data from any page — tables, lists, links, forms. Export product catalogs, search results, or any page content.",
+  "features.extraction.desc": "Extract structured data from any page — tables, lists, links, forms. Export product catalogs, search results, or any page content. Works with PDFs.",
   "features.multi_provider.title": "Multi-Provider LLM",
   "features.multi_provider.desc": "Works with local llama.cpp, OpenAI, Claude, and OpenRouter. Use your preferred model — or run completely offline with local AI.",
   "features.privacy.title": "Privacy First",

--- a/web/build/locales/es.json
+++ b/web/build/locales/es.json
@@ -48,7 +48,7 @@
   "features.agent.title": "Agente completo de navegador",
   "features.agent.desc": "Hace clic, escribe, desplaza, navega e interactúa con las páginas por ti. Automatiza tareas repetitivas con instrucciones en lenguaje natural.",
   "features.extraction.title": "Extracción de datos",
-  "features.extraction.desc": "Extrae datos estructurados de cualquier página — tablas, listas, enlaces, formularios. Exporta catálogos de productos, resultados de búsqueda o cualquier contenido.",
+  "features.extraction.desc": "Extrae datos estructurados de cualquier página — tablas, listas, enlaces, formularios. Exporta catálogos de productos, resultados de búsqueda o cualquier contenido. Compatible con PDF.",
   "features.multi_provider.title": "Multi-proveedor de LLM",
   "features.multi_provider.desc": "Funciona con llama.cpp local, OpenAI, Claude y OpenRouter. Usa el modelo que prefieras — o trabaja totalmente sin conexión con IA local.",
   "features.privacy.title": "Privacidad primero",

--- a/web/build/locales/fr.json
+++ b/web/build/locales/fr.json
@@ -48,7 +48,7 @@
   "features.agent.title": "Agent complet de navigateur",
   "features.agent.desc": "Clique, tape, défile, navigue et interagit avec les pages à votre place. Automatisez les tâches répétitives avec des instructions en langage naturel.",
   "features.extraction.title": "Extraction de données",
-  "features.extraction.desc": "Extrayez des données structurées de n'importe quelle page — tableaux, listes, liens, formulaires. Exportez catalogues produits, résultats de recherche ou tout contenu de page.",
+  "features.extraction.desc": "Extrayez des données structurées de n'importe quelle page — tableaux, listes, liens, formulaires. Exportez catalogues produits, résultats de recherche ou tout contenu de page. Compatible avec les PDF.",
   "features.multi_provider.title": "Multi-fournisseur de LLM",
   "features.multi_provider.desc": "Fonctionne avec llama.cpp en local, OpenAI, Claude et OpenRouter. Utilisez votre modèle préféré — ou travaillez totalement hors ligne avec une IA locale.",
   "features.privacy.title": "Vie privée d'abord",

--- a/web/build/locales/tr.json
+++ b/web/build/locales/tr.json
@@ -48,7 +48,7 @@
   "features.agent.title": "Tam tarayıcı ajanı",
   "features.agent.desc": "Senin yerine tıklar, yazar, kaydırır, gezinir ve sayfalarla etkileşir. Doğal dil talimatlarıyla tekrar eden işleri otomatikleştir.",
   "features.extraction.title": "Veri çıkarma",
-  "features.extraction.desc": "Her sayfadan yapılandırılmış veri çıkar — tablolar, listeler, bağlantılar, formlar. Ürün kataloglarını, arama sonuçlarını ya da herhangi bir sayfa içeriğini dışa aktar.",
+  "features.extraction.desc": "Her sayfadan yapılandırılmış veri çıkar — tablolar, listeler, bağlantılar, formlar. Ürün kataloglarını, arama sonuçlarını ya da herhangi bir sayfa içeriğini dışa aktar. PDF'lerle çalışır.",
   "features.multi_provider.title": "Çoklu LLM sağlayıcı",
   "features.multi_provider.desc": "Yerel llama.cpp, OpenAI, Claude ve OpenRouter ile çalışır. Tercih ettiğin modeli kullan — ya da yerel AI ile tamamen çevrimdışı çalış.",
   "features.privacy.title": "Önce gizlilik",

--- a/web/build/locales/zh.json
+++ b/web/build/locales/zh.json
@@ -48,7 +48,7 @@
   "features.agent.title": "完整浏览器代理",
   "features.agent.desc": "代你点击、输入、滚动、导航,并与页面交互。用自然语言指令自动化重复性任务。",
   "features.extraction.title": "数据提取",
-  "features.extraction.desc": "从任何页面提取结构化数据 —— 表格、列表、链接、表单。导出产品目录、搜索结果或任何页面内容。",
+  "features.extraction.desc": "从任何页面提取结构化数据 —— 表格、列表、链接、表单。导出产品目录、搜索结果或任何页面内容。支持 PDF。",
   "features.multi_provider.title": "多提供商 LLM",
   "features.multi_provider.desc": "兼容本地 llama.cpp、OpenAI、Claude 和 OpenRouter。使用你偏好的模型 —— 或用本地 AI 完全离线运行。",
   "features.privacy.title": "隐私优先",

--- a/web/es/index.html
+++ b/web/es/index.html
@@ -47,7 +47,7 @@
   "url": "https://webbrain.one/es/",
   "inLanguage": "es-ES",
   "downloadUrl": "https://chromewebstore.google.com/detail/webbrain/ljhijonmfahplgbbacgcfnaihbjljhhb",
-  "softwareVersion": "6.1.0",
+  "softwareVersion": "5.1.0",
   "author": {
     "@type": "Person",
     "name": "Emre Sokullu",
@@ -1250,7 +1250,7 @@
     <div class="feature-card">
       <div class="feature-icon">📊</div>
       <h3>Extracción de datos</h3>
-      <p>Extrae datos estructurados de cualquier página — tablas, listas, enlaces, formularios. Exporta catálogos de productos, resultados de búsqueda o cualquier contenido.</p>
+      <p>Extrae datos estructurados de cualquier página — tablas, listas, enlaces, formularios. Exporta catálogos de productos, resultados de búsqueda o cualquier contenido. Compatible con PDF.</p>
     </div>
     <div class="feature-card">
       <div class="feature-icon">🔌</div>

--- a/web/fr/index.html
+++ b/web/fr/index.html
@@ -47,7 +47,7 @@
   "url": "https://webbrain.one/fr/",
   "inLanguage": "fr-FR",
   "downloadUrl": "https://chromewebstore.google.com/detail/webbrain/ljhijonmfahplgbbacgcfnaihbjljhhb",
-  "softwareVersion": "6.1.0",
+  "softwareVersion": "5.1.0",
   "author": {
     "@type": "Person",
     "name": "Emre Sokullu",
@@ -1250,7 +1250,7 @@
     <div class="feature-card">
       <div class="feature-icon">📊</div>
       <h3>Extraction de données</h3>
-      <p>Extrayez des données structurées de n&#39;importe quelle page — tableaux, listes, liens, formulaires. Exportez catalogues produits, résultats de recherche ou tout contenu de page.</p>
+      <p>Extrayez des données structurées de n&#39;importe quelle page — tableaux, listes, liens, formulaires. Exportez catalogues produits, résultats de recherche ou tout contenu de page. Compatible avec les PDF.</p>
     </div>
     <div class="feature-card">
       <div class="feature-icon">🔌</div>

--- a/web/index.html
+++ b/web/index.html
@@ -47,7 +47,7 @@
   "url": "https://webbrain.one/",
   "inLanguage": "en-US",
   "downloadUrl": "https://chromewebstore.google.com/detail/webbrain/ljhijonmfahplgbbacgcfnaihbjljhhb",
-  "softwareVersion": "6.1.0",
+  "softwareVersion": "5.1.0",
   "author": {
     "@type": "Person",
     "name": "Emre Sokullu",
@@ -1250,7 +1250,7 @@
     <div class="feature-card">
       <div class="feature-icon">📊</div>
       <h3>Data Extraction</h3>
-      <p>Extract structured data from any page — tables, lists, links, forms. Export product catalogs, search results, or any page content.</p>
+      <p>Extract structured data from any page — tables, lists, links, forms. Export product catalogs, search results, or any page content. Works with PDFs.</p>
     </div>
     <div class="feature-card">
       <div class="feature-icon">🔌</div>

--- a/web/tr/index.html
+++ b/web/tr/index.html
@@ -47,7 +47,7 @@
   "url": "https://webbrain.one/tr/",
   "inLanguage": "tr-TR",
   "downloadUrl": "https://chromewebstore.google.com/detail/webbrain/ljhijonmfahplgbbacgcfnaihbjljhhb",
-  "softwareVersion": "6.1.0",
+  "softwareVersion": "5.1.0",
   "author": {
     "@type": "Person",
     "name": "Emre Sokullu",
@@ -1250,7 +1250,7 @@
     <div class="feature-card">
       <div class="feature-icon">📊</div>
       <h3>Veri çıkarma</h3>
-      <p>Her sayfadan yapılandırılmış veri çıkar — tablolar, listeler, bağlantılar, formlar. Ürün kataloglarını, arama sonuçlarını ya da herhangi bir sayfa içeriğini dışa aktar.</p>
+      <p>Her sayfadan yapılandırılmış veri çıkar — tablolar, listeler, bağlantılar, formlar. Ürün kataloglarını, arama sonuçlarını ya da herhangi bir sayfa içeriğini dışa aktar. PDF&#39;lerle çalışır.</p>
     </div>
     <div class="feature-card">
       <div class="feature-icon">🔌</div>

--- a/web/zh/index.html
+++ b/web/zh/index.html
@@ -47,7 +47,7 @@
   "url": "https://webbrain.one/zh/",
   "inLanguage": "zh-CN",
   "downloadUrl": "https://chromewebstore.google.com/detail/webbrain/ljhijonmfahplgbbacgcfnaihbjljhhb",
-  "softwareVersion": "6.1.0",
+  "softwareVersion": "5.1.0",
   "author": {
     "@type": "Person",
     "name": "Emre Sokullu",
@@ -1250,7 +1250,7 @@
     <div class="feature-card">
       <div class="feature-icon">📊</div>
       <h3>数据提取</h3>
-      <p>从任何页面提取结构化数据 —— 表格、列表、链接、表单。导出产品目录、搜索结果或任何页面内容。</p>
+      <p>从任何页面提取结构化数据 —— 表格、列表、链接、表单。导出产品目录、搜索结果或任何页面内容。支持 PDF。</p>
     </div>
     <div class="feature-card">
       <div class="feature-icon">🔌</div>


### PR DESCRIPTION
Adds the new sentence to the features.extraction.desc string in all five locale JSONs (en/es/fr/tr/zh) and rebuilds the marketing-site HTMLs via build:web. Surfaces the PDF support shipped in this PR.