### PR TITLE
Provider filters + collapsible cards + 4 new cloud providers (7.3.0)

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "WebBrain",
-  "version": "7.2.1",
+  "version": "7.3.0",
   "description": "Open-source AI browser agent — chat with pages, automate tasks, multi-provider LLM support.",
   "permissions": [
     "sidePanel",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "webbrain",
-  "version": "7.2.1",
+  "version": "7.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "webbrain",
-      "version": "7.2.1",
+      "version": "7.3.0",
       "license": "MIT",
       "devDependencies": {
         "playwright": "^1.48.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webbrain",
-  "version": "7.2.1",
+  "version": "7.3.0",
   "description": "Open-source AI browser agent — chat with pages, automate tasks, multi-provider LLM support.",
   "private": true,
   "type": "module",

--- a/src/chrome/ARCHITECTURE.md
+++ b/src/chrome/ARCHITECTURE.md
@@ -1,6 +1,6 @@
 # WebBrain Chrome Extension — Architecture
 
-> Version 7.2.1 · Manifest V3 · Service Worker background
+> Version 7.3.0 · Manifest V3 · Service Worker background
 
 ## High-Level Overview
 

--- a/src/chrome/manifest.json
+++ b/src/chrome/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "WebBrain",
-  "version": "7.2.1",
+  "version": "7.3.0",
   "description": "Open-source AI browser agent — chat with pages, automate tasks, multi-provider LLM support.",
   "permissions": [
     "sidePanel",

--- a/src/chrome/src/providers/manager.js
+++ b/src/chrome/src/providers/manager.js
@@ -59,6 +59,7 @@ export class ProviderManager {
     return {
       llamacpp: {
         type: 'llamacpp',
+        category: 'local',
         label: 'llama.cpp (Local)',
         baseUrl: 'http://localhost:8080',
         model: '',
@@ -67,6 +68,7 @@ export class ProviderManager {
       },
       ollama: {
         type: 'openai',
+        category: 'local',
         label: 'Ollama (Local)',
         providerName: 'ollama',
         baseUrl: 'http://localhost:11434/v1',
@@ -77,6 +79,7 @@ export class ProviderManager {
       },
       lmstudio: {
         type: 'openai',
+        category: 'local',
         label: 'LM Studio (Local)',
         providerName: 'lmstudio',
         baseUrl: 'http://localhost:1234/v1',
@@ -87,6 +90,7 @@ export class ProviderManager {
       },
       openai: {
         type: 'openai',
+        category: 'cloud',
         label: 'OpenAI',
         providerName: 'openai',
         baseUrl: 'https://api.openai.com/v1',
@@ -94,20 +98,65 @@ export class ProviderManager {
         apiKey: '',
         enabled: false,
       },
+      anthropic: {
+        type: 'anthropic',
+        category: 'cloud',
+        label: 'Anthropic Claude',
+        baseUrl: 'https://api.anthropic.com',
+        model: 'claude-sonnet-4-6',
+        apiKey: '',
+        enabled: false,
+      },
+      // Google Gemini via the OpenAI-compatible endpoint. Pure REST, no
+      // separate SDK needed. Streaming, function-calling, vision all work
+      // through the same OpenAICompatibleProvider.
+      gemini: {
+        type: 'openai',
+        category: 'cloud',
+        label: 'Google Gemini',
+        providerName: 'gemini',
+        baseUrl: 'https://generativelanguage.googleapis.com/v1beta/openai',
+        model: 'gemini-2.0-flash',
+        apiKey: '',
+        enabled: false,
+      },
+      mistral: {
+        type: 'openai',
+        category: 'cloud',
+        label: 'Mistral AI',
+        providerName: 'mistral',
+        baseUrl: 'https://api.mistral.ai/v1',
+        model: 'mistral-large-latest',
+        apiKey: '',
+        enabled: false,
+      },
+      deepseek: {
+        type: 'openai',
+        category: 'cloud',
+        label: 'DeepSeek',
+        providerName: 'deepseek',
+        baseUrl: 'https://api.deepseek.com/v1',
+        model: 'deepseek-chat',
+        apiKey: '',
+        enabled: false,
+      },
+      xai: {
+        type: 'openai',
+        category: 'cloud',
+        label: 'xAI Grok',
+        providerName: 'xai',
+        baseUrl: 'https://api.x.ai/v1',
+        model: 'grok-4',
+        apiKey: '',
+        enabled: false,
+      },
       openrouter: {
         type: 'openai',
+        category: 'router',
         label: 'OpenRouter',
         providerName: 'openrouter',
         baseUrl: 'https://openrouter.ai/api/v1',
         model: 'anthropic/claude-sonnet-4',
-        apiKey: '',
-        enabled: false,
-      },
-      anthropic: {
-        type: 'anthropic',
-        label: 'Anthropic Claude',
-        baseUrl: 'https://api.anthropic.com',
-        model: 'claude-sonnet-4-6',
         apiKey: '',
         enabled: false,
       },
@@ -119,11 +168,27 @@ export class ProviderManager {
       // this provider instead of the API-key field.
       claude_subscription: {
         type: 'anthropic_oauth',
+        category: 'cloud',
         label: 'Claude (Pro/Max subscription)',
         model: 'claude-sonnet-4-6',
         enabled: false,
       },
     };
+  }
+
+  /**
+   * Provider category for filter UI. Returns one of:
+   *   'local'  — runs on the user's machine (llama.cpp, ollama, lmstudio)
+   *   'cloud'  — first-party API endpoint (openai, anthropic, gemini, etc.)
+   *   'router' — multi-model gateways that fan out to many backends (openrouter)
+   * Reads `config.category` first; falls back to a per-id table so configs
+   * written before 7.3 (which lacked the field) still classify correctly.
+   */
+  static categoryFor(id, config) {
+    if (config && config.category) return config.category;
+    if (['llamacpp', 'ollama', 'lmstudio'].includes(id)) return 'local';
+    if (id === 'openrouter') return 'router';
+    return 'cloud';
   }
 
   _createProvider(id, config) {
@@ -201,12 +266,19 @@ export class ProviderManager {
   }
 
   /**
-   * Get all provider configs for the settings UI.
+   * Get all provider configs for the settings UI. Each entry includes a
+   * `category` field ('local' | 'cloud' | 'router') so the UI can filter
+   * without re-deriving the classification.
    */
   getAll() {
     const result = {};
     for (const [id, provider] of this.providers) {
-      result[id] = { id, ...provider.config };
+      const config = provider.config;
+      result[id] = {
+        id,
+        ...config,
+        category: ProviderManager.categoryFor(id, config),
+      };
     }
     return result;
   }

--- a/src/chrome/src/ui/locales/en.js
+++ b/src/chrome/src/ui/locales/en.js
@@ -127,6 +127,11 @@ export default {
   'st.display.traces_link.open': 'Open Traces →',
 
   'st.providers.info.html': '<strong>Getting started with llama.cpp:</strong><br>Run <code>llama-server -m your-model.gguf --port 8080</code> to start a local server.<br>No API key needed — it runs entirely on your machine.',
+  'st.providers.filter.all': 'All',
+  'st.providers.filter.local': 'Local',
+  'st.providers.filter.cloud': 'Cloud',
+  'st.providers.filter.router': 'Router',
+  'st.providers.filter.empty': 'No providers in this category. Switch the filter to "All" to see everything.',
   'st.providers.save': 'Save',
   'st.providers.test': 'Test Connection',
   'st.providers.set_active': 'Set Active',

--- a/src/chrome/src/ui/settings.html
+++ b/src/chrome/src/ui/settings.html
@@ -93,6 +93,10 @@
       transition: border-color 0.2s;
     }
     .provider-card.active { border-color: var(--accent); }
+    /* Collapsed cards are just the header — keeps the providers list scannable
+       at a glance when many are configured. */
+    .provider-card.collapsed { padding: 12px 16px; }
+    .provider-card.collapsed .provider-header { margin-bottom: 0; }
 
     .provider-header {
       display: flex;
@@ -100,8 +104,82 @@
       justify-content: space-between;
       margin-bottom: 12px;
     }
+    .provider-header-clickable { cursor: pointer; user-select: none; }
+    .provider-header-clickable:hover .provider-name { color: var(--accent); }
+    .provider-header-left {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      flex-wrap: wrap;
+    }
+    .provider-chevron {
+      color: var(--text2);
+      font-size: 11px;
+      width: 10px;
+      display: inline-block;
+      transition: color 0.15s;
+    }
+    .provider-card.expanded .provider-chevron { color: var(--accent); }
     .provider-name { font-weight: 600; font-size: 14px; }
     .provider-type { color: var(--text2); font-size: 11px; }
+
+    /* Category badge — small uppercase pill next to the provider name so
+       the user can see at a glance which category each provider belongs to. */
+    .provider-category-badge {
+      font-size: 10px;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.5px;
+      padding: 2px 6px;
+      border-radius: 4px;
+      background: rgba(255,255,255,0.06);
+      color: var(--text2);
+    }
+    .provider-category-local  { background: rgba(76, 175, 80, 0.15); color: #8fd896; }
+    .provider-category-cloud  { background: rgba(108, 99, 255, 0.15); color: #a8a3ff; }
+    .provider-category-router { background: rgba(255, 152, 0, 0.15); color: #ffc870; }
+
+    /* Filter bar — pill row above the provider list. */
+    .provider-filter-bar {
+      display: flex;
+      gap: 6px;
+      flex-wrap: wrap;
+      margin: 0 0 16px 0;
+      padding: 4px;
+      background: var(--bg2);
+      border: 1px solid var(--border);
+      border-radius: var(--radius);
+    }
+    .provider-filter-pill {
+      flex: 1;
+      min-width: 60px;
+      background: transparent;
+      color: var(--text2);
+      border: none;
+      border-radius: 6px;
+      padding: 7px 10px;
+      font-size: 12px;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.4px;
+      cursor: pointer;
+      transition: background 0.12s, color 0.12s;
+    }
+    .provider-filter-pill:hover { color: var(--text); }
+    .provider-filter-pill.active {
+      background: var(--accent);
+      color: #fff;
+    }
+    .provider-filter-pill.active:hover { color: #fff; }
+    .provider-filter-empty {
+      padding: 16px;
+      text-align: center;
+      color: var(--text2);
+      font-size: 13px;
+      background: var(--bg2);
+      border: 1px dashed var(--border);
+      border-radius: var(--radius);
+    }
 
     .field { margin-bottom: 10px; }
     .field label {

--- a/src/chrome/src/ui/settings.html
+++ b/src/chrome/src/ui/settings.html
@@ -139,6 +139,22 @@
     .provider-category-cloud  { background: rgba(108, 99, 255, 0.15); color: #a8a3ff; }
     .provider-category-router { background: rgba(255, 152, 0, 0.15); color: #ffc870; }
 
+    /* Configured model — shown in the collapsed-card header so the user can
+       see at a glance which model is set for each provider. Mono font
+       signals "this is an identifier", and dimming + tabular-feel keeps it
+       from competing with the provider's own name. max-width + ellipsis so
+       long OpenRouter-style names ("anthropic/claude-sonnet-4-thinking-...")
+       don't push the active-indicator off the row. */
+    .provider-model {
+      color: var(--text2);
+      font-size: 11px;
+      font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+      max-width: 240px;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+
     /* Filter bar — pill row above the provider list. */
     .provider-filter-bar {
       display: flex;

--- a/src/chrome/src/ui/settings.js
+++ b/src/chrome/src/ui/settings.js
@@ -6,7 +6,7 @@ import { t, getLocale, setLocale, LANGUAGES } from './i18n.js';
 
 // Version shown in the subtitle. Kept here so it only needs one update per
 // release; the subtitle string itself is translated.
-const EXT_VERSION = '7.2.1';
+const EXT_VERSION = '7.3.0';
 
 const providersContainer = document.getElementById('providers');
 const verboseToggle = document.getElementById('toggle-verbose');
@@ -64,6 +64,13 @@ let authToken = '';
 let authEmail = '';
 let authDefaultModel = '';
 
+// Filter + collapse state for the providers panel. With 11+ providers the
+// flat list is unwieldy — filter keeps the visual surface small, and
+// per-card collapse defaults non-active cards to header-only so the page
+// doesn't scroll forever.
+let providerFilter = 'all';     // 'all' | 'local' | 'cloud' | 'router'
+const expandedProviders = new Set(); // ids the user explicitly expanded this session
+
 // --- Init ---
 
 async function init() {
@@ -75,7 +82,10 @@ async function init() {
   renderAuthSection();
 
   // Load display settings
-  const stored = await chrome.storage.local.get(['verboseMode', 'screenshotFallback', 'maxAgentSteps', 'autoScreenshot', 'useSiteAdapters', 'notifySound', 'tracingEnabled', 'strictSecretMode', 'agentAllowLocalNetwork']);
+  const stored = await chrome.storage.local.get(['verboseMode', 'screenshotFallback', 'maxAgentSteps', 'autoScreenshot', 'useSiteAdapters', 'notifySound', 'tracingEnabled', 'strictSecretMode', 'agentAllowLocalNetwork', 'providerFilter']);
+  if (typeof stored.providerFilter === 'string' && ['all','local','cloud','router'].includes(stored.providerFilter)) {
+    providerFilter = stored.providerFilter;
+  }
   verboseToggle.checked = stored.verboseMode || false;
   screenshotToggle.checked = stored.screenshotFallback ?? true; // on by default
   maxStepsRange.value = stored.maxAgentSteps || 60;
@@ -375,6 +385,34 @@ function renderProviders() {
         { key: 'baseUrl', labelKey: 'st.provider.field.api_base_url', type: 'text', placeholder: 'https://api.anthropic.com' },
       ],
     },
+    gemini: {
+      fields: [
+        { key: 'apiKey', labelKey: 'st.provider.field.api_key', type: 'password', placeholder: 'AIza...' },
+        { key: 'model', labelKey: 'st.provider.field.model', type: 'text', placeholder: 'gemini-2.0-flash' },
+        { key: 'baseUrl', labelKey: 'st.provider.field.api_base_url', type: 'text', placeholder: 'https://generativelanguage.googleapis.com/v1beta/openai' },
+      ],
+    },
+    mistral: {
+      fields: [
+        { key: 'apiKey', labelKey: 'st.provider.field.api_key', type: 'password', placeholder: 'API key' },
+        { key: 'model', labelKey: 'st.provider.field.model', type: 'text', placeholder: 'mistral-large-latest' },
+        { key: 'baseUrl', labelKey: 'st.provider.field.api_base_url', type: 'text', placeholder: 'https://api.mistral.ai/v1' },
+      ],
+    },
+    deepseek: {
+      fields: [
+        { key: 'apiKey', labelKey: 'st.provider.field.api_key', type: 'password', placeholder: 'sk-...' },
+        { key: 'model', labelKey: 'st.provider.field.model', type: 'text', placeholder: 'deepseek-chat' },
+        { key: 'baseUrl', labelKey: 'st.provider.field.api_base_url', type: 'text', placeholder: 'https://api.deepseek.com/v1' },
+      ],
+    },
+    xai: {
+      fields: [
+        { key: 'apiKey', labelKey: 'st.provider.field.api_key', type: 'password', placeholder: 'xai-...' },
+        { key: 'model', labelKey: 'st.provider.field.model', type: 'text', placeholder: 'grok-4' },
+        { key: 'baseUrl', labelKey: 'st.provider.field.api_base_url', type: 'text', placeholder: 'https://api.x.ai/v1' },
+      ],
+    },
     // OAuth-based Claude subscription provider. The card body is rendered
     // by renderClaudeOAuthCard() — it shows a sign-in/out button, the
     // current account state, and a disclaimer about Anthropic's terms.
@@ -387,19 +425,31 @@ function renderProviders() {
     },
   };
 
-  for (const [id, config] of Object.entries(providersData)) {
+  // Filter bar — sits above the list. Pill row, click-to-switch.
+  // "All" includes everything; the per-category pills hide cards whose
+  // `category` doesn't match. The active provider is ALWAYS visible
+  // regardless of filter (so the user never loses track of it).
+  providersContainer.appendChild(renderProviderFilterBar());
+
+  const entries = Object.entries(providersData);
+  let visibleCount = 0;
+  for (const [id, config] of entries) {
     const isActive = id === activeProviderId;
     const fieldDefs = providerConfigs[id]?.fields || [];
 
-    // Custom render for the OAuth Claude provider. Lives in its own
-    // function because the card body is mostly buttons + status, not
-    // form fields, and the auth state is fetched async.
+    // Filter: hide cards whose category doesn't match (active always shown).
+    const category = config.category || 'cloud';
+    if (providerFilter !== 'all' && category !== providerFilter && !isActive) continue;
+    visibleCount++;
+
+    // Custom render for the OAuth Claude provider — same collapsible
+    // wrapper, but the body comes from renderClaudeOAuthCard().
     if (providerConfigs[id]?.customRender === 'claude_oauth') {
-      providersContainer.appendChild(renderClaudeOAuthCard(id, config, isActive, fieldDefs));
+      providersContainer.appendChild(
+        wrapCollapsibleCard(id, config, isActive, renderClaudeOAuthCardBody(id, config, fieldDefs))
+      );
       continue;
     }
-    const card = document.createElement('div');
-    card.className = `provider-card ${isActive ? 'active' : ''}`;
 
     let fieldsHTML = '';
     for (const field of fieldDefs) {
@@ -445,14 +495,7 @@ function renderProviders() {
       }
     }
 
-    card.innerHTML = `
-      <div class="provider-header">
-        <div>
-          <span class="provider-name">${escapeHtml(config.label || id)}</span>
-          <span class="provider-type">${escapeHtml(config.type)}</span>
-        </div>
-        ${isActive ? `<span style="color:var(--accent);font-size:11px;font-weight:600">${escapeHtml(t('st.providers.active'))}</span>` : ''}
-      </div>
+    const body = `
       ${fieldsHTML}
       <div class="btn-row">
         <button class="btn-primary btn-save" data-provider="${id}">${escapeHtml(t('st.providers.save'))}</button>
@@ -462,7 +505,17 @@ function renderProviders() {
       <div class="test-result" id="test-${id}"></div>
     `;
 
-    providersContainer.appendChild(card);
+    providersContainer.appendChild(wrapCollapsibleCard(id, config, isActive, body));
+  }
+
+  // If the filter would leave the list empty (no cards match and no active
+  // provider in this category either), tell the user. Don't make them
+  // guess why nothing is showing.
+  if (visibleCount === 0) {
+    const empty = document.createElement('div');
+    empty.className = 'provider-filter-empty';
+    empty.textContent = t('st.providers.filter.empty') || 'No providers in this category. Switch filter to All.';
+    providersContainer.appendChild(empty);
   }
 
   document.querySelectorAll('.btn-save').forEach(btn => {
@@ -477,12 +530,100 @@ function renderProviders() {
   document.querySelectorAll('.btn-load-models').forEach(btn => {
     btn.addEventListener('click', () => loadOllamaModels(btn.dataset.provider));
   });
+  // OAuth-Claude-specific bindings. These only fire if the OAuth card is
+  // currently rendered (i.e., expanded — collapsed bodies aren't in DOM).
+  document.querySelectorAll('.btn-claude-signin').forEach(btn => {
+    btn.addEventListener('click', () => signInWithClaude(btn.dataset.provider));
+  });
+  document.querySelectorAll('.btn-claude-signout').forEach(btn => {
+    btn.addEventListener('click', () => signOutOfClaude(btn.dataset.provider));
+  });
+  document.querySelectorAll('.claude-oauth-status').forEach(el => {
+    const id = el.id.replace(/^claude-oauth-status-/, '');
+    if (id) queueMicrotask(() => refreshClaudeOAuthStatus(id));
+  });
 }
 
 /**
- * Render the Claude (Pro/Max subscription) provider card.
+ * Build the filter pill row. Clicking a pill updates `providerFilter`,
+ * persists it to storage, and re-renders. Categories: all / local /
+ * cloud / router.
+ */
+function renderProviderFilterBar() {
+  const bar = document.createElement('div');
+  bar.className = 'provider-filter-bar';
+  const filters = [
+    { key: 'all',    labelKey: 'st.providers.filter.all' },
+    { key: 'local',  labelKey: 'st.providers.filter.local' },
+    { key: 'cloud',  labelKey: 'st.providers.filter.cloud' },
+    { key: 'router', labelKey: 'st.providers.filter.router' },
+  ];
+  for (const f of filters) {
+    const btn = document.createElement('button');
+    btn.type = 'button';
+    btn.className = `provider-filter-pill${providerFilter === f.key ? ' active' : ''}`;
+    btn.dataset.filter = f.key;
+    btn.textContent = t(f.labelKey);
+    btn.addEventListener('click', () => {
+      if (providerFilter === f.key) return;
+      providerFilter = f.key;
+      try { chrome.storage.local.set({ providerFilter: f.key }); } catch {}
+      renderProviders();
+    });
+    bar.appendChild(btn);
+  }
+  return bar;
+}
+
+/**
+ * Wrap a provider card's body in a collapsible shell. Active provider
+ * starts expanded; everything else starts collapsed but the user can
+ * toggle individual cards open by clicking the header. Expansion state
+ * is session-only (resets on settings reload) — keeps the default
+ * predictable rather than reflecting whatever the user last poked at.
+ */
+function wrapCollapsibleCard(id, config, isActive, bodyHtml) {
+  const expanded = isActive || expandedProviders.has(id);
+  const card = document.createElement('div');
+  card.className = `provider-card ${isActive ? 'active' : ''} ${expanded ? 'expanded' : 'collapsed'}`;
+  card.dataset.providerId = id;
+  card.dataset.providerCategory = config.category || 'cloud';
+
+  const header = document.createElement('div');
+  header.className = 'provider-header provider-header-clickable';
+  header.innerHTML = `
+    <div class="provider-header-left">
+      <span class="provider-chevron" aria-hidden="true">${expanded ? '▾' : '▸'}</span>
+      <span class="provider-name">${escapeHtml(config.label || id)}</span>
+      <span class="provider-type">${escapeHtml(config.type)}</span>
+      ${config.category ? `<span class="provider-category-badge provider-category-${escapeHtml(config.category)}">${escapeHtml(config.category)}</span>` : ''}
+    </div>
+    ${isActive ? `<span style="color:var(--accent);font-size:11px;font-weight:600">${escapeHtml(t('st.providers.active'))}</span>` : ''}
+  `;
+  header.addEventListener('click', (e) => {
+    // Ignore clicks that originated on inputs/buttons inside the header
+    // (none today, but future-proof).
+    if (e.target.closest('button, input, a, select')) return;
+    if (expandedProviders.has(id)) expandedProviders.delete(id);
+    else expandedProviders.add(id);
+    renderProviders();
+  });
+
+  const body = document.createElement('div');
+  body.className = 'provider-body';
+  body.innerHTML = bodyHtml;
+
+  card.appendChild(header);
+  if (expanded) card.appendChild(body);
+  return card;
+}
+
+/**
+ * Render the BODY of the Claude (Pro/Max subscription) provider card.
  *
- * Differs from a normal provider card in three ways:
+ * Returns the inner HTML — header + outer wrapper come from
+ * wrapCollapsibleCard() in renderProviders(). Differs from a normal
+ * provider card in three ways:
  *   - No API-key field. Auth is via OAuth — handled by the background
  *     script. We just dispatch claude_oauth_start/signout/status.
  *   - Loaded auth state shows the obtained-at timestamp and a "Sign
@@ -490,13 +631,13 @@ function renderProviders() {
  *   - A persistent disclaimer warns the user that Anthropic's terms
  *     restrict third-party clients from using Pro/Max subs and that
  *     this integration may stop working at any time.
+ *
+ * Event bindings (sign-in/out) + the async status refresh fire from
+ * the per-card pass at the end of renderProviders() — see
+ * bindClaudeOAuthCards().
  */
-function renderClaudeOAuthCard(id, config, isActive, fieldDefs) {
-  const card = document.createElement('div');
-  card.className = `provider-card ${isActive ? 'active' : ''}`;
-
-  // Build the editable model field with the same pattern as the other
-  // provider cards so save/test/activate keep working uniformly.
+function renderClaudeOAuthCardBody(id, config, fieldDefs) {
+  const isActive = id === activeProviderId;
   let fieldsHTML = '';
   for (const field of fieldDefs) {
     const label = field.labelKey ? t(field.labelKey) : (field.label || field.key);
@@ -510,15 +651,7 @@ function renderClaudeOAuthCard(id, config, isActive, fieldDefs) {
     `;
   }
 
-  card.innerHTML = `
-    <div class="provider-header">
-      <div>
-        <span class="provider-name">${escapeHtml(config.label || id)}</span>
-        <span class="provider-type">oauth</span>
-      </div>
-      ${isActive ? `<span style="color:var(--accent);font-size:11px;font-weight:600">${escapeHtml(t('st.providers.active'))}</span>` : ''}
-    </div>
-
+  return `
     <div class="claude-oauth-status" id="claude-oauth-status-${id}"
          style="padding:10px 12px;border-radius:6px;background:var(--surface2,#f5f5f7);
                 margin-bottom:10px;font-size:13px;color:var(--text2);">
@@ -547,17 +680,6 @@ function renderClaudeOAuthCard(id, config, isActive, fieldDefs) {
       <strong>Heads up:</strong> Uses your Claude.ai Pro/Max subscription's quota via the OAuth flow Anthropic ships for Claude Code. This is a third-party use of that flow — Anthropic's terms restrict using Pro/Max subscriptions with non-Anthropic tools, and the integration could stop working at any time if Anthropic rotates their CLI's OAuth client. Your access + refresh tokens are stored in <code>chrome.storage.local</code> in plaintext (same as API keys). Use at your own risk; for production / reliability, prefer the API-key Anthropic provider above.
     </div>
   `;
-
-  card.querySelector('.btn-claude-signin').addEventListener('click', () => signInWithClaude(id));
-  card.querySelector('.btn-claude-signout').addEventListener('click', () => signOutOfClaude(id));
-  // Run after the caller appends the card; refreshClaudeOAuthStatus()
-  // looks up elements through document.getElementById().
-  queueMicrotask(() => refreshClaudeOAuthStatus(id));
-  // Save / Test / Activate share handlers with the normal provider
-  // cards via the document.querySelectorAll bindings at the end of
-  // renderProviders() — we don't need to re-bind here.
-
-  return card;
 }
 
 async function refreshClaudeOAuthStatus(id) {

--- a/src/chrome/src/ui/settings.js
+++ b/src/chrome/src/ui/settings.js
@@ -566,6 +566,11 @@ function renderProviderFilterBar() {
     btn.textContent = t(f.labelKey);
     btn.addEventListener('click', () => {
       if (providerFilter === f.key) return;
+      // Snapshot whatever the user has typed but not yet saved BEFORE we
+      // rebuild the DOM — otherwise input values for the currently-rendered
+      // cards are lost (e.g. typed an API key, then clicked a filter pill
+      // to compare two providers).
+      syncInputsIntoProvidersData();
       providerFilter = f.key;
       try { chrome.storage.local.set({ providerFilter: f.key }); } catch {}
       renderProviders();
@@ -611,6 +616,9 @@ function wrapCollapsibleCard(id, config, isActive, bodyHtml) {
     // Ignore clicks that originated on inputs/buttons inside the header
     // (none today, but future-proof).
     if (e.target.closest('button, input, a, select')) return;
+    // Snapshot unsaved typing in other expanded cards before we rebuild
+    // the DOM — same reason as the filter-pill handler above.
+    syncInputsIntoProvidersData();
     if (expandedProviders.has(id)) expandedProviders.delete(id);
     else expandedProviders.add(id);
     renderProviders();

--- a/src/chrome/src/ui/settings.js
+++ b/src/chrome/src/ui/settings.js
@@ -591,12 +591,19 @@ function wrapCollapsibleCard(id, config, isActive, bodyHtml) {
 
   const header = document.createElement('div');
   header.className = 'provider-header provider-header-clickable';
+  // Model name appears in the collapsed header as small mono-font text — the
+  // headline question for any AI tool is "what model is this set to?", and
+  // making the user expand the card to find out is bad UX. Empty model (e.g.
+  // LM Studio defaults to whatever's loaded) just renders nothing rather
+  // than a placeholder, to avoid pretending we know what they're running.
+  const modelStr = (config.model && String(config.model).trim()) || '';
   header.innerHTML = `
     <div class="provider-header-left">
       <span class="provider-chevron" aria-hidden="true">${expanded ? '▾' : '▸'}</span>
       <span class="provider-name">${escapeHtml(config.label || id)}</span>
       <span class="provider-type">${escapeHtml(config.type)}</span>
       ${config.category ? `<span class="provider-category-badge provider-category-${escapeHtml(config.category)}">${escapeHtml(config.category)}</span>` : ''}
+      ${modelStr ? `<span class="provider-model" title="${escapeHtml(modelStr)}">${escapeHtml(modelStr)}</span>` : ''}
     </div>
     ${isActive ? `<span style="color:var(--accent);font-size:11px;font-weight:600">${escapeHtml(t('st.providers.active'))}</span>` : ''}
   `;

--- a/src/firefox/ARCHITECTURE.md
+++ b/src/firefox/ARCHITECTURE.md
@@ -1,6 +1,6 @@
 # WebBrain Firefox Extension — Architecture
 
-> Version 7.2.1 · Manifest V2 · Background Page
+> Version 7.3.0 · Manifest V2 · Background Page
 
 ## How Firefox Differs from Chrome
 

--- a/src/firefox/manifest.json
+++ b/src/firefox/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "WebBrain",
-  "version": "7.2.1",
+  "version": "7.3.0",
   "description": "Open-source AI browser agent — chat with pages, automate tasks, multi-provider LLM support.",
   "permissions": [
     "activeTab",

--- a/src/firefox/src/providers/manager.js
+++ b/src/firefox/src/providers/manager.js
@@ -56,6 +56,7 @@ export class ProviderManager {
     return {
       llamacpp: {
         type: 'llamacpp',
+        category: 'local',
         label: 'llama.cpp (Local)',
         baseUrl: 'http://localhost:8080',
         model: '',
@@ -64,6 +65,7 @@ export class ProviderManager {
       },
       ollama: {
         type: 'openai',
+        category: 'local',
         label: 'Ollama (Local)',
         providerName: 'ollama',
         baseUrl: 'http://localhost:11434/v1',
@@ -74,6 +76,7 @@ export class ProviderManager {
       },
       lmstudio: {
         type: 'openai',
+        category: 'local',
         label: 'LM Studio (Local)',
         providerName: 'lmstudio',
         baseUrl: 'http://localhost:1234/v1',
@@ -84,6 +87,7 @@ export class ProviderManager {
       },
       openai: {
         type: 'openai',
+        category: 'cloud',
         label: 'OpenAI',
         providerName: 'openai',
         baseUrl: 'https://api.openai.com/v1',
@@ -91,20 +95,62 @@ export class ProviderManager {
         apiKey: '',
         enabled: false,
       },
+      anthropic: {
+        type: 'anthropic',
+        category: 'cloud',
+        label: 'Anthropic Claude',
+        baseUrl: 'https://api.anthropic.com',
+        model: 'claude-sonnet-4-20250514',
+        apiKey: '',
+        enabled: false,
+      },
+      gemini: {
+        type: 'openai',
+        category: 'cloud',
+        label: 'Google Gemini',
+        providerName: 'gemini',
+        baseUrl: 'https://generativelanguage.googleapis.com/v1beta/openai',
+        model: 'gemini-2.0-flash',
+        apiKey: '',
+        enabled: false,
+      },
+      mistral: {
+        type: 'openai',
+        category: 'cloud',
+        label: 'Mistral AI',
+        providerName: 'mistral',
+        baseUrl: 'https://api.mistral.ai/v1',
+        model: 'mistral-large-latest',
+        apiKey: '',
+        enabled: false,
+      },
+      deepseek: {
+        type: 'openai',
+        category: 'cloud',
+        label: 'DeepSeek',
+        providerName: 'deepseek',
+        baseUrl: 'https://api.deepseek.com/v1',
+        model: 'deepseek-chat',
+        apiKey: '',
+        enabled: false,
+      },
+      xai: {
+        type: 'openai',
+        category: 'cloud',
+        label: 'xAI Grok',
+        providerName: 'xai',
+        baseUrl: 'https://api.x.ai/v1',
+        model: 'grok-4',
+        apiKey: '',
+        enabled: false,
+      },
       openrouter: {
         type: 'openai',
+        category: 'router',
         label: 'OpenRouter',
         providerName: 'openrouter',
         baseUrl: 'https://openrouter.ai/api/v1',
         model: 'anthropic/claude-sonnet-4',
-        apiKey: '',
-        enabled: false,
-      },
-      anthropic: {
-        type: 'anthropic',
-        label: 'Anthropic Claude',
-        baseUrl: 'https://api.anthropic.com',
-        model: 'claude-sonnet-4-20250514',
         apiKey: '',
         enabled: false,
       },
@@ -114,11 +160,25 @@ export class ProviderManager {
       // oauth-claude.js), not in this config.
       claude_subscription: {
         type: 'anthropic_oauth',
+        category: 'cloud',
         label: 'Claude (Pro/Max subscription)',
         model: 'claude-sonnet-4-20250514',
         enabled: false,
       },
     };
+  }
+
+  /**
+   * Provider category for filter UI. See chrome/providers/manager.js for
+   * the canonical doc. Categories: 'local' | 'cloud' | 'router'. Reads
+   * config.category first; falls back to a per-id table so pre-7.3
+   * stored configs classify correctly.
+   */
+  static categoryFor(id, config) {
+    if (config && config.category) return config.category;
+    if (['llamacpp', 'ollama', 'lmstudio'].includes(id)) return 'local';
+    if (id === 'openrouter') return 'router';
+    return 'cloud';
   }
 
   _createProvider(id, config) {
@@ -196,12 +256,19 @@ export class ProviderManager {
   }
 
   /**
-   * Get all provider configs for the settings UI.
+   * Get all provider configs for the settings UI. Each entry includes a
+   * `category` field ('local' | 'cloud' | 'router') so the UI can filter
+   * without re-deriving the classification.
    */
   getAll() {
     const result = {};
     for (const [id, provider] of this.providers) {
-      result[id] = { id, ...provider.config };
+      const config = provider.config;
+      result[id] = {
+        id,
+        ...config,
+        category: ProviderManager.categoryFor(id, config),
+      };
     }
     return result;
   }

--- a/src/firefox/src/ui/locales/en.js
+++ b/src/firefox/src/ui/locales/en.js
@@ -127,6 +127,11 @@ export default {
   'st.display.traces_link.open': 'Open Traces →',
 
   'st.providers.info.html': '<strong>Getting started with llama.cpp:</strong><br>Run <code>llama-server -m your-model.gguf --port 8080</code> to start a local server.<br>No API key needed — it runs entirely on your machine.',
+  'st.providers.filter.all': 'All',
+  'st.providers.filter.local': 'Local',
+  'st.providers.filter.cloud': 'Cloud',
+  'st.providers.filter.router': 'Router',
+  'st.providers.filter.empty': 'No providers in this category. Switch the filter to "All" to see everything.',
   'st.providers.save': 'Save',
   'st.providers.test': 'Test Connection',
   'st.providers.set_active': 'Set Active',

--- a/src/firefox/src/ui/settings.html
+++ b/src/firefox/src/ui/settings.html
@@ -93,6 +93,8 @@
       transition: border-color 0.2s;
     }
     .provider-card.active { border-color: var(--accent); }
+    .provider-card.collapsed { padding: 12px 16px; }
+    .provider-card.collapsed .provider-header { margin-bottom: 0; }
 
     .provider-header {
       display: flex;
@@ -100,8 +102,79 @@
       justify-content: space-between;
       margin-bottom: 12px;
     }
+    .provider-header-clickable { cursor: pointer; user-select: none; }
+    .provider-header-clickable:hover .provider-name { color: var(--accent); }
+    .provider-header-left {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      flex-wrap: wrap;
+    }
+    .provider-chevron {
+      color: var(--text2);
+      font-size: 11px;
+      width: 10px;
+      display: inline-block;
+      transition: color 0.15s;
+    }
+    .provider-card.expanded .provider-chevron { color: var(--accent); }
     .provider-name { font-weight: 600; font-size: 14px; }
     .provider-type { color: var(--text2); font-size: 11px; }
+
+    .provider-category-badge {
+      font-size: 10px;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.5px;
+      padding: 2px 6px;
+      border-radius: 4px;
+      background: rgba(255,255,255,0.06);
+      color: var(--text2);
+    }
+    .provider-category-local  { background: rgba(76, 175, 80, 0.15); color: #8fd896; }
+    .provider-category-cloud  { background: rgba(108, 99, 255, 0.15); color: #a8a3ff; }
+    .provider-category-router { background: rgba(255, 152, 0, 0.15); color: #ffc870; }
+
+    .provider-filter-bar {
+      display: flex;
+      gap: 6px;
+      flex-wrap: wrap;
+      margin: 0 0 16px 0;
+      padding: 4px;
+      background: var(--bg2);
+      border: 1px solid var(--border);
+      border-radius: var(--radius);
+    }
+    .provider-filter-pill {
+      flex: 1;
+      min-width: 60px;
+      background: transparent;
+      color: var(--text2);
+      border: none;
+      border-radius: 6px;
+      padding: 7px 10px;
+      font-size: 12px;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.4px;
+      cursor: pointer;
+      transition: background 0.12s, color 0.12s;
+    }
+    .provider-filter-pill:hover { color: var(--text); }
+    .provider-filter-pill.active {
+      background: var(--accent);
+      color: #fff;
+    }
+    .provider-filter-pill.active:hover { color: #fff; }
+    .provider-filter-empty {
+      padding: 16px;
+      text-align: center;
+      color: var(--text2);
+      font-size: 13px;
+      background: var(--bg2);
+      border: 1px dashed var(--border);
+      border-radius: var(--radius);
+    }
 
     .field { margin-bottom: 10px; }
     .field label {

--- a/src/firefox/src/ui/settings.html
+++ b/src/firefox/src/ui/settings.html
@@ -135,6 +135,21 @@
     .provider-category-cloud  { background: rgba(108, 99, 255, 0.15); color: #a8a3ff; }
     .provider-category-router { background: rgba(255, 152, 0, 0.15); color: #ffc870; }
 
+    /* Configured model — shown in the collapsed-card header so the user can
+       see at a glance which model is set for each provider. Mono font
+       signals "this is an identifier", and dimming keeps it from competing
+       with the provider's own name. max-width + ellipsis so long
+       OpenRouter-style names don't push the active-indicator off the row. */
+    .provider-model {
+      color: var(--text2);
+      font-size: 11px;
+      font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+      max-width: 240px;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+
     .provider-filter-bar {
       display: flex;
       gap: 6px;

--- a/src/firefox/src/ui/settings.js
+++ b/src/firefox/src/ui/settings.js
@@ -6,7 +6,7 @@ import { t, getLocale, setLocale, LANGUAGES } from './i18n.js';
 
 // Version shown in the subtitle. Kept here so it only needs one update per
 // release; the subtitle string itself is translated.
-const EXT_VERSION = '7.2.1';
+const EXT_VERSION = '7.3.0';
 
 const providersContainer = document.getElementById('providers');
 const verboseToggle = document.getElementById('toggle-verbose');
@@ -62,6 +62,11 @@ let authToken = '';
 let authEmail = '';
 let authDefaultModel = '';
 
+// Filter + collapse state for the providers panel. See chrome/settings.js
+// for the rationale.
+let providerFilter = 'all';     // 'all' | 'local' | 'cloud' | 'router'
+const expandedProviders = new Set();
+
 // --- Init ---
 
 async function init() {
@@ -73,7 +78,10 @@ async function init() {
   renderAuthSection();
 
   // Load display settings
-  const stored = await browser.storage.local.get(['verboseMode', 'screenshotFallback', 'maxAgentSteps', 'autoScreenshot', 'useSiteAdapters', 'tracingEnabled', 'strictSecretMode', 'agentAllowLocalNetwork']);
+  const stored = await browser.storage.local.get(['verboseMode', 'screenshotFallback', 'maxAgentSteps', 'autoScreenshot', 'useSiteAdapters', 'tracingEnabled', 'strictSecretMode', 'agentAllowLocalNetwork', 'providerFilter']);
+  if (typeof stored.providerFilter === 'string' && ['all','local','cloud','router'].includes(stored.providerFilter)) {
+    providerFilter = stored.providerFilter;
+  }
   verboseToggle.checked = stored.verboseMode || false;
   screenshotToggle.checked = stored.screenshotFallback ?? true; // on by default
   maxStepsRange.value = stored.maxAgentSteps || 60;
@@ -357,8 +365,36 @@ function renderProviders() {
         { key: 'baseUrl', labelKey: 'st.provider.field.api_base_url', type: 'text', placeholder: 'https://api.anthropic.com' },
       ],
     },
+    gemini: {
+      fields: [
+        { key: 'apiKey', labelKey: 'st.provider.field.api_key', type: 'password', placeholder: 'AIza...' },
+        { key: 'model', labelKey: 'st.provider.field.model', type: 'text', placeholder: 'gemini-2.0-flash' },
+        { key: 'baseUrl', labelKey: 'st.provider.field.api_base_url', type: 'text', placeholder: 'https://generativelanguage.googleapis.com/v1beta/openai' },
+      ],
+    },
+    mistral: {
+      fields: [
+        { key: 'apiKey', labelKey: 'st.provider.field.api_key', type: 'password', placeholder: 'API key' },
+        { key: 'model', labelKey: 'st.provider.field.model', type: 'text', placeholder: 'mistral-large-latest' },
+        { key: 'baseUrl', labelKey: 'st.provider.field.api_base_url', type: 'text', placeholder: 'https://api.mistral.ai/v1' },
+      ],
+    },
+    deepseek: {
+      fields: [
+        { key: 'apiKey', labelKey: 'st.provider.field.api_key', type: 'password', placeholder: 'sk-...' },
+        { key: 'model', labelKey: 'st.provider.field.model', type: 'text', placeholder: 'deepseek-chat' },
+        { key: 'baseUrl', labelKey: 'st.provider.field.api_base_url', type: 'text', placeholder: 'https://api.deepseek.com/v1' },
+      ],
+    },
+    xai: {
+      fields: [
+        { key: 'apiKey', labelKey: 'st.provider.field.api_key', type: 'password', placeholder: 'xai-...' },
+        { key: 'model', labelKey: 'st.provider.field.model', type: 'text', placeholder: 'grok-4' },
+        { key: 'baseUrl', labelKey: 'st.provider.field.api_base_url', type: 'text', placeholder: 'https://api.x.ai/v1' },
+      ],
+    },
     // OAuth-based Claude subscription provider. Card body rendered by
-    // renderClaudeOAuthCard() — sign-in button + auth status + disclaimer.
+    // renderClaudeOAuthCardBody() — sign-in button + auth status + disclaimer.
     claude_subscription: {
       customRender: 'claude_oauth',
       fields: [
@@ -367,26 +403,31 @@ function renderProviders() {
     },
   };
 
-  for (const [id, config] of Object.entries(providersData)) {
+  // Filter pill row above the providers list.
+  providersContainer.appendChild(renderProviderFilterBar());
+
+  const entries = Object.entries(providersData);
+  let visibleCount = 0;
+  for (const [id, config] of entries) {
     const isActive = id === activeProviderId;
     const fieldDefs = providerConfigs[id]?.fields || [];
 
-    // Custom render for the OAuth Claude provider (sign-in button etc.).
+    const category = config.category || 'cloud';
+    if (providerFilter !== 'all' && category !== providerFilter && !isActive) continue;
+    visibleCount++;
+
     if (providerConfigs[id]?.customRender === 'claude_oauth') {
-      providersContainer.appendChild(renderClaudeOAuthCard(id, config, isActive, fieldDefs));
+      providersContainer.appendChild(
+        wrapCollapsibleCard(id, config, isActive, renderClaudeOAuthCardBody(id, config, fieldDefs))
+      );
       continue;
     }
-
-    const card = document.createElement('div');
-    card.className = `provider-card ${isActive ? 'active' : ''}`;
 
     let fieldsHTML = '';
     for (const field of fieldDefs) {
       const label = field.labelKey ? t(field.labelKey) : (field.label || field.key);
       const placeholder = field.placeholderKey ? t(field.placeholderKey) : (field.placeholder || '');
       if (field.type === 'checkbox') {
-        // For useCompactPrompt on local providers, default to checked when
-        // the config key hasn't been explicitly set yet (matches provider logic).
         let isChecked = config[field.key];
         if (field.key === 'useCompactPrompt' && config[field.key] == null) {
           const localProviders = ['llamacpp', 'ollama', 'lmstudio'];
@@ -401,8 +442,6 @@ function renderProviders() {
           </div>
         `;
       } else {
-        // For Ollama's model field, attach a <datalist> + a "Load models"
-        // button so users can pick from `ollama list` without typing.
         const isOllamaModel = id === 'ollama' && field.key === 'model';
         const listAttr = isOllamaModel ? `list="models-${id}"` : '';
         const datalistHTML = isOllamaModel ? `<datalist id="models-${id}"></datalist>` : '';
@@ -424,14 +463,7 @@ function renderProviders() {
       }
     }
 
-    card.innerHTML = `
-      <div class="provider-header">
-        <div>
-          <span class="provider-name">${escapeHtml(config.label || id)}</span>
-          <span class="provider-type">${escapeHtml(config.type)}</span>
-        </div>
-        ${isActive ? `<span style="color:var(--accent);font-size:11px;font-weight:600">${escapeHtml(t('st.providers.active'))}</span>` : ''}
-      </div>
+    const body = `
       ${fieldsHTML}
       <div class="btn-row">
         <button class="btn-primary btn-save" data-provider="${id}">${escapeHtml(t('st.providers.save'))}</button>
@@ -441,7 +473,14 @@ function renderProviders() {
       <div class="test-result" id="test-${id}"></div>
     `;
 
-    providersContainer.appendChild(card);
+    providersContainer.appendChild(wrapCollapsibleCard(id, config, isActive, body));
+  }
+
+  if (visibleCount === 0) {
+    const empty = document.createElement('div');
+    empty.className = 'provider-filter-empty';
+    empty.textContent = t('st.providers.filter.empty') || 'No providers in this category. Switch filter to All.';
+    providersContainer.appendChild(empty);
   }
 
   document.querySelectorAll('.btn-save').forEach(btn => {
@@ -456,6 +495,83 @@ function renderProviders() {
   document.querySelectorAll('.btn-load-models').forEach(btn => {
     btn.addEventListener('click', () => loadOllamaModels(btn.dataset.provider));
   });
+  document.querySelectorAll('.btn-claude-signin').forEach(btn => {
+    btn.addEventListener('click', () => signInWithClaude(btn.dataset.provider));
+  });
+  document.querySelectorAll('.btn-claude-signout').forEach(btn => {
+    btn.addEventListener('click', () => signOutOfClaude(btn.dataset.provider));
+  });
+  document.querySelectorAll('.claude-oauth-status').forEach(el => {
+    const id = el.id.replace(/^claude-oauth-status-/, '');
+    if (id) queueMicrotask(() => refreshClaudeOAuthStatus(id));
+  });
+}
+
+/**
+ * Build the filter pill row. See chrome/settings.js for the canonical doc.
+ */
+function renderProviderFilterBar() {
+  const bar = document.createElement('div');
+  bar.className = 'provider-filter-bar';
+  const filters = [
+    { key: 'all',    labelKey: 'st.providers.filter.all' },
+    { key: 'local',  labelKey: 'st.providers.filter.local' },
+    { key: 'cloud',  labelKey: 'st.providers.filter.cloud' },
+    { key: 'router', labelKey: 'st.providers.filter.router' },
+  ];
+  for (const f of filters) {
+    const btn = document.createElement('button');
+    btn.type = 'button';
+    btn.className = `provider-filter-pill${providerFilter === f.key ? ' active' : ''}`;
+    btn.dataset.filter = f.key;
+    btn.textContent = t(f.labelKey);
+    btn.addEventListener('click', () => {
+      if (providerFilter === f.key) return;
+      providerFilter = f.key;
+      try { browser.storage.local.set({ providerFilter: f.key }); } catch {}
+      renderProviders();
+    });
+    bar.appendChild(btn);
+  }
+  return bar;
+}
+
+/**
+ * Wrap a provider card body in a collapsible shell. See chrome/settings.js
+ * for the design notes.
+ */
+function wrapCollapsibleCard(id, config, isActive, bodyHtml) {
+  const expanded = isActive || expandedProviders.has(id);
+  const card = document.createElement('div');
+  card.className = `provider-card ${isActive ? 'active' : ''} ${expanded ? 'expanded' : 'collapsed'}`;
+  card.dataset.providerId = id;
+  card.dataset.providerCategory = config.category || 'cloud';
+
+  const header = document.createElement('div');
+  header.className = 'provider-header provider-header-clickable';
+  header.innerHTML = `
+    <div class="provider-header-left">
+      <span class="provider-chevron" aria-hidden="true">${expanded ? '▾' : '▸'}</span>
+      <span class="provider-name">${escapeHtml(config.label || id)}</span>
+      <span class="provider-type">${escapeHtml(config.type)}</span>
+      ${config.category ? `<span class="provider-category-badge provider-category-${escapeHtml(config.category)}">${escapeHtml(config.category)}</span>` : ''}
+    </div>
+    ${isActive ? `<span style="color:var(--accent);font-size:11px;font-weight:600">${escapeHtml(t('st.providers.active'))}</span>` : ''}
+  `;
+  header.addEventListener('click', (e) => {
+    if (e.target.closest('button, input, a, select')) return;
+    if (expandedProviders.has(id)) expandedProviders.delete(id);
+    else expandedProviders.add(id);
+    renderProviders();
+  });
+
+  const body = document.createElement('div');
+  body.className = 'provider-body';
+  body.innerHTML = bodyHtml;
+
+  card.appendChild(header);
+  if (expanded) card.appendChild(body);
+  return card;
 }
 
 /**
@@ -463,10 +579,8 @@ function renderProviders() {
  * the normal cards in that auth is via OAuth (Sign in with Claude button)
  * — see Chrome equivalent for full notes.
  */
-function renderClaudeOAuthCard(id, config, isActive, fieldDefs) {
-  const card = document.createElement('div');
-  card.className = `provider-card ${isActive ? 'active' : ''}`;
-
+function renderClaudeOAuthCardBody(id, config, fieldDefs) {
+  const isActive = id === activeProviderId;
   let fieldsHTML = '';
   for (const field of fieldDefs) {
     const label = field.labelKey ? t(field.labelKey) : (field.label || field.key);
@@ -480,15 +594,7 @@ function renderClaudeOAuthCard(id, config, isActive, fieldDefs) {
     `;
   }
 
-  card.innerHTML = `
-    <div class="provider-header">
-      <div>
-        <span class="provider-name">${escapeHtml(config.label || id)}</span>
-        <span class="provider-type">oauth</span>
-      </div>
-      ${isActive ? `<span style="color:var(--accent);font-size:11px;font-weight:600">${escapeHtml(t('st.providers.active'))}</span>` : ''}
-    </div>
-
+  return `
     <div class="claude-oauth-status" id="claude-oauth-status-${id}"
          style="padding:10px 12px;border-radius:6px;background:var(--surface2,#f5f5f7);
                 margin-bottom:10px;font-size:13px;color:var(--text2);">
@@ -517,14 +623,6 @@ function renderClaudeOAuthCard(id, config, isActive, fieldDefs) {
       <strong>Heads up:</strong> Uses your Claude.ai Pro/Max subscription's quota via the OAuth flow Anthropic ships for Claude Code. This is a third-party use of that flow — Anthropic's terms restrict using Pro/Max subscriptions with non-Anthropic tools, and the integration could stop working at any time if Anthropic rotates their CLI's OAuth client. Your access + refresh tokens are stored in <code>browser.storage.local</code> in plaintext (same as API keys). Use at your own risk; for production / reliability, prefer the API-key Anthropic provider above.
     </div>
   `;
-
-  card.querySelector('.btn-claude-signin').addEventListener('click', () => signInWithClaude(id));
-  card.querySelector('.btn-claude-signout').addEventListener('click', () => signOutOfClaude(id));
-  // Run after the caller appends the card; refreshClaudeOAuthStatus()
-  // looks up elements through document.getElementById().
-  queueMicrotask(() => refreshClaudeOAuthStatus(id));
-
-  return card;
 }
 
 async function refreshClaudeOAuthStatus(id) {

--- a/src/firefox/src/ui/settings.js
+++ b/src/firefox/src/ui/settings.js
@@ -527,6 +527,11 @@ function renderProviderFilterBar() {
     btn.textContent = t(f.labelKey);
     btn.addEventListener('click', () => {
       if (providerFilter === f.key) return;
+      // Snapshot whatever the user has typed but not yet saved BEFORE we
+      // rebuild the DOM — otherwise input values for the currently-rendered
+      // cards are lost (e.g. typed an API key, then clicked a filter pill
+      // to compare two providers).
+      syncInputsIntoProvidersData();
       providerFilter = f.key;
       try { browser.storage.local.set({ providerFilter: f.key }); } catch {}
       renderProviders();
@@ -567,6 +572,9 @@ function wrapCollapsibleCard(id, config, isActive, bodyHtml) {
   `;
   header.addEventListener('click', (e) => {
     if (e.target.closest('button, input, a, select')) return;
+    // Snapshot unsaved typing in other expanded cards before we rebuild
+    // the DOM — same reason as the filter-pill handler above.
+    syncInputsIntoProvidersData();
     if (expandedProviders.has(id)) expandedProviders.delete(id);
     else expandedProviders.add(id);
     renderProviders();

--- a/src/firefox/src/ui/settings.js
+++ b/src/firefox/src/ui/settings.js
@@ -549,12 +549,19 @@ function wrapCollapsibleCard(id, config, isActive, bodyHtml) {
 
   const header = document.createElement('div');
   header.className = 'provider-header provider-header-clickable';
+  // Model name appears in the collapsed header as small mono-font text — the
+  // headline question for any AI tool is "what model is this set to?", and
+  // making the user expand the card to find out is bad UX. Empty model (e.g.
+  // LM Studio defaults to whatever's loaded) just renders nothing rather
+  // than a placeholder.
+  const modelStr = (config.model && String(config.model).trim()) || '';
   header.innerHTML = `
     <div class="provider-header-left">
       <span class="provider-chevron" aria-hidden="true">${expanded ? '▾' : '▸'}</span>
       <span class="provider-name">${escapeHtml(config.label || id)}</span>
       <span class="provider-type">${escapeHtml(config.type)}</span>
       ${config.category ? `<span class="provider-category-badge provider-category-${escapeHtml(config.category)}">${escapeHtml(config.category)}</span>` : ''}
+      ${modelStr ? `<span class="provider-model" title="${escapeHtml(modelStr)}">${escapeHtml(modelStr)}</span>` : ''}
     </div>
     ${isActive ? `<span style="color:var(--accent);font-size:11px;font-weight:600">${escapeHtml(t('st.providers.active'))}</span>` : ''}
   `;

--- a/test/run.js
+++ b/test/run.js
@@ -57,6 +57,16 @@ const { bumpSemver, rewriteVersionInJsonText, rewriteVersionByAnchor, isReleaseB
   'file://' + path.join(ROOT, 'scripts/bump-version.mjs').replace(/\\/g, '/')
 );
 
+// providers/manager.js — pure ESM at module load (chrome.* only inside
+// methods). We import the class so we can exercise the static categoryFor()
+// helper and inspect the default-configs shape (categorization parity).
+const { ProviderManager: ProviderManagerCh } = await import(
+  'file://' + path.join(ROOT, 'src/chrome/src/providers/manager.js').replace(/\\/g, '/')
+);
+const { ProviderManager: ProviderManagerFx } = await import(
+  'file://' + path.join(ROOT, 'src/firefox/src/providers/manager.js').replace(/\\/g, '/')
+);
+
 // tools.js — pure ESM. We import getToolsForMode from each side so we can
 // verify the strict/loose `done` description swap.
 const { getToolsForMode: getToolsForModeCh } = await import(
@@ -1368,6 +1378,104 @@ test('reason is informative', () => {
   assert.equal(isCredentialField({ type: 'password' }).reason, 'input type=password');
   assert.match(isCredentialField({ type: 'text', autocomplete: 'one-time-code' }).reason, /autocomplete=one-time-code/);
   assert.match(isCredentialField({ type: 'text', name: 'api_key' }).reason, /name matches credential pattern/);
+});
+
+// ────────────────────────────────────────────────────────────────────────
+// Provider categorization (filter UI)
+// ────────────────────────────────────────────────────────────────────────
+
+console.log('\nprovider categorization');
+
+test('categoryFor: local family (llamacpp / ollama / lmstudio)', () => {
+  for (const PM of [ProviderManagerCh, ProviderManagerFx]) {
+    assert.equal(PM.categoryFor('llamacpp', { type: 'llamacpp' }), 'local');
+    assert.equal(PM.categoryFor('ollama', { type: 'openai' }), 'local');
+    assert.equal(PM.categoryFor('lmstudio', { type: 'openai' }), 'local');
+  }
+});
+
+test('categoryFor: cloud family (openai / anthropic / gemini / mistral / deepseek / xai / oauth)', () => {
+  for (const PM of [ProviderManagerCh, ProviderManagerFx]) {
+    assert.equal(PM.categoryFor('openai', { type: 'openai' }), 'cloud');
+    assert.equal(PM.categoryFor('anthropic', { type: 'anthropic' }), 'cloud');
+    assert.equal(PM.categoryFor('gemini', { type: 'openai' }), 'cloud');
+    assert.equal(PM.categoryFor('mistral', { type: 'openai' }), 'cloud');
+    assert.equal(PM.categoryFor('deepseek', { type: 'openai' }), 'cloud');
+    assert.equal(PM.categoryFor('xai', { type: 'openai' }), 'cloud');
+    assert.equal(PM.categoryFor('claude_subscription', { type: 'anthropic_oauth' }), 'cloud');
+  }
+});
+
+test('categoryFor: openrouter is router', () => {
+  for (const PM of [ProviderManagerCh, ProviderManagerFx]) {
+    assert.equal(PM.categoryFor('openrouter', { type: 'openai' }), 'router');
+  }
+});
+
+test('categoryFor: config.category overrides the per-id fallback', () => {
+  for (const PM of [ProviderManagerCh, ProviderManagerFx]) {
+    // If a stored config explicitly tags itself, that wins even if the id
+    // looks like something else (future-proofing for user-added providers).
+    assert.equal(PM.categoryFor('custom_proxy', { category: 'router', type: 'openai' }), 'router');
+    assert.equal(PM.categoryFor('openai', { category: 'local', type: 'openai' }), 'local');
+  }
+});
+
+test('categoryFor: unknown id with no category defaults to cloud', () => {
+  for (const PM of [ProviderManagerCh, ProviderManagerFx]) {
+    assert.equal(PM.categoryFor('some_new_thing', { type: 'openai' }), 'cloud');
+    assert.equal(PM.categoryFor('whatever', {}), 'cloud');
+  }
+});
+
+test('_defaultConfigs: every entry carries an explicit category', () => {
+  // Walk the actual default config table on each platform and assert
+  // each entry has a category field. Catches "I added a provider but
+  // forgot to set its category" at test time, not at user-render time.
+  for (const PM of [ProviderManagerCh, ProviderManagerFx]) {
+    const mgr = new PM();
+    const defaults = mgr._defaultConfigs();
+    for (const [id, config] of Object.entries(defaults)) {
+      assert.ok(
+        ['local', 'cloud', 'router'].includes(config.category),
+        `${PM.name}: provider ${id} missing/invalid category (got ${JSON.stringify(config.category)})`
+      );
+    }
+  }
+});
+
+test('_defaultConfigs: new cloud providers present and disabled by default', () => {
+  // Don't enable cloud providers by default — they all require an API key.
+  // Auto-enabling them would create dead entries in the UI.
+  for (const PM of [ProviderManagerCh, ProviderManagerFx]) {
+    const mgr = new PM();
+    const defaults = mgr._defaultConfigs();
+    for (const id of ['gemini', 'mistral', 'deepseek', 'xai']) {
+      assert.ok(defaults[id], `${PM.name}: missing default config for ${id}`);
+      assert.equal(defaults[id].category, 'cloud', `${PM.name}: ${id} should be cloud`);
+      assert.equal(defaults[id].enabled, false, `${PM.name}: ${id} should default to disabled`);
+      assert.ok(defaults[id].baseUrl, `${PM.name}: ${id} missing baseUrl`);
+      assert.ok(defaults[id].model, `${PM.name}: ${id} missing default model`);
+    }
+  }
+});
+
+test('_defaultConfigs: chrome and firefox share the same provider set', () => {
+  const chDefaults = new ProviderManagerCh()._defaultConfigs();
+  const fxDefaults = new ProviderManagerFx()._defaultConfigs();
+  assert.deepEqual(
+    Object.keys(chDefaults).sort(),
+    Object.keys(fxDefaults).sort(),
+    'chrome and firefox provider lists diverged'
+  );
+  // Categories must also match — drift here would mean the filter UI
+  // shows different buckets on each platform.
+  for (const id of Object.keys(chDefaults)) {
+    assert.equal(
+      chDefaults[id].category, fxDefaults[id].category,
+      `provider ${id}: category differs (chrome=${chDefaults[id].category}, firefox=${fxDefaults[id].category})`
+    );
+  }
 });
 
 await run();


### PR DESCRIPTION
## Summary

- Adds **filter pills** (All / Local / Cloud / Router) above the Providers tab; selection persists to `chrome.storage.local`. Active provider stays visible regardless of filter.
- Makes each provider card **collapsible** — header-only by default with a chevron + color-coded category badge. Active provider auto-expands; everything else starts collapsed. Session-only state (deliberate, keeps default predictable).
- Adds **4 new cloud providers**, all default-disabled and routed through the existing `OpenAICompatibleProvider`:
  - **Google Gemini** (`generativelanguage.googleapis.com/v1beta/openai`, default model `gemini-2.0-flash`)
  - **Mistral AI** (`api.mistral.ai/v1`, default `mistral-large-latest`)
  - **DeepSeek** (`api.deepseek.com/v1`, default `deepseek-chat`)
  - **xAI Grok** (`api.x.ai/v1`, default `grok-4`)
- Introduces `ProviderManager.categoryFor(id, config)` as the single source of truth for category lookup. Reads `config.category` first; falls back to a per-id table so pre-7.3 stored configs still classify correctly.
- Version bump 7.2.1 → 7.3.0.

## Why

The Providers tab was a flat list of 7 entries; with 11 now (and more coming) it needs structure. Filtering hides cards that don't match the category; collapsing reduces vertical space. The two work together — at default settings, the user sees the active provider expanded, everything else collapsed under category badges they can click to open.

The 4 new clouds are the obvious gaps in the previous lineup (OpenAI, Anthropic, OpenRouter only). All have OpenAI-compatible endpoints so they slot into the existing provider infrastructure with zero new code paths beyond config — no SDKs added.

## Reviewer notes

- **Chrome / Firefox parity:** every change is mirrored. Tests assert chrome and firefox provider sets stay in sync (same ids, same categories).
- **No migration needed for existing users.** Stored configs without a `category` field get classified by the per-id fallback in `categoryFor()`. Merge semantics in `_defaultConfigs()` mean new providers (gemini/mistral/deepseek/xai) automatically appear in the UI for existing users without clearing storage.
- **OAuth Claude card** was refactored: `renderClaudeOAuthCard` (returned Element) → `renderClaudeOAuthCardBody` (returns HTML string). Header + outer card now come from `wrapCollapsibleCard()`. Sign-in/out bindings + status-refresh moved from inline to a post-loop pass at the end of `renderProviders()`.
- **Active provider always visible.** Even with filter set to e.g. "Local" while OpenAI is active, OpenAI's card shows up — the user never loses sight of the active config.

## Tests

126 passing (8 new). Coverage:

- `categoryFor()` returns correct buckets per id; respects `config.category` overrides; defaults unknown ids to `cloud`.
- Every entry in `_defaultConfigs()` has a valid category — catches "added a provider, forgot to set category" at test time.
- The 4 new providers exist, have `category: 'cloud'`, default to `enabled: false`, and have non-empty `baseUrl` + `model`.
- Chrome and Firefox provider sets stay in sync (same keys, same categories) — drift fails the test.

## Test plan

- [ ] Open Settings → Providers. Verify filter pill row renders. Default selection = "ALL".
- [ ] Switch filter to "Local" → only llamacpp / ollama / lmstudio cards visible (+ active provider if it's not local).
- [ ] Switch to "Cloud" → openai / anthropic / gemini / mistral / deepseek / xai / claude_subscription visible.
- [ ] Switch to "Router" → openrouter visible.
- [ ] Reload settings page → filter selection persists.
- [ ] Click a collapsed header → card expands inline. Click again → collapses.
- [ ] Active provider's card starts expanded; everything else collapsed.
- [ ] Existing flows still work: Save / Test Connection / Set Active / Load models (Ollama).
- [ ] Claude OAuth card still works: sign in / sign out / status refresh.
- [ ] Configure Gemini with a real API key → Test Connection passes.
- [ ] Same for Mistral / DeepSeek / xAI Grok.
- [ ] Firefox parity: install the firefox build and verify the same UI + behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)