### PR TITLE
Remove execute_js from Chrome MV3 tool schema

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "WebBrain",
-  "version": "8.1.6",
+  "version": "8.2.0",
   "description": "Open-source AI browser agent — chat with pages, automate tasks, multi-provider LLM support.",
   "permissions": [
     "sidePanel",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "webbrain",
-  "version": "8.1.6",
+  "version": "8.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "webbrain",
-      "version": "8.1.6",
+      "version": "8.2.0",
       "license": "MIT",
       "devDependencies": {
         "playwright": "^1.48.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webbrain",
-  "version": "8.1.6",
+  "version": "8.2.0",
   "description": "Open-source AI browser agent — chat with pages, automate tasks, multi-provider LLM support.",
   "private": true,
   "type": "module",

--- a/src/chrome/ARCHITECTURE.md
+++ b/src/chrome/ARCHITECTURE.md
@@ -1,6 +1,6 @@
 # WebBrain Chrome Extension — Architecture
 
-> Version 8.1.6 · Manifest V3 · Service Worker background
+> Version 8.2.0 · Manifest V3 · Service Worker background
 
 ## High-Level Overview
 
@@ -320,7 +320,9 @@ When `click({text})` or `click({selector})` finds multiple matches, the error pa
 `get_accessibility_tree`, `read_page` (legacy prose), `screenshot`, `get_interactive_elements` (legacy indexed list), `get_selection`, `extract_data`, `get_shadow_dom`, `get_frames`
 
 ### Interaction
-`click_ax`, `type_ax`, `set_field`, `hover` (CDP-trusted, for reveal-on-hover menus), `drag_drop` (CDP-trusted pointer sequence, for Trello/Linear-style reordering), `click` (by text/selector/index/coords — legacy), `type_text`, `press_keys`, `scroll`, `navigate`, `new_tab`, `wait_for_element`, `wait_for_stable` (DOM mutations + network idle), `execute_js`, `iframe_read`, `iframe_click`, `iframe_type`, `upload_file`
+`click_ax`, `type_ax`, `set_field`, `hover` (CDP-trusted, for reveal-on-hover menus), `drag_drop` (CDP-trusted pointer sequence, for Trello/Linear-style reordering), `click` (by text/selector/index/coords — legacy), `type_text`, `press_keys`, `scroll`, `navigate`, `new_tab`, `wait_for_element`, `wait_for_stable` (DOM mutations + network idle), `iframe_read`, `iframe_click`, `iframe_type`, `upload_file`
+
+> **Note:** `execute_js` was removed from the Chrome MV3 tool schema — `new Function()` is blocked by the extension_pages CSP and always throws EvalError. The agent uses `read_page`, `click`, `type_text`, `scroll`, and other fine-grained tools instead. `execute_js` is still available on Firefox MV2.
 
 ### Network / files
 `fetch_url`, `research_url`, `list_downloads`, `read_downloaded_file`, `download_resource_from_page`, `download_files`
@@ -396,7 +398,7 @@ Three independent detectors, strongest action wins:
 
 1. **General repeat** — last 6 tool calls by (name + args hash + outcome). Nudge at 3 identical or ABAB. Stop at 8 nudges without 2 consecutive healthy calls between.
 2. **Coordinate click** — 5-pixel bucketing. Nudge at 5 same-bucket clicks. Stop at 8.
-3. **Navigation** — snapshot URL before `click`/`navigate`/`execute_js`/`iframe_click`, compare 200 ms later. Unexpected change → `[NAVIGATION OCCURRED]` warning.
+3. **Navigation** — snapshot URL before `click`/`navigate`/`iframe_click`, compare 200 ms later. Unexpected change → `[NAVIGATION OCCURRED]` warning.
 
 ---
 

--- a/src/chrome/manifest.json
+++ b/src/chrome/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "WebBrain",
-  "version": "8.1.6",
+  "version": "8.2.0",
   "description": "Open-source AI browser agent — chat with pages, automate tasks, multi-provider LLM support.",
   "permissions": [
     "sidePanel",

--- a/src/chrome/src/agent/agent.js
+++ b/src/chrome/src/agent/agent.js
@@ -555,7 +555,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
     // /allow-api for this tab. Inject only once per "allowed run" to avoid
     // bloating every subsequent turn.
     if (this.apiAllowedTabs.has(tabId) && !this.apiAllowedInjected.has(tabId)) {
-      contextLine += `[USER OVERRIDE — /allow-api: For this conversation the user has explicitly authorized you to use API mutations (POST/PUT/PATCH/DELETE via fetch_url, or fetch() with mutation methods via execute_js) when you judge API to be more reliable than UI for a specific step. The default UI-first rule still applies — only reach for the API when UI has actually failed or is genuinely unworkable. Before any destructive API call (anything that creates, deletes, transfers, or charges), state the URL, method, and payload in plain text in your response so the user can see what you're about to do.]\n\n`;
+      contextLine += `[USER OVERRIDE — /allow-api: For this conversation the user has explicitly authorized you to use API mutations (POST/PUT/PATCH/DELETE via fetch_url) when you judge API to be more reliable than UI for a specific step. The default UI-first rule still applies — only reach for the API when UI has actually failed or is genuinely unworkable. Before any destructive API call (anything that creates, deletes, transfers, or charges), state the URL, method, and payload in plain text in your response so the user can see what you're about to do.]\n\n`;
       this.apiAllowedInjected.add(tabId);
     }
 
@@ -698,7 +698,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
     // URL before these and re-check after, so we can warn the model when an
     // unintended navigation happens (the most common cause of "model keeps
     // executing the original plan on a totally different page").
-    const NAV_PRONE_TOOLS = new Set(['click', 'navigate', 'execute_js', 'iframe_click']);
+    const NAV_PRONE_TOOLS = new Set(['click', 'navigate', 'iframe_click']);
     const navNotices = []; // accumulated for injection after the loop
 
     for (const tc of toolCalls) {
@@ -4944,7 +4944,6 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
       'wait_for_element': 'wait_for_element',
       'wait_for_stable': 'wait_for_stable',
       'get_selection': 'get_selection',
-      'execute_js': 'execute_js',
     };
 
     const action = actionMap[name];
@@ -4982,7 +4981,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
           name === 'press_keys' || name === 'scroll' ||
           name === 'get_accessibility_tree' || name === 'get_interactive_elements' ||
           name === 'extract_data' || name === 'wait_for_element' || name === 'wait_for_stable' ||
-          name === 'get_selection' || name === 'execute_js'
+          name === 'get_selection'
         ) {
           return {
             success: false,

--- a/src/chrome/src/agent/tools.js
+++ b/src/chrome/src/agent/tools.js
@@ -324,20 +324,10 @@ export const AGENT_TOOLS = [
       },
     },
   },
-  {
-    type: 'function',
-    function: {
-      name: 'execute_js',
-      description: 'Execute custom JavaScript code on the page and return the result. Use for complex operations not covered by other tools.',
-      parameters: {
-        type: 'object',
-        properties: {
-          code: { type: 'string', description: 'JavaScript code to execute' },
-        },
-        required: ['code'],
-      },
-    },
-  },
+  // execute_js removed from Chrome MV3 — `new Function()` is blocked by
+  // the extension_pages CSP and always throws EvalError. The agent copes
+  // by using read_page, click, type_text, scroll, and other fine-grained
+  // tools instead. Kept on Firefox MV2 where eval is still allowed.
   {
     type: 'function',
     function: {
@@ -885,7 +875,6 @@ Available tools:
 - extract_data: Extract tables, headings, or images
 - wait_for_element: Wait for an element to appear
 - get_selection: Get highlighted text
-- execute_js: Run custom JavaScript
 - new_tab: Open a new tab
 - clarify: Pause and ask the user a question. Use ONLY for material ambiguity that you cannot resolve by reading the page (e.g. "my API key" on a site with multiple plugins that each have one). Do NOT use to confirm correct actions; do NOT call before every step. Budget 1-2 per run, max.
 - done: Signal task completion
@@ -970,7 +959,7 @@ DON'T REDO WORK YOU'VE ALREADY DONE — read this:
 - Watch for the loop: doubt → re-navigate to source → re-fetch / re-download → end up further from the goal. If you're about to navigate to a URL or path you've already used this session, STOP and read your scratchpad first.
 
 UI vs API — read this carefully:
-- For ANY action that creates, modifies, deletes, sends, submits, buys, transfers, posts, or publishes anything: ALWAYS go through the visible UI of the current page. NEVER call REST/GraphQL/API endpoints directly via \`fetch_url\` with POST/PUT/PATCH/DELETE, NEVER use \`execute_js\` to call \`fetch()\` with mutation methods, NEVER attempt to "call the API directly to save time".
+- For ANY action that creates, modifies, deletes, sends, submits, buys, transfers, posts, or publishes anything: ALWAYS go through the visible UI of the current page. NEVER call REST/GraphQL/API endpoints directly via \`fetch_url\` with POST/PUT/PATCH/DELETE, NEVER attempt to "call the API directly to save time".
 - The user wants to see what's happening. They want to verify before clicking the final button. They want the action to look exactly like a human did it through the page, not like a script ran in the background. UI flows also generally Just Work with the user's existing session, while API endpoints often require separate tokens the user hasn't configured.
 - TWO exceptions where API mutations are allowed:
   (1) The user explicitly says "use the API" or "call the endpoint directly" or "POST to /foo" in their message — do what they asked.
@@ -1060,10 +1049,10 @@ SCROLLING — read this:
 - After filling visible fields, always scroll down to check for more fields before submitting.
 
 SOCIAL MEDIA DOWNLOADS — read this:
-- When the user asks to download images or videos from Facebook, Instagram, X/Twitter, LinkedIn, Reddit, Pinterest, or YouTube (thumbnails), call \`download_social_media\` — it is a SINGLE tool call that handles the per-site DOM, picks the right resolution, and saves to the Downloads folder. Do NOT inspect the page with \`get_accessibility_tree\` + \`execute_js\` + \`download_file\` to figure it out yourself; the tool already knows.
+- When the user asks to download images or videos from Facebook, Instagram, X/Twitter, LinkedIn, Reddit, Pinterest, or YouTube (thumbnails), call \`download_social_media\` — it is a SINGLE tool call that handles the per-site DOM, picks the right resolution, and saves to the Downloads folder. Do NOT inspect the page with \`get_accessibility_tree\` + \`download_file\` to figure it out yourself; the tool already knows.
 - Defaults: on single-content pages (e.g. /photo/, /p/, /reel/, /status/.../photo/, /pin/, /comments/) it grabs the main item; pass \`scroll:true\` to walk a feed/profile/timeline and capture everything that lazy-loads.
 - After it returns, optionally call \`list_downloads\` to surface the saved filenames for the user. Some CDNs (notably media.licdn.com) block CORS and the tool will open the media in a new tab as fallback — that is expected behavior, not a failure.
-- The tool may return a \`recommendation\` field with shape \`{ kind, message }\`. This means SMD knowingly cannot handle the request well — most often YouTube full video (Widevine DRM + signatureCipher), an MSE blob the player hasn't loaded yet, or a site outside SMD's supported list. When it appears, RELAY \`recommendation.message\` to the user verbatim in your reply — it points them at the right external CLI tool (\`yt-dlp\` for video, \`gallery-dl\` for images) with a copy-pasteable command. Do NOT try to work around it with \`execute_js\`, \`get_accessibility_tree\`, or repeated tool calls — the recommendation exists precisely because those paths cannot help. Exception: \`kind: "mse_capture_available"\` is the one case where you SHOULD follow up — it means the MSE recorder buffered bytes while the page was open, and the message tells you to call \`await SocialMediaDownloader.saveMse()\` via \`execute_js\` to download them.
+- The tool may return a \`recommendation\` field with shape \`{ kind, message }\`. This means SMD knowingly cannot handle the request well — most often YouTube full video (Widevine DRM + signatureCipher), an MSE blob the player hasn't loaded yet, or a site outside SMD's supported list. When it appears, RELAY \`recommendation.message\` to the user verbatim in your reply — it points them at the right external CLI tool (\`yt-dlp\` for video, \`gallery-dl\` for images) with a copy-pasteable command. Do NOT try to work around it with \`get_accessibility_tree\` or repeated tool calls — the recommendation exists precisely because those paths cannot help.
 
 LISTINGS & PAGINATION — read this:
 - Listing / search-result pages (URLs with query params like ?page=, ?p=, ?sd=, ?offset=, ?after=, &cursor=; or pages that show many product/result cards with Next/Sonraki/Suivant/下一页 controls): EXTRACT first, paginate second.

--- a/src/chrome/src/ui/settings.js
+++ b/src/chrome/src/ui/settings.js
@@ -6,7 +6,7 @@ import { t, getLocale, setLocale, LANGUAGES } from './i18n.js';
 
 // Version shown in the subtitle. Kept here so it only needs one update per
 // release; the subtitle string itself is translated.
-const EXT_VERSION = '8.1.6';
+const EXT_VERSION = '8.2.0';
 
 const providersContainer = document.getElementById('providers');
 const verboseToggle = document.getElementById('toggle-verbose');

--- a/src/chrome/src/ui/sidepanel.js
+++ b/src/chrome/src/ui/sidepanel.js
@@ -184,7 +184,6 @@ const TOOL_KEYS = {
   extract_data: 'tool.extract_data',
   wait_for_element: 'tool.wait_for_element',
   get_selection: 'tool.get_selection',
-  execute_js: 'tool.execute_js',
   new_tab: 'tool.new_tab',
   screenshot: 'tool.screenshot',
   done: 'tool.done',
@@ -1141,7 +1140,7 @@ chrome.storage.onChanged.addListener((changes) => {
 });
 
 // Page inspection banner — shown when agent starts interacting with the page
-const PAGE_TOOLS = new Set(['read_page', 'get_interactive_elements', 'click', 'type_text', 'scroll', 'extract_data', 'wait_for_element', 'get_selection', 'execute_js', 'screenshot']);
+const PAGE_TOOLS = new Set(['read_page', 'get_interactive_elements', 'click', 'type_text', 'scroll', 'extract_data', 'wait_for_element', 'get_selection', 'screenshot']);
 let inspectionBannerShown = false;
 
 function showInspectionBanner(toolName) {

--- a/src/firefox/ARCHITECTURE.md
+++ b/src/firefox/ARCHITECTURE.md
@@ -1,6 +1,6 @@
 # WebBrain Firefox Extension — Architecture
 
-> Version 8.1.6 · Manifest V2 · Background Page
+> Version 8.2.0 · Manifest V2 · Background Page
 
 ## How Firefox Differs from Chrome
 

--- a/src/firefox/manifest.json
+++ b/src/firefox/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "WebBrain",
-  "version": "8.1.6",
+  "version": "8.2.0",
   "description": "Open-source AI browser agent — chat with pages, automate tasks, multi-provider LLM support.",
   "permissions": [
     "activeTab",

--- a/src/firefox/src/ui/settings.js
+++ b/src/firefox/src/ui/settings.js
@@ -6,7 +6,7 @@ import { t, getLocale, setLocale, LANGUAGES } from './i18n.js';
 
 // Version shown in the subtitle. Kept here so it only needs one update per
 // release; the subtitle string itself is translated.
-const EXT_VERSION = '8.1.6';
+const EXT_VERSION = '8.2.0';
 
 const providersContainer = document.getElementById('providers');
 const verboseToggle = document.getElementById('toggle-verbose');


### PR DESCRIPTION
## Summary
- Removed `execute_js` from Chrome's LLM tool schema — the tool was already dead on MV3 (`new Function()` blocked by CSP) and every call was a wasted LLM round-trip
- Cleaned up all functional references: dispatch mapping, `NAV_PRONE_TOOLS`, `PAGE_TOOLS`, system prompt, `/allow-api` context
- Content script handler left as safety net (returns clear CSP error for cached conversations)
- Firefox MV2 unchanged — `execute_js` still works there
- Updated ARCHITECTURE.md with note explaining the MV3 limitation

Closes #72

## Test plan
- [ ] Load Chrome extension — verify no `execute_js` in tool schema sent to LLM (check verbose mode or deep verbose log)
- [ ] Run a task that would previously trigger `execute_js` (e.g. "what's the value of the search input?") — verify agent uses `read_page` / `get_accessibility_tree` instead
- [ ] Verify Firefox build still has `execute_js` working normally
- [ ] Check that cached conversations referencing `execute_js` get the CSP error gracefully

🤖 Generated with [Claude Code](https://claude.com/claude-code)