### PR TITLE
Opt-in CapSolver integration for CAPTCHA solving

### DIFF
--- a/src/chrome/src/agent/agent.js
+++ b/src/chrome/src/agent/agent.js
@@ -19,6 +19,7 @@ import {
   PDF_PASSTHROUGH_MAX_BYTES,
 } from './pdf-tools.js';
 import * as trace from '../trace/recorder.js';
+import { solveCaptcha, detectCaptcha, injectToken } from './captcha-solver.js';
 
 /**
  * The WebBrain Agent — orchestrates multi-step LLM + tool-use loops.
@@ -66,6 +67,13 @@ export class Agent {
     // UI. Loaded in background.js alongside other settings.
     this.profileEnabled = false;
     this.profileText = '';
+
+    // CapSolver integration. Off by default. When enabled AND an API key
+    // is set, the system prompt grows a "[CAPTCHA SOLVER]" note that
+    // tells the model to try `solve_captcha` once before falling back to
+    // asking the user. The agent reads the key from chrome.storage.local
+    // at call time so rotating the key doesn't require a restart.
+    this.captchaSolverEnabled = false;
     // Stale click detection: per-tab last clicked element identity.
     this._lastCdpClickIdent = new Map(); // tabId -> string
     // Loop detection: per-tab ring buffer of recent tool calls + nudge count.
@@ -1854,6 +1862,14 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
         this.profileText.trim();
     }
 
+    // CAPTCHA solver. Only injected when the user has explicitly enabled
+    // CapSolver — otherwise the default "stop and ask the user" rule in
+    // SYSTEM_PROMPT_ACT stands. The note unlocks the solve_captcha tool
+    // path described there.
+    if (this.captchaSolverEnabled) {
+      prompt += `\n\n[CAPTCHA SOLVER — the user has configured CapSolver. When a CAPTCHA blocks a step, call \`solve_captcha\` once (with no arguments — it auto-detects reCAPTCHA v2/v3, hCaptcha, and Cloudflare Turnstile). On success, click the form's submit button and continue. On failure, ask the user to solve it manually — do not retry solve_captcha repeatedly.]`;
+    }
+
     return prompt;
   }
 
@@ -2243,6 +2259,11 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
       case 'screenshot':
       case 'full_page_screenshot':
         return parsed.success ? 'screenshot captured' : 'screenshot failed';
+      case 'solve_captcha': {
+        if (parsed.success === false) return `captcha solve failed: ${this._truncate(parsed.error || '', 100)}`;
+        const inj = parsed.injected ? 'injected' : 'token only';
+        return `${parsed.type || 'captcha'} solved (${inj})`;
+      }
       case 'scratchpad_write': {
         return `scratchpad ${parsed.mode || 'write'} (${parsed.bytes ?? '?'} chars)`;
       }
@@ -2790,6 +2811,94 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
     }
     if (name === 'download_files') {
       return await downloadFiles(args);
+    }
+
+    // ─── CAPTCHA solver ──────────────────────────────────────────────
+    // Only meaningfully wired when the user has enabled CapSolver in
+    // Settings. We re-check on every call so flipping the toggle or
+    // rotating the key takes effect without a restart.
+    if (name === 'solve_captcha') {
+      try {
+        const stored = await chrome.storage.local.get(['captchaSolverEnabled', 'capsolverApiKey']);
+        if (!stored.captchaSolverEnabled) {
+          return { success: false, error: 'CapSolver is not enabled. Ask the user to enable it in Settings → CAPTCHA, or fall back to asking them to solve the captcha manually.' };
+        }
+        const apiKey = (stored.capsolverApiKey || '').trim();
+        if (!apiKey) {
+          return { success: false, error: 'CapSolver is enabled but no API key is configured. Ask the user to set one in Settings → CAPTCHA, or fall back to asking them to solve the captcha manually.' };
+        }
+
+        // Resolve the website URL — the active tab's URL is what the
+        // captcha vendor needs to match its sitekey allowlist.
+        let websiteURL = '';
+        try {
+          const tab = await chrome.tabs.get(tabId);
+          websiteURL = tab?.url || '';
+        } catch {}
+
+        // Detect when the model didn't pre-specify a captcha type. Image-
+        // to-text is a special case that needs an explicit imageBase64.
+        let { type, websiteKey, isInvisible, pageAction, minScore, imageBase64 } = args || {};
+        if (!type) {
+          const detected = await detectCaptcha(tabId);
+          if (!detected) {
+            return { success: false, error: 'No CAPTCHA detected on the page. If the captcha lives inside a cross-origin iframe or uses a non-standard widget, pass `type` and `websiteKey` explicitly.' };
+          }
+          type = detected.type;
+          if (!websiteKey) websiteKey = detected.websiteKey;
+          if (isInvisible == null && detected.isInvisible != null) isInvisible = detected.isInvisible;
+          if (!pageAction && detected.pageAction) pageAction = detected.pageAction;
+        }
+
+        if (type === 'image_to_text') {
+          if (!imageBase64) {
+            return { success: false, error: 'solve_captcha: image_to_text requires `imageBase64`.' };
+          }
+        } else if (!websiteKey) {
+          return { success: false, error: `solve_captcha: ${type} requires a websiteKey (data-sitekey). Auto-detection didn't find one — pass it explicitly.` };
+        }
+
+        const result = await solveCaptcha(apiKey, {
+          type,
+          websiteURL,
+          websiteKey,
+          ...(isInvisible != null ? { isInvisible } : {}),
+          ...(pageAction ? { pageAction } : {}),
+          ...(minScore ? { minScore } : {}),
+          ...(imageBase64 ? { body: imageBase64 } : {}),
+        });
+
+        // For non-image types, push the token into the page response field
+        // unless the caller explicitly opted out.
+        const wantInject = args?.inject !== false && type !== 'image_to_text';
+        let injection = null;
+        if (wantInject && result.fieldName && result.token) {
+          try {
+            injection = await injectToken(tabId, {
+              fieldName: result.fieldName,
+              alsoSet: result.alsoSet,
+              token: result.token,
+            });
+          } catch (e) {
+            injection = { success: false, error: e.message };
+          }
+        }
+
+        return {
+          success: true,
+          type,
+          taskId: result.taskId,
+          token: result.token,
+          tokenPreview: result.token ? `${String(result.token).slice(0, 24)}…(${String(result.token).length} chars)` : null,
+          injected: injection?.success === true,
+          injection,
+          note: wantInject
+            ? 'Token was injected into the page response field. Click the form\'s submit button next; do NOT call solve_captcha again.'
+            : 'Token returned, not injected. Pass it to the form via type_text on the response field, then submit.',
+        };
+      } catch (e) {
+        return { success: false, error: `solve_captcha failed: ${e.message}` };
+      }
     }
 
     // ─── PDF reader ───────────────────────────────────────────────────

--- a/src/chrome/src/agent/captcha-solver.js
+++ b/src/chrome/src/agent/captcha-solver.js
@@ -179,23 +179,13 @@ function detectCaptchaInPage() {
   }
 
   for (const d of docs) {
-    // reCAPTCHA v2/v3 (.g-recaptcha or div[data-sitekey] with grecaptcha)
-    const recap = d.querySelector('.g-recaptcha[data-sitekey], div[data-sitekey][data-callback], div[id^="g-recaptcha"]');
-    if (recap) {
-      const sitekey = recap.getAttribute('data-sitekey');
-      if (sitekey) {
-        const size = recap.getAttribute('data-size');
-        const isInvisible = size === 'invisible';
-        // v3 widgets typically carry data-action; v2 doesn't.
-        const action = recap.getAttribute('data-action') || null;
-        return {
-          type: action ? 'recaptcha_v3' : 'recaptcha_v2',
-          websiteKey: sitekey,
-          isInvisible,
-          ...(action ? { pageAction: action } : {}),
-        };
-      }
-    }
+    // Order matters: check provider-specific widgets BEFORE the generic
+    // reCAPTCHA fallback. Cloudflare Turnstile and hCaptcha widgets can
+    // carry `data-sitekey` + `data-callback` too, and an earlier version
+    // of this function caught them with `div[data-sitekey][data-callback]`
+    // and misclassified them as reCAPTCHA → CapSolver got the wrong task
+    // type and failed.
+
     // hCaptcha (.h-captcha[data-sitekey])
     const hcap = d.querySelector('.h-captcha[data-sitekey], div[data-hcaptcha-widget-id]');
     if (hcap) {
@@ -215,6 +205,25 @@ function detectCaptchaInPage() {
       const sitekey = turn.getAttribute('data-sitekey') || turn.getAttribute('data-turnstile-sitekey');
       if (sitekey) {
         return { type: 'turnstile', websiteKey: sitekey };
+      }
+    }
+    // reCAPTCHA v2/v3. Match only on reCAPTCHA-specific markers — the
+    // `.g-recaptcha` class or `id="g-recaptcha-..."` — so we don't
+    // accidentally grab any `data-sitekey` element from another widget.
+    const recap = d.querySelector('.g-recaptcha[data-sitekey], div[id^="g-recaptcha"][data-sitekey]');
+    if (recap) {
+      const sitekey = recap.getAttribute('data-sitekey');
+      if (sitekey) {
+        const size = recap.getAttribute('data-size');
+        const isInvisible = size === 'invisible';
+        // v3 widgets typically carry data-action; v2 doesn't.
+        const action = recap.getAttribute('data-action') || null;
+        return {
+          type: action ? 'recaptcha_v3' : 'recaptcha_v2',
+          websiteKey: sitekey,
+          isInvisible,
+          ...(action ? { pageAction: action } : {}),
+        };
       }
     }
     // Cloudflare "challenge platform" (the bare interstitial — no sitekey

--- a/src/chrome/src/agent/captcha-solver.js
+++ b/src/chrome/src/agent/captcha-solver.js
@@ -1,0 +1,299 @@
+// CapSolver REST client + page-side detect/inject helpers.
+//
+// We do not bundle the CapSolver browser extension. Instead we talk directly
+// to https://api.capsolver.com:
+//   POST /createTask     → { taskId } | { errorId, errorCode, errorDescription }
+//   POST /getTaskResult  → { status: "ready"|"processing", solution? }
+//   POST /getBalance     → { balance, packages }
+//
+// Coverage today: reCAPTCHA v2 (checkbox/invisible), reCAPTCHA v3, hCaptcha,
+// Cloudflare Turnstile, plain image-to-text. Other types CapSolver supports
+// (FunCaptcha, AWS WAF, GeeTest, datadome) are not auto-detected here yet —
+// the agent can still drive them by passing an explicit `type` to
+// solve_captcha and the right `taskTypeOverride`.
+
+const API_BASE = 'https://api.capsolver.com';
+const POLL_INTERVAL_MS = 2500;
+const POLL_TIMEOUT_MS = 120_000;
+const DEFAULT_APP_ID = 'B7E57F27-0AD3-434D-A5B7-CF9EE7D093EE'; // CapSolver public affiliate id; used only to identify the integration.
+
+// ─── REST ──────────────────────────────────────────────────────────────
+
+async function postJson(path, body) {
+  const res = await fetch(`${API_BASE}${path}`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+  if (!res.ok) {
+    const text = await res.text().catch(() => '');
+    throw new Error(`CapSolver ${path} HTTP ${res.status}: ${text.slice(0, 200)}`);
+  }
+  return await res.json();
+}
+
+export async function getBalance(apiKey) {
+  if (!apiKey) throw new Error('No CapSolver API key configured.');
+  const res = await postJson('/getBalance', { clientKey: apiKey });
+  if (res.errorId) throw new Error(`CapSolver: ${res.errorDescription || res.errorCode}`);
+  return { balance: res.balance, packages: res.packages || [] };
+}
+
+async function createTask(apiKey, task) {
+  const res = await postJson('/createTask', {
+    clientKey: apiKey,
+    appId: DEFAULT_APP_ID,
+    task,
+  });
+  if (res.errorId) {
+    throw new Error(`CapSolver createTask: ${res.errorDescription || res.errorCode}`);
+  }
+  if (!res.taskId) throw new Error('CapSolver createTask returned no taskId.');
+  return res.taskId;
+}
+
+async function pollTaskResult(apiKey, taskId, { timeoutMs = POLL_TIMEOUT_MS } = {}) {
+  const start = Date.now();
+  while (Date.now() - start < timeoutMs) {
+    const res = await postJson('/getTaskResult', { clientKey: apiKey, taskId });
+    if (res.errorId) {
+      throw new Error(`CapSolver getTaskResult: ${res.errorDescription || res.errorCode}`);
+    }
+    if (res.status === 'ready') return res.solution || {};
+    await new Promise(r => setTimeout(r, POLL_INTERVAL_MS));
+  }
+  throw new Error(`CapSolver: timed out after ${Math.round(timeoutMs / 1000)}s waiting for solution.`);
+}
+
+// ─── Task builders ─────────────────────────────────────────────────────
+//
+// Each builder takes the params the agent / detector gathered from the page
+// and returns the task object CapSolver's createTask endpoint expects. We
+// default to the "proxyless" task types so the user doesn't need to BYO
+// proxy — that's the simplest path and what virtually every reCAPTCHA /
+// hCaptcha / Turnstile setup actually needs.
+
+function buildTask({ type, websiteURL, websiteKey, ...rest }) {
+  const t = String(type || '').toLowerCase();
+  if (t === 'recaptcha_v2' || t === 'recaptchav2') {
+    return {
+      type: 'ReCaptchaV2TaskProxyLess',
+      websiteURL,
+      websiteKey,
+      ...(rest.isInvisible != null ? { isInvisible: !!rest.isInvisible } : {}),
+      ...(rest.userAgent ? { userAgent: rest.userAgent } : {}),
+    };
+  }
+  if (t === 'recaptcha_v3' || t === 'recaptchav3') {
+    return {
+      type: 'ReCaptchaV3TaskProxyLess',
+      websiteURL,
+      websiteKey,
+      pageAction: rest.pageAction || rest.action || 'verify',
+      ...(rest.minScore ? { minScore: rest.minScore } : {}),
+    };
+  }
+  if (t === 'hcaptcha') {
+    return {
+      type: 'HCaptchaTaskProxyLess',
+      websiteURL,
+      websiteKey,
+      ...(rest.isInvisible != null ? { isInvisible: !!rest.isInvisible } : {}),
+      ...(rest.enterprisePayload ? { enterprisePayload: rest.enterprisePayload } : {}),
+      ...(rest.userAgent ? { userAgent: rest.userAgent } : {}),
+    };
+  }
+  if (t === 'turnstile' || t === 'cloudflare' || t === 'cf_turnstile') {
+    return {
+      type: 'AntiTurnstileTaskProxyLess',
+      websiteURL,
+      websiteKey,
+      ...(rest.metadata ? { metadata: rest.metadata } : {}),
+    };
+  }
+  if (t === 'image_to_text' || t === 'image') {
+    return {
+      type: 'ImageToTextTask',
+      body: rest.body, // base64 png/jpg, no data: prefix
+      ...(rest.module ? { module: rest.module } : {}),
+      ...(rest.case != null ? { case: !!rest.case } : {}),
+    };
+  }
+  throw new Error(`solve_captcha: unsupported type "${type}".`);
+}
+
+// Pick the right token-field name + injection strategy for each captcha
+// type. The DOM convention is well-documented for the ones we auto-handle.
+function solutionFor(type, solution) {
+  const t = String(type || '').toLowerCase();
+  if (t === 'recaptcha_v2' || t === 'recaptchav2' || t === 'recaptcha_v3' || t === 'recaptchav3') {
+    return { token: solution.gRecaptchaResponse, fieldName: 'g-recaptcha-response' };
+  }
+  if (t === 'hcaptcha') {
+    // Both names exist in the wild — old hCaptcha forms use h-captcha-response,
+    // some sites still listen on g-recaptcha-response for hCaptcha drop-ins.
+    return { token: solution.gRecaptchaResponse, fieldName: 'h-captcha-response', alsoSet: 'g-recaptcha-response' };
+  }
+  if (t === 'turnstile' || t === 'cloudflare' || t === 'cf_turnstile') {
+    return { token: solution.token, fieldName: 'cf-turnstile-response' };
+  }
+  if (t === 'image_to_text' || t === 'image') {
+    return { token: solution.text, fieldName: null }; // caller types it in
+  }
+  return { token: null, fieldName: null };
+}
+
+// ─── solveCaptcha — the public entry point ────────────────────────────
+
+export async function solveCaptcha(apiKey, params) {
+  if (!apiKey) throw new Error('No CapSolver API key configured.');
+  if (!params?.type) throw new Error('solve_captcha: type is required.');
+  const task = buildTask(params);
+  const taskId = await createTask(apiKey, task);
+  const solution = await pollTaskResult(apiKey, taskId);
+  const meta = solutionFor(params.type, solution);
+  return { taskId, solution, ...meta };
+}
+
+// ─── Page-side detection ───────────────────────────────────────────────
+//
+// Runs in the page world via chrome.scripting.executeScript. Looks for the
+// well-known DOM markers each provider drops in. Returns null when nothing
+// is found so the caller can decide whether to error or fall back to
+// asking the user.
+//
+// We intentionally inspect light DOM only — every major captcha widget
+// renders its container element (the `data-sitekey` host) in the host
+// page's light DOM, even if its UI lives inside a same-origin iframe.
+
+function detectCaptchaInPage() {
+  // Helper: visit same-origin iframes too, since reCAPTCHA on many sites
+  // is rendered inside a same-origin wrapper. Cross-origin frames are
+  // skipped (their .contentDocument throws on access).
+  const docs = [document];
+  for (const f of document.querySelectorAll('iframe')) {
+    try {
+      const d = f.contentDocument;
+      if (d) docs.push(d);
+    } catch { /* cross-origin */ }
+  }
+
+  for (const d of docs) {
+    // reCAPTCHA v2/v3 (.g-recaptcha or div[data-sitekey] with grecaptcha)
+    const recap = d.querySelector('.g-recaptcha[data-sitekey], div[data-sitekey][data-callback], div[id^="g-recaptcha"]');
+    if (recap) {
+      const sitekey = recap.getAttribute('data-sitekey');
+      if (sitekey) {
+        const size = recap.getAttribute('data-size');
+        const isInvisible = size === 'invisible';
+        // v3 widgets typically carry data-action; v2 doesn't.
+        const action = recap.getAttribute('data-action') || null;
+        return {
+          type: action ? 'recaptcha_v3' : 'recaptcha_v2',
+          websiteKey: sitekey,
+          isInvisible,
+          ...(action ? { pageAction: action } : {}),
+        };
+      }
+    }
+    // hCaptcha (.h-captcha[data-sitekey])
+    const hcap = d.querySelector('.h-captcha[data-sitekey], div[data-hcaptcha-widget-id]');
+    if (hcap) {
+      const sitekey = hcap.getAttribute('data-sitekey') || hcap.getAttribute('data-hcaptcha-sitekey');
+      if (sitekey) {
+        const size = hcap.getAttribute('data-size');
+        return {
+          type: 'hcaptcha',
+          websiteKey: sitekey,
+          isInvisible: size === 'invisible',
+        };
+      }
+    }
+    // Cloudflare Turnstile (.cf-turnstile[data-sitekey])
+    const turn = d.querySelector('.cf-turnstile[data-sitekey], [data-turnstile-sitekey]');
+    if (turn) {
+      const sitekey = turn.getAttribute('data-sitekey') || turn.getAttribute('data-turnstile-sitekey');
+      if (sitekey) {
+        return { type: 'turnstile', websiteKey: sitekey };
+      }
+    }
+    // Cloudflare "challenge platform" (the bare interstitial — no sitekey
+    // exposed in DOM, just the script tag). Best we can report is presence;
+    // solve_captcha will error if no key is provided.
+    if (d.querySelector('script[src*="challenges.cloudflare.com/turnstile"]') ||
+        d.querySelector('iframe[src*="challenges.cloudflare.com"]')) {
+      return { type: 'turnstile_challenge', websiteKey: null, note: 'Cloudflare interstitial detected but no sitekey was exposed in the DOM. Pass websiteKey explicitly if you have it.' };
+    }
+  }
+  return null;
+}
+
+export async function detectCaptcha(tabId) {
+  const results = await chrome.scripting.executeScript({
+    target: { tabId, allFrames: false },
+    func: detectCaptchaInPage,
+  });
+  for (const r of results || []) {
+    if (r?.result) return r.result;
+  }
+  return null;
+}
+
+// ─── Token injection ───────────────────────────────────────────────────
+
+function injectTokenIntoPage({ fieldName, alsoSet, token, callbackHint }) {
+  if (!fieldName || !token) return { success: false, error: 'no field/token' };
+  const docs = [document];
+  for (const f of document.querySelectorAll('iframe')) {
+    try { if (f.contentDocument) docs.push(f.contentDocument); } catch {}
+  }
+  const setOn = (d, name) => {
+    let el = d.querySelector(`textarea[name="${name}"]`)
+          || d.querySelector(`input[name="${name}"]`);
+    if (!el) {
+      // Some sites only render the response textarea after the user
+      // engages the widget. Create one if missing so the submit handler
+      // can pick it up.
+      el = d.createElement('textarea');
+      el.name = name;
+      el.style.display = 'none';
+      (d.body || d.documentElement).appendChild(el);
+    }
+    el.value = token;
+    el.textContent = token;
+    el.dispatchEvent(new Event('input', { bubbles: true }));
+    el.dispatchEvent(new Event('change', { bubbles: true }));
+    return el;
+  };
+  let touched = 0;
+  for (const d of docs) {
+    setOn(d, fieldName);
+    touched++;
+    if (alsoSet) setOn(d, alsoSet);
+  }
+  // Best-effort: trigger callback registered by the widget (reCAPTCHA
+  // v2/v3 sites usually wire `data-callback="onCaptcha"` on the host
+  // element; some hCaptcha sites do the same with `data-callback`).
+  let calledCallback = false;
+  for (const d of docs) {
+    const host = d.querySelector('[data-callback]');
+    const cbName = host?.getAttribute('data-callback');
+    if (cbName) {
+      try {
+        const fn = (typeof window !== 'undefined' && typeof window[cbName] === 'function') ? window[cbName] : null;
+        if (fn) { fn(token); calledCallback = true; }
+      } catch { /* ignore */ }
+    }
+  }
+  return { success: true, fieldsTouched: touched, calledCallback, callbackHint: callbackHint || null };
+}
+
+export async function injectToken(tabId, { fieldName, alsoSet, token, callbackHint }) {
+  if (!fieldName || !token) return { success: false, error: 'fieldName and token required' };
+  const results = await chrome.scripting.executeScript({
+    target: { tabId, allFrames: false },
+    args: [{ fieldName, alsoSet, token, callbackHint }],
+    func: injectTokenIntoPage,
+  });
+  return results?.[0]?.result || { success: false, error: 'injection script returned no result' };
+}

--- a/src/chrome/src/agent/tools.js
+++ b/src/chrome/src/agent/tools.js
@@ -613,6 +613,30 @@ export const AGENT_TOOLS = [
       },
     },
   },
+  {
+    type: 'function',
+    function: {
+      name: 'solve_captcha',
+      description: 'Solve a CAPTCHA on the current page using the CapSolver API (only available when the user has enabled CapSolver and provided an API key in Settings → CAPTCHA). If `type` and `websiteKey` are omitted, the tool scans the page for known widgets (reCAPTCHA v2/v3, hCaptcha, Cloudflare Turnstile) and uses what it finds. Returns the solution token and whether it was injected into the page; you usually still need to click the form\'s submit button afterward. On failure (no CapSolver key configured, unknown captcha type, API error, timeout) the tool returns `{ success: false, error: "..." }` — fall back to asking the user to solve it manually.',
+      parameters: {
+        type: 'object',
+        properties: {
+          type: {
+            type: 'string',
+            enum: ['recaptcha_v2', 'recaptcha_v3', 'hcaptcha', 'turnstile', 'image_to_text'],
+            description: 'CAPTCHA type. Omit to auto-detect from the page DOM.',
+          },
+          websiteKey: { type: 'string', description: 'Site key from the captcha widget\'s data-sitekey attribute. Auto-detected when omitted.' },
+          isInvisible: { type: 'boolean', description: 'reCAPTCHA v2 / hCaptcha only — true when the widget uses invisible mode (no visible checkbox). Auto-detected when omitted.' },
+          pageAction: { type: 'string', description: 'reCAPTCHA v3 only — the action name the page uses (e.g. "login", "submit"). Auto-detected from data-action when present.' },
+          minScore: { type: 'number', description: 'reCAPTCHA v3 only — minimum score requested (0.3 is the usual lower bound, 0.7+ is hard).' },
+          imageBase64: { type: 'string', description: 'image_to_text only — base64-encoded image bytes (no data: prefix).' },
+          inject: { type: 'boolean', description: 'After solving, inject the token into the page\'s response field (textarea[name=g-recaptcha-response] etc.) and fire the widget\'s callback. Default true. Set false to get just the token back.' },
+        },
+        required: [],
+      },
+    },
+  },
 ];
 
 /**
@@ -926,7 +950,7 @@ FORMS — read this:
 - You do NOT need verify_form for simple interactions: search boxes, single-field forms, or login forms. Use it for multi-field forms where wrong data has consequences (checkout, profile, issue creation, releases, etc.).
 - AFTER submitting a form, ALWAYS take a screenshot and read the page to confirm success BEFORE doing anything else. Do not resume other actions until you verify the submission result. Look for: a success message/toast, the newly created item appearing in a list, or a detail page for the new item. Check that the details (name, price, dates) match what you intended.
 - NEVER claim you created something unless you see CONFIRMATION on the page. If you see a list of items, check the creation date — if it says "2 months ago" or a past date, that is an EXISTING item, NOT something you just created. Only items with a timestamp from right now are yours.
-- If you encounter any CAPTCHA, anti-bot check, or human verification challenge, STOP immediately and ask the user to solve it. Do not attempt to bypass it and do not continue automation until the user confirms it is solved.
+- If you encounter any CAPTCHA, anti-bot check, or human verification challenge, the default is to STOP and ask the user to solve it — do not invent code or DOM tricks to bypass it. The single exception: when the user has configured CapSolver (you will see a "[CAPTCHA SOLVER]" note in the system prompt), call \`solve_captcha\` ONCE. If that returns success, click the form's submit button and continue. If it errors, fall back to asking the user — do not loop on solve_captcha.
 
 MODALS & DIALOGS — read this:
 - When a modal/dialog is open, treat the rest of the page as unreachable. click({text: ...}) and get_interactive_elements are automatically scoped to the topmost dialog, so queries for buttons behind the overlay will return "no match" — that's intentional.

--- a/src/chrome/src/background.js
+++ b/src/chrome/src/background.js
@@ -6,6 +6,7 @@ import {
   signOutClaude,
   getClaudeOAuthStatus,
 } from './providers/oauth-claude.js';
+import { getBalance as capsolverGetBalance } from './agent/captcha-solver.js';
 
 /**
  * WebBrain Service Worker (Background Script)
@@ -51,6 +52,17 @@ async function loadProfile() {
 }
 loadProfile();
 
+// CapSolver opt-in. We only need the toggle here — the API key is read at
+// call time inside the agent's solve_captcha handler so rotating it via
+// the settings page is picked up without a restart.
+async function loadCaptchaSolver() {
+  const stored = await chrome.storage.local.get('captchaSolverEnabled');
+  if (stored.captchaSolverEnabled != null) {
+    agent.captchaSolverEnabled = !!stored.captchaSolverEnabled;
+  }
+}
+loadCaptchaSolver();
+
 // Initialize on install
 chrome.runtime.onInstalled.addListener(async () => {
   await providerManager.load();
@@ -92,6 +104,10 @@ chrome.storage.onChanged.addListener((changes) => {
   }
   if (changes.profileText) {
     agent.profileText = changes.profileText.newValue || '';
+    refreshPrompts = true;
+  }
+  if (changes.captchaSolverEnabled) {
+    agent.captchaSolverEnabled = !!changes.captchaSolverEnabled.newValue;
     refreshPrompts = true;
   }
   if (refreshPrompts) agent._refreshSystemPrompts();
@@ -547,6 +563,20 @@ async function handleMessage(msg, sender) {
 
     case 'test_vision_provider': {
       return await providerManager.testVisionProvider();
+    }
+
+    case 'test_capsolver_balance': {
+      // Settings UI "Check balance" button. Uses the key from the request
+      // rather than re-reading storage so the user gets feedback before
+      // they've clicked Save.
+      try {
+        const key = String(msg.apiKey || '').trim();
+        if (!key) return { ok: false, error: 'No API key provided' };
+        const res = await capsolverGetBalance(key);
+        return { ok: true, balance: res.balance, packages: res.packages };
+      } catch (e) {
+        return { ok: false, error: e.message };
+      }
     }
 
     case 'list_ollama_models': {

--- a/src/chrome/src/ui/locales/en.js
+++ b/src/chrome/src/ui/locales/en.js
@@ -183,7 +183,7 @@ export default {
   'st.captcha.cleared': 'Cleared.',
   'st.captcha.checking': 'Checking balance…',
   'st.captcha.need_key': 'Enter an API key first.',
-  'st.captcha.balance_ok': 'OK — balance: ${balance}',
+  'st.captcha.balance_ok': 'OK — balance: {balance}',
   'st.captcha.balance_fail': 'Failed: {error}',
   'st.captcha.security_html': '<strong>Heads-up:</strong> the API key is stored <strong>in plaintext</strong> in browser local storage. CapSolver charges your account for every solve; the agent will only call it when a CAPTCHA actually blocks a step (max once per encounter — it won\'t retry on failure). Some sites\' terms of service prohibit automated CAPTCHA solving; use your judgement.',
 

--- a/src/chrome/src/ui/locales/en.js
+++ b/src/chrome/src/ui/locales/en.js
@@ -92,6 +92,7 @@ export default {
   'st.tab.vision': 'Vision',
   'st.tab.profile': 'Profile',
   'st.tab.account': 'Account',
+  'st.tab.captcha': 'CAPTCHA',
 
   'st.account.not_signed_in': 'Not signed in',
   'st.account.sign_in': 'Sign In / Register',
@@ -170,6 +171,21 @@ export default {
   'st.profile.saved': 'Saved.',
   'st.profile.cleared': 'Cleared.',
   'st.profile.security_html': '<strong>Security — read this:</strong><br><ul style="margin:6px 0 0 18px;padding:0;line-height:1.55;"><li>The text you enter here is stored <strong>in plaintext</strong> in your browser\'s local storage. It is <strong>not</strong> transmitted to the WebBrain project — but it <strong>is</strong> sent to whichever LLM provider you have configured on every turn, as part of the system prompt.</li><li><strong>Do not put passwords for important accounts</strong> here (Google, Apple, iCloud, banking, work SSO, primary email). Those accounts should use 2FA and you shouldn\'t need to hand them to an agent anyway.</li><li>A <strong>throwaway password</strong> you reuse for low-stakes site signups (newsletters, free trials, forum accounts) is the intended use case.</li><li>If this browser profile is ever compromised, an attacker with disk access can read this text. Keep it minimal.</li></ul>',
+
+  'st.captcha.desc_html': 'Let the agent solve CAPTCHAs automatically via the <a href="https://capsolver.com" target="_blank" style="color:var(--accent);">CapSolver</a> API. Supports reCAPTCHA v2/v3, hCaptcha, and Cloudflare Turnstile. Off by default — when off, the agent stops and asks you to solve the captcha yourself. CapSolver charges per solve (~$0.001–$0.003); you bring your own account and API key.',
+  'st.captcha.enabled.label': 'Enable CapSolver',
+  'st.captcha.enabled.desc': 'When the agent hits a CAPTCHA it will call CapSolver once before falling back to asking you. Requires an API key below.',
+  'st.captcha.api_key.label': 'CapSolver API Key',
+  'st.captcha.save': 'Save Key',
+  'st.captcha.check_balance': 'Check Balance',
+  'st.captcha.clear': 'Clear',
+  'st.captcha.saved': 'Saved.',
+  'st.captcha.cleared': 'Cleared.',
+  'st.captcha.checking': 'Checking balance…',
+  'st.captcha.need_key': 'Enter an API key first.',
+  'st.captcha.balance_ok': 'OK — balance: ${balance}',
+  'st.captcha.balance_fail': 'Failed: {error}',
+  'st.captcha.security_html': '<strong>Heads-up:</strong> the API key is stored <strong>in plaintext</strong> in browser local storage. CapSolver charges your account for every solve; the agent will only call it when a CAPTCHA actually blocks a step (max once per encounter — it won\'t retry on failure). Some sites\' terms of service prohibit automated CAPTCHA solving; use your judgement.',
 
   // --- Traces page -------------------------------------------------------
   'tr.title': 'WebBrain Traces',

--- a/src/chrome/src/ui/settings.html
+++ b/src/chrome/src/ui/settings.html
@@ -322,6 +322,7 @@
     <button class="tab-btn" type="button" role="tab" data-tab="providers" data-i18n="st.tab.providers"></button>
     <button class="tab-btn" type="button" role="tab" data-tab="vision" data-i18n="st.tab.vision"></button>
     <button class="tab-btn" type="button" role="tab" data-tab="profile" data-i18n="st.tab.profile"></button>
+    <button class="tab-btn" type="button" role="tab" data-tab="captcha" data-i18n="st.tab.captcha"></button>
   </nav>
 
   <section class="tab-panel active" data-panel="display" role="tabpanel">
@@ -494,6 +495,37 @@
       <div class="test-result" id="test-profile"></div>
 
       <div class="info-box" style="margin-top:16px;" data-i18n-html="st.profile.security_html"></div>
+    </div>
+  </section>
+
+  <section class="tab-panel" data-panel="captcha" role="tabpanel">
+    <div class="provider-card" id="captcha-card">
+      <div style="font-size:12px;color:var(--text2);margin-bottom:14px;line-height:1.55;" data-i18n-html="st.captcha.desc_html"></div>
+
+      <div class="setting-row" style="margin-bottom:12px;">
+        <div class="setting-info">
+          <div class="setting-label" data-i18n="st.captcha.enabled.label"></div>
+          <div class="setting-desc" data-i18n="st.captcha.enabled.desc"></div>
+        </div>
+        <label class="toggle">
+          <input type="checkbox" id="toggle-captcha-enabled">
+          <span class="toggle-slider"></span>
+        </label>
+      </div>
+
+      <div class="field">
+        <label data-i18n="st.captcha.api_key.label"></label>
+        <input type="password" id="captcha-api-key" placeholder="CAP-XXXXXXXXXXXXXXXXXXXX">
+      </div>
+
+      <div class="btn-row">
+        <button class="btn-primary" id="btn-save-captcha" data-i18n="st.captcha.save"></button>
+        <button class="btn-secondary" id="btn-test-captcha" data-i18n="st.captcha.check_balance"></button>
+        <button class="btn-secondary" id="btn-clear-captcha" data-i18n="st.captcha.clear"></button>
+      </div>
+      <div class="test-result" id="test-captcha"></div>
+
+      <div class="info-box" style="margin-top:16px;" data-i18n-html="st.captcha.security_html"></div>
     </div>
   </section>
 

--- a/src/chrome/src/ui/settings.js
+++ b/src/chrome/src/ui/settings.js
@@ -368,7 +368,7 @@ if (btnTestCaptcha) {
     captchaTestResult.style.color = 'var(--text2)';
     const res = await sendToBackground('test_capsolver_balance', { apiKey: key });
     if (res.ok) {
-      flashCaptchaResult('ok', t('st.captcha.balance_ok', { balance: Number(res.balance).toFixed(4) }));
+      flashCaptchaResult('ok', t('st.captcha.balance_ok', { balance: `$${Number(res.balance).toFixed(4)}` }));
     } else {
       flashCaptchaResult('fail', t('st.captcha.balance_fail', { error: res.error }));
     }

--- a/src/chrome/src/ui/settings.js
+++ b/src/chrome/src/ui/settings.js
@@ -32,6 +32,12 @@ const profileTextArea = document.getElementById('profile-text');
 const btnSaveProfile = document.getElementById('btn-save-profile');
 const btnClearProfile = document.getElementById('btn-clear-profile');
 const profileTestResult = document.getElementById('test-profile');
+const captchaEnabledToggle = document.getElementById('toggle-captcha-enabled');
+const captchaApiKeyInput = document.getElementById('captcha-api-key');
+const btnSaveCaptcha = document.getElementById('btn-save-captcha');
+const btnTestCaptcha = document.getElementById('btn-test-captcha');
+const btnClearCaptcha = document.getElementById('btn-clear-captcha');
+const captchaTestResult = document.getElementById('test-captcha');
 const languageSelect = document.getElementById('select-language');
 const subtitleEl = document.getElementById('subtitle');
 
@@ -102,6 +108,11 @@ async function init() {
   const profileStored = await chrome.storage.local.get(['profileEnabled', 'profileText']);
   if (profileEnabledToggle) profileEnabledToggle.checked = !!profileStored.profileEnabled;
   if (profileTextArea) profileTextArea.value = profileStored.profileText || '';
+
+  // Load CapSolver config — off by default.
+  const captchaStored = await chrome.storage.local.get(['captchaSolverEnabled', 'capsolverApiKey']);
+  if (captchaEnabledToggle) captchaEnabledToggle.checked = !!captchaStored.captchaSolverEnabled;
+  if (captchaApiKeyInput) captchaApiKeyInput.value = captchaStored.capsolverApiKey || '';
 
   // Load providers
   const res = await sendToBackground('get_providers');
@@ -317,6 +328,59 @@ if (btnClearProfile) {
     if (profileTextArea) profileTextArea.value = '';
     await chrome.storage.local.set({ profileText: '' });
     flashProfileResult('ok', t('st.profile.cleared'));
+  });
+}
+
+// --- CapSolver (captcha solving) ---
+// Toggle persists immediately so the prompt updates on the next agent turn
+// without forcing a Save click. The API key needs an explicit Save.
+
+function flashCaptchaResult(className, text) {
+  if (!captchaTestResult) return;
+  captchaTestResult.className = `test-result show ${className}`;
+  captchaTestResult.textContent = text;
+  setTimeout(() => captchaTestResult.classList.remove('show'), 3000);
+}
+
+if (captchaEnabledToggle) {
+  captchaEnabledToggle.addEventListener('change', () => {
+    chrome.storage.local.set({ captchaSolverEnabled: captchaEnabledToggle.checked });
+  });
+}
+
+if (btnSaveCaptcha) {
+  btnSaveCaptcha.addEventListener('click', async () => {
+    const key = (captchaApiKeyInput?.value || '').trim();
+    await chrome.storage.local.set({ capsolverApiKey: key });
+    flashCaptchaResult('ok', t('st.captcha.saved'));
+  });
+}
+
+if (btnTestCaptcha) {
+  btnTestCaptcha.addEventListener('click', async () => {
+    const key = (captchaApiKeyInput?.value || '').trim();
+    if (!key) {
+      flashCaptchaResult('fail', t('st.captcha.need_key'));
+      return;
+    }
+    captchaTestResult.className = 'test-result show';
+    captchaTestResult.textContent = t('st.captcha.checking');
+    captchaTestResult.style.color = 'var(--text2)';
+    const res = await sendToBackground('test_capsolver_balance', { apiKey: key });
+    if (res.ok) {
+      flashCaptchaResult('ok', t('st.captcha.balance_ok', { balance: Number(res.balance).toFixed(4) }));
+    } else {
+      flashCaptchaResult('fail', t('st.captcha.balance_fail', { error: res.error }));
+    }
+  });
+}
+
+if (btnClearCaptcha) {
+  btnClearCaptcha.addEventListener('click', async () => {
+    if (captchaApiKeyInput) captchaApiKeyInput.value = '';
+    if (captchaEnabledToggle) captchaEnabledToggle.checked = false;
+    await chrome.storage.local.remove(['capsolverApiKey', 'captchaSolverEnabled']);
+    flashCaptchaResult('ok', t('st.captcha.cleared'));
   });
 }
 

--- a/src/firefox/src/agent/agent.js
+++ b/src/firefox/src/agent/agent.js
@@ -18,6 +18,7 @@ import {
   PDF_PASSTHROUGH_MAX_BYTES,
 } from './pdf-tools.js';
 import * as trace from '../trace/recorder.js';
+import { solveCaptcha, detectCaptcha, injectToken } from './captcha-solver.js';
 
 /**
  * The WebBrain Agent — orchestrates multi-step LLM + tool-use loops.
@@ -41,6 +42,11 @@ export class Agent {
     // signup forms). Loaded in background.js and refreshed live on change.
     this.profileEnabled = false;
     this.profileText = '';
+    // CapSolver opt-in. Off by default. When enabled AND an API key is
+    // set, the system prompt gets a "[CAPTCHA SOLVER]" note telling the
+    // model to try `solve_captcha` once before falling back to asking
+    // the user. The API key is read at call time from browser.storage.
+    this.captchaSolverEnabled = false;
     // Strict secret-handling mode — see chrome/agent.js for rationale.
     // Default off; user opts in via Settings → "Strict secret handling".
     this.strictSecretMode = false;
@@ -1106,6 +1112,9 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
         `\n\n[User profile — use these details when a form or signup needs them, INSTEAD of asking the user. The user has opted in to sharing this with you. Do NOT volunteer these details on pages that don't need them, and NEVER reveal the password in chat output or screenshots. Treat it as sensitive.]\n` +
         this.profileText.trim();
     }
+    if (this.captchaSolverEnabled) {
+      prompt += `\n\n[CAPTCHA SOLVER — the user has configured CapSolver. When a CAPTCHA blocks a step, call \`solve_captcha\` once (with no arguments — it auto-detects reCAPTCHA v2/v3, hCaptcha, and Cloudflare Turnstile). On success, click the form's submit button and continue. On failure, ask the user to solve it manually — do not retry solve_captcha repeatedly.]`;
+    }
     return prompt;
   }
 
@@ -1778,6 +1787,88 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
     }
     if (name === 'download_files') {
       return await downloadFiles(args);
+    }
+
+    // ─── CAPTCHA solver ──────────────────────────────────────────────
+    // Only meaningfully wired when the user has enabled CapSolver in
+    // Settings. We re-check on every call so flipping the toggle or
+    // rotating the key takes effect without a restart.
+    if (name === 'solve_captcha') {
+      try {
+        const stored = await browser.storage.local.get(['captchaSolverEnabled', 'capsolverApiKey']);
+        if (!stored.captchaSolverEnabled) {
+          return { success: false, error: 'CapSolver is not enabled. Ask the user to enable it in Settings → CAPTCHA, or fall back to asking them to solve the captcha manually.' };
+        }
+        const apiKey = (stored.capsolverApiKey || '').trim();
+        if (!apiKey) {
+          return { success: false, error: 'CapSolver is enabled but no API key is configured. Ask the user to set one in Settings → CAPTCHA, or fall back to asking them to solve the captcha manually.' };
+        }
+
+        let websiteURL = '';
+        try {
+          const tab = await browser.tabs.get(tabId);
+          websiteURL = tab?.url || '';
+        } catch {}
+
+        let { type, websiteKey, isInvisible, pageAction, minScore, imageBase64 } = args || {};
+        if (!type) {
+          const detected = await detectCaptcha(tabId);
+          if (!detected) {
+            return { success: false, error: 'No CAPTCHA detected on the page. If the captcha lives inside a cross-origin iframe or uses a non-standard widget, pass `type` and `websiteKey` explicitly.' };
+          }
+          type = detected.type;
+          if (!websiteKey) websiteKey = detected.websiteKey;
+          if (isInvisible == null && detected.isInvisible != null) isInvisible = detected.isInvisible;
+          if (!pageAction && detected.pageAction) pageAction = detected.pageAction;
+        }
+
+        if (type === 'image_to_text') {
+          if (!imageBase64) {
+            return { success: false, error: 'solve_captcha: image_to_text requires `imageBase64`.' };
+          }
+        } else if (!websiteKey) {
+          return { success: false, error: `solve_captcha: ${type} requires a websiteKey (data-sitekey). Auto-detection didn't find one — pass it explicitly.` };
+        }
+
+        const result = await solveCaptcha(apiKey, {
+          type,
+          websiteURL,
+          websiteKey,
+          ...(isInvisible != null ? { isInvisible } : {}),
+          ...(pageAction ? { pageAction } : {}),
+          ...(minScore ? { minScore } : {}),
+          ...(imageBase64 ? { body: imageBase64 } : {}),
+        });
+
+        const wantInject = args?.inject !== false && type !== 'image_to_text';
+        let injection = null;
+        if (wantInject && result.fieldName && result.token) {
+          try {
+            injection = await injectToken(tabId, {
+              fieldName: result.fieldName,
+              alsoSet: result.alsoSet,
+              token: result.token,
+            });
+          } catch (e) {
+            injection = { success: false, error: e.message };
+          }
+        }
+
+        return {
+          success: true,
+          type,
+          taskId: result.taskId,
+          token: result.token,
+          tokenPreview: result.token ? `${String(result.token).slice(0, 24)}…(${String(result.token).length} chars)` : null,
+          injected: injection?.success === true,
+          injection,
+          note: wantInject
+            ? 'Token was injected into the page response field. Click the form\'s submit button next; do NOT call solve_captcha again.'
+            : 'Token returned, not injected. Pass it to the form via type_text on the response field, then submit.',
+        };
+      } catch (e) {
+        return { success: false, error: `solve_captcha failed: ${e.message}` };
+      }
     }
 
     if (name === 'download_social_media') {

--- a/src/firefox/src/agent/captcha-solver.js
+++ b/src/firefox/src/agent/captcha-solver.js
@@ -145,20 +145,9 @@ const DETECT_CODE = `(() => {
     try { if (f.contentDocument) docs.push(f.contentDocument); } catch {}
   }
   for (const d of docs) {
-    const recap = d.querySelector('.g-recaptcha[data-sitekey], div[data-sitekey][data-callback], div[id^="g-recaptcha"]');
-    if (recap) {
-      const sitekey = recap.getAttribute('data-sitekey');
-      if (sitekey) {
-        const size = recap.getAttribute('data-size');
-        const action = recap.getAttribute('data-action') || null;
-        return {
-          type: action ? 'recaptcha_v3' : 'recaptcha_v2',
-          websiteKey: sitekey,
-          isInvisible: size === 'invisible',
-          ...(action ? { pageAction: action } : {}),
-        };
-      }
-    }
+    // Provider-specific widgets are checked BEFORE the generic reCAPTCHA
+    // fallback so a Turnstile/hCaptcha widget with data-sitekey + data-callback
+    // doesn't get misclassified as reCAPTCHA.
     const hcap = d.querySelector('.h-captcha[data-sitekey], div[data-hcaptcha-widget-id]');
     if (hcap) {
       const sitekey = hcap.getAttribute('data-sitekey') || hcap.getAttribute('data-hcaptcha-sitekey');
@@ -171,6 +160,20 @@ const DETECT_CODE = `(() => {
     if (turn) {
       const sitekey = turn.getAttribute('data-sitekey') || turn.getAttribute('data-turnstile-sitekey');
       if (sitekey) return { type: 'turnstile', websiteKey: sitekey };
+    }
+    const recap = d.querySelector('.g-recaptcha[data-sitekey], div[id^="g-recaptcha"][data-sitekey]');
+    if (recap) {
+      const sitekey = recap.getAttribute('data-sitekey');
+      if (sitekey) {
+        const size = recap.getAttribute('data-size');
+        const action = recap.getAttribute('data-action') || null;
+        return {
+          type: action ? 'recaptcha_v3' : 'recaptcha_v2',
+          websiteKey: sitekey,
+          isInvisible: size === 'invisible',
+          ...(action ? { pageAction: action } : {}),
+        };
+      }
     }
     if (d.querySelector('script[src*="challenges.cloudflare.com/turnstile"]') ||
         d.querySelector('iframe[src*="challenges.cloudflare.com"]')) {

--- a/src/firefox/src/agent/captcha-solver.js
+++ b/src/firefox/src/agent/captcha-solver.js
@@ -1,0 +1,239 @@
+// CapSolver REST client + page-side detect/inject helpers (Firefox MV2).
+//
+// Mirror of the Chrome MV3 version, with two differences:
+//   1. `browser.*` namespace.
+//   2. Page-side helpers use `browser.tabs.executeScript(tabId, {code})`
+//      instead of `chrome.scripting.executeScript({func, args})`.
+//
+// We do not bundle the CapSolver extension. All work goes through:
+//   POST /createTask     → { taskId } | { errorId, errorCode, errorDescription }
+//   POST /getTaskResult  → { status: "ready"|"processing", solution? }
+//   POST /getBalance     → { balance, packages }
+
+const API_BASE = 'https://api.capsolver.com';
+const POLL_INTERVAL_MS = 2500;
+const POLL_TIMEOUT_MS = 120_000;
+const DEFAULT_APP_ID = 'B7E57F27-0AD3-434D-A5B7-CF9EE7D093EE';
+
+async function postJson(path, body) {
+  const res = await fetch(`${API_BASE}${path}`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+  if (!res.ok) {
+    const text = await res.text().catch(() => '');
+    throw new Error(`CapSolver ${path} HTTP ${res.status}: ${text.slice(0, 200)}`);
+  }
+  return await res.json();
+}
+
+export async function getBalance(apiKey) {
+  if (!apiKey) throw new Error('No CapSolver API key configured.');
+  const res = await postJson('/getBalance', { clientKey: apiKey });
+  if (res.errorId) throw new Error(`CapSolver: ${res.errorDescription || res.errorCode}`);
+  return { balance: res.balance, packages: res.packages || [] };
+}
+
+async function createTask(apiKey, task) {
+  const res = await postJson('/createTask', {
+    clientKey: apiKey,
+    appId: DEFAULT_APP_ID,
+    task,
+  });
+  if (res.errorId) {
+    throw new Error(`CapSolver createTask: ${res.errorDescription || res.errorCode}`);
+  }
+  if (!res.taskId) throw new Error('CapSolver createTask returned no taskId.');
+  return res.taskId;
+}
+
+async function pollTaskResult(apiKey, taskId, { timeoutMs = POLL_TIMEOUT_MS } = {}) {
+  const start = Date.now();
+  while (Date.now() - start < timeoutMs) {
+    const res = await postJson('/getTaskResult', { clientKey: apiKey, taskId });
+    if (res.errorId) {
+      throw new Error(`CapSolver getTaskResult: ${res.errorDescription || res.errorCode}`);
+    }
+    if (res.status === 'ready') return res.solution || {};
+    await new Promise(r => setTimeout(r, POLL_INTERVAL_MS));
+  }
+  throw new Error(`CapSolver: timed out after ${Math.round(timeoutMs / 1000)}s waiting for solution.`);
+}
+
+function buildTask({ type, websiteURL, websiteKey, ...rest }) {
+  const t = String(type || '').toLowerCase();
+  if (t === 'recaptcha_v2' || t === 'recaptchav2') {
+    return {
+      type: 'ReCaptchaV2TaskProxyLess',
+      websiteURL,
+      websiteKey,
+      ...(rest.isInvisible != null ? { isInvisible: !!rest.isInvisible } : {}),
+      ...(rest.userAgent ? { userAgent: rest.userAgent } : {}),
+    };
+  }
+  if (t === 'recaptcha_v3' || t === 'recaptchav3') {
+    return {
+      type: 'ReCaptchaV3TaskProxyLess',
+      websiteURL,
+      websiteKey,
+      pageAction: rest.pageAction || rest.action || 'verify',
+      ...(rest.minScore ? { minScore: rest.minScore } : {}),
+    };
+  }
+  if (t === 'hcaptcha') {
+    return {
+      type: 'HCaptchaTaskProxyLess',
+      websiteURL,
+      websiteKey,
+      ...(rest.isInvisible != null ? { isInvisible: !!rest.isInvisible } : {}),
+      ...(rest.enterprisePayload ? { enterprisePayload: rest.enterprisePayload } : {}),
+      ...(rest.userAgent ? { userAgent: rest.userAgent } : {}),
+    };
+  }
+  if (t === 'turnstile' || t === 'cloudflare' || t === 'cf_turnstile') {
+    return {
+      type: 'AntiTurnstileTaskProxyLess',
+      websiteURL,
+      websiteKey,
+      ...(rest.metadata ? { metadata: rest.metadata } : {}),
+    };
+  }
+  if (t === 'image_to_text' || t === 'image') {
+    return {
+      type: 'ImageToTextTask',
+      body: rest.body,
+      ...(rest.module ? { module: rest.module } : {}),
+      ...(rest.case != null ? { case: !!rest.case } : {}),
+    };
+  }
+  throw new Error(`solve_captcha: unsupported type "${type}".`);
+}
+
+function solutionFor(type, solution) {
+  const t = String(type || '').toLowerCase();
+  if (t === 'recaptcha_v2' || t === 'recaptchav2' || t === 'recaptcha_v3' || t === 'recaptchav3') {
+    return { token: solution.gRecaptchaResponse, fieldName: 'g-recaptcha-response' };
+  }
+  if (t === 'hcaptcha') {
+    return { token: solution.gRecaptchaResponse, fieldName: 'h-captcha-response', alsoSet: 'g-recaptcha-response' };
+  }
+  if (t === 'turnstile' || t === 'cloudflare' || t === 'cf_turnstile') {
+    return { token: solution.token, fieldName: 'cf-turnstile-response' };
+  }
+  if (t === 'image_to_text' || t === 'image') {
+    return { token: solution.text, fieldName: null };
+  }
+  return { token: null, fieldName: null };
+}
+
+export async function solveCaptcha(apiKey, params) {
+  if (!apiKey) throw new Error('No CapSolver API key configured.');
+  if (!params?.type) throw new Error('solve_captcha: type is required.');
+  const task = buildTask(params);
+  const taskId = await createTask(apiKey, task);
+  const solution = await pollTaskResult(apiKey, taskId);
+  const meta = solutionFor(params.type, solution);
+  return { taskId, solution, ...meta };
+}
+
+// ─── Page-side helpers (Firefox MV2 executeScript with code string) ──
+
+const DETECT_CODE = `(() => {
+  const docs = [document];
+  for (const f of document.querySelectorAll('iframe')) {
+    try { if (f.contentDocument) docs.push(f.contentDocument); } catch {}
+  }
+  for (const d of docs) {
+    const recap = d.querySelector('.g-recaptcha[data-sitekey], div[data-sitekey][data-callback], div[id^="g-recaptcha"]');
+    if (recap) {
+      const sitekey = recap.getAttribute('data-sitekey');
+      if (sitekey) {
+        const size = recap.getAttribute('data-size');
+        const action = recap.getAttribute('data-action') || null;
+        return {
+          type: action ? 'recaptcha_v3' : 'recaptcha_v2',
+          websiteKey: sitekey,
+          isInvisible: size === 'invisible',
+          ...(action ? { pageAction: action } : {}),
+        };
+      }
+    }
+    const hcap = d.querySelector('.h-captcha[data-sitekey], div[data-hcaptcha-widget-id]');
+    if (hcap) {
+      const sitekey = hcap.getAttribute('data-sitekey') || hcap.getAttribute('data-hcaptcha-sitekey');
+      if (sitekey) {
+        const size = hcap.getAttribute('data-size');
+        return { type: 'hcaptcha', websiteKey: sitekey, isInvisible: size === 'invisible' };
+      }
+    }
+    const turn = d.querySelector('.cf-turnstile[data-sitekey], [data-turnstile-sitekey]');
+    if (turn) {
+      const sitekey = turn.getAttribute('data-sitekey') || turn.getAttribute('data-turnstile-sitekey');
+      if (sitekey) return { type: 'turnstile', websiteKey: sitekey };
+    }
+    if (d.querySelector('script[src*="challenges.cloudflare.com/turnstile"]') ||
+        d.querySelector('iframe[src*="challenges.cloudflare.com"]')) {
+      return { type: 'turnstile_challenge', websiteKey: null, note: 'Cloudflare interstitial detected but no sitekey was exposed in the DOM. Pass websiteKey explicitly if you have it.' };
+    }
+  }
+  return null;
+})()`;
+
+export async function detectCaptcha(tabId) {
+  const results = await browser.tabs.executeScript(tabId, { code: DETECT_CODE });
+  for (const r of results || []) {
+    if (r) return r;
+  }
+  return null;
+}
+
+export async function injectToken(tabId, { fieldName, alsoSet, token }) {
+  if (!fieldName || !token) return { success: false, error: 'fieldName and token required' };
+  // Inline the params into the code string — Firefox MV2 doesn't have
+  // chrome.scripting's args[] mechanism. JSON.stringify guarantees we
+  // don't break out of the string literal.
+  const code = `(() => {
+    const fieldName = ${JSON.stringify(fieldName)};
+    const alsoSet = ${JSON.stringify(alsoSet || null)};
+    const token = ${JSON.stringify(token)};
+    const docs = [document];
+    for (const f of document.querySelectorAll('iframe')) {
+      try { if (f.contentDocument) docs.push(f.contentDocument); } catch {}
+    }
+    const setOn = (d, name) => {
+      let el = d.querySelector('textarea[name="' + name + '"]')
+            || d.querySelector('input[name="' + name + '"]');
+      if (!el) {
+        el = d.createElement('textarea');
+        el.name = name;
+        el.style.display = 'none';
+        (d.body || d.documentElement).appendChild(el);
+      }
+      el.value = token;
+      el.textContent = token;
+      el.dispatchEvent(new Event('input', { bubbles: true }));
+      el.dispatchEvent(new Event('change', { bubbles: true }));
+      return el;
+    };
+    let touched = 0;
+    for (const d of docs) {
+      setOn(d, fieldName); touched++;
+      if (alsoSet) setOn(d, alsoSet);
+    }
+    let calledCallback = false;
+    for (const d of docs) {
+      const host = d.querySelector('[data-callback]');
+      const cbName = host && host.getAttribute('data-callback');
+      if (cbName) {
+        try {
+          const fn = (typeof window !== 'undefined' && typeof window[cbName] === 'function') ? window[cbName] : null;
+          if (fn) { fn(token); calledCallback = true; }
+        } catch {}
+      }
+    }
+    return { success: true, fieldsTouched: touched, calledCallback };
+  })()`;
+  const results = await browser.tabs.executeScript(tabId, { code });
+  return results?.[0] || { success: false, error: 'injection script returned no result' };
+}

--- a/src/firefox/src/agent/tools.js
+++ b/src/firefox/src/agent/tools.js
@@ -551,6 +551,30 @@ export const AGENT_TOOLS = [
       },
     },
   },
+  {
+    type: 'function',
+    function: {
+      name: 'solve_captcha',
+      description: 'Solve a CAPTCHA on the current page using the CapSolver API (only available when the user has enabled CapSolver and provided an API key in Settings → CAPTCHA). If `type` and `websiteKey` are omitted, the tool scans the page for known widgets (reCAPTCHA v2/v3, hCaptcha, Cloudflare Turnstile) and uses what it finds. Returns the solution token and whether it was injected into the page; you usually still need to click the form\'s submit button afterward. On failure (no CapSolver key configured, unknown captcha type, API error, timeout) the tool returns `{ success: false, error: "..." }` — fall back to asking the user to solve it manually.',
+      parameters: {
+        type: 'object',
+        properties: {
+          type: {
+            type: 'string',
+            enum: ['recaptcha_v2', 'recaptcha_v3', 'hcaptcha', 'turnstile', 'image_to_text'],
+            description: 'CAPTCHA type. Omit to auto-detect from the page DOM.',
+          },
+          websiteKey: { type: 'string', description: 'Site key from the captcha widget\'s data-sitekey attribute. Auto-detected when omitted.' },
+          isInvisible: { type: 'boolean', description: 'reCAPTCHA v2 / hCaptcha only — true when the widget uses invisible mode (no visible checkbox). Auto-detected when omitted.' },
+          pageAction: { type: 'string', description: 'reCAPTCHA v3 only — the action name the page uses (e.g. "login", "submit"). Auto-detected from data-action when present.' },
+          minScore: { type: 'number', description: 'reCAPTCHA v3 only — minimum score requested (0.3 is the usual lower bound, 0.7+ is hard).' },
+          imageBase64: { type: 'string', description: 'image_to_text only — base64-encoded image bytes (no data: prefix).' },
+          inject: { type: 'boolean', description: 'After solving, inject the token into the page\'s response field (textarea[name=g-recaptcha-response] etc.) and fire the widget\'s callback. Default true. Set false to get just the token back.' },
+        },
+        required: [],
+      },
+    },
+  },
 ];
 
 /**
@@ -780,7 +804,7 @@ FORMS — read this:
 - You do NOT need verify_form for simple interactions: search boxes, single-field forms, or login forms. Use it for multi-field forms where wrong data has consequences (checkout, profile, issue creation, releases, etc.).
 - AFTER submitting a form, ALWAYS take a screenshot and read the page to confirm success BEFORE doing anything else. Do not resume other actions until you verify the submission result. Look for: a success message/toast, the newly created item appearing in a list, or a detail page for the new item. Check that the details (name, price, dates) match what you intended.
 - NEVER claim you created something unless you see CONFIRMATION on the page. If you see a list of items, check the creation date — if it says "2 months ago" or a past date, that is an EXISTING item, NOT something you just created. Only items with a timestamp from right now are yours.
-- If you encounter any CAPTCHA, anti-bot check, or human verification challenge, STOP immediately and ask the user to solve it. Do not attempt to bypass it and do not continue automation until the user confirms it is solved.
+- If you encounter any CAPTCHA, anti-bot check, or human verification challenge, the default is to STOP and ask the user to solve it — do not invent code or DOM tricks to bypass it. The single exception: when the user has configured CapSolver (you will see a "[CAPTCHA SOLVER]" note in the system prompt), call \`solve_captcha\` ONCE. If that returns success, click the form's submit button and continue. If it errors, fall back to asking the user — do not loop on solve_captcha.
 
 MODALS & DIALOGS — read this:
 - When a modal/dialog is open, treat the rest of the page as unreachable. click({text: ...}) is automatically scoped to the topmost dialog, so text queries for buttons behind the overlay will return "no match" — that's intentional.

--- a/src/firefox/src/background.js
+++ b/src/firefox/src/background.js
@@ -6,6 +6,7 @@ import {
   signOutClaude,
   getClaudeOAuthStatus,
 } from './providers/oauth-claude.js';
+import { getBalance as capsolverGetBalance } from './agent/captcha-solver.js';
 
 /**
  * WebBrain Background Script (Firefox)
@@ -46,6 +47,16 @@ async function loadProfile() {
 }
 loadProfile();
 
+// CapSolver opt-in. API key itself is read at solve time so rotating
+// keys via Settings doesn't need a restart.
+async function loadCaptchaSolver() {
+  const stored = await browser.storage.local.get('captchaSolverEnabled');
+  if (stored.captchaSolverEnabled != null) {
+    agent.captchaSolverEnabled = !!stored.captchaSolverEnabled;
+  }
+}
+loadCaptchaSolver();
+
 // Initialize on install
 browser.runtime.onInstalled.addListener(async () => {
   await providerManager.load();
@@ -78,6 +89,10 @@ browser.storage.onChanged.addListener((changes) => {
   }
   if (changes.profileText) {
     agent.profileText = changes.profileText.newValue || '';
+    refreshPrompts = true;
+  }
+  if (changes.captchaSolverEnabled) {
+    agent.captchaSolverEnabled = !!changes.captchaSolverEnabled.newValue;
     refreshPrompts = true;
   }
   if (refreshPrompts) agent._refreshSystemPrompts();
@@ -377,6 +392,17 @@ async function handleMessage(msg, sender) {
 
     case 'test_vision_provider': {
       return await providerManager.testVisionProvider();
+    }
+
+    case 'test_capsolver_balance': {
+      try {
+        const key = String(msg.apiKey || '').trim();
+        if (!key) return { ok: false, error: 'No API key provided' };
+        const res = await capsolverGetBalance(key);
+        return { ok: true, balance: res.balance, packages: res.packages };
+      } catch (e) {
+        return { ok: false, error: e.message };
+      }
     }
 
     case 'list_ollama_models': {

--- a/src/firefox/src/ui/locales/en.js
+++ b/src/firefox/src/ui/locales/en.js
@@ -183,7 +183,7 @@ export default {
   'st.captcha.cleared': 'Cleared.',
   'st.captcha.checking': 'Checking balance…',
   'st.captcha.need_key': 'Enter an API key first.',
-  'st.captcha.balance_ok': 'OK — balance: ${balance}',
+  'st.captcha.balance_ok': 'OK — balance: {balance}',
   'st.captcha.balance_fail': 'Failed: {error}',
   'st.captcha.security_html': '<strong>Heads-up:</strong> the API key is stored <strong>in plaintext</strong> in browser local storage. CapSolver charges your account for every solve; the agent will only call it when a CAPTCHA actually blocks a step (max once per encounter — it won\'t retry on failure). Some sites\' terms of service prohibit automated CAPTCHA solving; use your judgement.',
 

--- a/src/firefox/src/ui/locales/en.js
+++ b/src/firefox/src/ui/locales/en.js
@@ -92,6 +92,7 @@ export default {
   'st.tab.vision': 'Vision',
   'st.tab.profile': 'Profile',
   'st.tab.account': 'Account',
+  'st.tab.captcha': 'CAPTCHA',
 
   'st.account.not_signed_in': 'Not signed in',
   'st.account.sign_in': 'Sign In / Register',
@@ -170,6 +171,21 @@ export default {
   'st.profile.saved': 'Saved.',
   'st.profile.cleared': 'Cleared.',
   'st.profile.security_html': '<strong>Security — read this:</strong><br><ul style="margin:6px 0 0 18px;padding:0;line-height:1.55;"><li>The text you enter here is stored <strong>in plaintext</strong> in your browser\'s local storage. It is <strong>not</strong> transmitted to the WebBrain project — but it <strong>is</strong> sent to whichever LLM provider you have configured on every turn, as part of the system prompt.</li><li><strong>Do not put passwords for important accounts</strong> here (Google, Apple, iCloud, banking, work SSO, primary email). Those accounts should use 2FA and you shouldn\'t need to hand them to an agent anyway.</li><li>A <strong>throwaway password</strong> you reuse for low-stakes site signups (newsletters, free trials, forum accounts) is the intended use case.</li><li>If this browser profile is ever compromised, an attacker with disk access can read this text. Keep it minimal.</li></ul>',
+
+  'st.captcha.desc_html': 'Let the agent solve CAPTCHAs automatically via the <a href="https://capsolver.com" target="_blank" style="color:var(--accent);">CapSolver</a> API. Supports reCAPTCHA v2/v3, hCaptcha, and Cloudflare Turnstile. Off by default — when off, the agent stops and asks you to solve the captcha yourself. CapSolver charges per solve (~$0.001–$0.003); you bring your own account and API key.',
+  'st.captcha.enabled.label': 'Enable CapSolver',
+  'st.captcha.enabled.desc': 'When the agent hits a CAPTCHA it will call CapSolver once before falling back to asking you. Requires an API key below.',
+  'st.captcha.api_key.label': 'CapSolver API Key',
+  'st.captcha.save': 'Save Key',
+  'st.captcha.check_balance': 'Check Balance',
+  'st.captcha.clear': 'Clear',
+  'st.captcha.saved': 'Saved.',
+  'st.captcha.cleared': 'Cleared.',
+  'st.captcha.checking': 'Checking balance…',
+  'st.captcha.need_key': 'Enter an API key first.',
+  'st.captcha.balance_ok': 'OK — balance: ${balance}',
+  'st.captcha.balance_fail': 'Failed: {error}',
+  'st.captcha.security_html': '<strong>Heads-up:</strong> the API key is stored <strong>in plaintext</strong> in browser local storage. CapSolver charges your account for every solve; the agent will only call it when a CAPTCHA actually blocks a step (max once per encounter — it won\'t retry on failure). Some sites\' terms of service prohibit automated CAPTCHA solving; use your judgement.',
 
   // --- Traces page -------------------------------------------------------
   'tr.title': 'WebBrain Traces',

--- a/src/firefox/src/ui/settings.html
+++ b/src/firefox/src/ui/settings.html
@@ -322,6 +322,7 @@
     <button class="tab-btn" type="button" role="tab" data-tab="providers" data-i18n="st.tab.providers"></button>
     <button class="tab-btn" type="button" role="tab" data-tab="vision" data-i18n="st.tab.vision"></button>
     <button class="tab-btn" type="button" role="tab" data-tab="profile" data-i18n="st.tab.profile"></button>
+    <button class="tab-btn" type="button" role="tab" data-tab="captcha" data-i18n="st.tab.captcha"></button>
   </nav>
 
   <section class="tab-panel active" data-panel="display" role="tabpanel">
@@ -494,6 +495,37 @@
       <div class="test-result" id="test-profile"></div>
 
       <div class="info-box" style="margin-top:16px;" data-i18n-html="st.profile.security_html"></div>
+    </div>
+  </section>
+
+  <section class="tab-panel" data-panel="captcha" role="tabpanel">
+    <div class="provider-card" id="captcha-card">
+      <div style="font-size:12px;color:var(--text2);margin-bottom:14px;line-height:1.55;" data-i18n-html="st.captcha.desc_html"></div>
+
+      <div class="setting-row" style="margin-bottom:12px;">
+        <div class="setting-info">
+          <div class="setting-label" data-i18n="st.captcha.enabled.label"></div>
+          <div class="setting-desc" data-i18n="st.captcha.enabled.desc"></div>
+        </div>
+        <label class="toggle">
+          <input type="checkbox" id="toggle-captcha-enabled">
+          <span class="toggle-slider"></span>
+        </label>
+      </div>
+
+      <div class="field">
+        <label data-i18n="st.captcha.api_key.label"></label>
+        <input type="password" id="captcha-api-key" placeholder="CAP-XXXXXXXXXXXXXXXXXXXX">
+      </div>
+
+      <div class="btn-row">
+        <button class="btn-primary" id="btn-save-captcha" data-i18n="st.captcha.save"></button>
+        <button class="btn-secondary" id="btn-test-captcha" data-i18n="st.captcha.check_balance"></button>
+        <button class="btn-secondary" id="btn-clear-captcha" data-i18n="st.captcha.clear"></button>
+      </div>
+      <div class="test-result" id="test-captcha"></div>
+
+      <div class="info-box" style="margin-top:16px;" data-i18n-html="st.captcha.security_html"></div>
     </div>
   </section>
 

--- a/src/firefox/src/ui/settings.js
+++ b/src/firefox/src/ui/settings.js
@@ -349,7 +349,7 @@ if (btnTestCaptcha) {
     captchaTestResult.style.color = 'var(--text2)';
     const res = await sendToBackground('test_capsolver_balance', { apiKey: key });
     if (res.ok) {
-      flashCaptchaResult('ok', t('st.captcha.balance_ok', { balance: Number(res.balance).toFixed(4) }));
+      flashCaptchaResult('ok', t('st.captcha.balance_ok', { balance: `$${Number(res.balance).toFixed(4)}` }));
     } else {
       flashCaptchaResult('fail', t('st.captcha.balance_fail', { error: res.error }));
     }

--- a/src/firefox/src/ui/settings.js
+++ b/src/firefox/src/ui/settings.js
@@ -31,6 +31,12 @@ const profileTextArea = document.getElementById('profile-text');
 const btnSaveProfile = document.getElementById('btn-save-profile');
 const btnClearProfile = document.getElementById('btn-clear-profile');
 const profileTestResult = document.getElementById('test-profile');
+const captchaEnabledToggle = document.getElementById('toggle-captcha-enabled');
+const captchaApiKeyInput = document.getElementById('captcha-api-key');
+const btnSaveCaptcha = document.getElementById('btn-save-captcha');
+const btnTestCaptcha = document.getElementById('btn-test-captcha');
+const btnClearCaptcha = document.getElementById('btn-clear-captcha');
+const captchaTestResult = document.getElementById('test-captcha');
 const languageSelect = document.getElementById('select-language');
 const subtitleEl = document.getElementById('subtitle');
 
@@ -95,6 +101,11 @@ async function init() {
   const profileStored = await browser.storage.local.get(['profileEnabled', 'profileText']);
   if (profileEnabledToggle) profileEnabledToggle.checked = !!profileStored.profileEnabled;
   if (profileTextArea) profileTextArea.value = profileStored.profileText || '';
+
+  // Load CapSolver config — off by default.
+  const captchaStored = await browser.storage.local.get(['captchaSolverEnabled', 'capsolverApiKey']);
+  if (captchaEnabledToggle) captchaEnabledToggle.checked = !!captchaStored.captchaSolverEnabled;
+  if (captchaApiKeyInput) captchaApiKeyInput.value = captchaStored.capsolverApiKey || '';
 
   // Load providers
   const res = await sendToBackground('get_providers');
@@ -299,6 +310,58 @@ if (btnClearProfile) {
     if (profileTextArea) profileTextArea.value = '';
     await browser.storage.local.set({ profileText: '' });
     flashProfileResult('ok', t('st.profile.cleared'));
+  });
+}
+
+// --- CapSolver (captcha solving) ---
+// Toggle persists immediately. The API key needs an explicit Save.
+
+function flashCaptchaResult(className, text) {
+  if (!captchaTestResult) return;
+  captchaTestResult.className = `test-result show ${className}`;
+  captchaTestResult.textContent = text;
+  setTimeout(() => captchaTestResult.classList.remove('show'), 3000);
+}
+
+if (captchaEnabledToggle) {
+  captchaEnabledToggle.addEventListener('change', () => {
+    browser.storage.local.set({ captchaSolverEnabled: captchaEnabledToggle.checked });
+  });
+}
+
+if (btnSaveCaptcha) {
+  btnSaveCaptcha.addEventListener('click', async () => {
+    const key = (captchaApiKeyInput?.value || '').trim();
+    await browser.storage.local.set({ capsolverApiKey: key });
+    flashCaptchaResult('ok', t('st.captcha.saved'));
+  });
+}
+
+if (btnTestCaptcha) {
+  btnTestCaptcha.addEventListener('click', async () => {
+    const key = (captchaApiKeyInput?.value || '').trim();
+    if (!key) {
+      flashCaptchaResult('fail', t('st.captcha.need_key'));
+      return;
+    }
+    captchaTestResult.className = 'test-result show';
+    captchaTestResult.textContent = t('st.captcha.checking');
+    captchaTestResult.style.color = 'var(--text2)';
+    const res = await sendToBackground('test_capsolver_balance', { apiKey: key });
+    if (res.ok) {
+      flashCaptchaResult('ok', t('st.captcha.balance_ok', { balance: Number(res.balance).toFixed(4) }));
+    } else {
+      flashCaptchaResult('fail', t('st.captcha.balance_fail', { error: res.error }));
+    }
+  });
+}
+
+if (btnClearCaptcha) {
+  btnClearCaptcha.addEventListener('click', async () => {
+    if (captchaApiKeyInput) captchaApiKeyInput.value = '';
+    if (captchaEnabledToggle) captchaEnabledToggle.checked = false;
+    await browser.storage.local.remove(['capsolverApiKey', 'captchaSolverEnabled']);
+    flashCaptchaResult('ok', t('st.captcha.cleared'));
   });
 }
 

--- a/web/ar/index.html
+++ b/web/ar/index.html
@@ -801,6 +801,10 @@
     .pn-bubble.openrouter { background: rgba(108,99,255,0.12); color: var(--accent2); border-color: rgba(108,99,255,0.3); }
     .pn-bubble.studiolm { background: rgba(245,158,11,0.12); color: #f59e0b; border-color: rgba(245,158,11,0.25); }
     .pn-bubble.vllm { background: rgba(99,102,241,0.12); color: #6366f1; border-color: rgba(99,102,241,0.25); }
+    .pn-bubble.grok { background: rgba(255,255,255,0.06); color: #e5e5e5; border-color: rgba(255,255,255,0.2); }
+    .pn-bubble.gemini { background: rgba(66,133,244,0.12); color: #4285f4; border-color: rgba(66,133,244,0.25); }
+    .pn-bubble.deepseek { background: rgba(72,191,255,0.12); color: #48bfff; border-color: rgba(72,191,255,0.25); }
+    .pn-bubble.mistral { background: rgba(255,127,80,0.12); color: #ff7f50; border-color: rgba(255,127,80,0.25); }
 
     /* Reduced-motion: kill the float + ring pulse so users on
        prefers-reduced-motion see a static layout. */
@@ -1320,6 +1324,11 @@
       <p>يُغلق لافتات الموافقة (OneTrust، Cookiebot، Didomi، Quantcast) قبل التفكير في الصفحة. يكتشف حوائط الدفع ويُبلِغك بصدق بدلًا من اختلاق محتوى المقالة أو محاولة تجاوزه.</p>
     </div>
     <div class="feature-card">
+      <div class="feature-icon">🧩</div>
+      <h3>محلِّل CAPTCHA اختياري</h3>
+      <p>أضف مفتاح <a href="https://capsolver.com" target="_blank" rel="noopener" style="color:var(--accent);text-decoration:none;">CapSolver</a> ليحل الوكيل تلقائيًا اختبارات reCAPTCHA v2/v3 و hCaptcha و Cloudflare Turnstile عندما توقف خطوة — بدلًا من التوقف ليسألك. مغلق افتراضيًا، تجلب مفتاحك بنفسك، ولا يتم الاتصال بأي خدمة CAPTCHA إلا إذا قمت بتفعيلها.</p>
+    </div>
+    <div class="feature-card">
       <div class="feature-icon">🌐</div>
       <h3>واجهة متعدّدة اللغات</h3>
       <p>تصدر الإضافة بـ English و Español و Français و Türkçe و 中文. تكشف لغة متصفحك تلقائيًا عند أول استخدام؛ وتستطيع التبديل في أي وقت من أيقونة الكرة الأرضية في اللوحة الجانبية. الموقع التسويقي مُترجَم بشكل متوافق.</p>
@@ -1338,21 +1347,29 @@
   <h2 class="section-title">أحضر ذكاءك الخاص</h2>
   <p class="section-subtitle">اتّصل بأي واجهة API متوافقة مع OpenAI أو شغّل موديلًا محليًا. غيّر المزوّد متى شئت من إعدادات الإضافة.</p>
 
-  <!-- Constellation: central WebBrain core, 7 provider nodes orbiting on
-       two arcs. Connection lines drawn in SVG (viewBox is in % units via
-       a 0–100 coordinate space so the line endpoints follow the % values
-       used to position each node). The node order matches the line order
-       so JS can map a hovered node → its line for highlight. -->
+  <!-- Constellation: central WebBrain core, 11 provider nodes orbiting on
+       two arcs (5 above, 6 below). Connection lines drawn in SVG (viewBox
+       is in % units via a 0–100 coordinate space so the line endpoints
+       follow the % values used to position each node). The node order
+       matches the line order so JS can map a hovered node → its line for
+       highlight. Local runtimes (llama.cpp, Ollama, LM Studio, vLLM) are
+       on the left edges of each arc; cloud providers fan out toward the
+       right. Grok / Gemini / DeepSeek / Mistral are reached via the
+       OpenAI-compatible config — any OpenAI-style endpoint works. -->
   <div class="provider-constellation" aria-label="أحضر ذكاءك الخاص">
     <svg class="constellation-lines" viewBox="0 0 100 100" preserveAspectRatio="none" aria-hidden="true">
-      <!-- order: llama.cpp, ollama, openai, anthropic, openrouter, studiolm, vllm -->
+      <!-- order: llama.cpp, ollama, openai, anthropic, openrouter, lmstudio, vllm, grok, gemini, deepseek, mistral -->
       <line x1="50" y1="50" x2="10" y2="28"></line>
-      <line x1="50" y1="50" x2="22" y2="78"></line>
       <line x1="50" y1="50" x2="28" y2="12"></line>
-      <line x1="50" y1="50" x2="50" y2="92"></line>
+      <line x1="50" y1="50" x2="50" y2="6"></line>
       <line x1="50" y1="50" x2="72" y2="12"></line>
-      <line x1="50" y1="50" x2="78" y2="78"></line>
       <line x1="50" y1="50" x2="90" y2="28"></line>
+      <line x1="50" y1="50" x2="8" y2="72"></line>
+      <line x1="50" y1="50" x2="24" y2="88"></line>
+      <line x1="50" y1="50" x2="40" y2="95"></line>
+      <line x1="50" y1="50" x2="60" y2="95"></line>
+      <line x1="50" y1="50" x2="76" y2="88"></line>
+      <line x1="50" y1="50" x2="92" y2="72"></line>
     </svg>
 
     <div class="constellation-center" aria-hidden="true">
@@ -1365,29 +1382,45 @@
       <div class="pn-bubble local">🦙</div>
       <div class="pn-label">llama.cpp</div>
     </a>
-    <a class="provider-node" href="https://ollama.com" target="_blank" rel="noopener" style="--x: 22%; --y: 78%; --d: 0.8s;" data-line="1">
+    <a class="provider-node" href="https://ollama.com" target="_blank" rel="noopener" style="--x: 28%; --y: 12%; --d: 0.6s;" data-line="1">
       <div class="pn-bubble ollama">◉</div>
       <div class="pn-label">Ollama</div>
     </a>
-    <a class="provider-node" href="https://platform.openai.com" target="_blank" rel="noopener" style="--x: 28%; --y: 12%; --d: 1.6s;" data-line="2">
+    <a class="provider-node" href="https://platform.openai.com" target="_blank" rel="noopener" style="--x: 50%; --y: 6%; --d: 1.2s;" data-line="2">
       <div class="pn-bubble openai">⬡</div>
       <div class="pn-label">OpenAI</div>
     </a>
-    <a class="provider-node" href="https://www.anthropic.com" target="_blank" rel="noopener" style="--x: 50%; --y: 92%; --d: 2.4s;" data-line="3">
+    <a class="provider-node" href="https://www.anthropic.com" target="_blank" rel="noopener" style="--x: 72%; --y: 12%; --d: 1.8s;" data-line="3">
       <div class="pn-bubble anthropic">◈</div>
       <div class="pn-label">Claude</div>
     </a>
-    <a class="provider-node" href="https://openrouter.ai" target="_blank" rel="noopener" style="--x: 72%; --y: 12%; --d: 3.2s;" data-line="4">
+    <a class="provider-node" href="https://openrouter.ai" target="_blank" rel="noopener" style="--x: 90%; --y: 28%; --d: 2.4s;" data-line="4">
       <div class="pn-bubble openrouter">◆</div>
       <div class="pn-label">OpenRouter</div>
     </a>
-    <a class="provider-node" href="https://lmstudio.ai" target="_blank" rel="noopener" style="--x: 78%; --y: 78%; --d: 4.0s;" data-line="5">
+    <a class="provider-node" href="https://lmstudio.ai" target="_blank" rel="noopener" style="--x: 8%; --y: 72%; --d: 3.0s;" data-line="5">
       <div class="pn-bubble studiolm">✦</div>
-      <div class="pn-label">StudioLM</div>
+      <div class="pn-label">LM Studio</div>
     </a>
-    <a class="provider-node" href="https://docs.vllm.ai" target="_blank" rel="noopener" style="--x: 90%; --y: 28%; --d: 4.8s;" data-line="6">
+    <a class="provider-node" href="https://docs.vllm.ai" target="_blank" rel="noopener" style="--x: 24%; --y: 88%; --d: 3.6s;" data-line="6">
       <div class="pn-bubble vllm">▣</div>
-      <div class="pn-label">VLLM</div>
+      <div class="pn-label">vLLM</div>
+    </a>
+    <a class="provider-node" href="https://x.ai/api" target="_blank" rel="noopener" style="--x: 40%; --y: 95%; --d: 4.2s;" data-line="7">
+      <div class="pn-bubble grok">✕</div>
+      <div class="pn-label">Grok</div>
+    </a>
+    <a class="provider-node" href="https://ai.google.dev/gemini-api/docs/openai" target="_blank" rel="noopener" style="--x: 60%; --y: 95%; --d: 4.8s;" data-line="8">
+      <div class="pn-bubble gemini">◊</div>
+      <div class="pn-label">Gemini</div>
+    </a>
+    <a class="provider-node" href="https://api-docs.deepseek.com" target="_blank" rel="noopener" style="--x: 76%; --y: 88%; --d: 5.4s;" data-line="9">
+      <div class="pn-bubble deepseek">⬣</div>
+      <div class="pn-label">DeepSeek</div>
+    </a>
+    <a class="provider-node" href="https://docs.mistral.ai/api/" target="_blank" rel="noopener" style="--x: 92%; --y: 72%; --d: 6.0s;" data-line="10">
+      <div class="pn-bubble mistral">▲</div>
+      <div class="pn-label">Mistral</div>
     </a>
   </div>
 </section>
@@ -1471,7 +1504,7 @@
         <tr><td>مفتوح المصدر</td><td class="highlight">رخصة MIT</td><td>مملوك</td></tr>
         <tr><td>السعر</td><td class="highlight">مجاني للأبد</td><td>يتطلّب Claude Pro (20$/شهر)</td></tr>
         <tr><td>دعم LLM محلية</td><td class="highlight">llama.cpp و Ollama</td><td>لا — Claude فقط</td></tr>
-        <tr><td>متعدّد المزوّدين</td><td class="highlight">4 مزوّدين (محلي + سحابي)</td><td>Claude فقط</td></tr>
+        <tr><td>متعدّد المزوّدين</td><td class="highlight">جميع نقاط النهاية المتوافقة مع OpenAI</td><td>Claude فقط</td></tr>
         <tr><td>Chrome</td><td class="highlight">نعم (MV3)</td><td>نعم</td></tr>
         <tr><td>Firefox</td><td class="highlight">نعم (MV2)</td><td>لا</td></tr>
         <tr><td>واجهة في لوحة جانبية</td><td class="highlight">نعم</td><td>نعم</td></tr>

--- a/web/es/index.html
+++ b/web/es/index.html
@@ -801,6 +801,10 @@
     .pn-bubble.openrouter { background: rgba(108,99,255,0.12); color: var(--accent2); border-color: rgba(108,99,255,0.3); }
     .pn-bubble.studiolm { background: rgba(245,158,11,0.12); color: #f59e0b; border-color: rgba(245,158,11,0.25); }
     .pn-bubble.vllm { background: rgba(99,102,241,0.12); color: #6366f1; border-color: rgba(99,102,241,0.25); }
+    .pn-bubble.grok { background: rgba(255,255,255,0.06); color: #e5e5e5; border-color: rgba(255,255,255,0.2); }
+    .pn-bubble.gemini { background: rgba(66,133,244,0.12); color: #4285f4; border-color: rgba(66,133,244,0.25); }
+    .pn-bubble.deepseek { background: rgba(72,191,255,0.12); color: #48bfff; border-color: rgba(72,191,255,0.25); }
+    .pn-bubble.mistral { background: rgba(255,127,80,0.12); color: #ff7f50; border-color: rgba(255,127,80,0.25); }
 
     /* Reduced-motion: kill the float + ring pulse so users on
        prefers-reduced-motion see a static layout. */
@@ -1320,6 +1324,11 @@
       <p>Rechaza banners de consentimiento (OneTrust, Cookiebot, Didomi, Quantcast) antes de razonar sobre la página. Detecta muros de pago y te lo dice con honestidad en lugar de fabricar contenido o intentar evitarlos.</p>
     </div>
     <div class="feature-card">
+      <div class="feature-icon">🧩</div>
+      <h3>Solucionador opcional de CAPTCHA</h3>
+      <p>Conecta una clave de API de <a href="https://capsolver.com" target="_blank" rel="noopener" style="color:var(--accent);text-decoration:none;">CapSolver</a> y el agente resolverá automáticamente reCAPTCHA v2/v3, hCaptcha y Cloudflare Turnstile cuando bloqueen un paso — en lugar de detenerse para preguntarte. Desactivado por defecto, tú aportas la clave; no se envía nada a ningún servicio de captcha a menos que lo actives.</p>
+    </div>
+    <div class="feature-card">
       <div class="feature-icon">🌐</div>
       <h3>Interfaz multilingüe</h3>
       <p>El plugin se distribuye en English, Español, Français, Türkçe y 中文. Detecta automáticamente el idioma del navegador al primer uso; puedes cambiarlo en cualquier momento desde el icono del globo en el panel lateral. La web está localizada en consecuencia.</p>
@@ -1338,21 +1347,29 @@
   <h2 class="section-title">Usa tu propia IA</h2>
   <p class="section-subtitle">Conecta con cualquier API compatible con OpenAI o ejecuta un modelo local. Cambia de proveedor en cualquier momento desde los ajustes de la extensión.</p>
 
-  <!-- Constellation: central WebBrain core, 7 provider nodes orbiting on
-       two arcs. Connection lines drawn in SVG (viewBox is in % units via
-       a 0–100 coordinate space so the line endpoints follow the % values
-       used to position each node). The node order matches the line order
-       so JS can map a hovered node → its line for highlight. -->
+  <!-- Constellation: central WebBrain core, 11 provider nodes orbiting on
+       two arcs (5 above, 6 below). Connection lines drawn in SVG (viewBox
+       is in % units via a 0–100 coordinate space so the line endpoints
+       follow the % values used to position each node). The node order
+       matches the line order so JS can map a hovered node → its line for
+       highlight. Local runtimes (llama.cpp, Ollama, LM Studio, vLLM) are
+       on the left edges of each arc; cloud providers fan out toward the
+       right. Grok / Gemini / DeepSeek / Mistral are reached via the
+       OpenAI-compatible config — any OpenAI-style endpoint works. -->
   <div class="provider-constellation" aria-label="Usa tu propia IA">
     <svg class="constellation-lines" viewBox="0 0 100 100" preserveAspectRatio="none" aria-hidden="true">
-      <!-- order: llama.cpp, ollama, openai, anthropic, openrouter, studiolm, vllm -->
+      <!-- order: llama.cpp, ollama, openai, anthropic, openrouter, lmstudio, vllm, grok, gemini, deepseek, mistral -->
       <line x1="50" y1="50" x2="10" y2="28"></line>
-      <line x1="50" y1="50" x2="22" y2="78"></line>
       <line x1="50" y1="50" x2="28" y2="12"></line>
-      <line x1="50" y1="50" x2="50" y2="92"></line>
+      <line x1="50" y1="50" x2="50" y2="6"></line>
       <line x1="50" y1="50" x2="72" y2="12"></line>
-      <line x1="50" y1="50" x2="78" y2="78"></line>
       <line x1="50" y1="50" x2="90" y2="28"></line>
+      <line x1="50" y1="50" x2="8" y2="72"></line>
+      <line x1="50" y1="50" x2="24" y2="88"></line>
+      <line x1="50" y1="50" x2="40" y2="95"></line>
+      <line x1="50" y1="50" x2="60" y2="95"></line>
+      <line x1="50" y1="50" x2="76" y2="88"></line>
+      <line x1="50" y1="50" x2="92" y2="72"></line>
     </svg>
 
     <div class="constellation-center" aria-hidden="true">
@@ -1365,29 +1382,45 @@
       <div class="pn-bubble local">🦙</div>
       <div class="pn-label">llama.cpp</div>
     </a>
-    <a class="provider-node" href="https://ollama.com" target="_blank" rel="noopener" style="--x: 22%; --y: 78%; --d: 0.8s;" data-line="1">
+    <a class="provider-node" href="https://ollama.com" target="_blank" rel="noopener" style="--x: 28%; --y: 12%; --d: 0.6s;" data-line="1">
       <div class="pn-bubble ollama">◉</div>
       <div class="pn-label">Ollama</div>
     </a>
-    <a class="provider-node" href="https://platform.openai.com" target="_blank" rel="noopener" style="--x: 28%; --y: 12%; --d: 1.6s;" data-line="2">
+    <a class="provider-node" href="https://platform.openai.com" target="_blank" rel="noopener" style="--x: 50%; --y: 6%; --d: 1.2s;" data-line="2">
       <div class="pn-bubble openai">⬡</div>
       <div class="pn-label">OpenAI</div>
     </a>
-    <a class="provider-node" href="https://www.anthropic.com" target="_blank" rel="noopener" style="--x: 50%; --y: 92%; --d: 2.4s;" data-line="3">
+    <a class="provider-node" href="https://www.anthropic.com" target="_blank" rel="noopener" style="--x: 72%; --y: 12%; --d: 1.8s;" data-line="3">
       <div class="pn-bubble anthropic">◈</div>
       <div class="pn-label">Claude</div>
     </a>
-    <a class="provider-node" href="https://openrouter.ai" target="_blank" rel="noopener" style="--x: 72%; --y: 12%; --d: 3.2s;" data-line="4">
+    <a class="provider-node" href="https://openrouter.ai" target="_blank" rel="noopener" style="--x: 90%; --y: 28%; --d: 2.4s;" data-line="4">
       <div class="pn-bubble openrouter">◆</div>
       <div class="pn-label">OpenRouter</div>
     </a>
-    <a class="provider-node" href="https://lmstudio.ai" target="_blank" rel="noopener" style="--x: 78%; --y: 78%; --d: 4.0s;" data-line="5">
+    <a class="provider-node" href="https://lmstudio.ai" target="_blank" rel="noopener" style="--x: 8%; --y: 72%; --d: 3.0s;" data-line="5">
       <div class="pn-bubble studiolm">✦</div>
-      <div class="pn-label">StudioLM</div>
+      <div class="pn-label">LM Studio</div>
     </a>
-    <a class="provider-node" href="https://docs.vllm.ai" target="_blank" rel="noopener" style="--x: 90%; --y: 28%; --d: 4.8s;" data-line="6">
+    <a class="provider-node" href="https://docs.vllm.ai" target="_blank" rel="noopener" style="--x: 24%; --y: 88%; --d: 3.6s;" data-line="6">
       <div class="pn-bubble vllm">▣</div>
-      <div class="pn-label">VLLM</div>
+      <div class="pn-label">vLLM</div>
+    </a>
+    <a class="provider-node" href="https://x.ai/api" target="_blank" rel="noopener" style="--x: 40%; --y: 95%; --d: 4.2s;" data-line="7">
+      <div class="pn-bubble grok">✕</div>
+      <div class="pn-label">Grok</div>
+    </a>
+    <a class="provider-node" href="https://ai.google.dev/gemini-api/docs/openai" target="_blank" rel="noopener" style="--x: 60%; --y: 95%; --d: 4.8s;" data-line="8">
+      <div class="pn-bubble gemini">◊</div>
+      <div class="pn-label">Gemini</div>
+    </a>
+    <a class="provider-node" href="https://api-docs.deepseek.com" target="_blank" rel="noopener" style="--x: 76%; --y: 88%; --d: 5.4s;" data-line="9">
+      <div class="pn-bubble deepseek">⬣</div>
+      <div class="pn-label">DeepSeek</div>
+    </a>
+    <a class="provider-node" href="https://docs.mistral.ai/api/" target="_blank" rel="noopener" style="--x: 92%; --y: 72%; --d: 6.0s;" data-line="10">
+      <div class="pn-bubble mistral">▲</div>
+      <div class="pn-label">Mistral</div>
     </a>
   </div>
 </section>
@@ -1471,7 +1504,7 @@
         <tr><td>Código abierto</td><td class="highlight">Licencia MIT</td><td>Propietario</td></tr>
         <tr><td>Precio</td><td class="highlight">Gratis para siempre</td><td>Requiere Claude Pro (20 $/mes)</td></tr>
         <tr><td>Soporte de LLM local</td><td class="highlight">llama.cpp, Ollama</td><td>No — solo Claude</td></tr>
-        <tr><td>Multi-proveedor</td><td class="highlight">4 proveedores (local + nube)</td><td>Solo Claude</td></tr>
+        <tr><td>Multi-proveedor</td><td class="highlight">Cualquier endpoint compatible con OpenAI</td><td>Solo Claude</td></tr>
         <tr><td>Chrome</td><td class="highlight">Sí (MV3)</td><td>Sí</td></tr>
         <tr><td>Firefox</td><td class="highlight">Sí (MV2)</td><td>No</td></tr>
         <tr><td>Panel lateral</td><td class="highlight">Sí</td><td>Sí</td></tr>

--- a/web/fr/index.html
+++ b/web/fr/index.html
@@ -801,6 +801,10 @@
     .pn-bubble.openrouter { background: rgba(108,99,255,0.12); color: var(--accent2); border-color: rgba(108,99,255,0.3); }
     .pn-bubble.studiolm { background: rgba(245,158,11,0.12); color: #f59e0b; border-color: rgba(245,158,11,0.25); }
     .pn-bubble.vllm { background: rgba(99,102,241,0.12); color: #6366f1; border-color: rgba(99,102,241,0.25); }
+    .pn-bubble.grok { background: rgba(255,255,255,0.06); color: #e5e5e5; border-color: rgba(255,255,255,0.2); }
+    .pn-bubble.gemini { background: rgba(66,133,244,0.12); color: #4285f4; border-color: rgba(66,133,244,0.25); }
+    .pn-bubble.deepseek { background: rgba(72,191,255,0.12); color: #48bfff; border-color: rgba(72,191,255,0.25); }
+    .pn-bubble.mistral { background: rgba(255,127,80,0.12); color: #ff7f50; border-color: rgba(255,127,80,0.25); }
 
     /* Reduced-motion: kill the float + ring pulse so users on
        prefers-reduced-motion see a static layout. */
@@ -1320,6 +1324,11 @@
       <p>Rejette les bannières de consentement (OneTrust, Cookiebot, Didomi, Quantcast) avant de raisonner sur la page. Détecte les paywalls et le dit honnêtement au lieu d&#39;inventer du contenu ou de tenter de les contourner.</p>
     </div>
     <div class="feature-card">
+      <div class="feature-icon">🧩</div>
+      <h3>Résolveur CAPTCHA optionnel</h3>
+      <p>Renseignez une clé API <a href="https://capsolver.com" target="_blank" rel="noopener" style="color:var(--accent);text-decoration:none;">CapSolver</a> et l'agent résoudra automatiquement reCAPTCHA v2/v3, hCaptcha et Cloudflare Turnstile lorsqu'ils bloquent une étape — au lieu de s'arrêter pour vous demander. Désactivé par défaut, BYO clé, aucun service de captcha n'est contacté sans votre accord.</p>
+    </div>
+    <div class="feature-card">
       <div class="feature-icon">🌐</div>
       <h3>Interface multilingue</h3>
       <p>L&#39;extension existe en English, Español, Français, Türkçe et 中文. Détection automatique de la langue du navigateur à la première utilisation ; vous pouvez changer à tout moment via l&#39;icône globe du panneau latéral. Le site marketing est localisé en conséquence.</p>
@@ -1338,21 +1347,29 @@
   <h2 class="section-title">Apportez votre propre IA</h2>
   <p class="section-subtitle">Connectez-vous à n&#39;importe quelle API compatible OpenAI ou exécutez un modèle local. Changez de fournisseur à tout moment depuis les paramètres de l&#39;extension.</p>
 
-  <!-- Constellation: central WebBrain core, 7 provider nodes orbiting on
-       two arcs. Connection lines drawn in SVG (viewBox is in % units via
-       a 0–100 coordinate space so the line endpoints follow the % values
-       used to position each node). The node order matches the line order
-       so JS can map a hovered node → its line for highlight. -->
+  <!-- Constellation: central WebBrain core, 11 provider nodes orbiting on
+       two arcs (5 above, 6 below). Connection lines drawn in SVG (viewBox
+       is in % units via a 0–100 coordinate space so the line endpoints
+       follow the % values used to position each node). The node order
+       matches the line order so JS can map a hovered node → its line for
+       highlight. Local runtimes (llama.cpp, Ollama, LM Studio, vLLM) are
+       on the left edges of each arc; cloud providers fan out toward the
+       right. Grok / Gemini / DeepSeek / Mistral are reached via the
+       OpenAI-compatible config — any OpenAI-style endpoint works. -->
   <div class="provider-constellation" aria-label="Apportez votre propre IA">
     <svg class="constellation-lines" viewBox="0 0 100 100" preserveAspectRatio="none" aria-hidden="true">
-      <!-- order: llama.cpp, ollama, openai, anthropic, openrouter, studiolm, vllm -->
+      <!-- order: llama.cpp, ollama, openai, anthropic, openrouter, lmstudio, vllm, grok, gemini, deepseek, mistral -->
       <line x1="50" y1="50" x2="10" y2="28"></line>
-      <line x1="50" y1="50" x2="22" y2="78"></line>
       <line x1="50" y1="50" x2="28" y2="12"></line>
-      <line x1="50" y1="50" x2="50" y2="92"></line>
+      <line x1="50" y1="50" x2="50" y2="6"></line>
       <line x1="50" y1="50" x2="72" y2="12"></line>
-      <line x1="50" y1="50" x2="78" y2="78"></line>
       <line x1="50" y1="50" x2="90" y2="28"></line>
+      <line x1="50" y1="50" x2="8" y2="72"></line>
+      <line x1="50" y1="50" x2="24" y2="88"></line>
+      <line x1="50" y1="50" x2="40" y2="95"></line>
+      <line x1="50" y1="50" x2="60" y2="95"></line>
+      <line x1="50" y1="50" x2="76" y2="88"></line>
+      <line x1="50" y1="50" x2="92" y2="72"></line>
     </svg>
 
     <div class="constellation-center" aria-hidden="true">
@@ -1365,29 +1382,45 @@
       <div class="pn-bubble local">🦙</div>
       <div class="pn-label">llama.cpp</div>
     </a>
-    <a class="provider-node" href="https://ollama.com" target="_blank" rel="noopener" style="--x: 22%; --y: 78%; --d: 0.8s;" data-line="1">
+    <a class="provider-node" href="https://ollama.com" target="_blank" rel="noopener" style="--x: 28%; --y: 12%; --d: 0.6s;" data-line="1">
       <div class="pn-bubble ollama">◉</div>
       <div class="pn-label">Ollama</div>
     </a>
-    <a class="provider-node" href="https://platform.openai.com" target="_blank" rel="noopener" style="--x: 28%; --y: 12%; --d: 1.6s;" data-line="2">
+    <a class="provider-node" href="https://platform.openai.com" target="_blank" rel="noopener" style="--x: 50%; --y: 6%; --d: 1.2s;" data-line="2">
       <div class="pn-bubble openai">⬡</div>
       <div class="pn-label">OpenAI</div>
     </a>
-    <a class="provider-node" href="https://www.anthropic.com" target="_blank" rel="noopener" style="--x: 50%; --y: 92%; --d: 2.4s;" data-line="3">
+    <a class="provider-node" href="https://www.anthropic.com" target="_blank" rel="noopener" style="--x: 72%; --y: 12%; --d: 1.8s;" data-line="3">
       <div class="pn-bubble anthropic">◈</div>
       <div class="pn-label">Claude</div>
     </a>
-    <a class="provider-node" href="https://openrouter.ai" target="_blank" rel="noopener" style="--x: 72%; --y: 12%; --d: 3.2s;" data-line="4">
+    <a class="provider-node" href="https://openrouter.ai" target="_blank" rel="noopener" style="--x: 90%; --y: 28%; --d: 2.4s;" data-line="4">
       <div class="pn-bubble openrouter">◆</div>
       <div class="pn-label">OpenRouter</div>
     </a>
-    <a class="provider-node" href="https://lmstudio.ai" target="_blank" rel="noopener" style="--x: 78%; --y: 78%; --d: 4.0s;" data-line="5">
+    <a class="provider-node" href="https://lmstudio.ai" target="_blank" rel="noopener" style="--x: 8%; --y: 72%; --d: 3.0s;" data-line="5">
       <div class="pn-bubble studiolm">✦</div>
-      <div class="pn-label">StudioLM</div>
+      <div class="pn-label">LM Studio</div>
     </a>
-    <a class="provider-node" href="https://docs.vllm.ai" target="_blank" rel="noopener" style="--x: 90%; --y: 28%; --d: 4.8s;" data-line="6">
+    <a class="provider-node" href="https://docs.vllm.ai" target="_blank" rel="noopener" style="--x: 24%; --y: 88%; --d: 3.6s;" data-line="6">
       <div class="pn-bubble vllm">▣</div>
-      <div class="pn-label">VLLM</div>
+      <div class="pn-label">vLLM</div>
+    </a>
+    <a class="provider-node" href="https://x.ai/api" target="_blank" rel="noopener" style="--x: 40%; --y: 95%; --d: 4.2s;" data-line="7">
+      <div class="pn-bubble grok">✕</div>
+      <div class="pn-label">Grok</div>
+    </a>
+    <a class="provider-node" href="https://ai.google.dev/gemini-api/docs/openai" target="_blank" rel="noopener" style="--x: 60%; --y: 95%; --d: 4.8s;" data-line="8">
+      <div class="pn-bubble gemini">◊</div>
+      <div class="pn-label">Gemini</div>
+    </a>
+    <a class="provider-node" href="https://api-docs.deepseek.com" target="_blank" rel="noopener" style="--x: 76%; --y: 88%; --d: 5.4s;" data-line="9">
+      <div class="pn-bubble deepseek">⬣</div>
+      <div class="pn-label">DeepSeek</div>
+    </a>
+    <a class="provider-node" href="https://docs.mistral.ai/api/" target="_blank" rel="noopener" style="--x: 92%; --y: 72%; --d: 6.0s;" data-line="10">
+      <div class="pn-bubble mistral">▲</div>
+      <div class="pn-label">Mistral</div>
     </a>
   </div>
 </section>
@@ -1471,7 +1504,7 @@
         <tr><td>Open source</td><td class="highlight">Licence MIT</td><td>Propriétaire</td></tr>
         <tr><td>Prix</td><td class="highlight">Gratuit pour toujours</td><td>Nécessite Claude Pro (20 $/mois)</td></tr>
         <tr><td>Support LLM local</td><td class="highlight">llama.cpp, Ollama</td><td>Non — Claude uniquement</td></tr>
-        <tr><td>Multi-fournisseur</td><td class="highlight">4 fournisseurs (local + cloud)</td><td>Claude uniquement</td></tr>
+        <tr><td>Multi-fournisseur</td><td class="highlight">Tous les endpoints compatibles OpenAI</td><td>Claude uniquement</td></tr>
         <tr><td>Chrome</td><td class="highlight">Oui (MV3)</td><td>Oui</td></tr>
         <tr><td>Firefox</td><td class="highlight">Oui (MV2)</td><td>Non</td></tr>
         <tr><td>Panneau latéral</td><td class="highlight">Oui</td><td>Oui</td></tr>

--- a/web/id/index.html
+++ b/web/id/index.html
@@ -801,6 +801,10 @@
     .pn-bubble.openrouter { background: rgba(108,99,255,0.12); color: var(--accent2); border-color: rgba(108,99,255,0.3); }
     .pn-bubble.studiolm { background: rgba(245,158,11,0.12); color: #f59e0b; border-color: rgba(245,158,11,0.25); }
     .pn-bubble.vllm { background: rgba(99,102,241,0.12); color: #6366f1; border-color: rgba(99,102,241,0.25); }
+    .pn-bubble.grok { background: rgba(255,255,255,0.06); color: #e5e5e5; border-color: rgba(255,255,255,0.2); }
+    .pn-bubble.gemini { background: rgba(66,133,244,0.12); color: #4285f4; border-color: rgba(66,133,244,0.25); }
+    .pn-bubble.deepseek { background: rgba(72,191,255,0.12); color: #48bfff; border-color: rgba(72,191,255,0.25); }
+    .pn-bubble.mistral { background: rgba(255,127,80,0.12); color: #ff7f50; border-color: rgba(255,127,80,0.25); }
 
     /* Reduced-motion: kill the float + ring pulse so users on
        prefers-reduced-motion see a static layout. */
@@ -1320,6 +1324,11 @@
       <p>Menutup spanduk persetujuan (OneTrust, Cookiebot, Didomi, Quantcast) sebelum menalar isi halaman. Mendeteksi paywall dan memberi tahu Anda dengan jujur, alih-alih mengarang isi artikel atau mencoba menerobosnya.</p>
     </div>
     <div class="feature-card">
+      <div class="feature-icon">🧩</div>
+      <h3>Penyelesai CAPTCHA Opsional</h3>
+      <p>Pasang kunci API <a href="https://capsolver.com" target="_blank" rel="noopener" style="color:var(--accent);text-decoration:none;">CapSolver</a> dan agen akan otomatis menyelesaikan reCAPTCHA v2/v3, hCaptcha, dan Cloudflare Turnstile ketika menghalangi suatu langkah — alih-alih berhenti untuk bertanya. Nonaktif secara default, BYO kunci, tidak ada layanan captcha yang dihubungi kecuali kamu mengaktifkannya.</p>
+    </div>
+    <div class="feature-card">
       <div class="feature-icon">🌐</div>
       <h3>UI Multibahasa</h3>
       <p>Plugin tersedia dalam English, Español, Français, Türkçe, dan 中文. Mendeteksi bahasa peramban Anda secara otomatis saat pertama kali digunakan; ganti kapan saja melalui ikon bola dunia di panel samping. Situs marketing dilokalisasi senada.</p>
@@ -1338,21 +1347,29 @@
   <h2 class="section-title">Bawa AI Anda Sendiri</h2>
   <p class="section-subtitle">Hubungkan ke API kompatibel OpenAI apa pun atau jalankan model lokal. Ganti penyedia kapan saja dari pengaturan ekstensi.</p>
 
-  <!-- Constellation: central WebBrain core, 7 provider nodes orbiting on
-       two arcs. Connection lines drawn in SVG (viewBox is in % units via
-       a 0–100 coordinate space so the line endpoints follow the % values
-       used to position each node). The node order matches the line order
-       so JS can map a hovered node → its line for highlight. -->
+  <!-- Constellation: central WebBrain core, 11 provider nodes orbiting on
+       two arcs (5 above, 6 below). Connection lines drawn in SVG (viewBox
+       is in % units via a 0–100 coordinate space so the line endpoints
+       follow the % values used to position each node). The node order
+       matches the line order so JS can map a hovered node → its line for
+       highlight. Local runtimes (llama.cpp, Ollama, LM Studio, vLLM) are
+       on the left edges of each arc; cloud providers fan out toward the
+       right. Grok / Gemini / DeepSeek / Mistral are reached via the
+       OpenAI-compatible config — any OpenAI-style endpoint works. -->
   <div class="provider-constellation" aria-label="Bawa AI Anda Sendiri">
     <svg class="constellation-lines" viewBox="0 0 100 100" preserveAspectRatio="none" aria-hidden="true">
-      <!-- order: llama.cpp, ollama, openai, anthropic, openrouter, studiolm, vllm -->
+      <!-- order: llama.cpp, ollama, openai, anthropic, openrouter, lmstudio, vllm, grok, gemini, deepseek, mistral -->
       <line x1="50" y1="50" x2="10" y2="28"></line>
-      <line x1="50" y1="50" x2="22" y2="78"></line>
       <line x1="50" y1="50" x2="28" y2="12"></line>
-      <line x1="50" y1="50" x2="50" y2="92"></line>
+      <line x1="50" y1="50" x2="50" y2="6"></line>
       <line x1="50" y1="50" x2="72" y2="12"></line>
-      <line x1="50" y1="50" x2="78" y2="78"></line>
       <line x1="50" y1="50" x2="90" y2="28"></line>
+      <line x1="50" y1="50" x2="8" y2="72"></line>
+      <line x1="50" y1="50" x2="24" y2="88"></line>
+      <line x1="50" y1="50" x2="40" y2="95"></line>
+      <line x1="50" y1="50" x2="60" y2="95"></line>
+      <line x1="50" y1="50" x2="76" y2="88"></line>
+      <line x1="50" y1="50" x2="92" y2="72"></line>
     </svg>
 
     <div class="constellation-center" aria-hidden="true">
@@ -1365,29 +1382,45 @@
       <div class="pn-bubble local">🦙</div>
       <div class="pn-label">llama.cpp</div>
     </a>
-    <a class="provider-node" href="https://ollama.com" target="_blank" rel="noopener" style="--x: 22%; --y: 78%; --d: 0.8s;" data-line="1">
+    <a class="provider-node" href="https://ollama.com" target="_blank" rel="noopener" style="--x: 28%; --y: 12%; --d: 0.6s;" data-line="1">
       <div class="pn-bubble ollama">◉</div>
       <div class="pn-label">Ollama</div>
     </a>
-    <a class="provider-node" href="https://platform.openai.com" target="_blank" rel="noopener" style="--x: 28%; --y: 12%; --d: 1.6s;" data-line="2">
+    <a class="provider-node" href="https://platform.openai.com" target="_blank" rel="noopener" style="--x: 50%; --y: 6%; --d: 1.2s;" data-line="2">
       <div class="pn-bubble openai">⬡</div>
       <div class="pn-label">OpenAI</div>
     </a>
-    <a class="provider-node" href="https://www.anthropic.com" target="_blank" rel="noopener" style="--x: 50%; --y: 92%; --d: 2.4s;" data-line="3">
+    <a class="provider-node" href="https://www.anthropic.com" target="_blank" rel="noopener" style="--x: 72%; --y: 12%; --d: 1.8s;" data-line="3">
       <div class="pn-bubble anthropic">◈</div>
       <div class="pn-label">Claude</div>
     </a>
-    <a class="provider-node" href="https://openrouter.ai" target="_blank" rel="noopener" style="--x: 72%; --y: 12%; --d: 3.2s;" data-line="4">
+    <a class="provider-node" href="https://openrouter.ai" target="_blank" rel="noopener" style="--x: 90%; --y: 28%; --d: 2.4s;" data-line="4">
       <div class="pn-bubble openrouter">◆</div>
       <div class="pn-label">OpenRouter</div>
     </a>
-    <a class="provider-node" href="https://lmstudio.ai" target="_blank" rel="noopener" style="--x: 78%; --y: 78%; --d: 4.0s;" data-line="5">
+    <a class="provider-node" href="https://lmstudio.ai" target="_blank" rel="noopener" style="--x: 8%; --y: 72%; --d: 3.0s;" data-line="5">
       <div class="pn-bubble studiolm">✦</div>
-      <div class="pn-label">StudioLM</div>
+      <div class="pn-label">LM Studio</div>
     </a>
-    <a class="provider-node" href="https://docs.vllm.ai" target="_blank" rel="noopener" style="--x: 90%; --y: 28%; --d: 4.8s;" data-line="6">
+    <a class="provider-node" href="https://docs.vllm.ai" target="_blank" rel="noopener" style="--x: 24%; --y: 88%; --d: 3.6s;" data-line="6">
       <div class="pn-bubble vllm">▣</div>
-      <div class="pn-label">VLLM</div>
+      <div class="pn-label">vLLM</div>
+    </a>
+    <a class="provider-node" href="https://x.ai/api" target="_blank" rel="noopener" style="--x: 40%; --y: 95%; --d: 4.2s;" data-line="7">
+      <div class="pn-bubble grok">✕</div>
+      <div class="pn-label">Grok</div>
+    </a>
+    <a class="provider-node" href="https://ai.google.dev/gemini-api/docs/openai" target="_blank" rel="noopener" style="--x: 60%; --y: 95%; --d: 4.8s;" data-line="8">
+      <div class="pn-bubble gemini">◊</div>
+      <div class="pn-label">Gemini</div>
+    </a>
+    <a class="provider-node" href="https://api-docs.deepseek.com" target="_blank" rel="noopener" style="--x: 76%; --y: 88%; --d: 5.4s;" data-line="9">
+      <div class="pn-bubble deepseek">⬣</div>
+      <div class="pn-label">DeepSeek</div>
+    </a>
+    <a class="provider-node" href="https://docs.mistral.ai/api/" target="_blank" rel="noopener" style="--x: 92%; --y: 72%; --d: 6.0s;" data-line="10">
+      <div class="pn-bubble mistral">▲</div>
+      <div class="pn-label">Mistral</div>
     </a>
   </div>
 </section>
@@ -1471,7 +1504,7 @@
         <tr><td>Open Source</td><td class="highlight">Lisensi MIT</td><td>Tertutup</td></tr>
         <tr><td>Harga</td><td class="highlight">Gratis selamanya</td><td>Butuh Claude Pro ($20/bulan)</td></tr>
         <tr><td>Dukungan LLM lokal</td><td class="highlight">llama.cpp, Ollama</td><td>Tidak — Claude saja</td></tr>
-        <tr><td>Multi-penyedia</td><td class="highlight">4 penyedia (lokal + cloud)</td><td>Claude saja</td></tr>
+        <tr><td>Multi-penyedia</td><td class="highlight">Semua endpoint kompatibel OpenAI</td><td>Claude saja</td></tr>
         <tr><td>Chrome</td><td class="highlight">Ya (MV3)</td><td>Ya</td></tr>
         <tr><td>Firefox</td><td class="highlight">Ya (MV2)</td><td>Tidak</td></tr>
         <tr><td>UI panel samping</td><td class="highlight">Ya</td><td>Ya</td></tr>

--- a/web/index.html
+++ b/web/index.html
@@ -801,6 +801,10 @@
     .pn-bubble.openrouter { background: rgba(108,99,255,0.12); color: var(--accent2); border-color: rgba(108,99,255,0.3); }
     .pn-bubble.studiolm { background: rgba(245,158,11,0.12); color: #f59e0b; border-color: rgba(245,158,11,0.25); }
     .pn-bubble.vllm { background: rgba(99,102,241,0.12); color: #6366f1; border-color: rgba(99,102,241,0.25); }
+    .pn-bubble.grok { background: rgba(255,255,255,0.06); color: #e5e5e5; border-color: rgba(255,255,255,0.2); }
+    .pn-bubble.gemini { background: rgba(66,133,244,0.12); color: #4285f4; border-color: rgba(66,133,244,0.25); }
+    .pn-bubble.deepseek { background: rgba(72,191,255,0.12); color: #48bfff; border-color: rgba(72,191,255,0.25); }
+    .pn-bubble.mistral { background: rgba(255,127,80,0.12); color: #ff7f50; border-color: rgba(255,127,80,0.25); }
 
     /* Reduced-motion: kill the float + ring pulse so users on
        prefers-reduced-motion see a static layout. */
@@ -1320,6 +1324,11 @@
       <p>Dismisses consent banners (OneTrust, Cookiebot, Didomi, Quantcast) before reasoning about the page. Detects paywalls and tells you honestly instead of fabricating article content or trying to bypass them.</p>
     </div>
     <div class="feature-card">
+      <div class="feature-icon">🧩</div>
+      <h3>Optional CAPTCHA Solver</h3>
+      <p>Plug in a <a href="https://capsolver.com" target="_blank" rel="noopener" style="color:var(--accent);text-decoration:none;">CapSolver</a> API key and the agent will auto-solve reCAPTCHA v2/v3, hCaptcha, and Cloudflare Turnstile when they block a step — instead of stopping to ask. Off by default, BYO key, no captcha service is shipped or contacted unless you turn it on.</p>
+    </div>
+    <div class="feature-card">
       <div class="feature-icon">🌐</div>
       <h3>Multilingual UI</h3>
       <p>The plugin ships in English, Español, Français, Türkçe and 中文. Auto-detects your browser language on first use; switch anytime from the globe icon in the side panel. The marketing site is localized to match.</p>
@@ -1338,21 +1347,29 @@
   <h2 class="section-title">Bring your own AI</h2>
   <p class="section-subtitle">Connect to any OpenAI-compatible API or run a local model. Switch providers anytime from the extension settings.</p>
 
-  <!-- Constellation: central WebBrain core, 7 provider nodes orbiting on
-       two arcs. Connection lines drawn in SVG (viewBox is in % units via
-       a 0–100 coordinate space so the line endpoints follow the % values
-       used to position each node). The node order matches the line order
-       so JS can map a hovered node → its line for highlight. -->
+  <!-- Constellation: central WebBrain core, 11 provider nodes orbiting on
+       two arcs (5 above, 6 below). Connection lines drawn in SVG (viewBox
+       is in % units via a 0–100 coordinate space so the line endpoints
+       follow the % values used to position each node). The node order
+       matches the line order so JS can map a hovered node → its line for
+       highlight. Local runtimes (llama.cpp, Ollama, LM Studio, vLLM) are
+       on the left edges of each arc; cloud providers fan out toward the
+       right. Grok / Gemini / DeepSeek / Mistral are reached via the
+       OpenAI-compatible config — any OpenAI-style endpoint works. -->
   <div class="provider-constellation" aria-label="Bring your own AI">
     <svg class="constellation-lines" viewBox="0 0 100 100" preserveAspectRatio="none" aria-hidden="true">
-      <!-- order: llama.cpp, ollama, openai, anthropic, openrouter, studiolm, vllm -->
+      <!-- order: llama.cpp, ollama, openai, anthropic, openrouter, lmstudio, vllm, grok, gemini, deepseek, mistral -->
       <line x1="50" y1="50" x2="10" y2="28"></line>
-      <line x1="50" y1="50" x2="22" y2="78"></line>
       <line x1="50" y1="50" x2="28" y2="12"></line>
-      <line x1="50" y1="50" x2="50" y2="92"></line>
+      <line x1="50" y1="50" x2="50" y2="6"></line>
       <line x1="50" y1="50" x2="72" y2="12"></line>
-      <line x1="50" y1="50" x2="78" y2="78"></line>
       <line x1="50" y1="50" x2="90" y2="28"></line>
+      <line x1="50" y1="50" x2="8" y2="72"></line>
+      <line x1="50" y1="50" x2="24" y2="88"></line>
+      <line x1="50" y1="50" x2="40" y2="95"></line>
+      <line x1="50" y1="50" x2="60" y2="95"></line>
+      <line x1="50" y1="50" x2="76" y2="88"></line>
+      <line x1="50" y1="50" x2="92" y2="72"></line>
     </svg>
 
     <div class="constellation-center" aria-hidden="true">
@@ -1365,29 +1382,45 @@
       <div class="pn-bubble local">🦙</div>
       <div class="pn-label">llama.cpp</div>
     </a>
-    <a class="provider-node" href="https://ollama.com" target="_blank" rel="noopener" style="--x: 22%; --y: 78%; --d: 0.8s;" data-line="1">
+    <a class="provider-node" href="https://ollama.com" target="_blank" rel="noopener" style="--x: 28%; --y: 12%; --d: 0.6s;" data-line="1">
       <div class="pn-bubble ollama">◉</div>
       <div class="pn-label">Ollama</div>
     </a>
-    <a class="provider-node" href="https://platform.openai.com" target="_blank" rel="noopener" style="--x: 28%; --y: 12%; --d: 1.6s;" data-line="2">
+    <a class="provider-node" href="https://platform.openai.com" target="_blank" rel="noopener" style="--x: 50%; --y: 6%; --d: 1.2s;" data-line="2">
       <div class="pn-bubble openai">⬡</div>
       <div class="pn-label">OpenAI</div>
     </a>
-    <a class="provider-node" href="https://www.anthropic.com" target="_blank" rel="noopener" style="--x: 50%; --y: 92%; --d: 2.4s;" data-line="3">
+    <a class="provider-node" href="https://www.anthropic.com" target="_blank" rel="noopener" style="--x: 72%; --y: 12%; --d: 1.8s;" data-line="3">
       <div class="pn-bubble anthropic">◈</div>
       <div class="pn-label">Claude</div>
     </a>
-    <a class="provider-node" href="https://openrouter.ai" target="_blank" rel="noopener" style="--x: 72%; --y: 12%; --d: 3.2s;" data-line="4">
+    <a class="provider-node" href="https://openrouter.ai" target="_blank" rel="noopener" style="--x: 90%; --y: 28%; --d: 2.4s;" data-line="4">
       <div class="pn-bubble openrouter">◆</div>
       <div class="pn-label">OpenRouter</div>
     </a>
-    <a class="provider-node" href="https://lmstudio.ai" target="_blank" rel="noopener" style="--x: 78%; --y: 78%; --d: 4.0s;" data-line="5">
+    <a class="provider-node" href="https://lmstudio.ai" target="_blank" rel="noopener" style="--x: 8%; --y: 72%; --d: 3.0s;" data-line="5">
       <div class="pn-bubble studiolm">✦</div>
-      <div class="pn-label">StudioLM</div>
+      <div class="pn-label">LM Studio</div>
     </a>
-    <a class="provider-node" href="https://docs.vllm.ai" target="_blank" rel="noopener" style="--x: 90%; --y: 28%; --d: 4.8s;" data-line="6">
+    <a class="provider-node" href="https://docs.vllm.ai" target="_blank" rel="noopener" style="--x: 24%; --y: 88%; --d: 3.6s;" data-line="6">
       <div class="pn-bubble vllm">▣</div>
-      <div class="pn-label">VLLM</div>
+      <div class="pn-label">vLLM</div>
+    </a>
+    <a class="provider-node" href="https://x.ai/api" target="_blank" rel="noopener" style="--x: 40%; --y: 95%; --d: 4.2s;" data-line="7">
+      <div class="pn-bubble grok">✕</div>
+      <div class="pn-label">Grok</div>
+    </a>
+    <a class="provider-node" href="https://ai.google.dev/gemini-api/docs/openai" target="_blank" rel="noopener" style="--x: 60%; --y: 95%; --d: 4.8s;" data-line="8">
+      <div class="pn-bubble gemini">◊</div>
+      <div class="pn-label">Gemini</div>
+    </a>
+    <a class="provider-node" href="https://api-docs.deepseek.com" target="_blank" rel="noopener" style="--x: 76%; --y: 88%; --d: 5.4s;" data-line="9">
+      <div class="pn-bubble deepseek">⬣</div>
+      <div class="pn-label">DeepSeek</div>
+    </a>
+    <a class="provider-node" href="https://docs.mistral.ai/api/" target="_blank" rel="noopener" style="--x: 92%; --y: 72%; --d: 6.0s;" data-line="10">
+      <div class="pn-bubble mistral">▲</div>
+      <div class="pn-label">Mistral</div>
     </a>
   </div>
 </section>
@@ -1471,7 +1504,7 @@
         <tr><td>Open Source</td><td class="highlight">MIT License</td><td>Proprietary</td></tr>
         <tr><td>Price</td><td class="highlight">Free forever</td><td>Requires Claude Pro ($20/mo)</td></tr>
         <tr><td>Local LLM support</td><td class="highlight">llama.cpp, Ollama</td><td>No — Claude only</td></tr>
-        <tr><td>Multi-provider</td><td class="highlight">4 providers (local + cloud)</td><td>Claude only</td></tr>
+        <tr><td>Multi-provider</td><td class="highlight">All OpenAI-compatible endpoints</td><td>Claude only</td></tr>
         <tr><td>Chrome</td><td class="highlight">Yes (MV3)</td><td>Yes</td></tr>
         <tr><td>Firefox</td><td class="highlight">Yes (MV2)</td><td>No</td></tr>
         <tr><td>Side panel UI</td><td class="highlight">Yes</td><td>Yes</td></tr>

--- a/web/ja/index.html
+++ b/web/ja/index.html
@@ -801,6 +801,10 @@
     .pn-bubble.openrouter { background: rgba(108,99,255,0.12); color: var(--accent2); border-color: rgba(108,99,255,0.3); }
     .pn-bubble.studiolm { background: rgba(245,158,11,0.12); color: #f59e0b; border-color: rgba(245,158,11,0.25); }
     .pn-bubble.vllm { background: rgba(99,102,241,0.12); color: #6366f1; border-color: rgba(99,102,241,0.25); }
+    .pn-bubble.grok { background: rgba(255,255,255,0.06); color: #e5e5e5; border-color: rgba(255,255,255,0.2); }
+    .pn-bubble.gemini { background: rgba(66,133,244,0.12); color: #4285f4; border-color: rgba(66,133,244,0.25); }
+    .pn-bubble.deepseek { background: rgba(72,191,255,0.12); color: #48bfff; border-color: rgba(72,191,255,0.25); }
+    .pn-bubble.mistral { background: rgba(255,127,80,0.12); color: #ff7f50; border-color: rgba(255,127,80,0.25); }
 
     /* Reduced-motion: kill the float + ring pulse so users on
        prefers-reduced-motion see a static layout. */
@@ -1320,6 +1324,11 @@
       <p>ページを推論する前に同意バナー（OneTrust、Cookiebot、Didomi、Quantcast）を閉じます。ペイウォールを検出したら、本文を捏造したり迂回したりせず、その旨を正直に伝えます。</p>
     </div>
     <div class="feature-card">
+      <div class="feature-icon">🧩</div>
+      <h3>オプションの CAPTCHA ソルバー</h3>
+      <p><a href="https://capsolver.com" target="_blank" rel="noopener" style="color:var(--accent);text-decoration:none;">CapSolver</a> の API キーを設定すると、reCAPTCHA v2/v3、hCaptcha、Cloudflare Turnstile によって処理が止められたとき、エージェントが自動で解決します — 停止してあなたに尋ねる代わりに。デフォルトはオフ、キーは自前。有効にしない限り、CAPTCHA サービスに接続することはありません。</p>
+    </div>
+    <div class="feature-card">
       <div class="feature-icon">🌐</div>
       <h3>多言語 UI</h3>
       <p>拡張は English、Español、Français、Türkçe、中文 で提供されます。初回起動時にブラウザの言語を自動検出。サイドパネルの地球アイコンからいつでも切り替え可能。マーケティングサイトもそれに合わせてローカライズされています。</p>
@@ -1338,21 +1347,29 @@
   <h2 class="section-title">自分の AI を持ち込む</h2>
   <p class="section-subtitle">OpenAI 互換の任意の API に接続するか、ローカルモデルを動かす。プロバイダーは拡張設定からいつでも切り替えられます。</p>
 
-  <!-- Constellation: central WebBrain core, 7 provider nodes orbiting on
-       two arcs. Connection lines drawn in SVG (viewBox is in % units via
-       a 0–100 coordinate space so the line endpoints follow the % values
-       used to position each node). The node order matches the line order
-       so JS can map a hovered node → its line for highlight. -->
+  <!-- Constellation: central WebBrain core, 11 provider nodes orbiting on
+       two arcs (5 above, 6 below). Connection lines drawn in SVG (viewBox
+       is in % units via a 0–100 coordinate space so the line endpoints
+       follow the % values used to position each node). The node order
+       matches the line order so JS can map a hovered node → its line for
+       highlight. Local runtimes (llama.cpp, Ollama, LM Studio, vLLM) are
+       on the left edges of each arc; cloud providers fan out toward the
+       right. Grok / Gemini / DeepSeek / Mistral are reached via the
+       OpenAI-compatible config — any OpenAI-style endpoint works. -->
   <div class="provider-constellation" aria-label="自分の AI を持ち込む">
     <svg class="constellation-lines" viewBox="0 0 100 100" preserveAspectRatio="none" aria-hidden="true">
-      <!-- order: llama.cpp, ollama, openai, anthropic, openrouter, studiolm, vllm -->
+      <!-- order: llama.cpp, ollama, openai, anthropic, openrouter, lmstudio, vllm, grok, gemini, deepseek, mistral -->
       <line x1="50" y1="50" x2="10" y2="28"></line>
-      <line x1="50" y1="50" x2="22" y2="78"></line>
       <line x1="50" y1="50" x2="28" y2="12"></line>
-      <line x1="50" y1="50" x2="50" y2="92"></line>
+      <line x1="50" y1="50" x2="50" y2="6"></line>
       <line x1="50" y1="50" x2="72" y2="12"></line>
-      <line x1="50" y1="50" x2="78" y2="78"></line>
       <line x1="50" y1="50" x2="90" y2="28"></line>
+      <line x1="50" y1="50" x2="8" y2="72"></line>
+      <line x1="50" y1="50" x2="24" y2="88"></line>
+      <line x1="50" y1="50" x2="40" y2="95"></line>
+      <line x1="50" y1="50" x2="60" y2="95"></line>
+      <line x1="50" y1="50" x2="76" y2="88"></line>
+      <line x1="50" y1="50" x2="92" y2="72"></line>
     </svg>
 
     <div class="constellation-center" aria-hidden="true">
@@ -1365,29 +1382,45 @@
       <div class="pn-bubble local">🦙</div>
       <div class="pn-label">llama.cpp</div>
     </a>
-    <a class="provider-node" href="https://ollama.com" target="_blank" rel="noopener" style="--x: 22%; --y: 78%; --d: 0.8s;" data-line="1">
+    <a class="provider-node" href="https://ollama.com" target="_blank" rel="noopener" style="--x: 28%; --y: 12%; --d: 0.6s;" data-line="1">
       <div class="pn-bubble ollama">◉</div>
       <div class="pn-label">Ollama</div>
     </a>
-    <a class="provider-node" href="https://platform.openai.com" target="_blank" rel="noopener" style="--x: 28%; --y: 12%; --d: 1.6s;" data-line="2">
+    <a class="provider-node" href="https://platform.openai.com" target="_blank" rel="noopener" style="--x: 50%; --y: 6%; --d: 1.2s;" data-line="2">
       <div class="pn-bubble openai">⬡</div>
       <div class="pn-label">OpenAI</div>
     </a>
-    <a class="provider-node" href="https://www.anthropic.com" target="_blank" rel="noopener" style="--x: 50%; --y: 92%; --d: 2.4s;" data-line="3">
+    <a class="provider-node" href="https://www.anthropic.com" target="_blank" rel="noopener" style="--x: 72%; --y: 12%; --d: 1.8s;" data-line="3">
       <div class="pn-bubble anthropic">◈</div>
       <div class="pn-label">Claude</div>
     </a>
-    <a class="provider-node" href="https://openrouter.ai" target="_blank" rel="noopener" style="--x: 72%; --y: 12%; --d: 3.2s;" data-line="4">
+    <a class="provider-node" href="https://openrouter.ai" target="_blank" rel="noopener" style="--x: 90%; --y: 28%; --d: 2.4s;" data-line="4">
       <div class="pn-bubble openrouter">◆</div>
       <div class="pn-label">OpenRouter</div>
     </a>
-    <a class="provider-node" href="https://lmstudio.ai" target="_blank" rel="noopener" style="--x: 78%; --y: 78%; --d: 4.0s;" data-line="5">
+    <a class="provider-node" href="https://lmstudio.ai" target="_blank" rel="noopener" style="--x: 8%; --y: 72%; --d: 3.0s;" data-line="5">
       <div class="pn-bubble studiolm">✦</div>
-      <div class="pn-label">StudioLM</div>
+      <div class="pn-label">LM Studio</div>
     </a>
-    <a class="provider-node" href="https://docs.vllm.ai" target="_blank" rel="noopener" style="--x: 90%; --y: 28%; --d: 4.8s;" data-line="6">
+    <a class="provider-node" href="https://docs.vllm.ai" target="_blank" rel="noopener" style="--x: 24%; --y: 88%; --d: 3.6s;" data-line="6">
       <div class="pn-bubble vllm">▣</div>
-      <div class="pn-label">VLLM</div>
+      <div class="pn-label">vLLM</div>
+    </a>
+    <a class="provider-node" href="https://x.ai/api" target="_blank" rel="noopener" style="--x: 40%; --y: 95%; --d: 4.2s;" data-line="7">
+      <div class="pn-bubble grok">✕</div>
+      <div class="pn-label">Grok</div>
+    </a>
+    <a class="provider-node" href="https://ai.google.dev/gemini-api/docs/openai" target="_blank" rel="noopener" style="--x: 60%; --y: 95%; --d: 4.8s;" data-line="8">
+      <div class="pn-bubble gemini">◊</div>
+      <div class="pn-label">Gemini</div>
+    </a>
+    <a class="provider-node" href="https://api-docs.deepseek.com" target="_blank" rel="noopener" style="--x: 76%; --y: 88%; --d: 5.4s;" data-line="9">
+      <div class="pn-bubble deepseek">⬣</div>
+      <div class="pn-label">DeepSeek</div>
+    </a>
+    <a class="provider-node" href="https://docs.mistral.ai/api/" target="_blank" rel="noopener" style="--x: 92%; --y: 72%; --d: 6.0s;" data-line="10">
+      <div class="pn-bubble mistral">▲</div>
+      <div class="pn-label">Mistral</div>
     </a>
   </div>
 </section>
@@ -1471,7 +1504,7 @@
         <tr><td>オープンソース</td><td class="highlight">MIT ライセンス</td><td>プロプライエタリ</td></tr>
         <tr><td>価格</td><td class="highlight">永久無料</td><td>Claude Pro が必要 ($20/月)</td></tr>
         <tr><td>ローカル LLM 対応</td><td class="highlight">llama.cpp、Ollama</td><td>なし — Claude のみ</td></tr>
-        <tr><td>マルチプロバイダー</td><td class="highlight">4 プロバイダー (ローカル + クラウド)</td><td>Claude のみ</td></tr>
+        <tr><td>マルチプロバイダー</td><td class="highlight">OpenAI 互換のすべてのエンドポイント</td><td>Claude のみ</td></tr>
         <tr><td>Chrome</td><td class="highlight">あり (MV3)</td><td>あり</td></tr>
         <tr><td>Firefox</td><td class="highlight">あり (MV2)</td><td>なし</td></tr>
         <tr><td>サイドパネル UI</td><td class="highlight">あり</td><td>あり</td></tr>

--- a/web/ko/index.html
+++ b/web/ko/index.html
@@ -801,6 +801,10 @@
     .pn-bubble.openrouter { background: rgba(108,99,255,0.12); color: var(--accent2); border-color: rgba(108,99,255,0.3); }
     .pn-bubble.studiolm { background: rgba(245,158,11,0.12); color: #f59e0b; border-color: rgba(245,158,11,0.25); }
     .pn-bubble.vllm { background: rgba(99,102,241,0.12); color: #6366f1; border-color: rgba(99,102,241,0.25); }
+    .pn-bubble.grok { background: rgba(255,255,255,0.06); color: #e5e5e5; border-color: rgba(255,255,255,0.2); }
+    .pn-bubble.gemini { background: rgba(66,133,244,0.12); color: #4285f4; border-color: rgba(66,133,244,0.25); }
+    .pn-bubble.deepseek { background: rgba(72,191,255,0.12); color: #48bfff; border-color: rgba(72,191,255,0.25); }
+    .pn-bubble.mistral { background: rgba(255,127,80,0.12); color: #ff7f50; border-color: rgba(255,127,80,0.25); }
 
     /* Reduced-motion: kill the float + ring pulse so users on
        prefers-reduced-motion see a static layout. */
@@ -1320,6 +1324,11 @@
       <p>페이지에 대해 추론하기 전에 동의 배너(OneTrust, Cookiebot, Didomi, Quantcast)를 닫습니다. 페이월이 감지되면 기사 내용을 지어내거나 우회하려 하지 않고 정직하게 알려 줍니다.</p>
     </div>
     <div class="feature-card">
+      <div class="feature-icon">🧩</div>
+      <h3>선택적 CAPTCHA 해결기</h3>
+      <p><a href="https://capsolver.com" target="_blank" rel="noopener" style="color:var(--accent);text-decoration:none;">CapSolver</a> API 키를 연결하면 reCAPTCHA v2/v3, hCaptcha, Cloudflare Turnstile이 단계를 막을 때 에이전트가 자동으로 해결합니다 — 멈춰서 묻는 대신에. 기본값은 꺼짐, 키는 직접 가져오기, 사용자가 켜지 않는 한 어떤 CAPTCHA 서비스에도 연결되지 않습니다.</p>
+    </div>
+    <div class="feature-card">
       <div class="feature-icon">🌐</div>
       <h3>다국어 UI</h3>
       <p>플러그인은 English, Español, Français, Türkçe, 中文으로 제공됩니다. 처음 사용 시 브라우저 언어를 자동 감지하고, 사이드 패널의 지구본 아이콘으로 언제든 전환할 수 있습니다. 마케팅 사이트도 그에 맞춰 현지화되어 있습니다.</p>
@@ -1338,21 +1347,29 @@
   <h2 class="section-title">자신의 AI를 가져오세요</h2>
   <p class="section-subtitle">OpenAI 호환 API 어디에든 연결하거나 로컬 모델을 실행하세요. 확장 설정에서 프로바이더를 언제든 바꿀 수 있습니다.</p>
 
-  <!-- Constellation: central WebBrain core, 7 provider nodes orbiting on
-       two arcs. Connection lines drawn in SVG (viewBox is in % units via
-       a 0–100 coordinate space so the line endpoints follow the % values
-       used to position each node). The node order matches the line order
-       so JS can map a hovered node → its line for highlight. -->
+  <!-- Constellation: central WebBrain core, 11 provider nodes orbiting on
+       two arcs (5 above, 6 below). Connection lines drawn in SVG (viewBox
+       is in % units via a 0–100 coordinate space so the line endpoints
+       follow the % values used to position each node). The node order
+       matches the line order so JS can map a hovered node → its line for
+       highlight. Local runtimes (llama.cpp, Ollama, LM Studio, vLLM) are
+       on the left edges of each arc; cloud providers fan out toward the
+       right. Grok / Gemini / DeepSeek / Mistral are reached via the
+       OpenAI-compatible config — any OpenAI-style endpoint works. -->
   <div class="provider-constellation" aria-label="자신의 AI를 가져오세요">
     <svg class="constellation-lines" viewBox="0 0 100 100" preserveAspectRatio="none" aria-hidden="true">
-      <!-- order: llama.cpp, ollama, openai, anthropic, openrouter, studiolm, vllm -->
+      <!-- order: llama.cpp, ollama, openai, anthropic, openrouter, lmstudio, vllm, grok, gemini, deepseek, mistral -->
       <line x1="50" y1="50" x2="10" y2="28"></line>
-      <line x1="50" y1="50" x2="22" y2="78"></line>
       <line x1="50" y1="50" x2="28" y2="12"></line>
-      <line x1="50" y1="50" x2="50" y2="92"></line>
+      <line x1="50" y1="50" x2="50" y2="6"></line>
       <line x1="50" y1="50" x2="72" y2="12"></line>
-      <line x1="50" y1="50" x2="78" y2="78"></line>
       <line x1="50" y1="50" x2="90" y2="28"></line>
+      <line x1="50" y1="50" x2="8" y2="72"></line>
+      <line x1="50" y1="50" x2="24" y2="88"></line>
+      <line x1="50" y1="50" x2="40" y2="95"></line>
+      <line x1="50" y1="50" x2="60" y2="95"></line>
+      <line x1="50" y1="50" x2="76" y2="88"></line>
+      <line x1="50" y1="50" x2="92" y2="72"></line>
     </svg>
 
     <div class="constellation-center" aria-hidden="true">
@@ -1365,29 +1382,45 @@
       <div class="pn-bubble local">🦙</div>
       <div class="pn-label">llama.cpp</div>
     </a>
-    <a class="provider-node" href="https://ollama.com" target="_blank" rel="noopener" style="--x: 22%; --y: 78%; --d: 0.8s;" data-line="1">
+    <a class="provider-node" href="https://ollama.com" target="_blank" rel="noopener" style="--x: 28%; --y: 12%; --d: 0.6s;" data-line="1">
       <div class="pn-bubble ollama">◉</div>
       <div class="pn-label">Ollama</div>
     </a>
-    <a class="provider-node" href="https://platform.openai.com" target="_blank" rel="noopener" style="--x: 28%; --y: 12%; --d: 1.6s;" data-line="2">
+    <a class="provider-node" href="https://platform.openai.com" target="_blank" rel="noopener" style="--x: 50%; --y: 6%; --d: 1.2s;" data-line="2">
       <div class="pn-bubble openai">⬡</div>
       <div class="pn-label">OpenAI</div>
     </a>
-    <a class="provider-node" href="https://www.anthropic.com" target="_blank" rel="noopener" style="--x: 50%; --y: 92%; --d: 2.4s;" data-line="3">
+    <a class="provider-node" href="https://www.anthropic.com" target="_blank" rel="noopener" style="--x: 72%; --y: 12%; --d: 1.8s;" data-line="3">
       <div class="pn-bubble anthropic">◈</div>
       <div class="pn-label">Claude</div>
     </a>
-    <a class="provider-node" href="https://openrouter.ai" target="_blank" rel="noopener" style="--x: 72%; --y: 12%; --d: 3.2s;" data-line="4">
+    <a class="provider-node" href="https://openrouter.ai" target="_blank" rel="noopener" style="--x: 90%; --y: 28%; --d: 2.4s;" data-line="4">
       <div class="pn-bubble openrouter">◆</div>
       <div class="pn-label">OpenRouter</div>
     </a>
-    <a class="provider-node" href="https://lmstudio.ai" target="_blank" rel="noopener" style="--x: 78%; --y: 78%; --d: 4.0s;" data-line="5">
+    <a class="provider-node" href="https://lmstudio.ai" target="_blank" rel="noopener" style="--x: 8%; --y: 72%; --d: 3.0s;" data-line="5">
       <div class="pn-bubble studiolm">✦</div>
-      <div class="pn-label">StudioLM</div>
+      <div class="pn-label">LM Studio</div>
     </a>
-    <a class="provider-node" href="https://docs.vllm.ai" target="_blank" rel="noopener" style="--x: 90%; --y: 28%; --d: 4.8s;" data-line="6">
+    <a class="provider-node" href="https://docs.vllm.ai" target="_blank" rel="noopener" style="--x: 24%; --y: 88%; --d: 3.6s;" data-line="6">
       <div class="pn-bubble vllm">▣</div>
-      <div class="pn-label">VLLM</div>
+      <div class="pn-label">vLLM</div>
+    </a>
+    <a class="provider-node" href="https://x.ai/api" target="_blank" rel="noopener" style="--x: 40%; --y: 95%; --d: 4.2s;" data-line="7">
+      <div class="pn-bubble grok">✕</div>
+      <div class="pn-label">Grok</div>
+    </a>
+    <a class="provider-node" href="https://ai.google.dev/gemini-api/docs/openai" target="_blank" rel="noopener" style="--x: 60%; --y: 95%; --d: 4.8s;" data-line="8">
+      <div class="pn-bubble gemini">◊</div>
+      <div class="pn-label">Gemini</div>
+    </a>
+    <a class="provider-node" href="https://api-docs.deepseek.com" target="_blank" rel="noopener" style="--x: 76%; --y: 88%; --d: 5.4s;" data-line="9">
+      <div class="pn-bubble deepseek">⬣</div>
+      <div class="pn-label">DeepSeek</div>
+    </a>
+    <a class="provider-node" href="https://docs.mistral.ai/api/" target="_blank" rel="noopener" style="--x: 92%; --y: 72%; --d: 6.0s;" data-line="10">
+      <div class="pn-bubble mistral">▲</div>
+      <div class="pn-label">Mistral</div>
     </a>
   </div>
 </section>
@@ -1471,7 +1504,7 @@
         <tr><td>오픈소스</td><td class="highlight">MIT 라이선스</td><td>독점</td></tr>
         <tr><td>가격</td><td class="highlight">영구 무료</td><td>Claude Pro 필요 ($20/월)</td></tr>
         <tr><td>로컬 LLM 지원</td><td class="highlight">llama.cpp, Ollama</td><td>아니요 — Claude 전용</td></tr>
-        <tr><td>멀티 프로바이더</td><td class="highlight">4개 프로바이더 (로컬 + 클라우드)</td><td>Claude 전용</td></tr>
+        <tr><td>멀티 프로바이더</td><td class="highlight">OpenAI 호환 모든 엔드포인트</td><td>Claude 전용</td></tr>
         <tr><td>Chrome</td><td class="highlight">예 (MV3)</td><td>예</td></tr>
         <tr><td>Firefox</td><td class="highlight">예 (MV2)</td><td>아니요</td></tr>
         <tr><td>사이드 패널 UI</td><td class="highlight">예</td><td>예</td></tr>

--- a/web/ms/index.html
+++ b/web/ms/index.html
@@ -801,6 +801,10 @@
     .pn-bubble.openrouter { background: rgba(108,99,255,0.12); color: var(--accent2); border-color: rgba(108,99,255,0.3); }
     .pn-bubble.studiolm { background: rgba(245,158,11,0.12); color: #f59e0b; border-color: rgba(245,158,11,0.25); }
     .pn-bubble.vllm { background: rgba(99,102,241,0.12); color: #6366f1; border-color: rgba(99,102,241,0.25); }
+    .pn-bubble.grok { background: rgba(255,255,255,0.06); color: #e5e5e5; border-color: rgba(255,255,255,0.2); }
+    .pn-bubble.gemini { background: rgba(66,133,244,0.12); color: #4285f4; border-color: rgba(66,133,244,0.25); }
+    .pn-bubble.deepseek { background: rgba(72,191,255,0.12); color: #48bfff; border-color: rgba(72,191,255,0.25); }
+    .pn-bubble.mistral { background: rgba(255,127,80,0.12); color: #ff7f50; border-color: rgba(255,127,80,0.25); }
 
     /* Reduced-motion: kill the float + ring pulse so users on
        prefers-reduced-motion see a static layout. */
@@ -1320,6 +1324,11 @@
       <p>Menutup sepanduk persetujuan (OneTrust, Cookiebot, Didomi, Quantcast) sebelum berfikir tentang halaman. Mengesan paywall dan memberitahu anda dengan jujur dan bukannya mereka-reka kandungan artikel atau cuba memintasnya.</p>
     </div>
     <div class="feature-card">
+      <div class="feature-icon">🧩</div>
+      <h3>Penyelesai CAPTCHA Pilihan</h3>
+      <p>Pasangkan kunci API <a href="https://capsolver.com" target="_blank" rel="noopener" style="color:var(--accent);text-decoration:none;">CapSolver</a> dan agen akan menyelesaikan reCAPTCHA v2/v3, hCaptcha dan Cloudflare Turnstile secara automatik apabila ia menghalang sesuatu langkah — bukannya berhenti untuk bertanya. Dimatikan secara lalai, anda bawa kunci sendiri, tiada perkhidmatan captcha dihubungi melainkan anda menghidupkannya.</p>
+    </div>
+    <div class="feature-card">
       <div class="feature-icon">🌐</div>
       <h3>UI Berbilang Bahasa</h3>
       <p>Pemalam disediakan dalam English, Español, Français, Türkçe dan 中文. Mengesan bahasa pelayar anda secara automatik pada penggunaan pertama; tukar bila-bila masa daripada ikon globe di panel sisi. Laman pemasaran turut dilokalkan sepadan.</p>
@@ -1338,21 +1347,29 @@
   <h2 class="section-title">Bawa AI Anda Sendiri</h2>
   <p class="section-subtitle">Sambung ke mana-mana API serasi OpenAI atau jalankan model tempatan. Tukar pembekal bila-bila masa dari tetapan sambungan.</p>
 
-  <!-- Constellation: central WebBrain core, 7 provider nodes orbiting on
-       two arcs. Connection lines drawn in SVG (viewBox is in % units via
-       a 0–100 coordinate space so the line endpoints follow the % values
-       used to position each node). The node order matches the line order
-       so JS can map a hovered node → its line for highlight. -->
+  <!-- Constellation: central WebBrain core, 11 provider nodes orbiting on
+       two arcs (5 above, 6 below). Connection lines drawn in SVG (viewBox
+       is in % units via a 0–100 coordinate space so the line endpoints
+       follow the % values used to position each node). The node order
+       matches the line order so JS can map a hovered node → its line for
+       highlight. Local runtimes (llama.cpp, Ollama, LM Studio, vLLM) are
+       on the left edges of each arc; cloud providers fan out toward the
+       right. Grok / Gemini / DeepSeek / Mistral are reached via the
+       OpenAI-compatible config — any OpenAI-style endpoint works. -->
   <div class="provider-constellation" aria-label="Bawa AI Anda Sendiri">
     <svg class="constellation-lines" viewBox="0 0 100 100" preserveAspectRatio="none" aria-hidden="true">
-      <!-- order: llama.cpp, ollama, openai, anthropic, openrouter, studiolm, vllm -->
+      <!-- order: llama.cpp, ollama, openai, anthropic, openrouter, lmstudio, vllm, grok, gemini, deepseek, mistral -->
       <line x1="50" y1="50" x2="10" y2="28"></line>
-      <line x1="50" y1="50" x2="22" y2="78"></line>
       <line x1="50" y1="50" x2="28" y2="12"></line>
-      <line x1="50" y1="50" x2="50" y2="92"></line>
+      <line x1="50" y1="50" x2="50" y2="6"></line>
       <line x1="50" y1="50" x2="72" y2="12"></line>
-      <line x1="50" y1="50" x2="78" y2="78"></line>
       <line x1="50" y1="50" x2="90" y2="28"></line>
+      <line x1="50" y1="50" x2="8" y2="72"></line>
+      <line x1="50" y1="50" x2="24" y2="88"></line>
+      <line x1="50" y1="50" x2="40" y2="95"></line>
+      <line x1="50" y1="50" x2="60" y2="95"></line>
+      <line x1="50" y1="50" x2="76" y2="88"></line>
+      <line x1="50" y1="50" x2="92" y2="72"></line>
     </svg>
 
     <div class="constellation-center" aria-hidden="true">
@@ -1365,29 +1382,45 @@
       <div class="pn-bubble local">🦙</div>
       <div class="pn-label">llama.cpp</div>
     </a>
-    <a class="provider-node" href="https://ollama.com" target="_blank" rel="noopener" style="--x: 22%; --y: 78%; --d: 0.8s;" data-line="1">
+    <a class="provider-node" href="https://ollama.com" target="_blank" rel="noopener" style="--x: 28%; --y: 12%; --d: 0.6s;" data-line="1">
       <div class="pn-bubble ollama">◉</div>
       <div class="pn-label">Ollama</div>
     </a>
-    <a class="provider-node" href="https://platform.openai.com" target="_blank" rel="noopener" style="--x: 28%; --y: 12%; --d: 1.6s;" data-line="2">
+    <a class="provider-node" href="https://platform.openai.com" target="_blank" rel="noopener" style="--x: 50%; --y: 6%; --d: 1.2s;" data-line="2">
       <div class="pn-bubble openai">⬡</div>
       <div class="pn-label">OpenAI</div>
     </a>
-    <a class="provider-node" href="https://www.anthropic.com" target="_blank" rel="noopener" style="--x: 50%; --y: 92%; --d: 2.4s;" data-line="3">
+    <a class="provider-node" href="https://www.anthropic.com" target="_blank" rel="noopener" style="--x: 72%; --y: 12%; --d: 1.8s;" data-line="3">
       <div class="pn-bubble anthropic">◈</div>
       <div class="pn-label">Claude</div>
     </a>
-    <a class="provider-node" href="https://openrouter.ai" target="_blank" rel="noopener" style="--x: 72%; --y: 12%; --d: 3.2s;" data-line="4">
+    <a class="provider-node" href="https://openrouter.ai" target="_blank" rel="noopener" style="--x: 90%; --y: 28%; --d: 2.4s;" data-line="4">
       <div class="pn-bubble openrouter">◆</div>
       <div class="pn-label">OpenRouter</div>
     </a>
-    <a class="provider-node" href="https://lmstudio.ai" target="_blank" rel="noopener" style="--x: 78%; --y: 78%; --d: 4.0s;" data-line="5">
+    <a class="provider-node" href="https://lmstudio.ai" target="_blank" rel="noopener" style="--x: 8%; --y: 72%; --d: 3.0s;" data-line="5">
       <div class="pn-bubble studiolm">✦</div>
-      <div class="pn-label">StudioLM</div>
+      <div class="pn-label">LM Studio</div>
     </a>
-    <a class="provider-node" href="https://docs.vllm.ai" target="_blank" rel="noopener" style="--x: 90%; --y: 28%; --d: 4.8s;" data-line="6">
+    <a class="provider-node" href="https://docs.vllm.ai" target="_blank" rel="noopener" style="--x: 24%; --y: 88%; --d: 3.6s;" data-line="6">
       <div class="pn-bubble vllm">▣</div>
-      <div class="pn-label">VLLM</div>
+      <div class="pn-label">vLLM</div>
+    </a>
+    <a class="provider-node" href="https://x.ai/api" target="_blank" rel="noopener" style="--x: 40%; --y: 95%; --d: 4.2s;" data-line="7">
+      <div class="pn-bubble grok">✕</div>
+      <div class="pn-label">Grok</div>
+    </a>
+    <a class="provider-node" href="https://ai.google.dev/gemini-api/docs/openai" target="_blank" rel="noopener" style="--x: 60%; --y: 95%; --d: 4.8s;" data-line="8">
+      <div class="pn-bubble gemini">◊</div>
+      <div class="pn-label">Gemini</div>
+    </a>
+    <a class="provider-node" href="https://api-docs.deepseek.com" target="_blank" rel="noopener" style="--x: 76%; --y: 88%; --d: 5.4s;" data-line="9">
+      <div class="pn-bubble deepseek">⬣</div>
+      <div class="pn-label">DeepSeek</div>
+    </a>
+    <a class="provider-node" href="https://docs.mistral.ai/api/" target="_blank" rel="noopener" style="--x: 92%; --y: 72%; --d: 6.0s;" data-line="10">
+      <div class="pn-bubble mistral">▲</div>
+      <div class="pn-label">Mistral</div>
     </a>
   </div>
 </section>
@@ -1471,7 +1504,7 @@
         <tr><td>Sumber Terbuka</td><td class="highlight">Lesen MIT</td><td>Berhak milik</td></tr>
         <tr><td>Harga</td><td class="highlight">Percuma selamanya</td><td>Memerlukan Claude Pro ($20/bulan)</td></tr>
         <tr><td>Sokongan LLM tempatan</td><td class="highlight">llama.cpp, Ollama</td><td>Tidak — Claude sahaja</td></tr>
-        <tr><td>Berbilang pembekal</td><td class="highlight">4 pembekal (tempatan + awan)</td><td>Claude sahaja</td></tr>
+        <tr><td>Berbilang pembekal</td><td class="highlight">Semua endpoint serasi OpenAI</td><td>Claude sahaja</td></tr>
         <tr><td>Chrome</td><td class="highlight">Ya (MV3)</td><td>Ya</td></tr>
         <tr><td>Firefox</td><td class="highlight">Ya (MV2)</td><td>Tidak</td></tr>
         <tr><td>UI panel sisi</td><td class="highlight">Ya</td><td>Ya</td></tr>

--- a/web/ru/index.html
+++ b/web/ru/index.html
@@ -801,6 +801,10 @@
     .pn-bubble.openrouter { background: rgba(108,99,255,0.12); color: var(--accent2); border-color: rgba(108,99,255,0.3); }
     .pn-bubble.studiolm { background: rgba(245,158,11,0.12); color: #f59e0b; border-color: rgba(245,158,11,0.25); }
     .pn-bubble.vllm { background: rgba(99,102,241,0.12); color: #6366f1; border-color: rgba(99,102,241,0.25); }
+    .pn-bubble.grok { background: rgba(255,255,255,0.06); color: #e5e5e5; border-color: rgba(255,255,255,0.2); }
+    .pn-bubble.gemini { background: rgba(66,133,244,0.12); color: #4285f4; border-color: rgba(66,133,244,0.25); }
+    .pn-bubble.deepseek { background: rgba(72,191,255,0.12); color: #48bfff; border-color: rgba(72,191,255,0.25); }
+    .pn-bubble.mistral { background: rgba(255,127,80,0.12); color: #ff7f50; border-color: rgba(255,127,80,0.25); }
 
     /* Reduced-motion: kill the float + ring pulse so users on
        prefers-reduced-motion see a static layout. */
@@ -1320,6 +1324,11 @@
       <p>Закрывает баннеры согласия (OneTrust, Cookiebot, Didomi, Quantcast) перед тем, как анализировать страницу. Распознаёт paywall и честно сообщает об этом, а не выдумывает текст статьи и не пытается его обойти.</p>
     </div>
     <div class="feature-card">
+      <div class="feature-icon">🧩</div>
+      <h3>Опциональный решатель CAPTCHA</h3>
+      <p>Подключите ключ API <a href="https://capsolver.com" target="_blank" rel="noopener" style="color:var(--accent);text-decoration:none;">CapSolver</a>, и агент будет автоматически решать reCAPTCHA v2/v3, hCaptcha и Cloudflare Turnstile, когда они блокируют шаг — вместо того чтобы останавливаться и спрашивать вас. Выключено по умолчанию, ключ ваш, никакой captcha-сервис не запрашивается, пока вы сами не включите.</p>
+    </div>
+    <div class="feature-card">
       <div class="feature-icon">🌐</div>
       <h3>Многоязычный интерфейс</h3>
       <p>Плагин доступен на English, Español, Français, Türkçe и 中文. При первом запуске автоматически определяет язык браузера; переключайте в любой момент по значку глобуса в боковой панели. Маркетинговый сайт локализован соответственно.</p>
@@ -1338,21 +1347,29 @@
   <h2 class="section-title">Свой AI с собой</h2>
   <p class="section-subtitle">Подключайтесь к любому OpenAI-совместимому API или запускайте локальную модель. Меняйте провайдера в любой момент в настройках расширения.</p>
 
-  <!-- Constellation: central WebBrain core, 7 provider nodes orbiting on
-       two arcs. Connection lines drawn in SVG (viewBox is in % units via
-       a 0–100 coordinate space so the line endpoints follow the % values
-       used to position each node). The node order matches the line order
-       so JS can map a hovered node → its line for highlight. -->
+  <!-- Constellation: central WebBrain core, 11 provider nodes orbiting on
+       two arcs (5 above, 6 below). Connection lines drawn in SVG (viewBox
+       is in % units via a 0–100 coordinate space so the line endpoints
+       follow the % values used to position each node). The node order
+       matches the line order so JS can map a hovered node → its line for
+       highlight. Local runtimes (llama.cpp, Ollama, LM Studio, vLLM) are
+       on the left edges of each arc; cloud providers fan out toward the
+       right. Grok / Gemini / DeepSeek / Mistral are reached via the
+       OpenAI-compatible config — any OpenAI-style endpoint works. -->
   <div class="provider-constellation" aria-label="Свой AI с собой">
     <svg class="constellation-lines" viewBox="0 0 100 100" preserveAspectRatio="none" aria-hidden="true">
-      <!-- order: llama.cpp, ollama, openai, anthropic, openrouter, studiolm, vllm -->
+      <!-- order: llama.cpp, ollama, openai, anthropic, openrouter, lmstudio, vllm, grok, gemini, deepseek, mistral -->
       <line x1="50" y1="50" x2="10" y2="28"></line>
-      <line x1="50" y1="50" x2="22" y2="78"></line>
       <line x1="50" y1="50" x2="28" y2="12"></line>
-      <line x1="50" y1="50" x2="50" y2="92"></line>
+      <line x1="50" y1="50" x2="50" y2="6"></line>
       <line x1="50" y1="50" x2="72" y2="12"></line>
-      <line x1="50" y1="50" x2="78" y2="78"></line>
       <line x1="50" y1="50" x2="90" y2="28"></line>
+      <line x1="50" y1="50" x2="8" y2="72"></line>
+      <line x1="50" y1="50" x2="24" y2="88"></line>
+      <line x1="50" y1="50" x2="40" y2="95"></line>
+      <line x1="50" y1="50" x2="60" y2="95"></line>
+      <line x1="50" y1="50" x2="76" y2="88"></line>
+      <line x1="50" y1="50" x2="92" y2="72"></line>
     </svg>
 
     <div class="constellation-center" aria-hidden="true">
@@ -1365,29 +1382,45 @@
       <div class="pn-bubble local">🦙</div>
       <div class="pn-label">llama.cpp</div>
     </a>
-    <a class="provider-node" href="https://ollama.com" target="_blank" rel="noopener" style="--x: 22%; --y: 78%; --d: 0.8s;" data-line="1">
+    <a class="provider-node" href="https://ollama.com" target="_blank" rel="noopener" style="--x: 28%; --y: 12%; --d: 0.6s;" data-line="1">
       <div class="pn-bubble ollama">◉</div>
       <div class="pn-label">Ollama</div>
     </a>
-    <a class="provider-node" href="https://platform.openai.com" target="_blank" rel="noopener" style="--x: 28%; --y: 12%; --d: 1.6s;" data-line="2">
+    <a class="provider-node" href="https://platform.openai.com" target="_blank" rel="noopener" style="--x: 50%; --y: 6%; --d: 1.2s;" data-line="2">
       <div class="pn-bubble openai">⬡</div>
       <div class="pn-label">OpenAI</div>
     </a>
-    <a class="provider-node" href="https://www.anthropic.com" target="_blank" rel="noopener" style="--x: 50%; --y: 92%; --d: 2.4s;" data-line="3">
+    <a class="provider-node" href="https://www.anthropic.com" target="_blank" rel="noopener" style="--x: 72%; --y: 12%; --d: 1.8s;" data-line="3">
       <div class="pn-bubble anthropic">◈</div>
       <div class="pn-label">Claude</div>
     </a>
-    <a class="provider-node" href="https://openrouter.ai" target="_blank" rel="noopener" style="--x: 72%; --y: 12%; --d: 3.2s;" data-line="4">
+    <a class="provider-node" href="https://openrouter.ai" target="_blank" rel="noopener" style="--x: 90%; --y: 28%; --d: 2.4s;" data-line="4">
       <div class="pn-bubble openrouter">◆</div>
       <div class="pn-label">OpenRouter</div>
     </a>
-    <a class="provider-node" href="https://lmstudio.ai" target="_blank" rel="noopener" style="--x: 78%; --y: 78%; --d: 4.0s;" data-line="5">
+    <a class="provider-node" href="https://lmstudio.ai" target="_blank" rel="noopener" style="--x: 8%; --y: 72%; --d: 3.0s;" data-line="5">
       <div class="pn-bubble studiolm">✦</div>
-      <div class="pn-label">StudioLM</div>
+      <div class="pn-label">LM Studio</div>
     </a>
-    <a class="provider-node" href="https://docs.vllm.ai" target="_blank" rel="noopener" style="--x: 90%; --y: 28%; --d: 4.8s;" data-line="6">
+    <a class="provider-node" href="https://docs.vllm.ai" target="_blank" rel="noopener" style="--x: 24%; --y: 88%; --d: 3.6s;" data-line="6">
       <div class="pn-bubble vllm">▣</div>
-      <div class="pn-label">VLLM</div>
+      <div class="pn-label">vLLM</div>
+    </a>
+    <a class="provider-node" href="https://x.ai/api" target="_blank" rel="noopener" style="--x: 40%; --y: 95%; --d: 4.2s;" data-line="7">
+      <div class="pn-bubble grok">✕</div>
+      <div class="pn-label">Grok</div>
+    </a>
+    <a class="provider-node" href="https://ai.google.dev/gemini-api/docs/openai" target="_blank" rel="noopener" style="--x: 60%; --y: 95%; --d: 4.8s;" data-line="8">
+      <div class="pn-bubble gemini">◊</div>
+      <div class="pn-label">Gemini</div>
+    </a>
+    <a class="provider-node" href="https://api-docs.deepseek.com" target="_blank" rel="noopener" style="--x: 76%; --y: 88%; --d: 5.4s;" data-line="9">
+      <div class="pn-bubble deepseek">⬣</div>
+      <div class="pn-label">DeepSeek</div>
+    </a>
+    <a class="provider-node" href="https://docs.mistral.ai/api/" target="_blank" rel="noopener" style="--x: 92%; --y: 72%; --d: 6.0s;" data-line="10">
+      <div class="pn-bubble mistral">▲</div>
+      <div class="pn-label">Mistral</div>
     </a>
   </div>
 </section>
@@ -1471,7 +1504,7 @@
         <tr><td>Open-source</td><td class="highlight">Лицензия MIT</td><td>Проприетарно</td></tr>
         <tr><td>Цена</td><td class="highlight">Навсегда бесплатно</td><td>Нужен Claude Pro ($20/мес)</td></tr>
         <tr><td>Поддержка локальных LLM</td><td class="highlight">llama.cpp, Ollama</td><td>Нет — только Claude</td></tr>
-        <tr><td>Мульти-провайдер</td><td class="highlight">4 провайдера (локальные + облако)</td><td>Только Claude</td></tr>
+        <tr><td>Мульти-провайдер</td><td class="highlight">Все эндпоинты, совместимые с OpenAI</td><td>Только Claude</td></tr>
         <tr><td>Chrome</td><td class="highlight">Да (MV3)</td><td>Да</td></tr>
         <tr><td>Firefox</td><td class="highlight">Да (MV2)</td><td>Нет</td></tr>
         <tr><td>Интерфейс в боковой панели</td><td class="highlight">Да</td><td>Да</td></tr>

--- a/web/th/index.html
+++ b/web/th/index.html
@@ -801,6 +801,10 @@
     .pn-bubble.openrouter { background: rgba(108,99,255,0.12); color: var(--accent2); border-color: rgba(108,99,255,0.3); }
     .pn-bubble.studiolm { background: rgba(245,158,11,0.12); color: #f59e0b; border-color: rgba(245,158,11,0.25); }
     .pn-bubble.vllm { background: rgba(99,102,241,0.12); color: #6366f1; border-color: rgba(99,102,241,0.25); }
+    .pn-bubble.grok { background: rgba(255,255,255,0.06); color: #e5e5e5; border-color: rgba(255,255,255,0.2); }
+    .pn-bubble.gemini { background: rgba(66,133,244,0.12); color: #4285f4; border-color: rgba(66,133,244,0.25); }
+    .pn-bubble.deepseek { background: rgba(72,191,255,0.12); color: #48bfff; border-color: rgba(72,191,255,0.25); }
+    .pn-bubble.mistral { background: rgba(255,127,80,0.12); color: #ff7f50; border-color: rgba(255,127,80,0.25); }
 
     /* Reduced-motion: kill the float + ring pulse so users on
        prefers-reduced-motion see a static layout. */
@@ -1320,6 +1324,11 @@
       <p>ปิดแบนเนอร์ยินยอม (OneTrust, Cookiebot, Didomi, Quantcast) ก่อนวิเคราะห์หน้า ตรวจพบ paywall และบอกตามตรงแทนที่จะแต่งเนื้อหาบทความหรือพยายามหลีกเลี่ยง</p>
     </div>
     <div class="feature-card">
+      <div class="feature-icon">🧩</div>
+      <h3>ตัวแก้ CAPTCHA แบบเลือกใช้</h3>
+      <p>ใส่คีย์ API ของ <a href="https://capsolver.com" target="_blank" rel="noopener" style="color:var(--accent);text-decoration:none;">CapSolver</a> แล้วเอเจนต์จะแก้ reCAPTCHA v2/v3, hCaptcha และ Cloudflare Turnstile โดยอัตโนมัติเมื่อสิ่งเหล่านั้นขวางขั้นตอน — แทนที่จะหยุดถามคุณ ปิดตามค่าเริ่มต้น คุณนำคีย์มาเอง และจะไม่มีการเชื่อมต่อกับบริการ CAPTCHA ใด ๆ จนกว่าคุณจะเปิดใช้งาน</p>
+    </div>
+    <div class="feature-card">
       <div class="feature-icon">🌐</div>
       <h3>UI หลายภาษา</h3>
       <p>ปลั๊กอินมาพร้อม English, Español, Français, Türkçe และ 中文 ตรวจจับภาษาเบราว์เซอร์ของคุณอัตโนมัติเมื่อใช้งานครั้งแรก เปลี่ยนได้ทุกเมื่อจากไอคอนลูกโลกในแถบด้านข้าง เว็บไซต์การตลาดมีการแปลให้สอดคล้องกัน</p>
@@ -1338,21 +1347,29 @@
   <h2 class="section-title">นำ AI ของคุณมาเอง</h2>
   <p class="section-subtitle">เชื่อมต่อกับ API ที่เข้ากันได้กับ OpenAI ใด ๆ หรือรันโมเดลภายในเครื่อง สลับผู้ให้บริการได้ทุกเมื่อจากการตั้งค่าของส่วนขยาย</p>
 
-  <!-- Constellation: central WebBrain core, 7 provider nodes orbiting on
-       two arcs. Connection lines drawn in SVG (viewBox is in % units via
-       a 0–100 coordinate space so the line endpoints follow the % values
-       used to position each node). The node order matches the line order
-       so JS can map a hovered node → its line for highlight. -->
+  <!-- Constellation: central WebBrain core, 11 provider nodes orbiting on
+       two arcs (5 above, 6 below). Connection lines drawn in SVG (viewBox
+       is in % units via a 0–100 coordinate space so the line endpoints
+       follow the % values used to position each node). The node order
+       matches the line order so JS can map a hovered node → its line for
+       highlight. Local runtimes (llama.cpp, Ollama, LM Studio, vLLM) are
+       on the left edges of each arc; cloud providers fan out toward the
+       right. Grok / Gemini / DeepSeek / Mistral are reached via the
+       OpenAI-compatible config — any OpenAI-style endpoint works. -->
   <div class="provider-constellation" aria-label="นำ AI ของคุณมาเอง">
     <svg class="constellation-lines" viewBox="0 0 100 100" preserveAspectRatio="none" aria-hidden="true">
-      <!-- order: llama.cpp, ollama, openai, anthropic, openrouter, studiolm, vllm -->
+      <!-- order: llama.cpp, ollama, openai, anthropic, openrouter, lmstudio, vllm, grok, gemini, deepseek, mistral -->
       <line x1="50" y1="50" x2="10" y2="28"></line>
-      <line x1="50" y1="50" x2="22" y2="78"></line>
       <line x1="50" y1="50" x2="28" y2="12"></line>
-      <line x1="50" y1="50" x2="50" y2="92"></line>
+      <line x1="50" y1="50" x2="50" y2="6"></line>
       <line x1="50" y1="50" x2="72" y2="12"></line>
-      <line x1="50" y1="50" x2="78" y2="78"></line>
       <line x1="50" y1="50" x2="90" y2="28"></line>
+      <line x1="50" y1="50" x2="8" y2="72"></line>
+      <line x1="50" y1="50" x2="24" y2="88"></line>
+      <line x1="50" y1="50" x2="40" y2="95"></line>
+      <line x1="50" y1="50" x2="60" y2="95"></line>
+      <line x1="50" y1="50" x2="76" y2="88"></line>
+      <line x1="50" y1="50" x2="92" y2="72"></line>
     </svg>
 
     <div class="constellation-center" aria-hidden="true">
@@ -1365,29 +1382,45 @@
       <div class="pn-bubble local">🦙</div>
       <div class="pn-label">llama.cpp</div>
     </a>
-    <a class="provider-node" href="https://ollama.com" target="_blank" rel="noopener" style="--x: 22%; --y: 78%; --d: 0.8s;" data-line="1">
+    <a class="provider-node" href="https://ollama.com" target="_blank" rel="noopener" style="--x: 28%; --y: 12%; --d: 0.6s;" data-line="1">
       <div class="pn-bubble ollama">◉</div>
       <div class="pn-label">Ollama</div>
     </a>
-    <a class="provider-node" href="https://platform.openai.com" target="_blank" rel="noopener" style="--x: 28%; --y: 12%; --d: 1.6s;" data-line="2">
+    <a class="provider-node" href="https://platform.openai.com" target="_blank" rel="noopener" style="--x: 50%; --y: 6%; --d: 1.2s;" data-line="2">
       <div class="pn-bubble openai">⬡</div>
       <div class="pn-label">OpenAI</div>
     </a>
-    <a class="provider-node" href="https://www.anthropic.com" target="_blank" rel="noopener" style="--x: 50%; --y: 92%; --d: 2.4s;" data-line="3">
+    <a class="provider-node" href="https://www.anthropic.com" target="_blank" rel="noopener" style="--x: 72%; --y: 12%; --d: 1.8s;" data-line="3">
       <div class="pn-bubble anthropic">◈</div>
       <div class="pn-label">Claude</div>
     </a>
-    <a class="provider-node" href="https://openrouter.ai" target="_blank" rel="noopener" style="--x: 72%; --y: 12%; --d: 3.2s;" data-line="4">
+    <a class="provider-node" href="https://openrouter.ai" target="_blank" rel="noopener" style="--x: 90%; --y: 28%; --d: 2.4s;" data-line="4">
       <div class="pn-bubble openrouter">◆</div>
       <div class="pn-label">OpenRouter</div>
     </a>
-    <a class="provider-node" href="https://lmstudio.ai" target="_blank" rel="noopener" style="--x: 78%; --y: 78%; --d: 4.0s;" data-line="5">
+    <a class="provider-node" href="https://lmstudio.ai" target="_blank" rel="noopener" style="--x: 8%; --y: 72%; --d: 3.0s;" data-line="5">
       <div class="pn-bubble studiolm">✦</div>
-      <div class="pn-label">StudioLM</div>
+      <div class="pn-label">LM Studio</div>
     </a>
-    <a class="provider-node" href="https://docs.vllm.ai" target="_blank" rel="noopener" style="--x: 90%; --y: 28%; --d: 4.8s;" data-line="6">
+    <a class="provider-node" href="https://docs.vllm.ai" target="_blank" rel="noopener" style="--x: 24%; --y: 88%; --d: 3.6s;" data-line="6">
       <div class="pn-bubble vllm">▣</div>
-      <div class="pn-label">VLLM</div>
+      <div class="pn-label">vLLM</div>
+    </a>
+    <a class="provider-node" href="https://x.ai/api" target="_blank" rel="noopener" style="--x: 40%; --y: 95%; --d: 4.2s;" data-line="7">
+      <div class="pn-bubble grok">✕</div>
+      <div class="pn-label">Grok</div>
+    </a>
+    <a class="provider-node" href="https://ai.google.dev/gemini-api/docs/openai" target="_blank" rel="noopener" style="--x: 60%; --y: 95%; --d: 4.8s;" data-line="8">
+      <div class="pn-bubble gemini">◊</div>
+      <div class="pn-label">Gemini</div>
+    </a>
+    <a class="provider-node" href="https://api-docs.deepseek.com" target="_blank" rel="noopener" style="--x: 76%; --y: 88%; --d: 5.4s;" data-line="9">
+      <div class="pn-bubble deepseek">⬣</div>
+      <div class="pn-label">DeepSeek</div>
+    </a>
+    <a class="provider-node" href="https://docs.mistral.ai/api/" target="_blank" rel="noopener" style="--x: 92%; --y: 72%; --d: 6.0s;" data-line="10">
+      <div class="pn-bubble mistral">▲</div>
+      <div class="pn-label">Mistral</div>
     </a>
   </div>
 </section>
@@ -1471,7 +1504,7 @@
         <tr><td>โอเพนซอร์ส</td><td class="highlight">สัญญาอนุญาต MIT</td><td>เป็นกรรมสิทธิ์</td></tr>
         <tr><td>ราคา</td><td class="highlight">ฟรีตลอดไป</td><td>ต้องใช้ Claude Pro ($20/เดือน)</td></tr>
         <tr><td>รองรับ LLM ภายในเครื่อง</td><td class="highlight">llama.cpp, Ollama</td><td>ไม่ — เฉพาะ Claude</td></tr>
-        <tr><td>หลายผู้ให้บริการ</td><td class="highlight">4 ผู้ให้บริการ (ภายในเครื่อง + คลาวด์)</td><td>เฉพาะ Claude</td></tr>
+        <tr><td>หลายผู้ให้บริการ</td><td class="highlight">ทุกเอ็นด์พอยต์ที่เข้ากันได้กับ OpenAI</td><td>เฉพาะ Claude</td></tr>
         <tr><td>Chrome</td><td class="highlight">ใช่ (MV3)</td><td>ใช่</td></tr>
         <tr><td>Firefox</td><td class="highlight">ใช่ (MV2)</td><td>ไม่</td></tr>
         <tr><td>UI แถบด้านข้าง</td><td class="highlight">ใช่</td><td>ใช่</td></tr>

--- a/web/tl/index.html
+++ b/web/tl/index.html
@@ -801,6 +801,10 @@
     .pn-bubble.openrouter { background: rgba(108,99,255,0.12); color: var(--accent2); border-color: rgba(108,99,255,0.3); }
     .pn-bubble.studiolm { background: rgba(245,158,11,0.12); color: #f59e0b; border-color: rgba(245,158,11,0.25); }
     .pn-bubble.vllm { background: rgba(99,102,241,0.12); color: #6366f1; border-color: rgba(99,102,241,0.25); }
+    .pn-bubble.grok { background: rgba(255,255,255,0.06); color: #e5e5e5; border-color: rgba(255,255,255,0.2); }
+    .pn-bubble.gemini { background: rgba(66,133,244,0.12); color: #4285f4; border-color: rgba(66,133,244,0.25); }
+    .pn-bubble.deepseek { background: rgba(72,191,255,0.12); color: #48bfff; border-color: rgba(72,191,255,0.25); }
+    .pn-bubble.mistral { background: rgba(255,127,80,0.12); color: #ff7f50; border-color: rgba(255,127,80,0.25); }
 
     /* Reduced-motion: kill the float + ring pulse so users on
        prefers-reduced-motion see a static layout. */
@@ -1320,6 +1324,11 @@
       <p>Isinasara ang consent banners (OneTrust, Cookiebot, Didomi, Quantcast) bago mag-reason tungkol sa pahina. Tinutukoy ang paywall at sasabihin sa iyo nang totoo sa halip na gumawa-gawa ng nilalaman ng artikulo o subukang i-bypass ito.</p>
     </div>
     <div class="feature-card">
+      <div class="feature-icon">🧩</div>
+      <h3>Opsyonal na CAPTCHA Solver</h3>
+      <p>Mag-plug in ng <a href="https://capsolver.com" target="_blank" rel="noopener" style="color:var(--accent);text-decoration:none;">CapSolver</a> API key at awtomatikong solusyunan ng ahente ang reCAPTCHA v2/v3, hCaptcha at Cloudflare Turnstile kapag hinaharang ang isang hakbang — sa halip na huminto para magtanong. Naka-off bilang default, ikaw ang nagdadala ng key, at walang CAPTCHA service na kokontakin maliban kung iyong i-on.</p>
+    </div>
+    <div class="feature-card">
       <div class="feature-icon">🌐</div>
       <h3>Multilingual UI</h3>
       <p>Ang plugin ay nasa English, Español, Français, Türkçe at 中文. Awtomatikong tinutukoy ang wika ng iyong browser sa unang paggamit; lumipat anumang oras mula sa globe icon sa side panel. Ang marketing site ay isinalin upang tumugma.</p>
@@ -1338,21 +1347,29 @@
   <h2 class="section-title">Dalhin ang Sariling AI</h2>
   <p class="section-subtitle">Mag-connect sa anumang OpenAI-compatible na API o magpatakbo ng lokal na modelo. Lumipat ng provider anumang oras mula sa setting ng extension.</p>
 
-  <!-- Constellation: central WebBrain core, 7 provider nodes orbiting on
-       two arcs. Connection lines drawn in SVG (viewBox is in % units via
-       a 0–100 coordinate space so the line endpoints follow the % values
-       used to position each node). The node order matches the line order
-       so JS can map a hovered node → its line for highlight. -->
+  <!-- Constellation: central WebBrain core, 11 provider nodes orbiting on
+       two arcs (5 above, 6 below). Connection lines drawn in SVG (viewBox
+       is in % units via a 0–100 coordinate space so the line endpoints
+       follow the % values used to position each node). The node order
+       matches the line order so JS can map a hovered node → its line for
+       highlight. Local runtimes (llama.cpp, Ollama, LM Studio, vLLM) are
+       on the left edges of each arc; cloud providers fan out toward the
+       right. Grok / Gemini / DeepSeek / Mistral are reached via the
+       OpenAI-compatible config — any OpenAI-style endpoint works. -->
   <div class="provider-constellation" aria-label="Dalhin ang Sariling AI">
     <svg class="constellation-lines" viewBox="0 0 100 100" preserveAspectRatio="none" aria-hidden="true">
-      <!-- order: llama.cpp, ollama, openai, anthropic, openrouter, studiolm, vllm -->
+      <!-- order: llama.cpp, ollama, openai, anthropic, openrouter, lmstudio, vllm, grok, gemini, deepseek, mistral -->
       <line x1="50" y1="50" x2="10" y2="28"></line>
-      <line x1="50" y1="50" x2="22" y2="78"></line>
       <line x1="50" y1="50" x2="28" y2="12"></line>
-      <line x1="50" y1="50" x2="50" y2="92"></line>
+      <line x1="50" y1="50" x2="50" y2="6"></line>
       <line x1="50" y1="50" x2="72" y2="12"></line>
-      <line x1="50" y1="50" x2="78" y2="78"></line>
       <line x1="50" y1="50" x2="90" y2="28"></line>
+      <line x1="50" y1="50" x2="8" y2="72"></line>
+      <line x1="50" y1="50" x2="24" y2="88"></line>
+      <line x1="50" y1="50" x2="40" y2="95"></line>
+      <line x1="50" y1="50" x2="60" y2="95"></line>
+      <line x1="50" y1="50" x2="76" y2="88"></line>
+      <line x1="50" y1="50" x2="92" y2="72"></line>
     </svg>
 
     <div class="constellation-center" aria-hidden="true">
@@ -1365,29 +1382,45 @@
       <div class="pn-bubble local">🦙</div>
       <div class="pn-label">llama.cpp</div>
     </a>
-    <a class="provider-node" href="https://ollama.com" target="_blank" rel="noopener" style="--x: 22%; --y: 78%; --d: 0.8s;" data-line="1">
+    <a class="provider-node" href="https://ollama.com" target="_blank" rel="noopener" style="--x: 28%; --y: 12%; --d: 0.6s;" data-line="1">
       <div class="pn-bubble ollama">◉</div>
       <div class="pn-label">Ollama</div>
     </a>
-    <a class="provider-node" href="https://platform.openai.com" target="_blank" rel="noopener" style="--x: 28%; --y: 12%; --d: 1.6s;" data-line="2">
+    <a class="provider-node" href="https://platform.openai.com" target="_blank" rel="noopener" style="--x: 50%; --y: 6%; --d: 1.2s;" data-line="2">
       <div class="pn-bubble openai">⬡</div>
       <div class="pn-label">OpenAI</div>
     </a>
-    <a class="provider-node" href="https://www.anthropic.com" target="_blank" rel="noopener" style="--x: 50%; --y: 92%; --d: 2.4s;" data-line="3">
+    <a class="provider-node" href="https://www.anthropic.com" target="_blank" rel="noopener" style="--x: 72%; --y: 12%; --d: 1.8s;" data-line="3">
       <div class="pn-bubble anthropic">◈</div>
       <div class="pn-label">Claude</div>
     </a>
-    <a class="provider-node" href="https://openrouter.ai" target="_blank" rel="noopener" style="--x: 72%; --y: 12%; --d: 3.2s;" data-line="4">
+    <a class="provider-node" href="https://openrouter.ai" target="_blank" rel="noopener" style="--x: 90%; --y: 28%; --d: 2.4s;" data-line="4">
       <div class="pn-bubble openrouter">◆</div>
       <div class="pn-label">OpenRouter</div>
     </a>
-    <a class="provider-node" href="https://lmstudio.ai" target="_blank" rel="noopener" style="--x: 78%; --y: 78%; --d: 4.0s;" data-line="5">
+    <a class="provider-node" href="https://lmstudio.ai" target="_blank" rel="noopener" style="--x: 8%; --y: 72%; --d: 3.0s;" data-line="5">
       <div class="pn-bubble studiolm">✦</div>
-      <div class="pn-label">StudioLM</div>
+      <div class="pn-label">LM Studio</div>
     </a>
-    <a class="provider-node" href="https://docs.vllm.ai" target="_blank" rel="noopener" style="--x: 90%; --y: 28%; --d: 4.8s;" data-line="6">
+    <a class="provider-node" href="https://docs.vllm.ai" target="_blank" rel="noopener" style="--x: 24%; --y: 88%; --d: 3.6s;" data-line="6">
       <div class="pn-bubble vllm">▣</div>
-      <div class="pn-label">VLLM</div>
+      <div class="pn-label">vLLM</div>
+    </a>
+    <a class="provider-node" href="https://x.ai/api" target="_blank" rel="noopener" style="--x: 40%; --y: 95%; --d: 4.2s;" data-line="7">
+      <div class="pn-bubble grok">✕</div>
+      <div class="pn-label">Grok</div>
+    </a>
+    <a class="provider-node" href="https://ai.google.dev/gemini-api/docs/openai" target="_blank" rel="noopener" style="--x: 60%; --y: 95%; --d: 4.8s;" data-line="8">
+      <div class="pn-bubble gemini">◊</div>
+      <div class="pn-label">Gemini</div>
+    </a>
+    <a class="provider-node" href="https://api-docs.deepseek.com" target="_blank" rel="noopener" style="--x: 76%; --y: 88%; --d: 5.4s;" data-line="9">
+      <div class="pn-bubble deepseek">⬣</div>
+      <div class="pn-label">DeepSeek</div>
+    </a>
+    <a class="provider-node" href="https://docs.mistral.ai/api/" target="_blank" rel="noopener" style="--x: 92%; --y: 72%; --d: 6.0s;" data-line="10">
+      <div class="pn-bubble mistral">▲</div>
+      <div class="pn-label">Mistral</div>
     </a>
   </div>
 </section>
@@ -1471,7 +1504,7 @@
         <tr><td>Open Source</td><td class="highlight">MIT License</td><td>Proprietary</td></tr>
         <tr><td>Presyo</td><td class="highlight">Libre habambuhay</td><td>Kailangan ng Claude Pro ($20/buwan)</td></tr>
         <tr><td>Suporta sa lokal na LLM</td><td class="highlight">llama.cpp, Ollama</td><td>Hindi — Claude lamang</td></tr>
-        <tr><td>Multi-provider</td><td class="highlight">4 na provider (lokal + cloud)</td><td>Claude lamang</td></tr>
+        <tr><td>Multi-provider</td><td class="highlight">Lahat ng endpoint na compatible sa OpenAI</td><td>Claude lamang</td></tr>
         <tr><td>Chrome</td><td class="highlight">Oo (MV3)</td><td>Oo</td></tr>
         <tr><td>Firefox</td><td class="highlight">Oo (MV2)</td><td>Hindi</td></tr>
         <tr><td>UI sa side panel</td><td class="highlight">Oo</td><td>Oo</td></tr>

--- a/web/tr/index.html
+++ b/web/tr/index.html
@@ -801,6 +801,10 @@
     .pn-bubble.openrouter { background: rgba(108,99,255,0.12); color: var(--accent2); border-color: rgba(108,99,255,0.3); }
     .pn-bubble.studiolm { background: rgba(245,158,11,0.12); color: #f59e0b; border-color: rgba(245,158,11,0.25); }
     .pn-bubble.vllm { background: rgba(99,102,241,0.12); color: #6366f1; border-color: rgba(99,102,241,0.25); }
+    .pn-bubble.grok { background: rgba(255,255,255,0.06); color: #e5e5e5; border-color: rgba(255,255,255,0.2); }
+    .pn-bubble.gemini { background: rgba(66,133,244,0.12); color: #4285f4; border-color: rgba(66,133,244,0.25); }
+    .pn-bubble.deepseek { background: rgba(72,191,255,0.12); color: #48bfff; border-color: rgba(72,191,255,0.25); }
+    .pn-bubble.mistral { background: rgba(255,127,80,0.12); color: #ff7f50; border-color: rgba(255,127,80,0.25); }
 
     /* Reduced-motion: kill the float + ring pulse so users on
        prefers-reduced-motion see a static layout. */
@@ -1320,6 +1324,11 @@
       <p>Sayfa üzerinde akıl yürütmeden önce onam banner&#39;larını (OneTrust, Cookiebot, Didomi, Quantcast) kapatır. Ödeme duvarlarını algılar ve içerik uydurmak ya da aşmaya çalışmak yerine dürüstçe söyler.</p>
     </div>
     <div class="feature-card">
+      <div class="feature-icon">🧩</div>
+      <h3>İsteğe Bağlı CAPTCHA Çözücü</h3>
+      <p>Bir <a href="https://capsolver.com" target="_blank" rel="noopener" style="color:var(--accent);text-decoration:none;">CapSolver</a> API anahtarı ekleyin ve ajan reCAPTCHA v2/v3, hCaptcha ve Cloudflare Turnstile'ı bir adımı engellediklerinde otomatik olarak çözer — durup size sormak yerine. Varsayılan olarak kapalı, anahtarı sen getir, sen açmadıkça hiçbir captcha hizmetine bağlanılmaz.</p>
+    </div>
+    <div class="feature-card">
       <div class="feature-icon">🌐</div>
       <h3>Çok dilli arayüz</h3>
       <p>Eklenti English, Español, Français, Türkçe ve 中文 dillerinde geliyor. İlk kullanımda tarayıcı dilini otomatik algılar; yan paneldeki küre simgesinden istediğin an değiştirebilirsin. Pazarlama sitesi de buna uygun olarak yerelleştirildi.</p>
@@ -1338,21 +1347,29 @@
   <h2 class="section-title">Kendi AI&#39;nı getir</h2>
   <p class="section-subtitle">OpenAI uyumlu herhangi bir API&#39;ye bağlan veya yerel bir model çalıştır. Uzantı ayarlarından istediğin an sağlayıcı değiştir.</p>
 
-  <!-- Constellation: central WebBrain core, 7 provider nodes orbiting on
-       two arcs. Connection lines drawn in SVG (viewBox is in % units via
-       a 0–100 coordinate space so the line endpoints follow the % values
-       used to position each node). The node order matches the line order
-       so JS can map a hovered node → its line for highlight. -->
+  <!-- Constellation: central WebBrain core, 11 provider nodes orbiting on
+       two arcs (5 above, 6 below). Connection lines drawn in SVG (viewBox
+       is in % units via a 0–100 coordinate space so the line endpoints
+       follow the % values used to position each node). The node order
+       matches the line order so JS can map a hovered node → its line for
+       highlight. Local runtimes (llama.cpp, Ollama, LM Studio, vLLM) are
+       on the left edges of each arc; cloud providers fan out toward the
+       right. Grok / Gemini / DeepSeek / Mistral are reached via the
+       OpenAI-compatible config — any OpenAI-style endpoint works. -->
   <div class="provider-constellation" aria-label="Kendi AI&#39;nı getir">
     <svg class="constellation-lines" viewBox="0 0 100 100" preserveAspectRatio="none" aria-hidden="true">
-      <!-- order: llama.cpp, ollama, openai, anthropic, openrouter, studiolm, vllm -->
+      <!-- order: llama.cpp, ollama, openai, anthropic, openrouter, lmstudio, vllm, grok, gemini, deepseek, mistral -->
       <line x1="50" y1="50" x2="10" y2="28"></line>
-      <line x1="50" y1="50" x2="22" y2="78"></line>
       <line x1="50" y1="50" x2="28" y2="12"></line>
-      <line x1="50" y1="50" x2="50" y2="92"></line>
+      <line x1="50" y1="50" x2="50" y2="6"></line>
       <line x1="50" y1="50" x2="72" y2="12"></line>
-      <line x1="50" y1="50" x2="78" y2="78"></line>
       <line x1="50" y1="50" x2="90" y2="28"></line>
+      <line x1="50" y1="50" x2="8" y2="72"></line>
+      <line x1="50" y1="50" x2="24" y2="88"></line>
+      <line x1="50" y1="50" x2="40" y2="95"></line>
+      <line x1="50" y1="50" x2="60" y2="95"></line>
+      <line x1="50" y1="50" x2="76" y2="88"></line>
+      <line x1="50" y1="50" x2="92" y2="72"></line>
     </svg>
 
     <div class="constellation-center" aria-hidden="true">
@@ -1365,29 +1382,45 @@
       <div class="pn-bubble local">🦙</div>
       <div class="pn-label">llama.cpp</div>
     </a>
-    <a class="provider-node" href="https://ollama.com" target="_blank" rel="noopener" style="--x: 22%; --y: 78%; --d: 0.8s;" data-line="1">
+    <a class="provider-node" href="https://ollama.com" target="_blank" rel="noopener" style="--x: 28%; --y: 12%; --d: 0.6s;" data-line="1">
       <div class="pn-bubble ollama">◉</div>
       <div class="pn-label">Ollama</div>
     </a>
-    <a class="provider-node" href="https://platform.openai.com" target="_blank" rel="noopener" style="--x: 28%; --y: 12%; --d: 1.6s;" data-line="2">
+    <a class="provider-node" href="https://platform.openai.com" target="_blank" rel="noopener" style="--x: 50%; --y: 6%; --d: 1.2s;" data-line="2">
       <div class="pn-bubble openai">⬡</div>
       <div class="pn-label">OpenAI</div>
     </a>
-    <a class="provider-node" href="https://www.anthropic.com" target="_blank" rel="noopener" style="--x: 50%; --y: 92%; --d: 2.4s;" data-line="3">
+    <a class="provider-node" href="https://www.anthropic.com" target="_blank" rel="noopener" style="--x: 72%; --y: 12%; --d: 1.8s;" data-line="3">
       <div class="pn-bubble anthropic">◈</div>
       <div class="pn-label">Claude</div>
     </a>
-    <a class="provider-node" href="https://openrouter.ai" target="_blank" rel="noopener" style="--x: 72%; --y: 12%; --d: 3.2s;" data-line="4">
+    <a class="provider-node" href="https://openrouter.ai" target="_blank" rel="noopener" style="--x: 90%; --y: 28%; --d: 2.4s;" data-line="4">
       <div class="pn-bubble openrouter">◆</div>
       <div class="pn-label">OpenRouter</div>
     </a>
-    <a class="provider-node" href="https://lmstudio.ai" target="_blank" rel="noopener" style="--x: 78%; --y: 78%; --d: 4.0s;" data-line="5">
+    <a class="provider-node" href="https://lmstudio.ai" target="_blank" rel="noopener" style="--x: 8%; --y: 72%; --d: 3.0s;" data-line="5">
       <div class="pn-bubble studiolm">✦</div>
-      <div class="pn-label">StudioLM</div>
+      <div class="pn-label">LM Studio</div>
     </a>
-    <a class="provider-node" href="https://docs.vllm.ai" target="_blank" rel="noopener" style="--x: 90%; --y: 28%; --d: 4.8s;" data-line="6">
+    <a class="provider-node" href="https://docs.vllm.ai" target="_blank" rel="noopener" style="--x: 24%; --y: 88%; --d: 3.6s;" data-line="6">
       <div class="pn-bubble vllm">▣</div>
-      <div class="pn-label">VLLM</div>
+      <div class="pn-label">vLLM</div>
+    </a>
+    <a class="provider-node" href="https://x.ai/api" target="_blank" rel="noopener" style="--x: 40%; --y: 95%; --d: 4.2s;" data-line="7">
+      <div class="pn-bubble grok">✕</div>
+      <div class="pn-label">Grok</div>
+    </a>
+    <a class="provider-node" href="https://ai.google.dev/gemini-api/docs/openai" target="_blank" rel="noopener" style="--x: 60%; --y: 95%; --d: 4.8s;" data-line="8">
+      <div class="pn-bubble gemini">◊</div>
+      <div class="pn-label">Gemini</div>
+    </a>
+    <a class="provider-node" href="https://api-docs.deepseek.com" target="_blank" rel="noopener" style="--x: 76%; --y: 88%; --d: 5.4s;" data-line="9">
+      <div class="pn-bubble deepseek">⬣</div>
+      <div class="pn-label">DeepSeek</div>
+    </a>
+    <a class="provider-node" href="https://docs.mistral.ai/api/" target="_blank" rel="noopener" style="--x: 92%; --y: 72%; --d: 6.0s;" data-line="10">
+      <div class="pn-bubble mistral">▲</div>
+      <div class="pn-label">Mistral</div>
     </a>
   </div>
 </section>
@@ -1471,7 +1504,7 @@
         <tr><td>Açık kaynak</td><td class="highlight">MIT Lisansı</td><td>Tescilli</td></tr>
         <tr><td>Fiyat</td><td class="highlight">Sonsuza kadar ücretsiz</td><td>Claude Pro gerektirir (20$/ay)</td></tr>
         <tr><td>Yerel LLM desteği</td><td class="highlight">llama.cpp, Ollama</td><td>Hayır — yalnızca Claude</td></tr>
-        <tr><td>Çoklu sağlayıcı</td><td class="highlight">4 sağlayıcı (yerel + bulut)</td><td>Yalnızca Claude</td></tr>
+        <tr><td>Çoklu sağlayıcı</td><td class="highlight">OpenAI uyumlu tüm uç noktalar</td><td>Yalnızca Claude</td></tr>
         <tr><td>Chrome</td><td class="highlight">Evet (MV3)</td><td>Evet</td></tr>
         <tr><td>Firefox</td><td class="highlight">Evet (MV2)</td><td>Hayır</td></tr>
         <tr><td>Yan panel UI</td><td class="highlight">Evet</td><td>Evet</td></tr>

--- a/web/uk/index.html
+++ b/web/uk/index.html
@@ -801,6 +801,10 @@
     .pn-bubble.openrouter { background: rgba(108,99,255,0.12); color: var(--accent2); border-color: rgba(108,99,255,0.3); }
     .pn-bubble.studiolm { background: rgba(245,158,11,0.12); color: #f59e0b; border-color: rgba(245,158,11,0.25); }
     .pn-bubble.vllm { background: rgba(99,102,241,0.12); color: #6366f1; border-color: rgba(99,102,241,0.25); }
+    .pn-bubble.grok { background: rgba(255,255,255,0.06); color: #e5e5e5; border-color: rgba(255,255,255,0.2); }
+    .pn-bubble.gemini { background: rgba(66,133,244,0.12); color: #4285f4; border-color: rgba(66,133,244,0.25); }
+    .pn-bubble.deepseek { background: rgba(72,191,255,0.12); color: #48bfff; border-color: rgba(72,191,255,0.25); }
+    .pn-bubble.mistral { background: rgba(255,127,80,0.12); color: #ff7f50; border-color: rgba(255,127,80,0.25); }
 
     /* Reduced-motion: kill the float + ring pulse so users on
        prefers-reduced-motion see a static layout. */
@@ -1320,6 +1324,11 @@
       <p>Закриває банери згоди (OneTrust, Cookiebot, Didomi, Quantcast), перш ніж аналізувати сторінку. Розпізнає paywall і чесно повідомляє про нього, а не вигадує текст статті й не намагається його обійти.</p>
     </div>
     <div class="feature-card">
+      <div class="feature-icon">🧩</div>
+      <h3>Опціональний розв'язувач CAPTCHA</h3>
+      <p>Підключіть ключ API <a href="https://capsolver.com" target="_blank" rel="noopener" style="color:var(--accent);text-decoration:none;">CapSolver</a>, і агент автоматично розв'яже reCAPTCHA v2/v3, hCaptcha та Cloudflare Turnstile, коли вони блокують крок — замість того щоб зупинятися та запитувати вас. Вимкнено за замовчуванням, ключ ваш, до жодного captcha-сервісу немає звернень, поки ви не увімкнете.</p>
+    </div>
+    <div class="feature-card">
       <div class="feature-icon">🌐</div>
       <h3>Багатомовний інтерфейс</h3>
       <p>Плагін доступний у English, Español, Français, Türkçe та 中文. При першому запуску автоматично визначає мову браузера; перемикайте будь-коли значком глобуса в бічній панелі. Маркетинговий сайт локалізовано відповідно.</p>
@@ -1338,21 +1347,29 @@
   <h2 class="section-title">Свій AI з собою</h2>
   <p class="section-subtitle">Підключайтеся до будь-якого OpenAI-сумісного API або запускайте локальну модель. Змінюйте провайдера будь-коли в налаштуваннях розширення.</p>
 
-  <!-- Constellation: central WebBrain core, 7 provider nodes orbiting on
-       two arcs. Connection lines drawn in SVG (viewBox is in % units via
-       a 0–100 coordinate space so the line endpoints follow the % values
-       used to position each node). The node order matches the line order
-       so JS can map a hovered node → its line for highlight. -->
+  <!-- Constellation: central WebBrain core, 11 provider nodes orbiting on
+       two arcs (5 above, 6 below). Connection lines drawn in SVG (viewBox
+       is in % units via a 0–100 coordinate space so the line endpoints
+       follow the % values used to position each node). The node order
+       matches the line order so JS can map a hovered node → its line for
+       highlight. Local runtimes (llama.cpp, Ollama, LM Studio, vLLM) are
+       on the left edges of each arc; cloud providers fan out toward the
+       right. Grok / Gemini / DeepSeek / Mistral are reached via the
+       OpenAI-compatible config — any OpenAI-style endpoint works. -->
   <div class="provider-constellation" aria-label="Свій AI з собою">
     <svg class="constellation-lines" viewBox="0 0 100 100" preserveAspectRatio="none" aria-hidden="true">
-      <!-- order: llama.cpp, ollama, openai, anthropic, openrouter, studiolm, vllm -->
+      <!-- order: llama.cpp, ollama, openai, anthropic, openrouter, lmstudio, vllm, grok, gemini, deepseek, mistral -->
       <line x1="50" y1="50" x2="10" y2="28"></line>
-      <line x1="50" y1="50" x2="22" y2="78"></line>
       <line x1="50" y1="50" x2="28" y2="12"></line>
-      <line x1="50" y1="50" x2="50" y2="92"></line>
+      <line x1="50" y1="50" x2="50" y2="6"></line>
       <line x1="50" y1="50" x2="72" y2="12"></line>
-      <line x1="50" y1="50" x2="78" y2="78"></line>
       <line x1="50" y1="50" x2="90" y2="28"></line>
+      <line x1="50" y1="50" x2="8" y2="72"></line>
+      <line x1="50" y1="50" x2="24" y2="88"></line>
+      <line x1="50" y1="50" x2="40" y2="95"></line>
+      <line x1="50" y1="50" x2="60" y2="95"></line>
+      <line x1="50" y1="50" x2="76" y2="88"></line>
+      <line x1="50" y1="50" x2="92" y2="72"></line>
     </svg>
 
     <div class="constellation-center" aria-hidden="true">
@@ -1365,29 +1382,45 @@
       <div class="pn-bubble local">🦙</div>
       <div class="pn-label">llama.cpp</div>
     </a>
-    <a class="provider-node" href="https://ollama.com" target="_blank" rel="noopener" style="--x: 22%; --y: 78%; --d: 0.8s;" data-line="1">
+    <a class="provider-node" href="https://ollama.com" target="_blank" rel="noopener" style="--x: 28%; --y: 12%; --d: 0.6s;" data-line="1">
       <div class="pn-bubble ollama">◉</div>
       <div class="pn-label">Ollama</div>
     </a>
-    <a class="provider-node" href="https://platform.openai.com" target="_blank" rel="noopener" style="--x: 28%; --y: 12%; --d: 1.6s;" data-line="2">
+    <a class="provider-node" href="https://platform.openai.com" target="_blank" rel="noopener" style="--x: 50%; --y: 6%; --d: 1.2s;" data-line="2">
       <div class="pn-bubble openai">⬡</div>
       <div class="pn-label">OpenAI</div>
     </a>
-    <a class="provider-node" href="https://www.anthropic.com" target="_blank" rel="noopener" style="--x: 50%; --y: 92%; --d: 2.4s;" data-line="3">
+    <a class="provider-node" href="https://www.anthropic.com" target="_blank" rel="noopener" style="--x: 72%; --y: 12%; --d: 1.8s;" data-line="3">
       <div class="pn-bubble anthropic">◈</div>
       <div class="pn-label">Claude</div>
     </a>
-    <a class="provider-node" href="https://openrouter.ai" target="_blank" rel="noopener" style="--x: 72%; --y: 12%; --d: 3.2s;" data-line="4">
+    <a class="provider-node" href="https://openrouter.ai" target="_blank" rel="noopener" style="--x: 90%; --y: 28%; --d: 2.4s;" data-line="4">
       <div class="pn-bubble openrouter">◆</div>
       <div class="pn-label">OpenRouter</div>
     </a>
-    <a class="provider-node" href="https://lmstudio.ai" target="_blank" rel="noopener" style="--x: 78%; --y: 78%; --d: 4.0s;" data-line="5">
+    <a class="provider-node" href="https://lmstudio.ai" target="_blank" rel="noopener" style="--x: 8%; --y: 72%; --d: 3.0s;" data-line="5">
       <div class="pn-bubble studiolm">✦</div>
-      <div class="pn-label">StudioLM</div>
+      <div class="pn-label">LM Studio</div>
     </a>
-    <a class="provider-node" href="https://docs.vllm.ai" target="_blank" rel="noopener" style="--x: 90%; --y: 28%; --d: 4.8s;" data-line="6">
+    <a class="provider-node" href="https://docs.vllm.ai" target="_blank" rel="noopener" style="--x: 24%; --y: 88%; --d: 3.6s;" data-line="6">
       <div class="pn-bubble vllm">▣</div>
-      <div class="pn-label">VLLM</div>
+      <div class="pn-label">vLLM</div>
+    </a>
+    <a class="provider-node" href="https://x.ai/api" target="_blank" rel="noopener" style="--x: 40%; --y: 95%; --d: 4.2s;" data-line="7">
+      <div class="pn-bubble grok">✕</div>
+      <div class="pn-label">Grok</div>
+    </a>
+    <a class="provider-node" href="https://ai.google.dev/gemini-api/docs/openai" target="_blank" rel="noopener" style="--x: 60%; --y: 95%; --d: 4.8s;" data-line="8">
+      <div class="pn-bubble gemini">◊</div>
+      <div class="pn-label">Gemini</div>
+    </a>
+    <a class="provider-node" href="https://api-docs.deepseek.com" target="_blank" rel="noopener" style="--x: 76%; --y: 88%; --d: 5.4s;" data-line="9">
+      <div class="pn-bubble deepseek">⬣</div>
+      <div class="pn-label">DeepSeek</div>
+    </a>
+    <a class="provider-node" href="https://docs.mistral.ai/api/" target="_blank" rel="noopener" style="--x: 92%; --y: 72%; --d: 6.0s;" data-line="10">
+      <div class="pn-bubble mistral">▲</div>
+      <div class="pn-label">Mistral</div>
     </a>
   </div>
 </section>
@@ -1471,7 +1504,7 @@
         <tr><td>Open-source</td><td class="highlight">Ліцензія MIT</td><td>Пропрієтарно</td></tr>
         <tr><td>Ціна</td><td class="highlight">Назавжди безкоштовно</td><td>Потрібен Claude Pro ($20/міс)</td></tr>
         <tr><td>Підтримка локальних LLM</td><td class="highlight">llama.cpp, Ollama</td><td>Ні — лише Claude</td></tr>
-        <tr><td>Мульти-провайдер</td><td class="highlight">4 провайдери (локальні + хмара)</td><td>Лише Claude</td></tr>
+        <tr><td>Мульти-провайдер</td><td class="highlight">Усі точки доступу, сумісні з OpenAI</td><td>Лише Claude</td></tr>
         <tr><td>Chrome</td><td class="highlight">Так (MV3)</td><td>Так</td></tr>
         <tr><td>Firefox</td><td class="highlight">Так (MV2)</td><td>Ні</td></tr>
         <tr><td>Інтерфейс у бічній панелі</td><td class="highlight">Так</td><td>Так</td></tr>

--- a/web/zh/index.html
+++ b/web/zh/index.html
@@ -801,6 +801,10 @@
     .pn-bubble.openrouter { background: rgba(108,99,255,0.12); color: var(--accent2); border-color: rgba(108,99,255,0.3); }
     .pn-bubble.studiolm { background: rgba(245,158,11,0.12); color: #f59e0b; border-color: rgba(245,158,11,0.25); }
     .pn-bubble.vllm { background: rgba(99,102,241,0.12); color: #6366f1; border-color: rgba(99,102,241,0.25); }
+    .pn-bubble.grok { background: rgba(255,255,255,0.06); color: #e5e5e5; border-color: rgba(255,255,255,0.2); }
+    .pn-bubble.gemini { background: rgba(66,133,244,0.12); color: #4285f4; border-color: rgba(66,133,244,0.25); }
+    .pn-bubble.deepseek { background: rgba(72,191,255,0.12); color: #48bfff; border-color: rgba(72,191,255,0.25); }
+    .pn-bubble.mistral { background: rgba(255,127,80,0.12); color: #ff7f50; border-color: rgba(255,127,80,0.25); }
 
     /* Reduced-motion: kill the float + ring pulse so users on
        prefers-reduced-motion see a static layout. */
@@ -1320,6 +1324,11 @@
       <p>在推理页面之前关闭常见框架的同意横幅(OneTrust、Cookiebot、Didomi、Quantcast)。检测到付费墙会如实告知,而不是编造文章内容或尝试绕过。</p>
     </div>
     <div class="feature-card">
+      <div class="feature-icon">🧩</div>
+      <h3>可选 CAPTCHA 解决器</h3>
+      <p>接入 <a href="https://capsolver.com" target="_blank" rel="noopener" style="color:var(--accent);text-decoration:none;">CapSolver</a> API 密钥后，当 reCAPTCHA v2/v3、hCaptcha 或 Cloudflare Turnstile 阻挡某一步时，代理会自动解决它们，而不是停下来向你询问。默认关闭，自带密钥；除非你开启，否则不会接触任何 CAPTCHA 服务。</p>
+    </div>
+    <div class="feature-card">
       <div class="feature-icon">🌐</div>
       <h3>多语言界面</h3>
       <p>插件提供 English、Español、Français、Türkçe 和 中文 五种语言。首次使用时自动检测浏览器语言;随时可通过侧边栏中的地球图标切换。本站也相应本地化。</p>
@@ -1338,21 +1347,29 @@
   <h2 class="section-title">自带 AI</h2>
   <p class="section-subtitle">连接任何 OpenAI 兼容 API,或运行一个本地模型。随时在扩展设置中切换提供商。</p>
 
-  <!-- Constellation: central WebBrain core, 7 provider nodes orbiting on
-       two arcs. Connection lines drawn in SVG (viewBox is in % units via
-       a 0–100 coordinate space so the line endpoints follow the % values
-       used to position each node). The node order matches the line order
-       so JS can map a hovered node → its line for highlight. -->
+  <!-- Constellation: central WebBrain core, 11 provider nodes orbiting on
+       two arcs (5 above, 6 below). Connection lines drawn in SVG (viewBox
+       is in % units via a 0–100 coordinate space so the line endpoints
+       follow the % values used to position each node). The node order
+       matches the line order so JS can map a hovered node → its line for
+       highlight. Local runtimes (llama.cpp, Ollama, LM Studio, vLLM) are
+       on the left edges of each arc; cloud providers fan out toward the
+       right. Grok / Gemini / DeepSeek / Mistral are reached via the
+       OpenAI-compatible config — any OpenAI-style endpoint works. -->
   <div class="provider-constellation" aria-label="自带 AI">
     <svg class="constellation-lines" viewBox="0 0 100 100" preserveAspectRatio="none" aria-hidden="true">
-      <!-- order: llama.cpp, ollama, openai, anthropic, openrouter, studiolm, vllm -->
+      <!-- order: llama.cpp, ollama, openai, anthropic, openrouter, lmstudio, vllm, grok, gemini, deepseek, mistral -->
       <line x1="50" y1="50" x2="10" y2="28"></line>
-      <line x1="50" y1="50" x2="22" y2="78"></line>
       <line x1="50" y1="50" x2="28" y2="12"></line>
-      <line x1="50" y1="50" x2="50" y2="92"></line>
+      <line x1="50" y1="50" x2="50" y2="6"></line>
       <line x1="50" y1="50" x2="72" y2="12"></line>
-      <line x1="50" y1="50" x2="78" y2="78"></line>
       <line x1="50" y1="50" x2="90" y2="28"></line>
+      <line x1="50" y1="50" x2="8" y2="72"></line>
+      <line x1="50" y1="50" x2="24" y2="88"></line>
+      <line x1="50" y1="50" x2="40" y2="95"></line>
+      <line x1="50" y1="50" x2="60" y2="95"></line>
+      <line x1="50" y1="50" x2="76" y2="88"></line>
+      <line x1="50" y1="50" x2="92" y2="72"></line>
     </svg>
 
     <div class="constellation-center" aria-hidden="true">
@@ -1365,29 +1382,45 @@
       <div class="pn-bubble local">🦙</div>
       <div class="pn-label">llama.cpp</div>
     </a>
-    <a class="provider-node" href="https://ollama.com" target="_blank" rel="noopener" style="--x: 22%; --y: 78%; --d: 0.8s;" data-line="1">
+    <a class="provider-node" href="https://ollama.com" target="_blank" rel="noopener" style="--x: 28%; --y: 12%; --d: 0.6s;" data-line="1">
       <div class="pn-bubble ollama">◉</div>
       <div class="pn-label">Ollama</div>
     </a>
-    <a class="provider-node" href="https://platform.openai.com" target="_blank" rel="noopener" style="--x: 28%; --y: 12%; --d: 1.6s;" data-line="2">
+    <a class="provider-node" href="https://platform.openai.com" target="_blank" rel="noopener" style="--x: 50%; --y: 6%; --d: 1.2s;" data-line="2">
       <div class="pn-bubble openai">⬡</div>
       <div class="pn-label">OpenAI</div>
     </a>
-    <a class="provider-node" href="https://www.anthropic.com" target="_blank" rel="noopener" style="--x: 50%; --y: 92%; --d: 2.4s;" data-line="3">
+    <a class="provider-node" href="https://www.anthropic.com" target="_blank" rel="noopener" style="--x: 72%; --y: 12%; --d: 1.8s;" data-line="3">
       <div class="pn-bubble anthropic">◈</div>
       <div class="pn-label">Claude</div>
     </a>
-    <a class="provider-node" href="https://openrouter.ai" target="_blank" rel="noopener" style="--x: 72%; --y: 12%; --d: 3.2s;" data-line="4">
+    <a class="provider-node" href="https://openrouter.ai" target="_blank" rel="noopener" style="--x: 90%; --y: 28%; --d: 2.4s;" data-line="4">
       <div class="pn-bubble openrouter">◆</div>
       <div class="pn-label">OpenRouter</div>
     </a>
-    <a class="provider-node" href="https://lmstudio.ai" target="_blank" rel="noopener" style="--x: 78%; --y: 78%; --d: 4.0s;" data-line="5">
+    <a class="provider-node" href="https://lmstudio.ai" target="_blank" rel="noopener" style="--x: 8%; --y: 72%; --d: 3.0s;" data-line="5">
       <div class="pn-bubble studiolm">✦</div>
-      <div class="pn-label">StudioLM</div>
+      <div class="pn-label">LM Studio</div>
     </a>
-    <a class="provider-node" href="https://docs.vllm.ai" target="_blank" rel="noopener" style="--x: 90%; --y: 28%; --d: 4.8s;" data-line="6">
+    <a class="provider-node" href="https://docs.vllm.ai" target="_blank" rel="noopener" style="--x: 24%; --y: 88%; --d: 3.6s;" data-line="6">
       <div class="pn-bubble vllm">▣</div>
-      <div class="pn-label">VLLM</div>
+      <div class="pn-label">vLLM</div>
+    </a>
+    <a class="provider-node" href="https://x.ai/api" target="_blank" rel="noopener" style="--x: 40%; --y: 95%; --d: 4.2s;" data-line="7">
+      <div class="pn-bubble grok">✕</div>
+      <div class="pn-label">Grok</div>
+    </a>
+    <a class="provider-node" href="https://ai.google.dev/gemini-api/docs/openai" target="_blank" rel="noopener" style="--x: 60%; --y: 95%; --d: 4.8s;" data-line="8">
+      <div class="pn-bubble gemini">◊</div>
+      <div class="pn-label">Gemini</div>
+    </a>
+    <a class="provider-node" href="https://api-docs.deepseek.com" target="_blank" rel="noopener" style="--x: 76%; --y: 88%; --d: 5.4s;" data-line="9">
+      <div class="pn-bubble deepseek">⬣</div>
+      <div class="pn-label">DeepSeek</div>
+    </a>
+    <a class="provider-node" href="https://docs.mistral.ai/api/" target="_blank" rel="noopener" style="--x: 92%; --y: 72%; --d: 6.0s;" data-line="10">
+      <div class="pn-bubble mistral">▲</div>
+      <div class="pn-label">Mistral</div>
     </a>
   </div>
 </section>
@@ -1471,7 +1504,7 @@
         <tr><td>开源</td><td class="highlight">MIT 许可</td><td>闭源</td></tr>
         <tr><td>价格</td><td class="highlight">永久免费</td><td>需要 Claude Pro(20 美元/月)</td></tr>
         <tr><td>本地 LLM 支持</td><td class="highlight">llama.cpp、Ollama</td><td>否 —— 仅限 Claude</td></tr>
-        <tr><td>多提供商</td><td class="highlight">4 家提供商(本地 + 云端)</td><td>仅限 Claude</td></tr>
+        <tr><td>多提供商</td><td class="highlight">所有兼容 OpenAI 的端点</td><td>仅限 Claude</td></tr>
         <tr><td>Chrome</td><td class="highlight">是(MV3)</td><td>是</td></tr>
         <tr><td>Firefox</td><td class="highlight">是(MV2)</td><td>否</td></tr>
         <tr><td>侧边栏 UI</td><td class="highlight">是</td><td>是</td></tr>


### PR DESCRIPTION
## Summary

- Adds an opt-in CAPTCHA solver wired through the [CapSolver](https://capsolver.com) REST API. **Off by default** — the agent still stops and asks the user to solve captchas unless you turn it on.
- Covers reCAPTCHA v2/v3, hCaptcha, and Cloudflare Turnstile (auto-detected from the page DOM) plus explicit `image_to_text` for arbitrary image captchas.
- New settings tab (Settings → CAPTCHA) with toggle, API key field, and a Check Balance button.

## How it works

When enabled + an API key is configured:
1. The system prompt grows a `[CAPTCHA SOLVER]` note instructing the model to call `solve_captcha` once on a CAPTCHA encounter and fall back to asking the user on failure — no retry loops.
2. `solve_captcha` (with no args) inspects the page DOM for known widget containers (`.g-recaptcha[data-sitekey]`, `.h-captcha[data-sitekey]`, `.cf-turnstile[data-sitekey]`), `POST`s to `api.capsolver.com/createTask`, polls `/getTaskResult` until `status === "ready"` (max 120s), then injects the token into the standard response field (`g-recaptcha-response` / `h-captcha-response` / `cf-turnstile-response`) and fires the widget's `data-callback` if one is registered.
3. The agent then just needs to click the form's submit button.

## Why this design

I considered three options when scoping this:
1. **Bundle CapSolver's content scripts** — turns out their JS is single-line minified bundles that depend on their own background script's message routing and storage keys. Bundling them would mean running a second extension inside webbrain. Hard to audit, license-ambiguous, brittle to upstream changes.
2. **Auto-detect on every page load** — would require dynamic content-script registration and runs even when not needed.
3. **Just a `solve_captcha` agent tool** ← chose this. ~300 LoC of readable code we own, only runs when the agent actually hits a captcha, no auto-injection on every page.

No vendor JS is bundled. Direct REST calls only.

## Files

| Area | Files |
|---|---|
| New module | `src/{chrome,firefox}/src/agent/captcha-solver.js` |
| Tool definition + system prompt | `src/{chrome,firefox}/src/agent/tools.js` |
| Executor wiring + conditional prompt note | `src/{chrome,firefox}/src/agent/agent.js` |
| Settings load + balance handler | `src/{chrome,firefox}/src/background.js` |
| Settings UI (new tab) | `src/{chrome,firefox}/src/ui/settings.{html,js}` + `locales/en.js` |

Chrome uses MV3 `chrome.scripting.executeScript({func,args})`; Firefox uses MV2 `browser.tabs.executeScript({code})`. The detect/inject helpers are written separately for each because of that difference; the REST client is identical.

## Test plan

- [ ] Load the Chrome extension unpacked, confirm new "CAPTCHA" tab renders in Settings
- [ ] With the toggle off, agent encountering a CAPTCHA still falls back to "stop and ask user"
- [ ] Enable + paste an API key, click **Check Balance** → confirm it shows the account balance
- [ ] On a page with a real reCAPTCHA v2 widget, send the agent a task that hits the form, confirm `solve_captcha` runs and the token lands in `textarea[name=g-recaptcha-response]`
- [ ] Same for hCaptcha and Cloudflare Turnstile sample pages
- [ ] On the Firefox build, repeat the toggle + balance check + at least one solve to confirm `browser.tabs.executeScript` path works
- [ ] Disable the toggle mid-conversation, confirm the next turn's system prompt drops the `[CAPTCHA SOLVER]` note

## Notes for reviewer

- The API key is stored in `chrome.storage.local` in plaintext (consistent with how Vision API keys and Profile text are stored). A heads-up about this lives in the settings panel's security info box.
- `solve_captcha` calls are **not** auto-retried — by design. Looping on a failing captcha solver wastes the user's CapSolver credits.
- Some sites' ToS prohibit automated captcha solving. The settings panel surfaces that caveat; we don't try to police it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)