### PR TITLE
Fix narrow-layout horizontal overflow in hero mockup and nav

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -576,12 +576,16 @@
     .browser-dots span:nth-child(3) { background: #34d399; }
     .browser-url {
       flex: 1;
+      min-width: 0;
       margin-inline-start: 12px;
       background: var(--url-bg);
       border-radius: 6px;
       padding: 5px 12px;
       font-size: 12px;
       color: var(--text-dim);
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
     }
     .browser-body {
       display: flex;
@@ -1450,10 +1454,16 @@
        RESPONSIVE
        ================================================================ */
     @media (max-width: 768px) {
+      body { overflow-x: hidden; }
       .browser-body { flex-direction: column; }
       .side-panel { width: 100%; border-inline-start: none; border-top: 1px solid var(--border); min-height: 260px; }
       .modes-grid { grid-template-columns: 1fr; }
+      .nav-inner { padding: 12px 14px; gap: 10px; }
+      .nav-brand { min-width: 0; font-size: 18px; }
+      .nav-links { gap: 10px; flex-shrink: 0; }
       .nav-links a:not(.nav-cta) { display: none; }
+      .nav-cta { padding: 8px 14px; font-size: 12px; }
+      .lang-dropdown { max-width: 42vw; }
       .gh-stars { display: none; }
       /* The theme toggle would overflow the 24px-padded header at phone
          widths. prefers-color-scheme still auto-picks the right theme


### PR DESCRIPTION
### Motivation
- Long URL text inside the hero browser mockup and oversized header controls could push the page wider than the viewport on narrow screens, producing a white gap and horizontal panning.

### Description
- Truncate the hero mockup URL by setting `.browser-url { min-width: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }` so long text is clipped instead of expanding the layout.
- Tighten mobile header layout under `@media (max-width: 768px)` by adding `body { overflow-x: hidden; }`, reducing header padding/gaps, allowing the brand to shrink, making `.nav-links` shrinkable, scaling down the GitHub CTA (`.nav-cta`) and capping the language dropdown width (`.lang-dropdown`).
- These are CSS-only adjustments in `web/index.html` to prevent overflow and improve narrow-view visuals.

### Testing
- No automated tests were executed for this CSS-only change.
- Changes were validated by reviewing the diff and the updated responsive CSS rules to ensure the overflow and sizing fixes are applied.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a182cf6daec8327b21a1ab356fa1318)