### PR TITLE
fix: comprehensive bug audit — 65+ fixes across Chrome and Firefox

### DIFF
--- a/src/chrome/src/agent/agent.js
+++ b/src/chrome/src/agent/agent.js
@@ -123,6 +123,9 @@ export class Agent {
     // resolved is-PDF flag per (tabId,url) so the agent doesn't probe
     // on every executeTool call within a turn.
     this._isPdfTabCache = new Map(); // tabId -> { url, isPdf }
+    this._doneBlockCount = new Map(); // tabId -> consecutive done-blocks
+    this._recentSubmitClicks = new Map(); // tabId -> recent submit click timestamps
+    this._runningTabs = new Set(); // tabIds with an active processMessage/Stream in flight
   }
 
   /**
@@ -1924,18 +1927,28 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
   /**
    * Clear conversation for a tab.
    */
+  _cleanupTab(tabId) {
+    this._isPdfTabCache.delete(tabId);
+    this._lastCdpClickIdent?.delete(tabId);
+    this.lastAutoScreenshotTs.delete(tabId);
+    this.lastSeenAdapter.delete(tabId);
+    this._lastInteractionRect.delete(tabId);
+    this._doneBlockCount.delete(tabId);
+    this._recentSubmitClicks.delete(tabId);
+    this._runningTabs.delete(tabId);
+    this.currentRunId.delete(tabId);
+    this._clearLoopState(tabId);
+  }
+
   clearConversation(tabId) {
     this._cancelClarifications(tabId, 'conversation cleared');
     this.conversations.delete(tabId);
     this.conversationModes.delete(tabId);
-    this.conversationIds.delete(tabId); // next getConversation() mints a fresh id
+    this.conversationIds.delete(tabId);
     this.hydratedTabs.delete(tabId);
     this.apiAllowedTabs.delete(tabId);
     this.apiAllowedInjected.delete(tabId);
-    this._lastInteractionRect.delete(tabId);
-    if (this._doneBlockCount) this._doneBlockCount.delete(tabId);
-    if (this._recentSubmitClicks) this._recentSubmitClicks.delete(tabId);
-    this._clearLoopState(tabId);
+    this._cleanupTab(tabId);
     const t = this.persistTimers.get(tabId);
     if (t) { clearTimeout(t); this.persistTimers.delete(tabId); }
     try {
@@ -2803,7 +2816,6 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
           // can escape if the heuristic is wrong (e.g. the "form" is a
           // search/filter bar, not a submit form).
           if (completionWarning) {
-            if (!this._doneBlockCount) this._doneBlockCount = new Map();
             const blocks = (this._doneBlockCount.get(tabId) || 0) + 1;
             this._doneBlockCount.set(tabId, blocks);
             if (blocks <= 2) {
@@ -2818,7 +2830,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
             // After 2 blocks, let done through with a loud note in verification.
           }
           // Reset block count on successful done.
-          if (this._doneBlockCount) this._doneBlockCount.delete(tabId);
+          this._doneBlockCount.delete(tabId);
 
           return {
             done: true,
@@ -3586,7 +3598,6 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
           if (submitLikeRE.test(rawText)) {
             let curUrl = '';
             try { const t = await chrome.tabs.get(tabId); curUrl = t?.url || ''; } catch (e) {}
-            if (!this._recentSubmitClicks) this._recentSubmitClicks = new Map();
             const buf = this._recentSubmitClicks.get(tabId) || [];
             const key = `${rawText.toLowerCase()}|${curUrl}`;
             const now = Date.now();
@@ -5221,6 +5232,18 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
   // ─────────────────────────────────────────────────────────────────────
 
   async processMessage(tabId, userMessage, onUpdate = () => {}, mode = 'ask') {
+    if (this._runningTabs.has(tabId)) {
+      throw new Error('An agent run is already in progress for this tab.');
+    }
+    this._runningTabs.add(tabId);
+    try {
+      return await this._processMessageInner(tabId, userMessage, onUpdate, mode);
+    } finally {
+      this._runningTabs.delete(tabId);
+    }
+  }
+
+  async _processMessageInner(tabId, userMessage, onUpdate, mode) {
     await this._hydrate(tabId);
     const messages = this.getConversation(tabId, mode);
 
@@ -5439,6 +5462,18 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
    * Process a message with streaming output.
    */
   async processMessageStream(tabId, userMessage, onUpdate = () => {}, mode = 'ask') {
+    if (this._runningTabs.has(tabId)) {
+      throw new Error('An agent run is already in progress for this tab.');
+    }
+    this._runningTabs.add(tabId);
+    try {
+      return await this._processMessageStreamInner(tabId, userMessage, onUpdate, mode);
+    } finally {
+      this._runningTabs.delete(tabId);
+    }
+  }
+
+  async _processMessageStreamInner(tabId, userMessage, onUpdate, mode) {
     await this._hydrate(tabId);
     const messages = this.getConversation(tabId, mode);
 
@@ -5486,8 +5521,8 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
             onUpdate('text_delta', { content: chunk.content });
           } else if (chunk.type === 'tool_call') {
             hasToolCalls = true;
-            // Accumulate streaming tool call deltas (OpenAI format)
-            for (const tc of chunk.content) {
+            const calls = Array.isArray(chunk.content) ? chunk.content : [];
+            for (const tc of calls) {
               const idx = tc.index ?? 0;
               if (!toolCallsAccumulator[idx]) {
                 toolCallsAccumulator[idx] = { id: '', function: { name: '', arguments: '' } };
@@ -5500,13 +5535,13 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
             hasToolCalls = true;
             const idx = Object.keys(toolCallsAccumulator).length;
             toolCallsAccumulator[idx] = {
-              id: chunk.content.id,
-              function: { name: chunk.content.name, arguments: '' },
+              id: chunk.content?.id || '',
+              function: { name: chunk.content?.name || '', arguments: '' },
             };
           } else if (chunk.type === 'tool_call_delta') {
             const idx = Object.keys(toolCallsAccumulator).length - 1;
-            if (toolCallsAccumulator[idx]) {
-              toolCallsAccumulator[idx].function.arguments += chunk.content;
+            if (idx >= 0 && toolCallsAccumulator[idx]) {
+              toolCallsAccumulator[idx].function.arguments += String(chunk.content ?? '');
             }
           } else if (chunk.type === 'done') {
             break;

--- a/src/chrome/src/agent/agent.js
+++ b/src/chrome/src/agent/agent.js
@@ -1927,7 +1927,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
   /**
    * Clear conversation for a tab.
    */
-  _cleanupTab(tabId) {
+  _cleanupTab(tabId, { preserveRunGuard = false } = {}) {
     this._isPdfTabCache.delete(tabId);
     this._lastCdpClickIdent?.delete(tabId);
     this.lastAutoScreenshotTs.delete(tabId);
@@ -1935,8 +1935,10 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
     this._lastInteractionRect.delete(tabId);
     this._doneBlockCount.delete(tabId);
     this._recentSubmitClicks.delete(tabId);
-    this._runningTabs.delete(tabId);
-    this.currentRunId.delete(tabId);
+    if (!preserveRunGuard) {
+      this._runningTabs.delete(tabId);
+      this.currentRunId.delete(tabId);
+    }
     this._clearLoopState(tabId);
   }
 
@@ -1948,7 +1950,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
     this.hydratedTabs.delete(tabId);
     this.apiAllowedTabs.delete(tabId);
     this.apiAllowedInjected.delete(tabId);
-    this._cleanupTab(tabId);
+    this._cleanupTab(tabId, { preserveRunGuard: true });
     const t = this.persistTimers.get(tabId);
     if (t) { clearTimeout(t); this.persistTimers.delete(tabId); }
     try {

--- a/src/chrome/src/agent/captcha-solver.js
+++ b/src/chrome/src/agent/captcha-solver.js
@@ -29,7 +29,9 @@ async function postJson(path, body) {
     const text = await res.text().catch(() => '');
     throw new Error(`CapSolver ${path} HTTP ${res.status}: ${text.slice(0, 200)}`);
   }
-  return await res.json();
+  try { return await res.json(); } catch {
+    throw new Error(`CapSolver ${path} returned invalid JSON.`);
+  }
 }
 
 // Wrap a CapSolver error response in a friendlier message.
@@ -64,8 +66,9 @@ function capsolverError(prefix, body) {
 export async function getBalance(apiKey) {
   if (!apiKey) throw new Error('No CapSolver API key configured.');
   const res = await postJson('/getBalance', { clientKey: apiKey });
+  if (!res || typeof res !== 'object') throw new Error('CapSolver getBalance returned unexpected response.');
   if (res.errorId) throw capsolverError('CapSolver', res);
-  return { balance: res.balance, packages: res.packages || [] };
+  return { balance: res.balance ?? 0, packages: res.packages || [] };
 }
 
 async function createTask(apiKey, task) {
@@ -74,15 +77,18 @@ async function createTask(apiKey, task) {
     appId: DEFAULT_APP_ID,
     task,
   });
+  if (!res || typeof res !== 'object') throw new Error('CapSolver createTask returned unexpected response.');
   if (res.errorId) throw capsolverError('CapSolver createTask', res);
   if (!res.taskId) throw new Error('CapSolver createTask returned no taskId.');
   return res.taskId;
 }
 
 async function pollTaskResult(apiKey, taskId, { timeoutMs = POLL_TIMEOUT_MS } = {}) {
+  const effectiveTimeout = (typeof timeoutMs === 'number' && timeoutMs > 0) ? timeoutMs : POLL_TIMEOUT_MS;
   const start = Date.now();
-  while (Date.now() - start < timeoutMs) {
+  while (Date.now() - start < effectiveTimeout) {
     const res = await postJson('/getTaskResult', { clientKey: apiKey, taskId });
+    if (!res || typeof res !== 'object') throw new Error('CapSolver getTaskResult returned unexpected response.');
     if (res.errorId) throw capsolverError('CapSolver getTaskResult', res);
     if (res.status === 'ready') return res.solution || {};
     await new Promise(r => setTimeout(r, POLL_INTERVAL_MS));

--- a/src/chrome/src/agent/credential-fields.js
+++ b/src/chrome/src/agent/credential-fields.js
@@ -66,19 +66,20 @@ export const CREDENTIAL_NOTE = CREDENTIAL_NOTE_LOOSE;
  * @returns {{sensitive: boolean, reason: string|null}}
  */
 export function isCredentialField(meta) {
-  if (!meta || typeof meta !== 'object') return { sensitive: false, reason: null };
+  if (!meta || typeof meta !== 'object' || Array.isArray(meta)) return { sensitive: false, reason: null };
 
-  const type = String(meta.type || '').toLowerCase();
+  const type = String(meta.type ?? '').toLowerCase();
   if (type === 'password') return { sensitive: true, reason: 'input type=password' };
 
-  const ac = String(meta.autocomplete || '').trim();
+  const ac = String(meta.autocomplete ?? '').trim();
   if (ac && SENSITIVE_AUTOCOMPLETE_RE.test(ac)) {
     return { sensitive: true, reason: `autocomplete=${ac}` };
   }
 
   for (const key of ['name', 'id', 'ariaLabel', 'placeholder', 'labelText']) {
     const v = meta[key];
-    if (v && SENSITIVE_NAME_RE.test(String(v))) {
+    if (v != null && typeof v !== 'string' && typeof v !== 'number') continue;
+    if (v && SENSITIVE_NAME_RE.test(String(v).slice(0, 200))) {
       return { sensitive: true, reason: `${key} matches credential pattern: ${JSON.stringify(String(v).slice(0, 60))}` };
     }
   }

--- a/src/chrome/src/agent/pdf-tools.js
+++ b/src/chrome/src/agent/pdf-tools.js
@@ -45,7 +45,12 @@ async function getPdfjs() {
  * stack on multi-MB PDFs. fromCharCode.apply has a per-call argument
  * limit (~64k in V8), so we chunk.
  */
+const BASE64_MAX_INPUT_BYTES = 32 * 1024 * 1024; // 32 MB safety cap
+
 function bytesToBase64(bytes) {
+  if (bytes.length > BASE64_MAX_INPUT_BYTES) {
+    throw new Error(`PDF too large for base64 conversion (${bytes.length} bytes, cap ${BASE64_MAX_INPUT_BYTES}).`);
+  }
   let bin = '';
   const chunk = 0x8000;
   for (let i = 0; i < bytes.length; i += chunk) {
@@ -91,7 +96,10 @@ export async function fetchPdfBytes(url) {
     // anonymous and we get back a login page or 403 even though the
     // user is signed in. Same posture as `network-tools.js#fetchUrl`.
     // No-op for file:// URLs.
-    res = await fetch(url, { credentials: 'include' });
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), 60000);
+    res = await fetch(url, { credentials: 'include', signal: controller.signal });
+    clearTimeout(timeout);
   } catch (e) {
     if (typeof url === 'string' && url.startsWith('file://')) {
       throw new Error(

--- a/src/chrome/src/agent/pdf-tools.js
+++ b/src/chrome/src/agent/pdf-tools.js
@@ -87,35 +87,31 @@ export function isPdfUrl(url) {
  * agent guessing.
  */
 export async function fetchPdfBytes(url) {
-  let res;
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), 60000);
   try {
-    // `credentials: 'include'` forwards the user's cookies for this
-    // origin so PDFs gated behind a session (dashboards, internal
-    // docs, signed-in apps) are reachable by the same identity that
-    // can view the file in-tab. Without it, the extension's fetch is
-    // anonymous and we get back a login page or 403 even though the
-    // user is signed in. Same posture as `network-tools.js#fetchUrl`.
-    // No-op for file:// URLs.
-    const controller = new AbortController();
-    const timeout = setTimeout(() => controller.abort(), 60000);
-    res = await fetch(url, { credentials: 'include', signal: controller.signal });
-    clearTimeout(timeout);
-  } catch (e) {
-    if (typeof url === 'string' && url.startsWith('file://')) {
-      throw new Error(
-        'Cannot fetch local PDF from a file:// URL. WebBrain needs ' +
-        'file-URL access in Chrome: open chrome://extensions, find ' +
-        'WebBrain, click "Details", and enable "Allow access to file URLs". ' +
-        'Then reload the PDF tab and try read_pdf again.'
-      );
+    let res;
+    try {
+      res = await fetch(url, { credentials: 'include', signal: controller.signal });
+    } catch (e) {
+      if (typeof url === 'string' && url.startsWith('file://')) {
+        throw new Error(
+          'Cannot fetch local PDF from a file:// URL. WebBrain needs ' +
+          'file-URL access in Chrome: open chrome://extensions, find ' +
+          'WebBrain, click "Details", and enable "Allow access to file URLs". ' +
+          'Then reload the PDF tab and try read_pdf again.'
+        );
+      }
+      throw new Error(`PDF fetch failed: ${e.message}`);
     }
-    throw new Error(`PDF fetch failed: ${e.message}`);
+    if (!res.ok) {
+      throw new Error(`PDF fetch returned HTTP ${res.status} ${res.statusText}`);
+    }
+    const buf = await res.arrayBuffer();
+    return new Uint8Array(buf);
+  } finally {
+    clearTimeout(timeout);
   }
-  if (!res.ok) {
-    throw new Error(`PDF fetch returned HTTP ${res.status} ${res.statusText}`);
-  }
-  const buf = await res.arrayBuffer();
-  return new Uint8Array(buf);
 }
 
 /**

--- a/src/chrome/src/background.js
+++ b/src/chrome/src/background.js
@@ -382,11 +382,8 @@ chrome.windows?.onRemoved?.addListener?.((windowId) => {
 chrome.tabs.onRemoved.addListener((tabId) => {
   panelTabs.delete(tabId);
   savePanelTabs();
-  // Also clear any persisted chat state for that tab.
   chrome.storage.session?.remove(`tabChat:${tabId}`).catch(() => {});
-  // Drop per-tab agent state (last interaction rect, etc.) so stale data
-  // can't resurface if Chrome recycles the tab id for a new tab.
-  try { agent._lastInteractionRect?.delete(tabId); } catch { /* ignore */ }
+  try { agent._cleanupTab(tabId); } catch { /* ignore */ }
 });
 
 // SPA navigation tracking. Many sites change route via History API without

--- a/src/chrome/src/offscreen/offscreen.js
+++ b/src/chrome/src/offscreen/offscreen.js
@@ -19,23 +19,13 @@ chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
         body: msg.body || undefined,
       });
 
-      if (msg.stream) {
-        // For streaming, read the full body and return it
-        // (offscreen can't stream back via sendResponse)
-        const text = await res.text();
-        sendResponse({
-          ok: res.ok,
-          status: res.status,
-          body: text,
-        });
-      } else {
-        const text = await res.text();
-        sendResponse({
-          ok: res.ok,
-          status: res.status,
-          body: text,
-        });
-      }
+      const text = await res.text();
+      sendResponse({
+        ok: res.ok,
+        status: res.status,
+        contentType: res.headers.get('content-type') || '',
+        body: text,
+      });
     } catch (e) {
       sendResponse({
         ok: false,

--- a/src/chrome/src/providers/anthropic.js
+++ b/src/chrome/src/providers/anthropic.js
@@ -158,11 +158,15 @@ export class AnthropicProvider extends BaseLLMProvider {
     });
 
     if (!res.ok) {
-      const err = await res.text();
+      let err = '';
+      try { err = (await res.text()).slice(0, 500); } catch {}
       throw new Error(`Anthropic error ${res.status}: ${err}`);
     }
 
-    const data = await res.json();
+    let data;
+    try { data = await res.json(); } catch {
+      throw new Error('Anthropic returned invalid JSON in chat response.');
+    }
 
     // Extract text content and tool use blocks
     let content = '';
@@ -170,15 +174,15 @@ export class AnthropicProvider extends BaseLLMProvider {
 
     for (const block of data.content || []) {
       if (block.type === 'text') {
-        content += block.text;
+        content += block.text || '';
       } else if (block.type === 'tool_use') {
         if (!toolCalls) toolCalls = [];
         toolCalls.push({
-          id: block.id,
+          id: block.id || '',
           type: 'function',
           function: {
-            name: block.name,
-            arguments: JSON.stringify(block.input),
+            name: block.name || '',
+            arguments: JSON.stringify(block.input ?? {}),
           },
         });
       }
@@ -219,7 +223,8 @@ export class AnthropicProvider extends BaseLLMProvider {
     });
 
     if (!res.ok) {
-      const err = await res.text();
+      let err = '';
+      try { err = (await res.text()).slice(0, 500); } catch {}
       throw new Error(`Anthropic stream error ${res.status}: ${err}`);
     }
 
@@ -252,8 +257,8 @@ export class AnthropicProvider extends BaseLLMProvider {
               yield {
                 type: 'tool_call_start',
                 content: {
-                  id: event.content_block.id,
-                  name: event.content_block.name,
+                  id: event.content_block.id || '',
+                  name: event.content_block.name || '',
                 },
               };
             }
@@ -261,8 +266,8 @@ export class AnthropicProvider extends BaseLLMProvider {
             yield { type: 'done', content: '' };
             return;
           }
-        } catch {
-          // skip
+        } catch (e) {
+          console.warn('[anthropic] malformed SSE chunk skipped:', payload?.slice(0, 120), e?.message);
         }
       }
     }
@@ -295,6 +300,7 @@ export class AnthropicOAuthProvider extends AnthropicProvider {
   constructor(config) {
     super(config);
     this._accessToken = null;
+    this._refreshPromise = null;
   }
 
   get name() {
@@ -345,6 +351,15 @@ export class AnthropicOAuthProvider extends AnthropicProvider {
     this._accessToken = await getClaudeAccessToken();
   }
 
+  async _refreshOnce() {
+    if (!this._refreshPromise) {
+      this._refreshPromise = refreshClaudeAccessToken().finally(() => {
+        this._refreshPromise = null;
+      });
+    }
+    return this._refreshPromise;
+  }
+
   async chat(messages, options = {}) {
     await this._ensureFreshToken();
     try {
@@ -354,7 +369,7 @@ export class AnthropicOAuthProvider extends AnthropicProvider {
       // check and the request landing. One retry-after-refresh is
       // safe; further failures bubble out as auth errors.
       if (/Anthropic error 401/.test(e.message)) {
-        await refreshClaudeAccessToken();
+        await this._refreshOnce();
         await this._ensureFreshToken();
         return await super.chat(messages, options);
       }
@@ -369,7 +384,7 @@ export class AnthropicOAuthProvider extends AnthropicProvider {
       return;
     } catch (e) {
       if (/Anthropic stream error 401/.test(e.message)) {
-        await refreshClaudeAccessToken();
+        await this._refreshOnce();
         await this._ensureFreshToken();
         yield* super.chatStream(messages, options);
         return;

--- a/src/chrome/src/providers/fetch-with-fallback.js
+++ b/src/chrome/src/providers/fetch-with-fallback.js
@@ -31,6 +31,7 @@ import { ensureOffscreen } from '../offscreen/ensure.js';
 // reconstruction.
 let _cachedTimeoutMs = 120000;
 let _timeoutInitialized = false;
+let _storageListener = null;
 const TIMEOUT_FLOOR_MS = 5000;        // 5s — anything lower than this is a typo
 const TIMEOUT_CEILING_MS = 600000;    // 10 min — well past any reasonable first-byte wait
 
@@ -47,17 +48,17 @@ async function _ensureTimeoutInitialized() {
     if (typeof v === 'number' && v >= TIMEOUT_FLOOR_MS && v <= TIMEOUT_CEILING_MS) {
       _cachedTimeoutMs = v;
     }
-    // Live refresh when the user edits the setting.
-    if (api.storage.onChanged?.addListener) {
-      api.storage.onChanged.addListener((changes, area) => {
+    if (api.storage.onChanged?.addListener && !_storageListener) {
+      _storageListener = (changes, area) => {
         if (area !== 'local' || !changes.requestTimeoutMs) return;
         const next = changes.requestTimeoutMs.newValue;
         if (typeof next === 'number' && next >= TIMEOUT_FLOOR_MS && next <= TIMEOUT_CEILING_MS) {
           _cachedTimeoutMs = next;
         } else if (next == null) {
-          _cachedTimeoutMs = 120000; // setting was cleared — back to default
+          _cachedTimeoutMs = 120000;
         }
-      });
+      };
+      api.storage.onChanged.addListener(_storageListener);
     }
   } catch { /* keep the hardcoded default */ }
 }
@@ -135,11 +136,10 @@ export async function fetchWithFallback(url, options = {}) {
         );
       }
 
-      // Wrap the proxy response to look like a fetch Response
       return new Response(proxyResult.body, {
         status: proxyResult.status,
         statusText: proxyResult.ok ? 'OK' : 'Error',
-        headers: { 'Content-Type': 'application/json' },
+        headers: { 'Content-Type': proxyResult.contentType || 'application/json' },
       });
     } catch (proxyError) {
       // Offscreen proxy also failed — throw the most useful error

--- a/src/chrome/src/providers/llamacpp.js
+++ b/src/chrome/src/providers/llamacpp.js
@@ -61,11 +61,15 @@ export class LlamaCppProvider extends BaseLLMProvider {
     }
 
     if (!res.ok) {
-      const err = await res.text();
+      let err = '';
+      try { err = (await res.text()).slice(0, 500); } catch {}
       throw new Error(`llama.cpp error ${res.status}: ${err}`);
     }
 
-    const data = await res.json();
+    let data;
+    try { data = await res.json(); } catch {
+      throw new Error('llama.cpp returned invalid JSON in chat response.');
+    }
     const choice = data.choices?.[0];
     const message = choice?.message;
 
@@ -140,8 +144,8 @@ export class LlamaCppProvider extends BaseLLMProvider {
           if (delta?.tool_calls) {
             yield { type: 'tool_call', content: delta.tool_calls };
           }
-        } catch {
-          // skip malformed chunks
+        } catch (e) {
+          console.warn('[llama.cpp] malformed SSE chunk skipped:', payload?.slice(0, 120), e?.message);
         }
       }
     }

--- a/src/chrome/src/providers/oauth-claude.js
+++ b/src/chrome/src/providers/oauth-claude.js
@@ -202,10 +202,15 @@ async function exchangeCodeForTokens(code, codeVerifier) {
     body: JSON.stringify(body),
   });
   if (!res.ok) {
-    const text = await res.text();
-    throw new Error(`Token exchange failed (HTTP ${res.status}): ${text.slice(0, 400)}`);
+    let errMsg = '';
+    try { errMsg = (await res.text()).slice(0, 200); } catch {}
+    errMsg = errMsg.replace(/[A-Za-z0-9_-]{40,}/g, '[REDACTED]');
+    throw new Error(`Token exchange failed (HTTP ${res.status}): ${errMsg}`);
   }
-  const data = await res.json();
+  let data;
+  try { data = await res.json(); } catch {
+    throw new Error('Token exchange returned invalid JSON.');
+  }
   return await persistTokens(data);
 }
 
@@ -258,9 +263,18 @@ export async function refreshClaudeAccessToken() {
       await chrome.storage.local.remove([STORAGE_KEY]);
       throw new Error('Claude refresh token rejected — please sign in again.');
     }
-    throw new Error(`Token refresh failed (HTTP ${res.status}): ${text.slice(0, 400)}`);
+    if (res.status === 429) {
+      const retryAfter = res.headers.get('retry-after');
+      const waitHint = retryAfter ? ` (retry-after: ${retryAfter}s)` : '';
+      throw new Error(`Token refresh rate-limited (HTTP 429)${waitHint}. Try again in a moment.`);
+    }
+    const safeText = text.slice(0, 200).replace(/[A-Za-z0-9_-]{40,}/g, '[REDACTED]');
+    throw new Error(`Token refresh failed (HTTP ${res.status}): ${safeText}`);
   }
-  const data = await res.json();
+  let data;
+  try { data = await res.json(); } catch {
+    throw new Error('Token refresh returned invalid JSON.');
+  }
   return await persistTokens(data, tokens.refreshToken);
 }
 

--- a/src/chrome/src/providers/openai.js
+++ b/src/chrome/src/providers/openai.js
@@ -124,11 +124,15 @@ export class OpenAICompatibleProvider extends BaseLLMProvider {
     }
 
     if (!res.ok) {
-      const err = await res.text();
+      let err = '';
+      try { err = (await res.text()).slice(0, 500); } catch {}
       throw new Error(`${this.name} error ${res.status}: ${this._formatHttpError(res.status, err)}`);
     }
 
-    const data = await res.json();
+    let data;
+    try { data = await res.json(); } catch {
+      throw new Error(`${this.name} returned invalid JSON in chat response.`);
+    }
     const choice = data.choices?.[0];
     const message = choice?.message;
 
@@ -200,8 +204,8 @@ export class OpenAICompatibleProvider extends BaseLLMProvider {
           if (delta?.tool_calls) {
             yield { type: 'tool_call', content: delta.tool_calls };
           }
-        } catch {
-          // skip
+        } catch (e) {
+          console.warn(`[${this.name}] malformed SSE chunk skipped:`, payload?.slice(0, 120), e?.message);
         }
       }
     }

--- a/src/chrome/src/ui/sidepanel.js
+++ b/src/chrome/src/ui/sidepanel.js
@@ -219,6 +219,7 @@ async function init() {
     const html = await loadTabChat(currentTabId);
     if (html) {
       messagesEl.innerHTML = html;
+      messagesEl.querySelectorAll('[data-bound]').forEach(el => delete el.dataset.bound);
       rebindCopyButtons();
       scrollToBottom();
     }
@@ -317,6 +318,7 @@ async function switchToTab(newTabId) {
   const html = await loadTabChat(newTabId);
   if (html) {
     messagesEl.innerHTML = html;
+    messagesEl.querySelectorAll('[data-bound]').forEach(el => delete el.dataset.bound);
     rebindCopyButtons();
   } else {
     messagesEl.innerHTML = '';

--- a/src/firefox/src/agent/agent.js
+++ b/src/firefox/src/agent/agent.js
@@ -61,6 +61,9 @@ export class Agent {
     // Cache for `_isPdfTab` HEAD probes — see Chrome agent.js for
     // design notes. Same (tabId,url) → isPdf shape.
     this._isPdfTabCache = new Map();
+    this._doneBlockCount = new Map();
+    this._recentSubmitClicks = new Map();
+    this._runningTabs = new Set(); // tabIds with an active processMessage/Stream in flight
     // Pending clarify() tool calls awaiting user input — see Chrome
     // agent.js. Keyed by tabId → (clarifyId → {resolve, ts}).
     this._pendingClarifications = new Map();
@@ -1161,8 +1164,15 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
   clearConversation(tabId) {
     this._cancelClarifications(tabId, 'conversation cleared');
     this.conversations.delete(tabId);
-    this.conversationIds.delete(tabId); // next getConversation() mints a fresh id
-    if (this._doneBlockCount) this._doneBlockCount.delete(tabId);
+    this.conversationIds.delete(tabId);
+    this._cleanupTab(tabId);
+  }
+
+  _cleanupTab(tabId) {
+    this._isPdfTabCache.delete(tabId);
+    this._doneBlockCount.delete(tabId);
+    this._recentSubmitClicks.delete(tabId);
+    this._runningTabs.delete(tabId);
     this._clearLoopState(tabId);
   }
 
@@ -1733,7 +1743,6 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
             // can escape if the heuristic is wrong (e.g. the "form" is a
             // search/filter bar, not a submit form).
             if (completionWarning) {
-              if (!this._doneBlockCount) this._doneBlockCount = new Map();
               const blocks = (this._doneBlockCount.get(tabId) || 0) + 1;
               this._doneBlockCount.set(tabId, blocks);
               if (blocks <= 2) {
@@ -1748,7 +1757,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
               // After 2 blocks, let done through with a loud note in verification.
             }
             // Reset block count on successful done.
-            if (this._doneBlockCount) this._doneBlockCount.delete(tabId);
+            this._doneBlockCount.delete(tabId);
 
             return {
               done: true,
@@ -2476,6 +2485,18 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
    * @returns {Promise<string>} final text response
    */
   async processMessage(tabId, userMessage, onUpdate = () => {}, mode = 'ask') {
+    if (this._runningTabs.has(tabId)) {
+      throw new Error('An agent run is already in progress for this tab.');
+    }
+    this._runningTabs.add(tabId);
+    try {
+      return await this._processMessageInner(tabId, userMessage, onUpdate, mode);
+    } finally {
+      this._runningTabs.delete(tabId);
+    }
+  }
+
+  async _processMessageInner(tabId, userMessage, onUpdate, mode) {
     const messages = this.getConversation(tabId, mode);
 
     // Trim context if it's getting too long
@@ -2680,6 +2701,18 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
    * Process a message with streaming output.
    */
   async processMessageStream(tabId, userMessage, onUpdate = () => {}, mode = 'ask') {
+    if (this._runningTabs.has(tabId)) {
+      throw new Error('An agent run is already in progress for this tab.');
+    }
+    this._runningTabs.add(tabId);
+    try {
+      return await this._processMessageStreamInner(tabId, userMessage, onUpdate, mode);
+    } finally {
+      this._runningTabs.delete(tabId);
+    }
+  }
+
+  async _processMessageStreamInner(tabId, userMessage, onUpdate, mode) {
     const messages = this.getConversation(tabId, mode);
 
     // Trim context if it's getting too long
@@ -2725,8 +2758,8 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
             onUpdate('text_delta', { content: chunk.content });
           } else if (chunk.type === 'tool_call') {
             hasToolCalls = true;
-            // Accumulate streaming tool call deltas (OpenAI format)
-            for (const tc of chunk.content) {
+            const calls = Array.isArray(chunk.content) ? chunk.content : [];
+            for (const tc of calls) {
               const idx = tc.index ?? 0;
               if (!toolCallsAccumulator[idx]) {
                 toolCallsAccumulator[idx] = { id: '', function: { name: '', arguments: '' } };
@@ -2739,13 +2772,13 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
             hasToolCalls = true;
             const idx = Object.keys(toolCallsAccumulator).length;
             toolCallsAccumulator[idx] = {
-              id: chunk.content.id,
-              function: { name: chunk.content.name, arguments: '' },
+              id: chunk.content?.id || '',
+              function: { name: chunk.content?.name || '', arguments: '' },
             };
           } else if (chunk.type === 'tool_call_delta') {
             const idx = Object.keys(toolCallsAccumulator).length - 1;
-            if (toolCallsAccumulator[idx]) {
-              toolCallsAccumulator[idx].function.arguments += chunk.content;
+            if (idx >= 0 && toolCallsAccumulator[idx]) {
+              toolCallsAccumulator[idx].function.arguments += String(chunk.content ?? '');
             }
           } else if (chunk.type === 'done') {
             break;

--- a/src/firefox/src/agent/agent.js
+++ b/src/firefox/src/agent/agent.js
@@ -1165,14 +1165,16 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
     this._cancelClarifications(tabId, 'conversation cleared');
     this.conversations.delete(tabId);
     this.conversationIds.delete(tabId);
-    this._cleanupTab(tabId);
+    this._cleanupTab(tabId, { preserveRunGuard: true });
   }
 
-  _cleanupTab(tabId) {
+  _cleanupTab(tabId, { preserveRunGuard = false } = {}) {
     this._isPdfTabCache.delete(tabId);
     this._doneBlockCount.delete(tabId);
     this._recentSubmitClicks.delete(tabId);
-    this._runningTabs.delete(tabId);
+    if (!preserveRunGuard) {
+      this._runningTabs.delete(tabId);
+    }
     this._clearLoopState(tabId);
   }
 

--- a/src/firefox/src/agent/captcha-solver.js
+++ b/src/firefox/src/agent/captcha-solver.js
@@ -25,7 +25,9 @@ async function postJson(path, body) {
     const text = await res.text().catch(() => '');
     throw new Error(`CapSolver ${path} HTTP ${res.status}: ${text.slice(0, 200)}`);
   }
-  return await res.json();
+  try { return await res.json(); } catch {
+    throw new Error(`CapSolver ${path} returned invalid JSON.`);
+  }
 }
 
 // Wrap a CapSolver error response in a friendlier message. See the chrome
@@ -52,8 +54,9 @@ function capsolverError(prefix, body) {
 export async function getBalance(apiKey) {
   if (!apiKey) throw new Error('No CapSolver API key configured.');
   const res = await postJson('/getBalance', { clientKey: apiKey });
+  if (!res || typeof res !== 'object') throw new Error('CapSolver getBalance returned unexpected response.');
   if (res.errorId) throw capsolverError('CapSolver', res);
-  return { balance: res.balance, packages: res.packages || [] };
+  return { balance: res.balance ?? 0, packages: res.packages || [] };
 }
 
 async function createTask(apiKey, task) {
@@ -62,15 +65,18 @@ async function createTask(apiKey, task) {
     appId: DEFAULT_APP_ID,
     task,
   });
+  if (!res || typeof res !== 'object') throw new Error('CapSolver createTask returned unexpected response.');
   if (res.errorId) throw capsolverError('CapSolver createTask', res);
   if (!res.taskId) throw new Error('CapSolver createTask returned no taskId.');
   return res.taskId;
 }
 
 async function pollTaskResult(apiKey, taskId, { timeoutMs = POLL_TIMEOUT_MS } = {}) {
+  const effectiveTimeout = (typeof timeoutMs === 'number' && timeoutMs > 0) ? timeoutMs : POLL_TIMEOUT_MS;
   const start = Date.now();
-  while (Date.now() - start < timeoutMs) {
+  while (Date.now() - start < effectiveTimeout) {
     const res = await postJson('/getTaskResult', { clientKey: apiKey, taskId });
+    if (!res || typeof res !== 'object') throw new Error('CapSolver getTaskResult returned unexpected response.');
     if (res.errorId) throw capsolverError('CapSolver getTaskResult', res);
     if (res.status === 'ready') return res.solution || {};
     await new Promise(r => setTimeout(r, POLL_INTERVAL_MS));

--- a/src/firefox/src/agent/credential-fields.js
+++ b/src/firefox/src/agent/credential-fields.js
@@ -66,19 +66,20 @@ export const CREDENTIAL_NOTE = CREDENTIAL_NOTE_LOOSE;
  * @returns {{sensitive: boolean, reason: string|null}}
  */
 export function isCredentialField(meta) {
-  if (!meta || typeof meta !== 'object') return { sensitive: false, reason: null };
+  if (!meta || typeof meta !== 'object' || Array.isArray(meta)) return { sensitive: false, reason: null };
 
-  const type = String(meta.type || '').toLowerCase();
+  const type = String(meta.type ?? '').toLowerCase();
   if (type === 'password') return { sensitive: true, reason: 'input type=password' };
 
-  const ac = String(meta.autocomplete || '').trim();
+  const ac = String(meta.autocomplete ?? '').trim();
   if (ac && SENSITIVE_AUTOCOMPLETE_RE.test(ac)) {
     return { sensitive: true, reason: `autocomplete=${ac}` };
   }
 
   for (const key of ['name', 'id', 'ariaLabel', 'placeholder', 'labelText']) {
     const v = meta[key];
-    if (v && SENSITIVE_NAME_RE.test(String(v))) {
+    if (v != null && typeof v !== 'string' && typeof v !== 'number') continue;
+    if (v && SENSITIVE_NAME_RE.test(String(v).slice(0, 200))) {
       return { sensitive: true, reason: `${key} matches credential pattern: ${JSON.stringify(String(v).slice(0, 60))}` };
     }
   }

--- a/src/firefox/src/agent/pdf-tools.js
+++ b/src/firefox/src/agent/pdf-tools.js
@@ -44,7 +44,12 @@ async function getPdfjs() {
  * stack on multi-MB PDFs. fromCharCode.apply has a per-call argument
  * limit (~64k in V8), so we chunk.
  */
+const BASE64_MAX_INPUT_BYTES = 32 * 1024 * 1024; // 32 MB safety cap
+
 function bytesToBase64(bytes) {
+  if (bytes.length > BASE64_MAX_INPUT_BYTES) {
+    throw new Error(`PDF too large for base64 conversion (${bytes.length} bytes, cap ${BASE64_MAX_INPUT_BYTES}).`);
+  }
   let bin = '';
   const chunk = 0x8000;
   for (let i = 0; i < bytes.length; i += chunk) {
@@ -90,7 +95,10 @@ export async function fetchPdfBytes(url) {
     // extension's fetch is anonymous and a signed-in PDF returns a
     // login page or 403. Same posture as the Chrome build.
     // No-op for file:// URLs.
-    res = await fetch(url, { credentials: 'include' });
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), 60000);
+    res = await fetch(url, { credentials: 'include', signal: controller.signal });
+    clearTimeout(timeout);
   } catch (e) {
     if (typeof url === 'string' && url.startsWith('file://')) {
       throw new Error(

--- a/src/firefox/src/agent/pdf-tools.js
+++ b/src/firefox/src/agent/pdf-tools.js
@@ -87,34 +87,31 @@ export function isPdfUrl(url) {
  * error instead of leaving the agent guessing.
  */
 export async function fetchPdfBytes(url) {
-  let res;
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), 60000);
   try {
-    // `credentials: 'include'` forwards the user's cookies for this
-    // origin so PDFs gated behind a session are reachable by the
-    // same identity that can view the file in-tab. Without it, the
-    // extension's fetch is anonymous and a signed-in PDF returns a
-    // login page or 403. Same posture as the Chrome build.
-    // No-op for file:// URLs.
-    const controller = new AbortController();
-    const timeout = setTimeout(() => controller.abort(), 60000);
-    res = await fetch(url, { credentials: 'include', signal: controller.signal });
-    clearTimeout(timeout);
-  } catch (e) {
-    if (typeof url === 'string' && url.startsWith('file://')) {
-      throw new Error(
-        'Cannot fetch local PDF from a file:// URL. Firefox blocks ' +
-        'extension fetches against file:// for privacy. Workaround: ' +
-        'open the PDF over http(s) (e.g. drag it into a local web ' +
-        'server, or upload it to a file host) and try read_pdf again.'
-      );
+    let res;
+    try {
+      res = await fetch(url, { credentials: 'include', signal: controller.signal });
+    } catch (e) {
+      if (typeof url === 'string' && url.startsWith('file://')) {
+        throw new Error(
+          'Cannot fetch local PDF from a file:// URL. Firefox blocks ' +
+          'extension fetches against file:// for privacy. Workaround: ' +
+          'open the PDF over http(s) (e.g. drag it into a local web ' +
+          'server, or upload it to a file host) and try read_pdf again.'
+        );
+      }
+      throw new Error(`PDF fetch failed: ${e.message}`);
     }
-    throw new Error(`PDF fetch failed: ${e.message}`);
+    if (!res.ok) {
+      throw new Error(`PDF fetch returned HTTP ${res.status} ${res.statusText}`);
+    }
+    const buf = await res.arrayBuffer();
+    return new Uint8Array(buf);
+  } finally {
+    clearTimeout(timeout);
   }
-  if (!res.ok) {
-    throw new Error(`PDF fetch returned HTTP ${res.status} ${res.statusText}`);
-  }
-  const buf = await res.arrayBuffer();
-  return new Uint8Array(buf);
 }
 
 /**

--- a/src/firefox/src/background.js
+++ b/src/firefox/src/background.js
@@ -206,6 +206,11 @@ browser.windows?.onRemoved?.addListener?.((windowId) => {
   }
 });
 
+// Clean up per-tab agent state when a tab is closed.
+browser.tabs.onRemoved.addListener((tabId) => {
+  try { agent._cleanupTab(tabId); } catch { /* ignore */ }
+});
+
 // Action click: toggle sidebar (existing UX) AND ensure source tab is
 // in the WebBrain group so the colored label appears immediately.
 browser.browserAction.onClicked.addListener((tab) => {
@@ -451,6 +456,12 @@ async function handleMessage(msg, sender) {
       }
     }
 
+    case 'start_tab_recording':
+    case 'stop_tab_recording':
+      return { ok: false, error: 'Tab recording is not supported in Firefox. This feature requires Chrome\'s tabCapture and OffscreenDocument APIs.' };
+    case 'get_recording_state':
+      return { ok: true, state: { recording: false, supported: false } };
+
     case 'get_page_info': {
       const tabId = msg.tabId || sender.tab?.id;
       try {
@@ -459,6 +470,9 @@ async function handleMessage(msg, sender) {
           action: 'get_page_info',
         });
       } catch {
+        await browser.tabs.executeScript(tabId, {
+          file: 'src/content/accessibility-tree.js',
+        });
         await browser.tabs.executeScript(tabId, {
           file: 'src/content/content.js',
         });

--- a/src/firefox/src/content/content.js
+++ b/src/firefox/src/content/content.js
@@ -499,6 +499,31 @@
     return el; // no interactive ancestor found — use original
   }
 
+  /**
+   * querySelector with resilience against selectors that contain unescaped
+   * React-Aria-style IDs like `#react-aria-:r1a:` — the literal colons
+   * blow up CSS parsing. If the selector is a bare id-hash and throws,
+   * retry with the `[id="..."]` attribute-selector form. Also handles
+   * escaping colons as a last resort.
+   */
+  function safeQuerySelector(selector) {
+    if (typeof selector !== 'string' || !selector) return null;
+    try { return document.querySelector(selector); } catch {}
+    if (selector.startsWith('#') && !/[\s>+~,\[\]\.:]/.test(selector.slice(1).replace(/\\:/g, ''))) {
+      const rawId = selector.slice(1).replace(/\\:/g, ':');
+      try {
+        const byId = document.getElementById(rawId);
+        if (byId) return byId;
+      } catch {}
+      try { return document.querySelector(`[id="${rawId.replace(/"/g, '\\"')}"]`); } catch {}
+    }
+    try {
+      const escaped = selector.replace(/(^|[^\\]):/g, '$1\\:');
+      return document.querySelector(escaped);
+    } catch {}
+    return null;
+  }
+
   let _lastClickIdent = null;
 
   /**
@@ -732,7 +757,7 @@
         el = _resolveInteractiveAncestor(resolved);
       }
     } else if (params.selector) {
-      el = document.querySelector(params.selector);
+      el = safeQuerySelector(params.selector);
     } else if (params.index != null) {
       // Same traversal as getInteractiveElements — index stability.
       const interactive = queryInteractive();
@@ -981,7 +1006,7 @@
   function _typeTextInner(params) {
     let el;
     if (params.selector) {
-      el = document.querySelector(params.selector);
+      el = safeQuerySelector(params.selector);
     } else if (params.index != null) {
       const interactive = queryInteractive();
       el = interactive[params.index];

--- a/src/firefox/src/providers/anthropic.js
+++ b/src/firefox/src/providers/anthropic.js
@@ -156,11 +156,15 @@ export class AnthropicProvider extends BaseLLMProvider {
     });
 
     if (!res.ok) {
-      const err = await res.text();
+      let err = '';
+      try { err = (await res.text()).slice(0, 500); } catch {}
       throw new Error(`Anthropic error ${res.status}: ${err}`);
     }
 
-    const data = await res.json();
+    let data;
+    try { data = await res.json(); } catch {
+      throw new Error('Anthropic returned invalid JSON in chat response.');
+    }
 
     // Extract text content and tool use blocks
     let content = '';
@@ -168,15 +172,15 @@ export class AnthropicProvider extends BaseLLMProvider {
 
     for (const block of data.content || []) {
       if (block.type === 'text') {
-        content += block.text;
+        content += block.text || '';
       } else if (block.type === 'tool_use') {
         if (!toolCalls) toolCalls = [];
         toolCalls.push({
-          id: block.id,
+          id: block.id || '',
           type: 'function',
           function: {
-            name: block.name,
-            arguments: JSON.stringify(block.input),
+            name: block.name || '',
+            arguments: JSON.stringify(block.input ?? {}),
           },
         });
       }
@@ -217,7 +221,8 @@ export class AnthropicProvider extends BaseLLMProvider {
     });
 
     if (!res.ok) {
-      const err = await res.text();
+      let err = '';
+      try { err = (await res.text()).slice(0, 500); } catch {}
       throw new Error(`Anthropic stream error ${res.status}: ${err}`);
     }
 
@@ -250,8 +255,8 @@ export class AnthropicProvider extends BaseLLMProvider {
               yield {
                 type: 'tool_call_start',
                 content: {
-                  id: event.content_block.id,
-                  name: event.content_block.name,
+                  id: event.content_block.id || '',
+                  name: event.content_block.name || '',
                 },
               };
             }
@@ -259,8 +264,8 @@ export class AnthropicProvider extends BaseLLMProvider {
             yield { type: 'done', content: '' };
             return;
           }
-        } catch {
-          // skip
+        } catch (e) {
+          console.warn('[anthropic] malformed SSE chunk skipped:', e?.message);
         }
       }
     }
@@ -283,6 +288,7 @@ export class AnthropicOAuthProvider extends AnthropicProvider {
   constructor(config) {
     super(config);
     this._accessToken = null;
+    this._refreshPromise = null;
   }
 
   get name() {
@@ -319,13 +325,22 @@ export class AnthropicOAuthProvider extends AnthropicProvider {
     this._accessToken = await getClaudeAccessToken();
   }
 
+  async _refreshOnce() {
+    if (!this._refreshPromise) {
+      this._refreshPromise = refreshClaudeAccessToken().finally(() => {
+        this._refreshPromise = null;
+      });
+    }
+    return this._refreshPromise;
+  }
+
   async chat(messages, options = {}) {
     await this._ensureFreshToken();
     try {
       return await super.chat(messages, options);
     } catch (e) {
       if (/Anthropic error 401/.test(e.message)) {
-        await refreshClaudeAccessToken();
+        await this._refreshOnce();
         await this._ensureFreshToken();
         return await super.chat(messages, options);
       }
@@ -340,7 +355,7 @@ export class AnthropicOAuthProvider extends AnthropicProvider {
       return;
     } catch (e) {
       if (/Anthropic stream error 401/.test(e.message)) {
-        await refreshClaudeAccessToken();
+        await this._refreshOnce();
         await this._ensureFreshToken();
         yield* super.chatStream(messages, options);
         return;

--- a/src/firefox/src/providers/llamacpp.js
+++ b/src/firefox/src/providers/llamacpp.js
@@ -55,11 +55,15 @@ export class LlamaCppProvider extends BaseLLMProvider {
     }
 
     if (!res.ok) {
-      const err = await res.text();
+      let err = '';
+      try { err = (await res.text()).slice(0, 500); } catch {}
       throw new Error(`llama.cpp error ${res.status}: ${err}`);
     }
 
-    const data = await res.json();
+    let data;
+    try { data = await res.json(); } catch {
+      throw new Error('llama.cpp returned invalid JSON in chat response.');
+    }
     const choice = data.choices?.[0];
     const message = choice?.message;
 
@@ -134,8 +138,8 @@ export class LlamaCppProvider extends BaseLLMProvider {
           if (delta?.tool_calls) {
             yield { type: 'tool_call', content: delta.tool_calls };
           }
-        } catch {
-          // skip malformed chunks
+        } catch (e) {
+          console.warn('[llama.cpp] malformed SSE chunk skipped:', payload?.slice(0, 120), e?.message);
         }
       }
     }

--- a/src/firefox/src/providers/manager.js
+++ b/src/firefox/src/providers/manager.js
@@ -35,7 +35,8 @@ export class ProviderManager {
       if (!configs[id]) configs[id] = stored[id];
     }
     delete configs.webbrain;
-    this.activeProviderId = data.activeProvider === 'webbrain'
+    delete configs.openai_subscription;
+    this.activeProviderId = ['webbrain', 'openai_subscription'].includes(data.activeProvider)
       ? 'llamacpp'
       : (data.activeProvider || 'llamacpp');
 
@@ -115,7 +116,7 @@ export class ProviderManager {
         category: 'cloud',
         label: 'Anthropic Claude',
         baseUrl: 'https://api.anthropic.com',
-        model: 'claude-sonnet-4-20250514',
+        model: 'claude-sonnet-4-6',
         apiKey: '',
         apiKeyUrl: 'https://console.anthropic.com/settings/keys',
         enabled: false,
@@ -226,7 +227,7 @@ export class ProviderManager {
         type: 'anthropic_oauth',
         category: 'cloud',
         label: 'Claude (Pro/Max subscription)',
-        model: 'claude-sonnet-4-20250514',
+        model: 'claude-sonnet-4-6',
         enabled: false,
       },
     };

--- a/src/firefox/src/providers/oauth-claude.js
+++ b/src/firefox/src/providers/oauth-claude.js
@@ -138,10 +138,15 @@ async function exchangeCodeForTokens(code, codeVerifier) {
     body: JSON.stringify(body),
   });
   if (!res.ok) {
-    const text = await res.text();
-    throw new Error(`Token exchange failed (HTTP ${res.status}): ${text.slice(0, 400)}`);
+    let errMsg = '';
+    try { errMsg = (await res.text()).slice(0, 200); } catch {}
+    errMsg = errMsg.replace(/[A-Za-z0-9_-]{40,}/g, '[REDACTED]');
+    throw new Error(`Token exchange failed (HTTP ${res.status}): ${errMsg}`);
   }
-  const data = await res.json();
+  let data;
+  try { data = await res.json(); } catch {
+    throw new Error('Token exchange returned invalid JSON.');
+  }
   return await persistTokens(data);
 }
 
@@ -181,9 +186,18 @@ export async function refreshClaudeAccessToken() {
       await browser.storage.local.remove([STORAGE_KEY]);
       throw new Error('Claude refresh token rejected — please sign in again.');
     }
-    throw new Error(`Token refresh failed (HTTP ${res.status}): ${text.slice(0, 400)}`);
+    if (res.status === 429) {
+      const retryAfter = res.headers.get('retry-after');
+      const waitHint = retryAfter ? ` (retry-after: ${retryAfter}s)` : '';
+      throw new Error(`Token refresh rate-limited (HTTP 429)${waitHint}. Try again in a moment.`);
+    }
+    const safeText = text.slice(0, 200).replace(/[A-Za-z0-9_-]{40,}/g, '[REDACTED]');
+    throw new Error(`Token refresh failed (HTTP ${res.status}): ${safeText}`);
   }
-  const data = await res.json();
+  let data;
+  try { data = await res.json(); } catch {
+    throw new Error('Token refresh returned invalid JSON.');
+  }
   return await persistTokens(data, tokens.refreshToken);
 }
 

--- a/src/firefox/src/providers/openai.js
+++ b/src/firefox/src/providers/openai.js
@@ -111,11 +111,15 @@ export class OpenAICompatibleProvider extends BaseLLMProvider {
     }
 
     if (!res.ok) {
-      const err = await res.text();
+      let err = '';
+      try { err = (await res.text()).slice(0, 500); } catch {}
       throw new Error(`${this.name} error ${res.status}: ${this._formatHttpError(res.status, err)}`);
     }
 
-    const data = await res.json();
+    let data;
+    try { data = await res.json(); } catch {
+      throw new Error(`${this.name} returned invalid JSON in chat response.`);
+    }
     const choice = data.choices?.[0];
     const message = choice?.message;
 
@@ -187,8 +191,8 @@ export class OpenAICompatibleProvider extends BaseLLMProvider {
           if (delta?.tool_calls) {
             yield { type: 'tool_call', content: delta.tool_calls };
           }
-        } catch {
-          // skip
+        } catch (e) {
+          console.warn(`[${this.name}] malformed SSE chunk skipped:`, payload?.slice(0, 120), e?.message);
         }
       }
     }


### PR DESCRIPTION
## Summary
- Four independent audit agents scanned every major file in the codebase
- **65+ bugs found and fixed** across 23 files (326 insertions, 125 deletions)
- **45 specific audit findings** individually re-verified — 39 fixed, 6 confirmed not-bugs
- **195/195 tests pass**

### Security
- OAuth error messages redact token-like strings, truncate to 200 chars
- All provider error bodies truncated with try/catch protection
- OAuth 429 rate-limit handling with retry-after hint
- Credential-field regex input truncated to prevent unbounded execution

### JSON/response validation
- `res.json()` wrapped in try/catch across all 6 provider files (Chrome + Firefox)
- OAuth token exchange/refresh JSON parse protection
- CapSolver response shape validation on all API endpoints

### Null safety
- Anthropic tool_use block fields defaulted (`block.id || ''`, `block.input ?? {}`)
- Streaming accumulator: `Array.isArray` guard, `idx >= 0` check, `String(content ?? '')`
- CapSolver balance defaults to 0 via nullish coalescing

### Memory leak prevention
- New `_cleanupTab()` method consolidates all per-tab Map/Set cleanup (10 structures)
- `tabs.onRemoved` calls `_cleanupTab` in both Chrome and Firefox
- `fetch-with-fallback.js` stores listener ref to prevent double-registration

### Concurrency
- `AnthropicOAuthProvider._refreshOnce()` coalesces concurrent 401 token refreshes
- `_runningTabs` Set prevents overlapping agent runs on the same tab

### Firefox parity
- `safeQuerySelector` ported for React-Aria/Radix component compatibility
- `openai_subscription` deprecated provider cleanup added
- Default Claude model aligned to `claude-sonnet-4-6`
- Content script injection fallback now injects `accessibility-tree.js`
- Tab recorder stub routes return descriptive unsupported error
- `tabs.onRemoved` handler added for per-tab state cleanup

### Observability
- SSE stream catch blocks now `console.warn` with chunk excerpt (all 3 providers)

### Timeout/resource protection
- PDF fetch: 60-second AbortController timeout
- PDF `bytesToBase64`: 32MB size guard

### UI
- Sidepanel copy button `data-bound` flags cleared on innerHTML restore

## Test plan
- [x] `npm test` — 195/195 passing
- [ ] Manual: verify Chrome extension loads and agent runs Ask + Act mode
- [ ] Manual: verify Firefox extension loads and agent runs Ask + Act mode
- [ ] Manual: verify OAuth sign-in flow works on Chrome
- [ ] Manual: verify settings page renders all providers correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)