### PR TITLE
docs: add PDF reading tool (`read_pdf`) to README changelog

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,6 +195,7 @@ The default UI-first rule exists because API actions are invisible (you don't se
 - **Cross-origin iframe interaction tools** (`iframe_read`, `iframe_click`, `iframe_type`) for embedded forms and widgets
 - **Network research tools** (`fetch_url`, `research_url`) for fast read-only data retrieval
 - **Download workflow tools** (`download_file`, `download_files`, `list_downloads`, `read_downloaded_file`)
+- **PDF reading tool** (`read_pdf`) for direct PDF extraction when viewer pages block DOM access
 - **Trace viewer and quality-of-life upgrades** including step-limit continuation and stronger context controls
 
 ## Roadmap


### PR DESCRIPTION
### Motivation
- Add missing mention of the new PDF reading tool to the 4.2.0 changelog so users know about `read_pdf` for extracting PDFs when viewer pages block DOM access.

### Description
- Update `README.md` changelog under "4.2.0" to include the bullet "**PDF reading tool** (`read_pdf`) for direct PDF extraction when viewer pages block DOM access".

### Testing
- Documentation-only change; no code tests were required and no automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fcc6f5fb0083278296a9a9462e8346)