### PR TITLE
fix: stop stale-click warning on editable targets, add Medium editor note

### DIFF
--- a/src/chrome/src/agent/adapters.js
+++ b/src/chrome/src/agent/adapters.js
@@ -199,7 +199,8 @@ const ADAPTERS = [
     notes: `
 - Member-only articles show a paywall partway through — the agent sees "Read more" or a sign-up gate, not the full text.
 - The clap button increments per click up to 50; long-press equivalent is multiple clicks.
-- Highlights are inline annotations; hovering text shows the highlight popover.`,
+- Highlights are inline annotations; hovering text shows the highlight popover.
+- Editor (medium.com/new-story and /p/<id>/edit): the whole article is ONE contenteditable "textbox" containing an H1 (title) followed by paragraphs (body) as sibling blocks. The a11y tree exposes it as one ref_id even though it visually looks like multiple fields. DO NOT call set_field or type_text({selector: 'div[contenteditable]'}) on the outer textbox — that replaces the entire article (title AND body) with one string. Instead: click the "Title" placeholder, type the title, press Enter to start the body paragraph, then type the body. Use press_keys({key: "Enter"}) between blocks, not newlines inside one type_text call.`,
   },
   {
     name: 'substack',

--- a/src/chrome/src/agent/agent.js
+++ b/src/chrome/src/agent/agent.js
@@ -4303,11 +4303,23 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
             };
           }
 
-          // Stale click detection
+          // Stale click detection — skip for editable targets, where re-clicking
+          // is legitimate (positions cursor / re-focuses field) and "no page change"
+          // is the expected outcome, not a failure signal.
+          const postEditable = await cdpClient.evaluate(tabId, `
+            (() => {
+              const ae = document.activeElement;
+              if (!ae) return false;
+              if (ae.isContentEditable) return true;
+              const tag = ae.tagName;
+              return tag === 'INPUT' || tag === 'TEXTAREA';
+            })()
+          `);
+          const isEditableTarget = postEditable?.result?.value === true;
           const clickIdent = `${info.tag}|${(info.text || '').slice(0, 50)}`;
           const prevIdent = this._lastCdpClickIdent.get(tabId);
           this._lastCdpClickIdent.set(tabId, clickIdent);
-          const warning = (prevIdent === clickIdent)
+          const warning = (prevIdent === clickIdent && !isEditableTarget)
             ? 'Same element clicked again with no page change. Try click({x, y}) with coordinates from a screenshot, or click({index: N}) from get_interactive_elements.'
             : undefined;
 

--- a/src/chrome/src/content/content.js
+++ b/src/chrome/src/content/content.js
@@ -698,10 +698,14 @@
       };
     }
 
-    // Stale click detection: warn if the same element is clicked again
+    // Stale click detection: warn if the same element is clicked again.
+    // Skip for editable targets — re-clicking a text field / contenteditable
+    // is legitimate (positions cursor / re-focuses) and "no page change" is
+    // the expected outcome there, not a failure signal.
+    const isEditableTarget = el.isContentEditable || el.tagName === 'INPUT' || el.tagName === 'TEXTAREA';
     const ident = `${el.tagName}|${(el.innerText || '').slice(0, 50)}|${location.href}`;
     let warning;
-    if (_lastClickIdent === ident) {
+    if (_lastClickIdent === ident && !isEditableTarget) {
       warning = 'Same element clicked again with no page change. Try click({x, y}) with coordinates from a screenshot, or click({index: N}) from get_interactive_elements.';
     }
     _lastClickIdent = ident;

--- a/src/firefox/src/content/content.js
+++ b/src/firefox/src/content/content.js
@@ -863,10 +863,14 @@
       };
     }
 
-    // Stale click detection: warn if the same element is clicked again
+    // Stale click detection: warn if the same element is clicked again.
+    // Skip for editable targets — re-clicking a text field / contenteditable
+    // is legitimate (positions cursor / re-focuses) and "no page change" is
+    // the expected outcome there, not a failure signal.
+    const isEditableTarget = el.isContentEditable || el.tagName === 'INPUT' || el.tagName === 'TEXTAREA';
     const ident = `${el.tagName}|${(el.innerText || '').slice(0, 50)}|${location.href}`;
     let warning;
-    if (_lastClickIdent === ident) {
+    if (_lastClickIdent === ident && !isEditableTarget) {
       warning = 'Same element clicked again with no page change. Try click({x, y}) with coordinates from a screenshot, or click({index: N}) from get_interactive_elements.';
     }
     _lastClickIdent = ident;


### PR DESCRIPTION
## Summary

Two related fixes from a Qwen 3.6-35B-A3B trace where the agent was tasked with posting to Medium and ended in a loop on the editor:

- **Stale-click warning false positive.** The "Same element clicked again with no page change" warning fires when `(tag, text)` of the clicked target matches the previous click. But re-clicking a `contenteditable` / `<input>` / `<textarea>` is legitimate — it positions the cursor or re-focuses the field — and there's no page change to expect. Qwen kept clicking into Medium's body paragraph (`DIV` with text "I benchmarked 13 L"), reading the warning as "click failed", and looping until the agent-level loop guard tripped at 8 nudges.
- **Medium editor confusion.** Medium's `/new-story` editor is ONE contenteditable "textbox" containing an H1 (title) and `<p>` blocks (body) as sibling children under a single `ref_id`. The a11y tree exposes it as one ref even though it visually looks like two fields. `set_field({ref_id: ref_12, ...})` on the outer textbox replaces the entire article with one string — wiping either the title or the body depending on call order. That's what kicked off the recovery spiral in the first place.

## Changes

- [`src/chrome/src/agent/agent.js`](src/chrome/src/agent/agent.js#L4306) — in the CDP click-by-text path, after dispatching the click, eval `document.activeElement` to check `isContentEditable` / `INPUT` / `TEXTAREA`. Skip the stale-click warning when the target is editable.
- [`src/chrome/src/content/content.js`](src/chrome/src/content/content.js#L701) — same fix in the content-script click path using `el.isContentEditable || el.tagName === 'INPUT' || el.tagName === 'TEXTAREA'`.
- [`src/firefox/src/content/content.js`](src/firefox/src/content/content.js#L866) — same fix mirrored to Firefox.
- [`src/chrome/src/agent/adapters.js`](src/chrome/src/agent/adapters.js#L196) — Medium adapter gets a new editor note: don't `set_field` / `type_text({selector: 'div[contenteditable]'})` on the outer textbox; instead click the "Title" placeholder, type the title, press Enter, then type the body. Use `press_keys({key: 'Enter'})` between blocks rather than newlines inside one `type_text` call.

The agent-level loop detector in [`agent.js:428`](src/chrome/src/agent/agent.js#L428) is unchanged — it still fires if a model genuinely spins on identical calls. This PR only stops the misleading warning that pushed Qwen into that loop, plus the upstream Medium editor confusion that started the whole failure.

## Test plan

- [x] `npm test` — 195 passed, 0 failed
- [ ] Manual: load the unpacked extension, open https://medium.com/new-story, run a prompt like "post a short article with title X and body Y". Verify the agent uses click → type → Enter → type rather than `set_field` on `ref_12`.
- [ ] Manual: click into any contenteditable area (Medium body, Gmail compose, Notion) twice in a row via the agent and confirm no "Same element clicked again" warning is returned.
- [ ] Manual (Firefox): same as above to confirm the content-script fix is symmetric.

🤖 Generated with [Claude Code](https://claude.com/claude-code)