### PR TITLE
feat: add slash commands — /help, /compact, /reset, /screenshot, /exp…

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,11 +190,18 @@ Source: [`lmstudio-plugin/`](./lmstudio-plugin/).
 
 ## Slash Commands
 
-WebBrain accepts a small set of slash commands as the first thing on a line in the input box:
+WebBrain accepts slash commands as the first thing on a line in the input box. Type `/help` to see the list inside the panel.
 
 | Command | What it does |
 |---------|--------------|
-| `/allow-api` | **Per-conversation API mutation override.** By default WebBrain refuses to use API endpoints (POST/PUT/PATCH/DELETE via `fetch_url`) for any action that creates, modifies, deletes, or sends — it always goes through the visible UI of the current page so you can see what's happening. Type `/allow-api` (optionally followed by a task description) to lift that restriction *for the current conversation only*. The agent will still prefer UI when UI works, but may fall back to API mutations when UI is genuinely failing or unworkable. A sticky badge appears above the input area while the override is active. The flag clears when you reset the conversation. |
+| `/help` | Show the list of available commands |
+| `/allow-api` | **Per-conversation API mutation override.** Lifts the UI-first restriction so the agent may use POST/PUT/PATCH/DELETE via `fetch_url` when UI is failing. Badge appears while active; clears on `/reset`. |
+| `/compact` | Toggle verbose/compact tool display (same as the toolbar button) |
+| `/reset` | Clear the conversation and all per-conversation flags |
+| `/screenshot` | Capture the visible tab and display the image inline in chat |
+| `/export` | Download the current conversation as a Markdown file |
+| `/profile` | Toggle profile auto-fill on/off without opening Settings |
+| `/vision` | Toggle vision mode (screenshot understanding) on the active provider |
 
 The default UI-first rule exists because API actions are invisible (you don't see what's being sent), often require separate auth tokens you may not have configured, and can have a much larger blast radius than a visible mis-click. Only use `/allow-api` when you've decided you want that tradeoff for a specific job.
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "WebBrain",
-  "version": "8.5.0",
+  "version": "8.6.0",
   "description": "Open-source AI browser agent — chat with pages, automate tasks, multi-provider LLM support.",
   "permissions": [
     "sidePanel",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "webbrain",
-  "version": "8.5.0",
+  "version": "8.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "webbrain",
-      "version": "8.5.0",
+      "version": "8.6.0",
       "license": "MIT",
       "devDependencies": {
         "playwright": "^1.48.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webbrain",
-  "version": "8.5.0",
+  "version": "8.6.0",
   "description": "Open-source AI browser agent — chat with pages, automate tasks, multi-provider LLM support.",
   "private": true,
   "type": "module",

--- a/src/chrome/ARCHITECTURE.md
+++ b/src/chrome/ARCHITECTURE.md
@@ -1,6 +1,6 @@
 # WebBrain Chrome Extension — Architecture
 
-> Version 8.5.0 · Manifest V3 · Service Worker background
+> Version 8.6.0 · Manifest V3 · Service Worker background
 
 ## High-Level Overview
 

--- a/src/chrome/manifest.json
+++ b/src/chrome/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "WebBrain",
-  "version": "8.5.0",
+  "version": "8.6.0",
   "description": "Open-source AI browser agent — chat with pages, automate tasks, multi-provider LLM support.",
   "permissions": [
     "sidePanel",

--- a/src/chrome/src/ui/locales/en.js
+++ b/src/chrome/src/ui/locales/en.js
@@ -69,6 +69,17 @@ export default {
   'sp.api.enabled_html': '🔓 <strong>API mutations enabled</strong> for this conversation. The agent may now use POST/PUT/PATCH/DELETE via fetch_url and execute_js when it judges API to be more reliable than UI for a step. UI-first remains the default. This flag clears when you reset the conversation.',
   'sp.api.badge_html': '<span>🔓 API mutations allowed</span>',
 
+  'sp.help_html': '<strong>Slash Commands</strong><br><code>/help</code> — Show this list<br><code>/allow-api</code> — Allow API mutations for this conversation<br><code>/compact</code> — Toggle verbose/compact tool display<br><code>/reset</code> — Clear conversation<br><code>/screenshot</code> — Capture current tab<br><code>/export</code> — Download conversation as Markdown<br><code>/profile</code> — Toggle profile auto-fill<br><code>/vision</code> — Toggle vision mode on active provider',
+  'sp.compact.verbose_on': 'Verbose mode <strong>on</strong> — full tool call JSON visible.',
+  'sp.compact.verbose_off': 'Verbose mode <strong>off</strong> — compact tool display.',
+  'sp.screenshot.error': 'Screenshot failed: {msg}',
+  'sp.export.done': 'Conversation exported.',
+  'sp.profile.on': 'Profile auto-fill <strong>enabled</strong>.',
+  'sp.profile.off': 'Profile auto-fill <strong>disabled</strong>.',
+  'sp.vision.on': 'Vision mode <strong>enabled</strong> for active provider.',
+  'sp.vision.off': 'Vision mode <strong>disabled</strong> for active provider.',
+  'sp.vision.error': 'Vision toggle failed: {msg}',
+
   // --- Tool labels -------------------------------------------------------
   'tool.read_page': 'Reading page',
   'tool.get_interactive_elements': 'Scanning interactive elements',

--- a/src/chrome/src/ui/settings.js
+++ b/src/chrome/src/ui/settings.js
@@ -6,7 +6,7 @@ import { t, getLocale, setLocale, LANGUAGES } from './i18n.js';
 
 // Version shown in the subtitle. Kept here so it only needs one update per
 // release; the subtitle string itself is translated.
-const EXT_VERSION = '8.5.0';
+const EXT_VERSION = '8.6.0';
 
 const providersContainer = document.getElementById('providers');
 const verboseToggle = document.getElementById('toggle-verbose');

--- a/src/chrome/src/ui/sidepanel.js
+++ b/src/chrome/src/ui/sidepanel.js
@@ -1176,6 +1176,8 @@ function addMessage(role, content) {
   textEl.className = 'message-text';
   if (role === 'user') {
     textEl.textContent = content;
+  } else if (role === 'system') {
+    textEl.innerHTML = content || '';
   } else {
     textEl.innerHTML = content ? formatMarkdown(content) : '';
   }

--- a/src/chrome/src/ui/sidepanel.js
+++ b/src/chrome/src/ui/sidepanel.js
@@ -403,21 +403,130 @@ async function testConnection() {
 let apiMutationsAllowed = false;
 
 /**
- * Parse leading slash commands out of the user's message. Currently:
- *   /allow-api  → enable API mutation override for this conversation.
- * Returns the cleaned text. May trigger UI side effects (toast, badge).
+ * Parse leading slash commands out of the user's message.
+ * Returns the cleaned text (empty string if fully consumed).
+ * May trigger async UI side effects (screenshot, export, etc.).
  */
-function parseSlashCommands(text) {
-  const m = text.match(/^\/allow-api\b\s*/i);
-  if (m) {
+async function parseSlashCommands(text) {
+  // /help — list all available slash commands
+  if (/^\/help\b\s*/i.test(text)) {
+    addMessage('system', t('sp.help_html'));
+    return '';
+  }
+
+  // /allow-api — enable API mutation override
+  const mApi = text.match(/^\/allow-api\b\s*/i);
+  if (mApi) {
     const wasAlreadyAllowed = apiMutationsAllowed;
     apiMutationsAllowed = true;
     updateApiBadge();
     if (!wasAlreadyAllowed) {
       addMessage('system', t('sp.api.enabled_html'));
     }
-    return text.slice(m[0].length).trim();
+    return text.slice(mApi[0].length).trim();
   }
+
+  // /compact — toggle verbose/compact mode
+  if (/^\/compact\b\s*/i.test(text)) {
+    verboseMode = !verboseMode;
+    if (verboseBtn) verboseBtn.classList.toggle('active', verboseMode);
+    chrome.storage.local.set({ verboseMode }).catch(() => {});
+    addMessage('system', verboseMode
+      ? t('sp.compact.verbose_on')
+      : t('sp.compact.verbose_off'));
+    return '';
+  }
+
+  // /reset — clear conversation (same as clear button)
+  if (/^\/reset\b\s*/i.test(text)) {
+    await sendToBackground('clear_conversation', { tabId: currentTabId });
+    messagesEl.innerHTML = '';
+    addMessage('system', t('sp.cleared_message'));
+    if (currentTabId != null) {
+      tabChats.delete(currentTabId);
+      chrome.storage.session?.remove(TAB_CHAT_PREFIX + currentTabId).catch(() => {});
+    }
+    apiMutationsAllowed = false;
+    updateApiBadge();
+    return '';
+  }
+
+  // /screenshot — capture visible tab and display in chat
+  if (/^\/screenshot\b\s*/i.test(text)) {
+    try {
+      const tab = await chrome.tabs.query({ active: true, currentWindow: true });
+      const windowId = tab[0]?.windowId;
+      if (windowId) {
+        const dataUrl = await chrome.tabs.captureVisibleTab(windowId, { format: 'png' });
+        const imgHtml = `<img src="${dataUrl}" style="max-width:100%;border-radius:6px;margin:4px 0;" alt="Screenshot"/>`;
+        addMessage('system', imgHtml);
+      }
+    } catch (e) {
+      addMessage('system', t('sp.screenshot.error', { msg: e.message }));
+    }
+    return '';
+  }
+
+  // /export — export conversation as markdown
+  if (/^\/export\b\s*/i.test(text)) {
+    const messages = messagesEl.querySelectorAll('.message');
+    let md = '# WebBrain Conversation\n\n';
+    for (const msg of messages) {
+      const textEl = msg.querySelector('.message-text');
+      if (!textEl) continue;
+      const content = textEl.textContent.trim();
+      if (!content) continue;
+      if (msg.classList.contains('user')) {
+        md += `**You:** ${content}\n\n`;
+      } else if (msg.classList.contains('assistant')) {
+        md += `**WebBrain:** ${content}\n\n`;
+      } else if (msg.classList.contains('system')) {
+        md += `*${content}*\n\n`;
+      }
+    }
+    const blob = new Blob([md], { type: 'text/markdown' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = `webbrain-chat-${Date.now()}.md`;
+    a.click();
+    URL.revokeObjectURL(url);
+    addMessage('system', t('sp.export.done'));
+    return '';
+  }
+
+  // /profile — toggle profile auto-fill on/off
+  if (/^\/profile\b\s*/i.test(text)) {
+    const stored = await chrome.storage.local.get(['profileEnabled', 'profileText']);
+    const newState = !stored.profileEnabled;
+    await chrome.storage.local.set({ profileEnabled: newState });
+    addMessage('system', newState
+      ? t('sp.profile.on')
+      : t('sp.profile.off'));
+    return '';
+  }
+
+  // /vision — toggle vision support on active provider
+  if (/^\/vision\b\s*/i.test(text)) {
+    try {
+      const { providers, active } = await sendToBackground('get_providers');
+      const config = providers[active];
+      if (config) {
+        const newVision = !config.supportsVision;
+        await sendToBackground('update_provider', {
+          providerId: active,
+          config: { ...config, supportsVision: newVision },
+        });
+        addMessage('system', newVision
+          ? t('sp.vision.on')
+          : t('sp.vision.off'));
+      }
+    } catch (e) {
+      addMessage('system', t('sp.vision.error', { msg: e.message }));
+    }
+    return '';
+  }
+
   return text;
 }
 
@@ -441,9 +550,15 @@ async function sendMessage() {
   let text = inputEl.value.trim();
   if (!text || isProcessing) return;
 
+  // Clear input early so slash commands don't linger visually.
+  if (text.startsWith('/')) {
+    inputEl.value = '';
+    autoResizeInput();
+  }
+
   // Parse any leading slash command. parseSlashCommands may strip the
   // command from `text` and toggle apiMutationsAllowed as a side effect.
-  text = parseSlashCommands(text);
+  text = await parseSlashCommands(text);
   // If the entire message was just the slash command, there's nothing
   // left to send to the agent — bail out after the side effect.
   if (!text) {

--- a/src/firefox/ARCHITECTURE.md
+++ b/src/firefox/ARCHITECTURE.md
@@ -1,6 +1,6 @@
 # WebBrain Firefox Extension — Architecture
 
-> Version 8.5.0 · Manifest V2 · Background Page
+> Version 8.6.0 · Manifest V2 · Background Page
 
 ## How Firefox Differs from Chrome
 

--- a/src/firefox/manifest.json
+++ b/src/firefox/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "WebBrain",
-  "version": "8.5.0",
+  "version": "8.6.0",
   "description": "Open-source AI browser agent — chat with pages, automate tasks, multi-provider LLM support.",
   "permissions": [
     "activeTab",

--- a/src/firefox/src/ui/locales/en.js
+++ b/src/firefox/src/ui/locales/en.js
@@ -61,6 +61,17 @@ export default {
   'sp.api.enabled_html': '🔓 <strong>API mutations enabled</strong> for this conversation. The agent may now use POST/PUT/PATCH/DELETE via fetch_url and execute_js when it judges API to be more reliable than UI for a step. UI-first remains the default. This flag clears when you reset the conversation.',
   'sp.api.badge_html': '<span>🔓 API mutations allowed</span>',
 
+  'sp.help_html': '<strong>Slash Commands</strong><br><code>/help</code> — Show this list<br><code>/allow-api</code> — Allow API mutations for this conversation<br><code>/compact</code> — Toggle verbose/compact tool display<br><code>/reset</code> — Clear conversation<br><code>/screenshot</code> — Capture current tab<br><code>/export</code> — Download conversation as Markdown<br><code>/profile</code> — Toggle profile auto-fill<br><code>/vision</code> — Toggle vision mode on active provider',
+  'sp.compact.verbose_on': 'Verbose mode <strong>on</strong> — full tool call JSON visible.',
+  'sp.compact.verbose_off': 'Verbose mode <strong>off</strong> — compact tool display.',
+  'sp.screenshot.error': 'Screenshot failed: {msg}',
+  'sp.export.done': 'Conversation exported.',
+  'sp.profile.on': 'Profile auto-fill <strong>enabled</strong>.',
+  'sp.profile.off': 'Profile auto-fill <strong>disabled</strong>.',
+  'sp.vision.on': 'Vision mode <strong>enabled</strong> for active provider.',
+  'sp.vision.off': 'Vision mode <strong>disabled</strong> for active provider.',
+  'sp.vision.error': 'Vision toggle failed: {msg}',
+
   // --- Tool labels -------------------------------------------------------
   'tool.read_page': 'Reading page',
   'tool.get_interactive_elements': 'Scanning interactive elements',

--- a/src/firefox/src/ui/settings.js
+++ b/src/firefox/src/ui/settings.js
@@ -6,7 +6,7 @@ import { t, getLocale, setLocale, LANGUAGES } from './i18n.js';
 
 // Version shown in the subtitle. Kept here so it only needs one update per
 // release; the subtitle string itself is translated.
-const EXT_VERSION = '8.5.0';
+const EXT_VERSION = '8.6.0';
 
 const providersContainer = document.getElementById('providers');
 const verboseToggle = document.getElementById('toggle-verbose');

--- a/src/firefox/src/ui/sidepanel.js
+++ b/src/firefox/src/ui/sidepanel.js
@@ -842,6 +842,8 @@ function addMessage(role, content) {
   textEl.className = 'message-text';
   if (role === 'user') {
     textEl.textContent = content;
+  } else if (role === 'system') {
+    textEl.innerHTML = content || '';
   } else {
     textEl.innerHTML = content ? formatMarkdown(content) : '';
   }

--- a/src/firefox/src/ui/sidepanel.js
+++ b/src/firefox/src/ui/sidepanel.js
@@ -258,17 +258,121 @@ async function testConnection() {
 // Per-conversation API mutation override (set via /allow-api).
 let apiMutationsAllowed = false;
 
-function parseSlashCommands(text) {
-  const m = text.match(/^\/allow-api\b\s*/i);
-  if (m) {
+async function parseSlashCommands(text) {
+  // /help — list all available slash commands
+  if (/^\/help\b\s*/i.test(text)) {
+    addMessage('system', t('sp.help_html'));
+    return '';
+  }
+
+  // /allow-api — enable API mutation override
+  const mApi = text.match(/^\/allow-api\b\s*/i);
+  if (mApi) {
     const wasAlreadyAllowed = apiMutationsAllowed;
     apiMutationsAllowed = true;
     updateApiBadge();
     if (!wasAlreadyAllowed) {
       addMessage('system', t('sp.api.enabled_html'));
     }
-    return text.slice(m[0].length).trim();
+    return text.slice(mApi[0].length).trim();
   }
+
+  // /compact — toggle verbose/compact mode
+  if (/^\/compact\b\s*/i.test(text)) {
+    verboseMode = !verboseMode;
+    if (verboseBtn) verboseBtn.classList.toggle('active', verboseMode);
+    browser.storage.local.set({ verboseMode }).catch(() => {});
+    addMessage('system', verboseMode
+      ? t('sp.compact.verbose_on')
+      : t('sp.compact.verbose_off'));
+    return '';
+  }
+
+  // /reset — clear conversation (same as clear button)
+  if (/^\/reset\b\s*/i.test(text)) {
+    await sendToBackground('clear_conversation', { tabId: currentTabId });
+    messagesEl.innerHTML = '';
+    addMessage('system', t('sp.cleared_message'));
+    if (currentTabId != null) {
+      tabChats.delete(currentTabId);
+    }
+    apiMutationsAllowed = false;
+    updateApiBadge();
+    return '';
+  }
+
+  // /screenshot — capture visible tab and display in chat
+  if (/^\/screenshot\b\s*/i.test(text)) {
+    try {
+      const dataUrl = await browser.tabs.captureVisibleTab(null, { format: 'png' });
+      const imgHtml = `<img src="${dataUrl}" style="max-width:100%;border-radius:6px;margin:4px 0;" alt="Screenshot"/>`;
+      addMessage('system', imgHtml);
+    } catch (e) {
+      addMessage('system', t('sp.screenshot.error', { msg: e.message }));
+    }
+    return '';
+  }
+
+  // /export — export conversation as markdown
+  if (/^\/export\b\s*/i.test(text)) {
+    const messages = messagesEl.querySelectorAll('.message');
+    let md = '# WebBrain Conversation\n\n';
+    for (const msg of messages) {
+      const textEl = msg.querySelector('.message-text');
+      if (!textEl) continue;
+      const content = textEl.textContent.trim();
+      if (!content) continue;
+      if (msg.classList.contains('user')) {
+        md += `**You:** ${content}\n\n`;
+      } else if (msg.classList.contains('assistant')) {
+        md += `**WebBrain:** ${content}\n\n`;
+      } else if (msg.classList.contains('system')) {
+        md += `*${content}*\n\n`;
+      }
+    }
+    const blob = new Blob([md], { type: 'text/markdown' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = `webbrain-chat-${Date.now()}.md`;
+    a.click();
+    URL.revokeObjectURL(url);
+    addMessage('system', t('sp.export.done'));
+    return '';
+  }
+
+  // /profile — toggle profile auto-fill on/off
+  if (/^\/profile\b\s*/i.test(text)) {
+    const stored = await browser.storage.local.get(['profileEnabled', 'profileText']);
+    const newState = !stored.profileEnabled;
+    await browser.storage.local.set({ profileEnabled: newState });
+    addMessage('system', newState
+      ? t('sp.profile.on')
+      : t('sp.profile.off'));
+    return '';
+  }
+
+  // /vision — toggle vision support on active provider
+  if (/^\/vision\b\s*/i.test(text)) {
+    try {
+      const { providers, active } = await sendToBackground('get_providers');
+      const config = providers[active];
+      if (config) {
+        const newVision = !config.supportsVision;
+        await sendToBackground('update_provider', {
+          providerId: active,
+          config: { ...config, supportsVision: newVision },
+        });
+        addMessage('system', newVision
+          ? t('sp.vision.on')
+          : t('sp.vision.off'));
+      }
+    } catch (e) {
+      addMessage('system', t('sp.vision.error', { msg: e.message }));
+    }
+    return '';
+  }
+
   return text;
 }
 
@@ -292,7 +396,12 @@ async function sendMessage() {
   let text = inputEl.value.trim();
   if (!text || isProcessing) return;
 
-  text = parseSlashCommands(text);
+  if (text.startsWith('/')) {
+    inputEl.value = '';
+    autoResizeInput();
+  }
+
+  text = await parseSlashCommands(text);
   if (!text) {
     inputEl.value = '';
     autoResizeInput();


### PR DESCRIPTION
…ort, /profile, /vision

All commands work in both Chrome and Firefox builds. Input clears immediately on slash prefix for responsive UX. i18n strings added to en.js locale; README updated with the full command table.