### PR TITLE
Simplify header nav and hide Interaction Modes

### DIFF
--- a/web/build/template.html
+++ b/web/build/template.html
@@ -966,8 +966,6 @@
     </a>
     <div class="nav-links">
       <a href="#features">{{t:nav.features}}</a>
-      <a href="#demo">{{t:nav.demo}}</a>
-      <a href="#providers">{{t:nav.providers}}</a>
       <a href="#compare">{{t:nav.compare}}</a>
       <a href="#download">{{t:nav.download}}</a>
       <a href="#faq">{{t:nav.faq}}</a>
@@ -1198,7 +1196,7 @@
 </section>
 
 <!-- MODES -->
-<section class="section" id="modes">
+<section class="section" id="modes" style="display:none;">
   <div class="section-label">{{t:modes.label}}</div>
   <h2 class="section-title">{{t:modes.title}}</h2>
   <p class="section-subtitle">{{t:modes.subtitle}}</p>

--- a/web/es/index.html
+++ b/web/es/index.html
@@ -1129,8 +1129,6 @@
     </a>
     <div class="nav-links">
       <a href="#features">Funciones</a>
-      <a href="#demo">Demo</a>
-      <a href="#providers">Proveedores</a>
       <a href="#compare">Comparar</a>
       <a href="#download">Descargar</a>
       <a href="#faq">Preguntas</a>
@@ -1361,7 +1359,7 @@
 </section>
 
 <!-- MODES -->
-<section class="section" id="modes">
+<section class="section" id="modes" style="display:none;">
   <div class="section-label">Modos de interacción</div>
   <h2 class="section-title">Preguntar o Actuar</h2>
   <p class="section-subtitle">Dos modos para necesidades distintas. Solo lectura por defecto, toda la potencia del agente cuando la necesitas.</p>

--- a/web/fr/index.html
+++ b/web/fr/index.html
@@ -1129,8 +1129,6 @@
     </a>
     <div class="nav-links">
       <a href="#features">Fonctionnalités</a>
-      <a href="#demo">Démo</a>
-      <a href="#providers">Fournisseurs</a>
       <a href="#compare">Comparer</a>
       <a href="#download">Télécharger</a>
       <a href="#faq">FAQ</a>
@@ -1361,7 +1359,7 @@
 </section>
 
 <!-- MODES -->
-<section class="section" id="modes">
+<section class="section" id="modes" style="display:none;">
   <div class="section-label">Modes d&#39;interaction</div>
   <h2 class="section-title">Demander ou Agir</h2>
   <p class="section-subtitle">Deux modes pour des besoins différents. Lecture seule par défaut, toute la puissance de l&#39;agent quand vous en avez besoin.</p>

--- a/web/index.html
+++ b/web/index.html
@@ -1129,8 +1129,6 @@
     </a>
     <div class="nav-links">
       <a href="#features">Features</a>
-      <a href="#demo">Demo</a>
-      <a href="#providers">Providers</a>
       <a href="#compare">Compare</a>
       <a href="#download">Download</a>
       <a href="#faq">FAQ</a>
@@ -1361,7 +1359,7 @@
 </section>
 
 <!-- MODES -->
-<section class="section" id="modes">
+<section class="section" id="modes" style="display:none;">
   <div class="section-label">Interaction Modes</div>
   <h2 class="section-title">Ask or Act</h2>
   <p class="section-subtitle">Two modes for different needs. Read-only by default, full agent power when you need it.</p>

--- a/web/tr/index.html
+++ b/web/tr/index.html
@@ -1129,8 +1129,6 @@
     </a>
     <div class="nav-links">
       <a href="#features">Özellikler</a>
-      <a href="#demo">Tanıtım</a>
-      <a href="#providers">Sağlayıcılar</a>
       <a href="#compare">Karşılaştır</a>
       <a href="#download">İndir</a>
       <a href="#faq">SSS</a>
@@ -1361,7 +1359,7 @@
 </section>
 
 <!-- MODES -->
-<section class="section" id="modes">
+<section class="section" id="modes" style="display:none;">
   <div class="section-label">Etkileşim kipleri</div>
   <h2 class="section-title">Sor ya da Uygula</h2>
   <p class="section-subtitle">Farklı ihtiyaçlar için iki kip. Varsayılan salt okunur, gerektiğinde tam ajan gücü.</p>

--- a/web/zh/index.html
+++ b/web/zh/index.html
@@ -1129,8 +1129,6 @@
     </a>
     <div class="nav-links">
       <a href="#features">功能</a>
-      <a href="#demo">演示</a>
-      <a href="#providers">提供商</a>
       <a href="#compare">对比</a>
       <a href="#download">下载</a>
       <a href="#faq">常见问题</a>
@@ -1361,7 +1359,7 @@
 </section>
 
 <!-- MODES -->
-<section class="section" id="modes">
+<section class="section" id="modes" style="display:none;">
   <div class="section-label">交互模式</div>
   <h2 class="section-title">询问或执行</h2>
   <p class="section-subtitle">两种模式应对不同需求。默认只读,需要时则具备完整代理能力。</p>


### PR DESCRIPTION
### Motivation
- Reduce header clutter by removing seldom-used `Demo` and `Providers` links while keeping their content available on the page. 
- De-emphasize the `Interaction Modes` marketing block on the homepage without deleting the section so it can be re-enabled later. 

### Description
- Removed the `Demo` and `Providers` links from the top nav in the site template by editing `web/build/template.html`. 
- Hid the homepage `Interaction Modes` section by adding `style="display:none;"` to the `#modes` section in `web/build/template.html`. 
- Regenerated the localized marketing pages so the changes propagated to `web/index.html` and locale builds (`web/es/index.html`, `web/fr/index.html`, `web/tr/index.html`, `web/zh/index.html`). 
- Changes are prepared on the `usability` branch and affect the template and generated HTML output files. 

### Testing
- Ran `npm run build:web` which completed successfully and wrote the updated `web/index.html` and localized pages.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9a144798c8327ad5d62edc3775b61)