### PR TITLE
fix: MSE recorder saves only the primary reel in mode=main/auto

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "WebBrain",
-  "version": "8.0.0",
+  "version": "8.0.1",
   "description": "Open-source AI browser agent — chat with pages, automate tasks, multi-provider LLM support.",
   "permissions": [
     "sidePanel",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "webbrain",
-  "version": "8.0.0",
+  "version": "8.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "webbrain",
-      "version": "8.0.0",
+      "version": "8.0.1",
       "license": "MIT",
       "devDependencies": {
         "playwright": "^1.48.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webbrain",
-  "version": "8.0.0",
+  "version": "8.0.1",
   "description": "Open-source AI browser agent — chat with pages, automate tasks, multi-provider LLM support.",
   "private": true,
   "type": "module",

--- a/src/chrome/ARCHITECTURE.md
+++ b/src/chrome/ARCHITECTURE.md
@@ -1,6 +1,6 @@
 # WebBrain Chrome Extension — Architecture
 
-> Version 8.0.0 · Manifest V3 · Service Worker background
+> Version 8.0.1 · Manifest V3 · Service Worker background
 
 ## High-Level Overview
 

--- a/src/chrome/manifest.json
+++ b/src/chrome/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "WebBrain",
-  "version": "8.0.0",
+  "version": "8.0.1",
   "description": "Open-source AI browser agent — chat with pages, automate tasks, multi-provider LLM support.",
   "permissions": [
     "sidePanel",

--- a/src/chrome/src/agent/agent.js
+++ b/src/chrome/src/agent/agent.js
@@ -3482,6 +3482,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
                 try {
                   mseSavedFiles = await window.SocialMediaDownloader.saveMse({
                     prefix: (window.location && window.location.hostname || 'mse').replace(/^www\./, ''),
+                    mode: runOpts.mode,
                   });
                 } catch (e) {
                   mseSaveError = (e && e.message) || String(e);

--- a/src/chrome/src/agent/social-media-downloader.js
+++ b/src/chrome/src/agent/social-media-downloader.js
@@ -794,14 +794,26 @@ window.SocialMediaDownloader = (() => {
     return candidates[0];
   };
 
-  // mode: 'all' saves every captured stream (gallery / multi-video pages
-  // that explicitly asked for everything). Any other value ('main',
-  // 'auto', default) saves only the primary stream so a single-reel
-  // URL doesn't dump every preloaded neighbour. Default 'all' preserves
-  // the pre-v4 contract for any external caller of saveMse() directly.
+  // mode mirrors collect()'s resolution so saveMse() doesn't break the
+  // documented `auto` semantics:
+  //   'main'  → keep only the primary stream
+  //   'all'   → keep every captured stream
+  //   'auto'  → main on a single-content URL (e.g. /reel/<id>),
+  //             all on a feed/timeline page (profile.isSingle()).
+  // Without auto resolving via the active profile, a feed page that
+  // captured several MSE streams would silently drop most of them on
+  // the default call. Default 'all' preserves the pre-v4 contract for
+  // any external caller of saveMse() directly (no profile assumed).
   const saveMse = async ({ prefix = 'mse', minBytes = 1, mode = 'all' } = {}) => {
     const groups = _groupMseBuffers(minBytes);
-    const toSave = (mode !== 'all' && groups.length > 1)
+    let primaryOnly;
+    if (mode === 'main') primaryOnly = true;
+    else if (mode === 'all') primaryOnly = false;
+    else { // 'auto' or anything unrecognised → follow the profile
+      try { primaryOnly = !!activeProfile().isSingle(); }
+      catch (_) { primaryOnly = false; }
+    }
+    const toSave = (primaryOnly && groups.length > 1)
       ? [_pickPrimaryMseGroup(groups)]
       : groups;
     let i = 1;

--- a/src/chrome/src/agent/social-media-downloader.js
+++ b/src/chrome/src/agent/social-media-downloader.js
@@ -731,24 +731,96 @@ window.SocialMediaDownloader = (() => {
     return '.bin';
   };
 
-  const saveMse = async ({ prefix = 'mse', minBytes = 1 } = {}) => {
+  // Group captured SourceBuffers by their parent MediaSource. Each
+  // MediaSource ≈ one stream on the page — typically one reel on
+  // infinite-feed viewers like Instagram /reels/, where the player
+  // preloads neighbours as the user scrolls. Without grouping,
+  // "download this reel" once produced 29 files (15 video + 14 audio,
+  // one per preloaded neighbour). Orphan buffers (appendBuffer fired
+  // before our addSourceBuffer hook) become their own group since we
+  // can't attribute them to a specific stream.
+  const _groupMseBuffers = (minBytes) => {
     const state = _mseStateRef();
+    const groups = []; // { url, entries: [bufferEntry], totalBytes }
+    const seen = new Set();
+    for (const [, msEntry] of state.mediaSources) {
+      const entries = [];
+      let totalBytes = 0;
+      for (const sb of msEntry.buffers) {
+        const e = state.buffers.get(sb);
+        if (!e || e.bytes < minBytes) continue;
+        entries.push(e);
+        totalBytes += e.bytes;
+        seen.add(e);
+      }
+      if (entries.length > 0) groups.push({ url: msEntry.url, entries, totalBytes });
+    }
+    const orphanEntries = [];
+    let orphanBytes = 0;
+    for (const [, entry] of state.buffers) {
+      if (seen.has(entry)) continue;
+      if (entry.bytes < minBytes) continue;
+      orphanEntries.push(entry);
+      orphanBytes += entry.bytes;
+    }
+    if (orphanEntries.length > 0) {
+      groups.push({ url: null, entries: orphanEntries, totalBytes: orphanBytes });
+    }
+    return groups;
+  };
+
+  // Pick the "primary" stream when the page captured multiple. Prefer a
+  // group whose MediaSource blob URL is currently attached to a <video>
+  // element in the DOM — that's the one the user is actually looking at.
+  // Among DOM-attached candidates (or all groups, if none match), pick
+  // the largest by bytes: longer playback ≈ what the user watched.
+  const _pickPrimaryMseGroup = (groups) => {
+    if (groups.length <= 1) return groups[0];
+    const byUrl = new Map();
+    for (const g of groups) {
+      if (g.url) byUrl.set(g.url, g);
+    }
+    const onPage = new Set();
+    try {
+      if (typeof document !== 'undefined') {
+        for (const v of document.querySelectorAll('video')) {
+          const g = byUrl.get(v.currentSrc) || byUrl.get(v.src);
+          if (g) onPage.add(g);
+        }
+      }
+    } catch (_) { /* detached doc — fall through to size heuristic */ }
+    const candidates = onPage.size > 0 ? [...onPage] : groups;
+    candidates.sort((a, b) => b.totalBytes - a.totalBytes);
+    return candidates[0];
+  };
+
+  // mode: 'all' saves every captured stream (gallery / multi-video pages
+  // that explicitly asked for everything). Any other value ('main',
+  // 'auto', default) saves only the primary stream so a single-reel
+  // URL doesn't dump every preloaded neighbour. Default 'all' preserves
+  // the pre-v4 contract for any external caller of saveMse() directly.
+  const saveMse = async ({ prefix = 'mse', minBytes = 1, mode = 'all' } = {}) => {
+    const groups = _groupMseBuffers(minBytes);
+    const toSave = (mode !== 'all' && groups.length > 1)
+      ? [_pickPrimaryMseGroup(groups)]
+      : groups;
     let i = 1;
     const saved = [];
-    for (const [, entry] of state.buffers) {
-      if (entry.bytes < minBytes) continue;
-      const merged = new Uint8Array(entry.bytes);
-      let off = 0;
-      for (const c of entry.chunks) { merged.set(c, off); off += c.length; }
-      const kind = /audio/i.test(entry.mime) ? 'audio' : 'video';
-      const ext = _mseExtForMime(entry.mime);
-      const fname = `${filenameSafe(prefix)}_${kind}_${String(i).padStart(2, '0')}${ext}`;
-      triggerBlobDownload(
-        new Blob([merged], { type: entry.mime || 'application/octet-stream' }),
-        fname
-      );
-      saved.push({ filename: fname, bytes: entry.bytes, mime: entry.mime });
-      i++;
+    for (const group of toSave) {
+      for (const entry of group.entries) {
+        const merged = new Uint8Array(entry.bytes);
+        let off = 0;
+        for (const c of entry.chunks) { merged.set(c, off); off += c.length; }
+        const kind = /audio/i.test(entry.mime) ? 'audio' : 'video';
+        const ext = _mseExtForMime(entry.mime);
+        const fname = `${filenameSafe(prefix)}_${kind}_${String(i).padStart(2, '0')}${ext}`;
+        triggerBlobDownload(
+          new Blob([merged], { type: entry.mime || 'application/octet-stream' }),
+          fname
+        );
+        saved.push({ filename: fname, bytes: entry.bytes, mime: entry.mime });
+        i++;
+      }
     }
     if (saved.length >= 2) {
       console.log(

--- a/src/chrome/src/agent/social-media-downloader.js
+++ b/src/chrome/src/agent/social-media-downloader.js
@@ -769,27 +769,59 @@ window.SocialMediaDownloader = (() => {
     return groups;
   };
 
-  // Pick the "primary" stream when the page captured multiple. Prefer a
-  // group whose MediaSource blob URL is currently attached to a <video>
-  // element in the DOM — that's the one the user is actually looking at.
-  // Among DOM-attached candidates (or all groups, if none match), pick
-  // the largest by bytes: longer playback ≈ what the user watched.
+  // Pick the "primary" stream when the page captured multiple. Instagram
+  // (and similar infinite-feed viewers) keeps adjacent preloaded reels
+  // mounted as their own <video> elements with their own MediaSources,
+  // so "is the MediaSource attached to any <video>" doesn't narrow at
+  // all — every captured group is. We need a tighter signal for "the
+  // one the user is watching". Probe in priority order:
+  //   1. video is actively playing AND its bounding rect intersects
+  //      the viewport (Instagram autoplays the focused reel; preloaded
+  //      neighbours are paused);
+  //   2. video bounding rect intersects the viewport (user paused, but
+  //      it's still the one on screen);
+  //   3. any <video> in the DOM (last resort).
+  // Within the narrowest non-empty tier we tie-break by total bytes —
+  // longer playback ≈ the one the user actually watched. Bytes alone
+  // are NOT used as the primary signal: an off-screen neighbour that
+  // happened to preload more frames than the focused reel would
+  // otherwise win.
   const _pickPrimaryMseGroup = (groups) => {
     if (groups.length <= 1) return groups[0];
     const byUrl = new Map();
     for (const g of groups) {
       if (g.url) byUrl.set(g.url, g);
     }
-    const onPage = new Set();
+    const playing = new Set();
+    const visible = new Set();
+    const anyDom = new Set();
     try {
       if (typeof document !== 'undefined') {
+        const vw = (typeof window !== 'undefined' && window.innerWidth) || 0;
+        const vh = (typeof window !== 'undefined' && window.innerHeight) || 0;
         for (const v of document.querySelectorAll('video')) {
           const g = byUrl.get(v.currentSrc) || byUrl.get(v.src);
-          if (g) onPage.add(g);
+          if (!g) continue;
+          anyDom.add(g);
+          let inView = false;
+          try {
+            const r = v.getBoundingClientRect();
+            inView = r.width > 0 && r.height > 0 &&
+                     r.bottom > 0 && r.top < vh &&
+                     r.right > 0 && r.left < vw;
+          } catch (_) { /* detached <video> — leave inView=false */ }
+          if (inView) {
+            visible.add(g);
+            if (v.paused === false) playing.add(g);
+          }
         }
       }
     } catch (_) { /* detached doc — fall through to size heuristic */ }
-    const candidates = onPage.size > 0 ? [...onPage] : groups;
+    const candidates =
+      playing.size > 0 ? [...playing] :
+      visible.size > 0 ? [...visible] :
+      anyDom.size > 0 ? [...anyDom] :
+      groups;
     candidates.sort((a, b) => b.totalBytes - a.totalBytes);
     return candidates[0];
   };

--- a/src/chrome/src/ui/settings.js
+++ b/src/chrome/src/ui/settings.js
@@ -6,7 +6,7 @@ import { t, getLocale, setLocale, LANGUAGES } from './i18n.js';
 
 // Version shown in the subtitle. Kept here so it only needs one update per
 // release; the subtitle string itself is translated.
-const EXT_VERSION = '8.0.0';
+const EXT_VERSION = '8.0.1';
 
 const providersContainer = document.getElementById('providers');
 const verboseToggle = document.getElementById('toggle-verbose');

--- a/src/firefox/ARCHITECTURE.md
+++ b/src/firefox/ARCHITECTURE.md
@@ -1,6 +1,6 @@
 # WebBrain Firefox Extension — Architecture
 
-> Version 8.0.0 · Manifest V2 · Background Page
+> Version 8.0.1 · Manifest V2 · Background Page
 
 ## How Firefox Differs from Chrome
 

--- a/src/firefox/manifest.json
+++ b/src/firefox/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "WebBrain",
-  "version": "8.0.0",
+  "version": "8.0.1",
   "description": "Open-source AI browser agent — chat with pages, automate tasks, multi-provider LLM support.",
   "permissions": [
     "activeTab",

--- a/src/firefox/src/agent/agent.js
+++ b/src/firefox/src/agent/agent.js
@@ -1930,6 +1930,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
                 try {
                   mseSavedFiles = await window.SocialMediaDownloader.saveMse({
                     prefix: (window.location && window.location.hostname || 'mse').replace(/^www\\./, ''),
+                    mode: ${JSON.stringify(opts.mode)},
                   });
                 } catch (e) {
                   mseSaveError = (e && e.message) || String(e);

--- a/src/firefox/src/agent/social-media-downloader.js
+++ b/src/firefox/src/agent/social-media-downloader.js
@@ -794,14 +794,26 @@ window.SocialMediaDownloader = (() => {
     return candidates[0];
   };
 
-  // mode: 'all' saves every captured stream (gallery / multi-video pages
-  // that explicitly asked for everything). Any other value ('main',
-  // 'auto', default) saves only the primary stream so a single-reel
-  // URL doesn't dump every preloaded neighbour. Default 'all' preserves
-  // the pre-v4 contract for any external caller of saveMse() directly.
+  // mode mirrors collect()'s resolution so saveMse() doesn't break the
+  // documented `auto` semantics:
+  //   'main'  → keep only the primary stream
+  //   'all'   → keep every captured stream
+  //   'auto'  → main on a single-content URL (e.g. /reel/<id>),
+  //             all on a feed/timeline page (profile.isSingle()).
+  // Without auto resolving via the active profile, a feed page that
+  // captured several MSE streams would silently drop most of them on
+  // the default call. Default 'all' preserves the pre-v4 contract for
+  // any external caller of saveMse() directly (no profile assumed).
   const saveMse = async ({ prefix = 'mse', minBytes = 1, mode = 'all' } = {}) => {
     const groups = _groupMseBuffers(minBytes);
-    const toSave = (mode !== 'all' && groups.length > 1)
+    let primaryOnly;
+    if (mode === 'main') primaryOnly = true;
+    else if (mode === 'all') primaryOnly = false;
+    else { // 'auto' or anything unrecognised → follow the profile
+      try { primaryOnly = !!activeProfile().isSingle(); }
+      catch (_) { primaryOnly = false; }
+    }
+    const toSave = (primaryOnly && groups.length > 1)
       ? [_pickPrimaryMseGroup(groups)]
       : groups;
     let i = 1;

--- a/src/firefox/src/agent/social-media-downloader.js
+++ b/src/firefox/src/agent/social-media-downloader.js
@@ -731,24 +731,96 @@ window.SocialMediaDownloader = (() => {
     return '.bin';
   };
 
-  const saveMse = async ({ prefix = 'mse', minBytes = 1 } = {}) => {
+  // Group captured SourceBuffers by their parent MediaSource. Each
+  // MediaSource ≈ one stream on the page — typically one reel on
+  // infinite-feed viewers like Instagram /reels/, where the player
+  // preloads neighbours as the user scrolls. Without grouping,
+  // "download this reel" once produced 29 files (15 video + 14 audio,
+  // one per preloaded neighbour). Orphan buffers (appendBuffer fired
+  // before our addSourceBuffer hook) become their own group since we
+  // can't attribute them to a specific stream.
+  const _groupMseBuffers = (minBytes) => {
     const state = _mseStateRef();
+    const groups = []; // { url, entries: [bufferEntry], totalBytes }
+    const seen = new Set();
+    for (const [, msEntry] of state.mediaSources) {
+      const entries = [];
+      let totalBytes = 0;
+      for (const sb of msEntry.buffers) {
+        const e = state.buffers.get(sb);
+        if (!e || e.bytes < minBytes) continue;
+        entries.push(e);
+        totalBytes += e.bytes;
+        seen.add(e);
+      }
+      if (entries.length > 0) groups.push({ url: msEntry.url, entries, totalBytes });
+    }
+    const orphanEntries = [];
+    let orphanBytes = 0;
+    for (const [, entry] of state.buffers) {
+      if (seen.has(entry)) continue;
+      if (entry.bytes < minBytes) continue;
+      orphanEntries.push(entry);
+      orphanBytes += entry.bytes;
+    }
+    if (orphanEntries.length > 0) {
+      groups.push({ url: null, entries: orphanEntries, totalBytes: orphanBytes });
+    }
+    return groups;
+  };
+
+  // Pick the "primary" stream when the page captured multiple. Prefer a
+  // group whose MediaSource blob URL is currently attached to a <video>
+  // element in the DOM — that's the one the user is actually looking at.
+  // Among DOM-attached candidates (or all groups, if none match), pick
+  // the largest by bytes: longer playback ≈ what the user watched.
+  const _pickPrimaryMseGroup = (groups) => {
+    if (groups.length <= 1) return groups[0];
+    const byUrl = new Map();
+    for (const g of groups) {
+      if (g.url) byUrl.set(g.url, g);
+    }
+    const onPage = new Set();
+    try {
+      if (typeof document !== 'undefined') {
+        for (const v of document.querySelectorAll('video')) {
+          const g = byUrl.get(v.currentSrc) || byUrl.get(v.src);
+          if (g) onPage.add(g);
+        }
+      }
+    } catch (_) { /* detached doc — fall through to size heuristic */ }
+    const candidates = onPage.size > 0 ? [...onPage] : groups;
+    candidates.sort((a, b) => b.totalBytes - a.totalBytes);
+    return candidates[0];
+  };
+
+  // mode: 'all' saves every captured stream (gallery / multi-video pages
+  // that explicitly asked for everything). Any other value ('main',
+  // 'auto', default) saves only the primary stream so a single-reel
+  // URL doesn't dump every preloaded neighbour. Default 'all' preserves
+  // the pre-v4 contract for any external caller of saveMse() directly.
+  const saveMse = async ({ prefix = 'mse', minBytes = 1, mode = 'all' } = {}) => {
+    const groups = _groupMseBuffers(minBytes);
+    const toSave = (mode !== 'all' && groups.length > 1)
+      ? [_pickPrimaryMseGroup(groups)]
+      : groups;
     let i = 1;
     const saved = [];
-    for (const [, entry] of state.buffers) {
-      if (entry.bytes < minBytes) continue;
-      const merged = new Uint8Array(entry.bytes);
-      let off = 0;
-      for (const c of entry.chunks) { merged.set(c, off); off += c.length; }
-      const kind = /audio/i.test(entry.mime) ? 'audio' : 'video';
-      const ext = _mseExtForMime(entry.mime);
-      const fname = `${filenameSafe(prefix)}_${kind}_${String(i).padStart(2, '0')}${ext}`;
-      triggerBlobDownload(
-        new Blob([merged], { type: entry.mime || 'application/octet-stream' }),
-        fname
-      );
-      saved.push({ filename: fname, bytes: entry.bytes, mime: entry.mime });
-      i++;
+    for (const group of toSave) {
+      for (const entry of group.entries) {
+        const merged = new Uint8Array(entry.bytes);
+        let off = 0;
+        for (const c of entry.chunks) { merged.set(c, off); off += c.length; }
+        const kind = /audio/i.test(entry.mime) ? 'audio' : 'video';
+        const ext = _mseExtForMime(entry.mime);
+        const fname = `${filenameSafe(prefix)}_${kind}_${String(i).padStart(2, '0')}${ext}`;
+        triggerBlobDownload(
+          new Blob([merged], { type: entry.mime || 'application/octet-stream' }),
+          fname
+        );
+        saved.push({ filename: fname, bytes: entry.bytes, mime: entry.mime });
+        i++;
+      }
     }
     if (saved.length >= 2) {
       console.log(

--- a/src/firefox/src/agent/social-media-downloader.js
+++ b/src/firefox/src/agent/social-media-downloader.js
@@ -769,27 +769,59 @@ window.SocialMediaDownloader = (() => {
     return groups;
   };
 
-  // Pick the "primary" stream when the page captured multiple. Prefer a
-  // group whose MediaSource blob URL is currently attached to a <video>
-  // element in the DOM — that's the one the user is actually looking at.
-  // Among DOM-attached candidates (or all groups, if none match), pick
-  // the largest by bytes: longer playback ≈ what the user watched.
+  // Pick the "primary" stream when the page captured multiple. Instagram
+  // (and similar infinite-feed viewers) keeps adjacent preloaded reels
+  // mounted as their own <video> elements with their own MediaSources,
+  // so "is the MediaSource attached to any <video>" doesn't narrow at
+  // all — every captured group is. We need a tighter signal for "the
+  // one the user is watching". Probe in priority order:
+  //   1. video is actively playing AND its bounding rect intersects
+  //      the viewport (Instagram autoplays the focused reel; preloaded
+  //      neighbours are paused);
+  //   2. video bounding rect intersects the viewport (user paused, but
+  //      it's still the one on screen);
+  //   3. any <video> in the DOM (last resort).
+  // Within the narrowest non-empty tier we tie-break by total bytes —
+  // longer playback ≈ the one the user actually watched. Bytes alone
+  // are NOT used as the primary signal: an off-screen neighbour that
+  // happened to preload more frames than the focused reel would
+  // otherwise win.
   const _pickPrimaryMseGroup = (groups) => {
     if (groups.length <= 1) return groups[0];
     const byUrl = new Map();
     for (const g of groups) {
       if (g.url) byUrl.set(g.url, g);
     }
-    const onPage = new Set();
+    const playing = new Set();
+    const visible = new Set();
+    const anyDom = new Set();
     try {
       if (typeof document !== 'undefined') {
+        const vw = (typeof window !== 'undefined' && window.innerWidth) || 0;
+        const vh = (typeof window !== 'undefined' && window.innerHeight) || 0;
         for (const v of document.querySelectorAll('video')) {
           const g = byUrl.get(v.currentSrc) || byUrl.get(v.src);
-          if (g) onPage.add(g);
+          if (!g) continue;
+          anyDom.add(g);
+          let inView = false;
+          try {
+            const r = v.getBoundingClientRect();
+            inView = r.width > 0 && r.height > 0 &&
+                     r.bottom > 0 && r.top < vh &&
+                     r.right > 0 && r.left < vw;
+          } catch (_) { /* detached <video> — leave inView=false */ }
+          if (inView) {
+            visible.add(g);
+            if (v.paused === false) playing.add(g);
+          }
         }
       }
     } catch (_) { /* detached doc — fall through to size heuristic */ }
-    const candidates = onPage.size > 0 ? [...onPage] : groups;
+    const candidates =
+      playing.size > 0 ? [...playing] :
+      visible.size > 0 ? [...visible] :
+      anyDom.size > 0 ? [...anyDom] :
+      groups;
     candidates.sort((a, b) => b.totalBytes - a.totalBytes);
     return candidates[0];
   };

--- a/src/firefox/src/ui/settings.js
+++ b/src/firefox/src/ui/settings.js
@@ -6,7 +6,7 @@ import { t, getLocale, setLocale, LANGUAGES } from './i18n.js';
 
 // Version shown in the subtitle. Kept here so it only needs one update per
 // release; the subtitle string itself is translated.
-const EXT_VERSION = '8.0.0';
+const EXT_VERSION = '8.0.1';
 
 const providersContainer = document.getElementById('providers');
 const verboseToggle = document.getElementById('toggle-verbose');

--- a/test/smd-tests/social-media-downloader.js
+++ b/test/smd-tests/social-media-downloader.js
@@ -794,14 +794,26 @@ window.SocialMediaDownloader = (() => {
     return candidates[0];
   };
 
-  // mode: 'all' saves every captured stream (gallery / multi-video pages
-  // that explicitly asked for everything). Any other value ('main',
-  // 'auto', default) saves only the primary stream so a single-reel
-  // URL doesn't dump every preloaded neighbour. Default 'all' preserves
-  // the pre-v4 contract for any external caller of saveMse() directly.
+  // mode mirrors collect()'s resolution so saveMse() doesn't break the
+  // documented `auto` semantics:
+  //   'main'  → keep only the primary stream
+  //   'all'   → keep every captured stream
+  //   'auto'  → main on a single-content URL (e.g. /reel/<id>),
+  //             all on a feed/timeline page (profile.isSingle()).
+  // Without auto resolving via the active profile, a feed page that
+  // captured several MSE streams would silently drop most of them on
+  // the default call. Default 'all' preserves the pre-v4 contract for
+  // any external caller of saveMse() directly (no profile assumed).
   const saveMse = async ({ prefix = 'mse', minBytes = 1, mode = 'all' } = {}) => {
     const groups = _groupMseBuffers(minBytes);
-    const toSave = (mode !== 'all' && groups.length > 1)
+    let primaryOnly;
+    if (mode === 'main') primaryOnly = true;
+    else if (mode === 'all') primaryOnly = false;
+    else { // 'auto' or anything unrecognised → follow the profile
+      try { primaryOnly = !!activeProfile().isSingle(); }
+      catch (_) { primaryOnly = false; }
+    }
+    const toSave = (primaryOnly && groups.length > 1)
       ? [_pickPrimaryMseGroup(groups)]
       : groups;
     let i = 1;

--- a/test/smd-tests/social-media-downloader.js
+++ b/test/smd-tests/social-media-downloader.js
@@ -731,24 +731,96 @@ window.SocialMediaDownloader = (() => {
     return '.bin';
   };
 
-  const saveMse = async ({ prefix = 'mse', minBytes = 1 } = {}) => {
+  // Group captured SourceBuffers by their parent MediaSource. Each
+  // MediaSource ≈ one stream on the page — typically one reel on
+  // infinite-feed viewers like Instagram /reels/, where the player
+  // preloads neighbours as the user scrolls. Without grouping,
+  // "download this reel" once produced 29 files (15 video + 14 audio,
+  // one per preloaded neighbour). Orphan buffers (appendBuffer fired
+  // before our addSourceBuffer hook) become their own group since we
+  // can't attribute them to a specific stream.
+  const _groupMseBuffers = (minBytes) => {
     const state = _mseStateRef();
+    const groups = []; // { url, entries: [bufferEntry], totalBytes }
+    const seen = new Set();
+    for (const [, msEntry] of state.mediaSources) {
+      const entries = [];
+      let totalBytes = 0;
+      for (const sb of msEntry.buffers) {
+        const e = state.buffers.get(sb);
+        if (!e || e.bytes < minBytes) continue;
+        entries.push(e);
+        totalBytes += e.bytes;
+        seen.add(e);
+      }
+      if (entries.length > 0) groups.push({ url: msEntry.url, entries, totalBytes });
+    }
+    const orphanEntries = [];
+    let orphanBytes = 0;
+    for (const [, entry] of state.buffers) {
+      if (seen.has(entry)) continue;
+      if (entry.bytes < minBytes) continue;
+      orphanEntries.push(entry);
+      orphanBytes += entry.bytes;
+    }
+    if (orphanEntries.length > 0) {
+      groups.push({ url: null, entries: orphanEntries, totalBytes: orphanBytes });
+    }
+    return groups;
+  };
+
+  // Pick the "primary" stream when the page captured multiple. Prefer a
+  // group whose MediaSource blob URL is currently attached to a <video>
+  // element in the DOM — that's the one the user is actually looking at.
+  // Among DOM-attached candidates (or all groups, if none match), pick
+  // the largest by bytes: longer playback ≈ what the user watched.
+  const _pickPrimaryMseGroup = (groups) => {
+    if (groups.length <= 1) return groups[0];
+    const byUrl = new Map();
+    for (const g of groups) {
+      if (g.url) byUrl.set(g.url, g);
+    }
+    const onPage = new Set();
+    try {
+      if (typeof document !== 'undefined') {
+        for (const v of document.querySelectorAll('video')) {
+          const g = byUrl.get(v.currentSrc) || byUrl.get(v.src);
+          if (g) onPage.add(g);
+        }
+      }
+    } catch (_) { /* detached doc — fall through to size heuristic */ }
+    const candidates = onPage.size > 0 ? [...onPage] : groups;
+    candidates.sort((a, b) => b.totalBytes - a.totalBytes);
+    return candidates[0];
+  };
+
+  // mode: 'all' saves every captured stream (gallery / multi-video pages
+  // that explicitly asked for everything). Any other value ('main',
+  // 'auto', default) saves only the primary stream so a single-reel
+  // URL doesn't dump every preloaded neighbour. Default 'all' preserves
+  // the pre-v4 contract for any external caller of saveMse() directly.
+  const saveMse = async ({ prefix = 'mse', minBytes = 1, mode = 'all' } = {}) => {
+    const groups = _groupMseBuffers(minBytes);
+    const toSave = (mode !== 'all' && groups.length > 1)
+      ? [_pickPrimaryMseGroup(groups)]
+      : groups;
     let i = 1;
     const saved = [];
-    for (const [, entry] of state.buffers) {
-      if (entry.bytes < minBytes) continue;
-      const merged = new Uint8Array(entry.bytes);
-      let off = 0;
-      for (const c of entry.chunks) { merged.set(c, off); off += c.length; }
-      const kind = /audio/i.test(entry.mime) ? 'audio' : 'video';
-      const ext = _mseExtForMime(entry.mime);
-      const fname = `${filenameSafe(prefix)}_${kind}_${String(i).padStart(2, '0')}${ext}`;
-      triggerBlobDownload(
-        new Blob([merged], { type: entry.mime || 'application/octet-stream' }),
-        fname
-      );
-      saved.push({ filename: fname, bytes: entry.bytes, mime: entry.mime });
-      i++;
+    for (const group of toSave) {
+      for (const entry of group.entries) {
+        const merged = new Uint8Array(entry.bytes);
+        let off = 0;
+        for (const c of entry.chunks) { merged.set(c, off); off += c.length; }
+        const kind = /audio/i.test(entry.mime) ? 'audio' : 'video';
+        const ext = _mseExtForMime(entry.mime);
+        const fname = `${filenameSafe(prefix)}_${kind}_${String(i).padStart(2, '0')}${ext}`;
+        triggerBlobDownload(
+          new Blob([merged], { type: entry.mime || 'application/octet-stream' }),
+          fname
+        );
+        saved.push({ filename: fname, bytes: entry.bytes, mime: entry.mime });
+        i++;
+      }
     }
     if (saved.length >= 2) {
       console.log(

--- a/test/smd-tests/social-media-downloader.js
+++ b/test/smd-tests/social-media-downloader.js
@@ -769,27 +769,59 @@ window.SocialMediaDownloader = (() => {
     return groups;
   };
 
-  // Pick the "primary" stream when the page captured multiple. Prefer a
-  // group whose MediaSource blob URL is currently attached to a <video>
-  // element in the DOM — that's the one the user is actually looking at.
-  // Among DOM-attached candidates (or all groups, if none match), pick
-  // the largest by bytes: longer playback ≈ what the user watched.
+  // Pick the "primary" stream when the page captured multiple. Instagram
+  // (and similar infinite-feed viewers) keeps adjacent preloaded reels
+  // mounted as their own <video> elements with their own MediaSources,
+  // so "is the MediaSource attached to any <video>" doesn't narrow at
+  // all — every captured group is. We need a tighter signal for "the
+  // one the user is watching". Probe in priority order:
+  //   1. video is actively playing AND its bounding rect intersects
+  //      the viewport (Instagram autoplays the focused reel; preloaded
+  //      neighbours are paused);
+  //   2. video bounding rect intersects the viewport (user paused, but
+  //      it's still the one on screen);
+  //   3. any <video> in the DOM (last resort).
+  // Within the narrowest non-empty tier we tie-break by total bytes —
+  // longer playback ≈ the one the user actually watched. Bytes alone
+  // are NOT used as the primary signal: an off-screen neighbour that
+  // happened to preload more frames than the focused reel would
+  // otherwise win.
   const _pickPrimaryMseGroup = (groups) => {
     if (groups.length <= 1) return groups[0];
     const byUrl = new Map();
     for (const g of groups) {
       if (g.url) byUrl.set(g.url, g);
     }
-    const onPage = new Set();
+    const playing = new Set();
+    const visible = new Set();
+    const anyDom = new Set();
     try {
       if (typeof document !== 'undefined') {
+        const vw = (typeof window !== 'undefined' && window.innerWidth) || 0;
+        const vh = (typeof window !== 'undefined' && window.innerHeight) || 0;
         for (const v of document.querySelectorAll('video')) {
           const g = byUrl.get(v.currentSrc) || byUrl.get(v.src);
-          if (g) onPage.add(g);
+          if (!g) continue;
+          anyDom.add(g);
+          let inView = false;
+          try {
+            const r = v.getBoundingClientRect();
+            inView = r.width > 0 && r.height > 0 &&
+                     r.bottom > 0 && r.top < vh &&
+                     r.right > 0 && r.left < vw;
+          } catch (_) { /* detached <video> — leave inView=false */ }
+          if (inView) {
+            visible.add(g);
+            if (v.paused === false) playing.add(g);
+          }
         }
       }
     } catch (_) { /* detached doc — fall through to size heuristic */ }
-    const candidates = onPage.size > 0 ? [...onPage] : groups;
+    const candidates =
+      playing.size > 0 ? [...playing] :
+      visible.size > 0 ? [...visible] :
+      anyDom.size > 0 ? [...anyDom] :
+      groups;
     candidates.sort((a, b) => b.totalBytes - a.totalBytes);
     return candidates[0];
   };


### PR DESCRIPTION
## Summary

- `download_social_media` on an Instagram reel URL was dumping every `MediaSource` the player touched — including the neighbours Instagram preloads as the user scrolls — producing **29 files** (15 video + 14 audio) for what the user perceives as one reel.
- `saveMse()` now groups captured `SourceBuffer`s by their parent `MediaSource` (one group ≈ one reel on the page) and, unless `mode='all'`, keeps only the **primary** group: the `MediaSource` currently attached to a `<video>` element on the page, tie-broken by total bytes (longest playback ≈ what the user actually watched).
- `agent.js` plumbs `mode` through to `saveMse()` in both Chrome and Firefox builds.

For a single reel URL this drops **29 → 2 files** (the video + audio pair from the visible reel). Going further to 1 muxed file needs `ffmpeg-wasm` or a native host, which the project doesn't have — left for a follow-up.

## Why

A trace (`download_social_media` on `instagram.com/reels/DTt5XEmk7fF/`, mode `"main"`) returned 29 files. Each Instagram reel uses its own `MediaSource` + `<video>`, and the viewer preloads neighbours as you scroll, so the MSE recorder ended up with ~14 reels' worth of buffers. `saveMse()` was iterating `state.buffers` flat and saving each one — it had no notion of "which stream does this buffer belong to."

## What changed

- `src/chrome/src/agent/social-media-downloader.js`, `src/firefox/src/agent/social-media-downloader.js`, `test/smd-tests/social-media-downloader.js` (kept in sync):
  - New `_groupMseBuffers()` — groups `SourceBuffer`s by parent `MediaSource`; orphan buffers (recorder armed mid-playback) form their own group.
  - New `_pickPrimaryMseGroup()` — prefers a group whose `MediaSource` blob URL is currently attached to a DOM `<video>`; falls back to all groups; sorts by total bytes; returns the largest.
  - `saveMse({ mode })` — default `'all'` (back-compat for direct callers). Any other value (`'main'`, `'auto'`) saves only the primary group.
- `src/chrome/src/agent/agent.js`, `src/firefox/src/agent/agent.js`:
  - Pass `mode` from `download_social_media` opts into `saveMse()`.

Default `mode='all'` in `saveMse` preserves the pre-v4 contract for anyone calling it directly from a DevTools console; the change in behaviour is gated entirely on the agent passing through `mode: 'main'` / `'auto'`.

## Test plan

- [x] `node test/run.js` — 195/195 pass.
- [x] `node --check` on all 5 modified files — clean.
- [ ] Manual: load an Instagram `/reels/...` URL, run `download_social_media { mode: "main" }`, confirm exactly two files (video + audio from the same MediaSource) land in Downloads.
- [ ] Manual: same URL, run `download_social_media { mode: "all" }` after scrolling through several reels, confirm every captured stream still saves (escape hatch intact).
- [ ] Manual on Chrome and Firefox builds.
- [ ] Manual on a single-video page (Twitter/X, TikTok) where the recorder only captures one MediaSource — confirm output identical to before (no regression from the `mode !== 'all' && groups.length > 1` guard).

🤖 Generated with [Claude Code](https://claude.com/claude-code)