### PR TITLE
Add OpenAI OAuth subscription provider alongside API-key option

### DIFF
--- a/src/chrome/src/background.js
+++ b/src/chrome/src/background.js
@@ -6,6 +6,12 @@ import {
   signOutClaude,
   getClaudeOAuthStatus,
 } from './providers/oauth-claude.js';
+import {
+  startOpenAIOAuth,
+  signOutOpenAI,
+  getOpenAIOAuthStatus,
+  getOpenAIAccessToken,
+} from './providers/oauth-openai.js';
 
 /**
  * WebBrain Service Worker (Background Script)
@@ -586,6 +592,24 @@ async function handleMessage(msg, sender) {
       } catch (e) {
         return { ok: false, error: e.message };
       }
+    }
+    case 'openai_oauth_start': {
+      try {
+        await startOpenAIOAuth();
+        const token = await getOpenAIAccessToken();
+        await providerManager.updateProvider('openai_subscription', { apiKey: token || '' });
+        return { ok: true };
+      } catch (e) {
+        return { ok: false, error: e.message };
+      }
+    }
+    case 'openai_oauth_signout': {
+      await signOutOpenAI();
+      await providerManager.updateProvider('openai_subscription', { apiKey: '' });
+      return { ok: true };
+    }
+    case 'openai_oauth_status': {
+      return await getOpenAIOAuthStatus();
     }
 
     // --- Page Info (quick, no agent loop) ---

--- a/src/chrome/src/providers/manager.js
+++ b/src/chrome/src/providers/manager.js
@@ -119,6 +119,15 @@ export class ProviderManager {
         model: 'claude-sonnet-4-6',
         enabled: false,
       },
+      openai_subscription: {
+        type: 'openai',
+        label: 'OpenAI (ChatGPT subscription)',
+        providerName: 'openai',
+        baseUrl: 'https://api.openai.com/v1',
+        model: 'gpt-5',
+        apiKey: '',
+        enabled: false,
+      },
       webbrain: {
         type: 'openai',
         label: 'WebBrain Cloud',

--- a/src/chrome/src/providers/oauth-openai.js
+++ b/src/chrome/src/providers/oauth-openai.js
@@ -1,0 +1,36 @@
+const STORAGE_KEY = 'openaiOauthTokens';
+const CLIENT_ID = 'webbrain-extension';
+const AUTH_URL = 'https://auth.openai.com/oauth/authorize';
+const TOKEN_URL = 'https://auth.openai.com/oauth/token';
+const REDIRECT = 'https://auth.openai.com/oauth/callback';
+const SCOPES = 'openid profile email offline_access';
+
+function b64(bytes){let b='';for(const x of bytes)b+=String.fromCharCode(x);return btoa(b).replace(/\+/g,'-').replace(/\//g,'_').replace(/=+$/,'');}
+async function sha(s){const h=await crypto.subtle.digest('SHA-256',new TextEncoder().encode(s));return b64(new Uint8Array(h));}
+function rand(n=32){return b64(crypto.getRandomValues(new Uint8Array(n)));}
+
+export async function startOpenAIOAuth(){
+  const verifier=rand(48), challenge=await sha(verifier), state=rand(16);
+  const params=new URLSearchParams({client_id:CLIENT_ID,response_type:'code',redirect_uri:REDIRECT,scope:SCOPES,code_challenge:challenge,code_challenge_method:'S256',state});
+  const tab=await chrome.tabs.create({url:`${AUTH_URL}?${params.toString()}`,active:true});
+  return new Promise((resolve,reject)=>{
+    const onUpdated=async (tabId,changeInfo)=>{ if(tabId!==tab.id||!changeInfo.url||!changeInfo.url.startsWith(REDIRECT)) return;
+      chrome.tabs.onUpdated.removeListener(onUpdated); chrome.tabs.remove(tab.id).catch(()=>{});
+      const u=new URL(changeInfo.url); const code=u.searchParams.get('code'); if(!code) return reject(new Error('Missing code'));
+      try { const tokens=await exchangeCodeForTokens(code,verifier); resolve(tokens);} catch(e){reject(e);} };
+    chrome.tabs.onUpdated.addListener(onUpdated);
+  });
+}
+
+async function exchangeCodeForTokens(code,verifier){
+  const res=await fetch(TOKEN_URL,{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({grant_type:'authorization_code',code,redirect_uri:REDIRECT,client_id:CLIENT_ID,code_verifier:verifier})});
+  if(!res.ok) throw new Error(`Token exchange failed (${res.status})`);
+  const data=await res.json();
+  const tokens={accessToken:data.access_token,refreshToken:data.refresh_token||null,expiresAt:Date.now()+((data.expires_in||3600)*1000)};
+  await chrome.storage.local.set({[STORAGE_KEY]:tokens});
+  return tokens;
+}
+
+export async function signOutOpenAI(){ await chrome.storage.local.remove([STORAGE_KEY]); }
+export async function getOpenAIOAuthStatus(){ const d=await chrome.storage.local.get([STORAGE_KEY]); return {signedIn:!!d[STORAGE_KEY]?.accessToken}; }
+export async function getOpenAIAccessToken(){ const d=await chrome.storage.local.get([STORAGE_KEY]); return d[STORAGE_KEY]?.accessToken||null; }

--- a/src/chrome/src/ui/settings.js
+++ b/src/chrome/src/ui/settings.js
@@ -378,6 +378,13 @@ function renderProviders() {
         { key: 'model', labelKey: 'st.provider.field.model', type: 'text', placeholder: 'claude-sonnet-4-6' },
       ],
     },
+    openai_subscription: {
+      customRender: 'openai_oauth',
+      fields: [
+        { key: 'model', labelKey: 'st.provider.field.model', type: 'text', placeholder: 'gpt-5' },
+        { key: 'baseUrl', labelKey: 'st.provider.field.api_base_url', type: 'text', placeholder: 'https://api.openai.com/v1' },
+      ],
+    },
     webbrain: {
       fields: [
         { key: 'baseUrl', labelKey: 'st.provider.field.api_base_url', type: 'text', placeholder: 'https://auth.webbrain.one/v1' },
@@ -395,6 +402,10 @@ function renderProviders() {
     // form fields, and the auth state is fetched async.
     if (providerConfigs[id]?.customRender === 'claude_oauth') {
       providersContainer.appendChild(renderClaudeOAuthCard(id, config, isActive, fieldDefs));
+      continue;
+    }
+    if (providerConfigs[id]?.customRender === 'openai_oauth') {
+      providersContainer.appendChild(renderOpenAIOAuthCard(id, config, isActive, fieldDefs));
       continue;
     }
 
@@ -602,6 +613,55 @@ async function signInWithClaude(id) {
 async function signOutOfClaude(id) {
   await sendToBackground('claude_oauth_signout');
   await refreshClaudeOAuthStatus(id);
+}
+
+function renderOpenAIOAuthCard(id, config, isActive, fieldDefs) {
+  const card = document.createElement('div');
+  card.className = `provider-card ${isActive ? 'active' : ''}`;
+  let fieldsHTML = '';
+  for (const field of fieldDefs) {
+    const label = field.labelKey ? t(field.labelKey) : (field.label || field.key);
+    const placeholder = field.placeholder || '';
+    fieldsHTML += `<div class="field"><label>${escapeHtml(label)}</label>
+      <input type="${field.type}" data-provider="${id}" data-key="${field.key}" value="${escapeHtml(config[field.key] || '')}" placeholder="${escapeHtml(placeholder)}"></div>`;
+  }
+  card.innerHTML = `<div class="provider-header"><div><span class="provider-name">${escapeHtml(config.label || id)}</span><span class="provider-type">oauth</span></div>${isActive ? `<span style="color:var(--accent);font-size:11px;font-weight:600">${escapeHtml(t('st.providers.active'))}</span>` : ''}</div>
+  <div class="openai-oauth-status" id="openai-oauth-status-${id}" style="padding:10px 12px;border-radius:6px;background:var(--surface2,#f5f5f7);margin-bottom:10px;font-size:13px;color:var(--text2);">Loading sign-in status…</div>
+  ${fieldsHTML}
+  <div class="btn-row"><button class="btn-primary btn-openai-signin" data-provider="${id}" style="display:none;">Sign in with OpenAI</button><button class="btn-secondary btn-openai-signout" data-provider="${id}" style="display:none;">Sign out</button>
+  <button class="btn-primary btn-save" data-provider="${id}">${escapeHtml(t('st.providers.save'))}</button><button class="btn-secondary btn-test" data-provider="${id}">${escapeHtml(t('st.providers.test'))}</button>${!isActive ? `<button class="btn-secondary btn-activate" data-provider="${id}">${escapeHtml(t('st.providers.set_active'))}</button>` : ''}</div>
+  <div class="test-result" id="test-${id}"></div>`;
+  refreshOpenAIOAuthStatus(id);
+  card.querySelector('.btn-openai-signin').addEventListener('click', () => signInWithOpenAI(id));
+  card.querySelector('.btn-openai-signout').addEventListener('click', () => signOutOfOpenAI(id));
+  return card;
+}
+
+async function refreshOpenAIOAuthStatus(id) {
+  const statusEl = document.getElementById(`openai-oauth-status-${id}`);
+  const signInBtn = document.querySelector(`.btn-openai-signin[data-provider="${id}"]`);
+  const signOutBtn = document.querySelector(`.btn-openai-signout[data-provider="${id}"]`);
+  if (!statusEl) return;
+  try {
+    const status = await sendToBackground('openai_oauth_status');
+    if (status?.signedIn) {
+      statusEl.innerHTML = `<strong style="color:var(--ok,#1a8a4a);">Signed in.</strong>`;
+      if (signInBtn) signInBtn.style.display = 'none';
+      if (signOutBtn) signOutBtn.style.display = '';
+    } else {
+      statusEl.innerHTML = `Not signed in. Click <strong>Sign in with OpenAI</strong>.`;
+      if (signInBtn) signInBtn.style.display = '';
+      if (signOutBtn) signOutBtn.style.display = 'none';
+    }
+  } catch (e) { statusEl.innerHTML = `Status unavailable: ${escapeHtml(e.message)}`; }
+}
+async function signInWithOpenAI(id) {
+  const res = await sendToBackground('openai_oauth_start');
+  if (res?.ok) await refreshOpenAIOAuthStatus(id);
+}
+async function signOutOfOpenAI(id) {
+  await sendToBackground('openai_oauth_signout');
+  await refreshOpenAIOAuthStatus(id);
 }
 
 async function loadOllamaModels(id) {


### PR DESCRIPTION
### Motivation
- Provide an OAuth-based sign-in option for OpenAI (ChatGPT subscription) analogous to the existing Claude OAuth flow so users can use their subscription without losing the current API-key configuration. 
- Keep the existing OpenAI API-key provider and settings intact so users may choose between API-key and OAuth workflows. 

### Description
- Add a new `openai_subscription` provider default entry in the Chrome provider manager so OAuth-mode OpenAI can coexist with API-key providers. 
- Introduce `src/chrome/src/providers/oauth-openai.js`, a PKCE-style OAuth helper that performs the auth tab flow, exchanges codes for tokens, persists tokens in `chrome.storage.local`, and exposes `startOpenAIOAuth`, `signOutOpenAI`, `getOpenAIOAuthStatus`, and `getOpenAIAccessToken`. 
- Extend the settings UI with a custom OAuth card (`renderOpenAIOAuthCard`) and status/sign-in/sign-out actions that mirror the Claude subscription UX and call background actions `openai_oauth_start`, `openai_oauth_signout`, and `openai_oauth_status`. 
- Wire background handlers to run the OAuth flow and, on success, copy the retrieved access token into the `openai_subscription.apiKey` so existing OpenAI-compatible request logic continues to work unchanged. 

### Testing
- Ran `node --check src/chrome/src/ui/settings.js` which completed successfully. 
- Ran `node --check src/chrome/src/background.js` which completed successfully. 
- Ran `node --check src/chrome/src/providers/oauth-openai.js` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9a22e98a48327923f4610c93123ff)