### PR TITLE
Replace footer GitHub link with Blog link

### DIFF
--- a/web/build/template.html
+++ b/web/build/template.html
@@ -1454,7 +1454,7 @@
       <a href="{{t:share.linkedin_intent_url}}" target="_blank" rel="noopener" aria-label="{{t:share.linkedin_btn}}" title="{{t:share.linkedin_btn}}" class="footer-icon">
         <svg viewBox="0 0 24 24" fill="currentColor" width="14" height="14" aria-hidden="true"><path d="M20.45 20.45h-3.555v-5.569c0-1.328-.024-3.038-1.852-3.038-1.853 0-2.136 1.447-2.136 2.94v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.268 2.37 4.268 5.455v6.284zM5.34 7.433a2.062 2.062 0 11.001-4.124 2.062 2.062 0 010 4.124zM7.119 20.45H3.555V9h3.564v11.45zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.222 0h.003z"/></svg>
       </a>
-      <a href="https://github.com/esokullu/webbrain" target="_blank" rel="noopener">{{t:footer.link_github}}</a>
+      <a href="/blog">{{t:nav.blog}}</a>
       <a href="#safety">{{t:footer.link_safety}}</a>
       <a href="/privacy">{{t:footer.link_privacy}}</a>
       <a href="https://github.com/esokullu/webbrain/issues" target="_blank" rel="noopener">{{t:footer.link_report_bug}}</a>

--- a/web/es/index.html
+++ b/web/es/index.html
@@ -1633,7 +1633,7 @@
       <a href="https://www.linkedin.com/sharing/share-offsite/?url=https%3A%2F%2Fwebbrain.one%2Fes%2F" target="_blank" rel="noopener" aria-label="Compartir en LinkedIn" title="Compartir en LinkedIn" class="footer-icon">
         <svg viewBox="0 0 24 24" fill="currentColor" width="14" height="14" aria-hidden="true"><path d="M20.45 20.45h-3.555v-5.569c0-1.328-.024-3.038-1.852-3.038-1.853 0-2.136 1.447-2.136 2.94v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.268 2.37 4.268 5.455v6.284zM5.34 7.433a2.062 2.062 0 11.001-4.124 2.062 2.062 0 010 4.124zM7.119 20.45H3.555V9h3.564v11.45zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.222 0h.003z"/></svg>
       </a>
-      <a href="https://github.com/esokullu/webbrain" target="_blank" rel="noopener">GitHub</a>
+      <a href="/blog">Blog</a>
       <a href="#safety">Aviso de seguridad</a>
       <a href="/privacy">Política de privacidad</a>
       <a href="https://github.com/esokullu/webbrain/issues" target="_blank" rel="noopener">Reportar un error</a>

--- a/web/fr/index.html
+++ b/web/fr/index.html
@@ -1633,7 +1633,7 @@
       <a href="https://www.linkedin.com/sharing/share-offsite/?url=https%3A%2F%2Fwebbrain.one%2Ffr%2F" target="_blank" rel="noopener" aria-label="Partager sur LinkedIn" title="Partager sur LinkedIn" class="footer-icon">
         <svg viewBox="0 0 24 24" fill="currentColor" width="14" height="14" aria-hidden="true"><path d="M20.45 20.45h-3.555v-5.569c0-1.328-.024-3.038-1.852-3.038-1.853 0-2.136 1.447-2.136 2.94v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.268 2.37 4.268 5.455v6.284zM5.34 7.433a2.062 2.062 0 11.001-4.124 2.062 2.062 0 010 4.124zM7.119 20.45H3.555V9h3.564v11.45zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.222 0h.003z"/></svg>
       </a>
-      <a href="https://github.com/esokullu/webbrain" target="_blank" rel="noopener">GitHub</a>
+      <a href="/blog">Blog</a>
       <a href="#safety">Avertissement</a>
       <a href="/privacy">Politique de confidentialité</a>
       <a href="https://github.com/esokullu/webbrain/issues" target="_blank" rel="noopener">Signaler un bug</a>

--- a/web/index.html
+++ b/web/index.html
@@ -1633,7 +1633,7 @@
       <a href="https://www.linkedin.com/sharing/share-offsite/?url=https%3A%2F%2Fwebbrain.one%2F" target="_blank" rel="noopener" aria-label="Share on LinkedIn" title="Share on LinkedIn" class="footer-icon">
         <svg viewBox="0 0 24 24" fill="currentColor" width="14" height="14" aria-hidden="true"><path d="M20.45 20.45h-3.555v-5.569c0-1.328-.024-3.038-1.852-3.038-1.853 0-2.136 1.447-2.136 2.94v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.268 2.37 4.268 5.455v6.284zM5.34 7.433a2.062 2.062 0 11.001-4.124 2.062 2.062 0 010 4.124zM7.119 20.45H3.555V9h3.564v11.45zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.222 0h.003z"/></svg>
       </a>
-      <a href="https://github.com/esokullu/webbrain" target="_blank" rel="noopener">GitHub</a>
+      <a href="/blog">Blog</a>
       <a href="#safety">Safety Notice</a>
       <a href="/privacy">Privacy Policy</a>
       <a href="https://github.com/esokullu/webbrain/issues" target="_blank" rel="noopener">Report Bug</a>

--- a/web/tr/index.html
+++ b/web/tr/index.html
@@ -1633,7 +1633,7 @@
       <a href="https://www.linkedin.com/sharing/share-offsite/?url=https%3A%2F%2Fwebbrain.one%2Ftr%2F" target="_blank" rel="noopener" aria-label="LinkedIn&#39;de paylaş" title="LinkedIn&#39;de paylaş" class="footer-icon">
         <svg viewBox="0 0 24 24" fill="currentColor" width="14" height="14" aria-hidden="true"><path d="M20.45 20.45h-3.555v-5.569c0-1.328-.024-3.038-1.852-3.038-1.853 0-2.136 1.447-2.136 2.94v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.268 2.37 4.268 5.455v6.284zM5.34 7.433a2.062 2.062 0 11.001-4.124 2.062 2.062 0 010 4.124zM7.119 20.45H3.555V9h3.564v11.45zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.222 0h.003z"/></svg>
       </a>
-      <a href="https://github.com/esokullu/webbrain" target="_blank" rel="noopener">GitHub</a>
+      <a href="/blog">Blog</a>
       <a href="#safety">Güvenlik uyarısı</a>
       <a href="/privacy">Gizlilik politikası</a>
       <a href="https://github.com/esokullu/webbrain/issues" target="_blank" rel="noopener">Hata bildir</a>

--- a/web/zh/index.html
+++ b/web/zh/index.html
@@ -1633,7 +1633,7 @@
       <a href="https://www.linkedin.com/sharing/share-offsite/?url=https%3A%2F%2Fwebbrain.one%2Fzh%2F" target="_blank" rel="noopener" aria-label="分享到 LinkedIn" title="分享到 LinkedIn" class="footer-icon">
         <svg viewBox="0 0 24 24" fill="currentColor" width="14" height="14" aria-hidden="true"><path d="M20.45 20.45h-3.555v-5.569c0-1.328-.024-3.038-1.852-3.038-1.853 0-2.136 1.447-2.136 2.94v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.268 2.37 4.268 5.455v6.284zM5.34 7.433a2.062 2.062 0 11.001-4.124 2.062 2.062 0 010 4.124zM7.119 20.45H3.555V9h3.564v11.45zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.222 0h.003z"/></svg>
       </a>
-      <a href="https://github.com/esokullu/webbrain" target="_blank" rel="noopener">GitHub</a>
+      <a href="/blog">博客</a>
       <a href="#safety">安全提示</a>
       <a href="/privacy">隐私政策</a>
       <a href="https://github.com/esokullu/webbrain/issues" target="_blank" rel="noopener">报告 Bug</a>


### PR DESCRIPTION
### Motivation
- Replace the footer’s external GitHub link with an internal Blog link to surface the blog from the site footer.

### Description
- Updated the footer in `web/build/template.html` to remove the `https://github.com/esokullu/webbrain` anchor and replace it with a `/blog` anchor using `{{t:nav.blog}}`, and regenerated the localized static pages `web/index.html`, `web/es/index.html`, `web/fr/index.html`, `web/tr/index.html`, and `web/zh/index.html`.

### Testing
- Ran the static site build `node web/build/build.mjs`, which completed successfully and wrote the updated localized pages listed above.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a03e9862a1c8327bd2dcad53fd2d87c)