### PR TITLE
Fix Firefox download card wrapping

### DIFF
--- a/web/ar/index.html
+++ b/web/ar/index.html
@@ -353,6 +353,7 @@
       backdrop-filter: blur(20px);
       background: var(--nav-bg);
       border-bottom: 1px solid var(--border);
+      overflow-x: clip;
     }
     .nav-inner {
       max-width: var(--max-w);
@@ -373,7 +374,7 @@
       -webkit-text-fill-color: transparent;
     }
     .nav-brand span.emoji { -webkit-text-fill-color: initial; font-size: 22px; }
-    .nav-links { display: flex; gap: 28px; align-items: center; }
+    .nav-links { display: flex; gap: 28px; align-items: center; margin-inline-start: auto; min-width: 0; }
     .nav-links a {
       color: var(--text-dim);
       font-size: 14px;
@@ -548,6 +549,7 @@
     .hero-visual {
       margin-top: 60px;
       position: relative;
+      overflow: hidden;
     }
     .browser-mockup {
       max-width: 820px;
@@ -576,12 +578,16 @@
     .browser-dots span:nth-child(3) { background: #34d399; }
     .browser-url {
       flex: 1;
+      min-width: 0;
       margin-inline-start: 12px;
       background: var(--url-bg);
       border-radius: 6px;
       padding: 5px 12px;
       font-size: 12px;
       color: var(--text-dim);
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
     }
     .browser-body {
       display: flex;
@@ -652,6 +658,7 @@
       font-size: 12px;
       line-height: 1.5;
       max-width: 90%;
+      overflow-wrap: anywhere;
       opacity: 0;
     }
     @keyframes fadeUp {
@@ -713,6 +720,7 @@
       grid-template-columns: minmax(0, 1fr);
       max-width: 820px;
       margin: 0 auto;
+      overflow: hidden;
     }
     .mockup-stack > .browser-mockup {
       grid-column: 1;
@@ -1221,13 +1229,23 @@
       gap: 10px;
       margin-top: auto;
     }
-    .download-card .btn { width: 100%; justify-content: center; }
-    /* Chrome is the more popular browser so the Chrome card gets ~25% more
-       horizontal real estate than Firefox via flex-grow. Both cards stay
+    .download-card .btn {
+      width: 100%;
+      justify-content: center;
+      line-height: 1.35;
+    }
+    .download-card .btn svg { flex: 0 0 auto; }
+    .download-card-firefox .btn-primary {
+      overflow-wrap: normal;
+      word-break: normal;
+      hyphens: none;
+    }
+    /* Chrome still gets a little extra emphasis, but keep the Firefox card
+       wide enough that its install CTA does not wrap awkwardly. Both cards stay
        on a single row at all desktop/tablet widths; the mobile breakpoint
        below stacks them. */
     .download-card-chrome {
-      flex-grow: 1.25;
+      flex-grow: 1.12;
       padding: 38px 32px;
       border-color: rgba(0, 212, 255, 0.45);
     }
@@ -1450,10 +1468,16 @@
        RESPONSIVE
        ================================================================ */
     @media (max-width: 768px) {
+      body { overflow-x: hidden; }
       .browser-body { flex-direction: column; }
       .side-panel { width: 100%; border-inline-start: none; border-top: 1px solid var(--border); min-height: 260px; }
       .modes-grid { grid-template-columns: 1fr; }
+      .nav-inner { width: 100%; padding: 12px 10px; gap: 8px; }
+      .nav-brand { min-width: 0; font-size: 17px; gap: 6px; }
+      .nav-links { gap: 8px; flex-shrink: 0; }
       .nav-links a:not(.nav-cta) { display: none; }
+      .nav-cta { padding: 8px 14px; font-size: 12px; }
+      .lang-dropdown { max-width: 42vw; }
       .gh-stars { display: none; }
       /* The theme toggle would overflow the 24px-padded header at phone
          widths. prefers-color-scheme still auto-picks the right theme
@@ -1980,14 +2004,14 @@
         </a>
       </div>
     </div>
-    <div class="download-card">
+    <div class="download-card download-card-firefox">
       <div class="browser-icon">🦊</div>
       <h3>Firefox</h3>
       <p>Manifest V2 · Firefox 109+</p>
       <div class="download-card-actions">
         <a href="https://addons.mozilla.org/en-US/firefox/addon/webbrain/" target="_blank" rel="noopener noreferrer" class="btn btn-primary" style="background: #ff9800;">
           <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" width="16" height="16"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>
-          نزّله من Firefox Add-ons
+          نزّله من Firefox Add‑ons
         </a>
         <a href="https://github.com/esokullu/webbrain/tree/main/src/firefox" target="_blank" rel="noopener noreferrer" class="btn btn-secondary">
           اعرض مصدر إصدار Firefox

--- a/web/build/locales/ar.json
+++ b/web/build/locales/ar.json
@@ -77,7 +77,7 @@
   "download.chrome.source": "اعرض مصدر إصدار Chrome",
   "download.firefox.name": "Firefox",
   "download.firefox.desc_html": "Manifest V2 · Firefox 109+",
-  "download.firefox.install": "نزّله من Firefox Add-ons",
+  "download.firefox.install": "نزّله من Firefox Add‑ons",
   "download.firefox.source": "اعرض مصدر إصدار Firefox",
   "compare.label": "لماذا WebBrain؟",
   "compare.title": "كيف تتم مقارنة WebBrain؟",

--- a/web/build/locales/en.json
+++ b/web/build/locales/en.json
@@ -108,7 +108,7 @@
   "download.chrome.source": "View Chrome source",
   "download.firefox.name": "Firefox",
   "download.firefox.desc_html": "Manifest V2 · Firefox 109+",
-  "download.firefox.install": "Download from Firefox Add-ons",
+  "download.firefox.install": "Download from Firefox Add‑ons",
   "download.firefox.source": "View Firefox source",
   "compare.label": "Why WebBrain?",
   "compare.title": "How does WebBrain compare?",

--- a/web/build/locales/es.json
+++ b/web/build/locales/es.json
@@ -77,7 +77,7 @@
   "download.chrome.source": "Ver código de Chrome",
   "download.firefox.name": "Firefox",
   "download.firefox.desc_html": "Manifest V2 · Firefox 109+",
-  "download.firefox.install": "Descargar desde Firefox Add-ons",
+  "download.firefox.install": "Descargar desde Firefox Add‑ons",
   "download.firefox.source": "Ver código de Firefox",
   "compare.label": "¿Por qué WebBrain?",
   "compare.title": "¿Cómo se compara WebBrain?",

--- a/web/build/locales/fr.json
+++ b/web/build/locales/fr.json
@@ -77,7 +77,7 @@
   "download.chrome.source": "Voir les sources Chrome",
   "download.firefox.name": "Firefox",
   "download.firefox.desc_html": "Manifest V2 · Firefox 109+",
-  "download.firefox.install": "Télécharger sur Firefox Add-ons",
+  "download.firefox.install": "Télécharger sur Firefox Add‑ons",
   "download.firefox.source": "Voir les sources Firefox",
   "compare.label": "Pourquoi WebBrain ?",
   "compare.title": "Comment WebBrain se compare-t-il ?",

--- a/web/build/locales/id.json
+++ b/web/build/locales/id.json
@@ -77,7 +77,7 @@
   "download.chrome.source": "Lihat sumber Chrome",
   "download.firefox.name": "Firefox",
   "download.firefox.desc_html": "Manifest V2 · Firefox 109+",
-  "download.firefox.install": "Unduh dari Firefox Add-ons",
+  "download.firefox.install": "Unduh dari Firefox Add‑ons",
   "download.firefox.source": "Lihat sumber Firefox",
   "compare.label": "Kenapa WebBrain?",
   "compare.title": "Bagaimana WebBrain dibandingkan?",

--- a/web/build/locales/ja.json
+++ b/web/build/locales/ja.json
@@ -77,7 +77,7 @@
   "download.chrome.source": "Chrome 版ソースを見る",
   "download.firefox.name": "Firefox",
   "download.firefox.desc_html": "Manifest V2 · Firefox 109+",
-  "download.firefox.install": "Firefox Add-ons でダウンロード",
+  "download.firefox.install": "Firefox Add‑ons でダウンロード",
   "download.firefox.source": "Firefox 版ソースを見る",
   "compare.label": "なぜ WebBrain?",
   "compare.title": "WebBrain は他と何が違う?",

--- a/web/build/locales/ms.json
+++ b/web/build/locales/ms.json
@@ -77,7 +77,7 @@
   "download.chrome.source": "Lihat sumber Chrome",
   "download.firefox.name": "Firefox",
   "download.firefox.desc_html": "Manifest V2 · Firefox 109+",
-  "download.firefox.install": "Muat turun dari Firefox Add-ons",
+  "download.firefox.install": "Muat turun dari Firefox Add‑ons",
   "download.firefox.source": "Lihat sumber Firefox",
   "compare.label": "Mengapa WebBrain?",
   "compare.title": "Bagaimana WebBrain berbanding?",

--- a/web/build/locales/ru.json
+++ b/web/build/locales/ru.json
@@ -77,7 +77,7 @@
   "download.chrome.source": "Исходники для Chrome",
   "download.firefox.name": "Firefox",
   "download.firefox.desc_html": "Manifest V2 · Firefox 109+",
-  "download.firefox.install": "Скачать на Firefox Add-ons",
+  "download.firefox.install": "Скачать на Firefox Add‑ons",
   "download.firefox.source": "Исходники для Firefox",
   "compare.label": "Почему WebBrain?",
   "compare.title": "Чем отличается WebBrain?",

--- a/web/build/locales/th.json
+++ b/web/build/locales/th.json
@@ -77,7 +77,7 @@
   "download.chrome.source": "ดูซอร์สโค้ดของเวอร์ชัน Chrome",
   "download.firefox.name": "Firefox",
   "download.firefox.desc_html": "Manifest V2 · Firefox 109+",
-  "download.firefox.install": "ดาวน์โหลดจาก Firefox Add-ons",
+  "download.firefox.install": "ดาวน์โหลดจาก Firefox Add‑ons",
   "download.firefox.source": "ดูซอร์สโค้ดของเวอร์ชัน Firefox",
   "compare.label": "ทำไมต้อง WebBrain?",
   "compare.title": "WebBrain เปรียบเทียบอย่างไร?",

--- a/web/build/locales/tl.json
+++ b/web/build/locales/tl.json
@@ -77,7 +77,7 @@
   "download.chrome.source": "Tingnan ang Chrome source",
   "download.firefox.name": "Firefox",
   "download.firefox.desc_html": "Manifest V2 · Firefox 109+",
-  "download.firefox.install": "I-download mula sa Firefox Add-ons",
+  "download.firefox.install": "I-download mula sa Firefox Add‑ons",
   "download.firefox.source": "Tingnan ang Firefox source",
   "compare.label": "Bakit WebBrain?",
   "compare.title": "Paano ihahambing ang WebBrain?",

--- a/web/build/locales/tr.json
+++ b/web/build/locales/tr.json
@@ -77,7 +77,7 @@
   "download.chrome.source": "Chrome kaynağını gör",
   "download.firefox.name": "Firefox",
   "download.firefox.desc_html": "Manifest V2 · Firefox 109+",
-  "download.firefox.install": "Firefox Add-ons'tan indir",
+  "download.firefox.install": "Firefox Add‑ons'tan indir",
   "download.firefox.source": "Firefox kaynağını gör",
   "compare.label": "Neden WebBrain?",
   "compare.title": "WebBrain nasıl karşılaştırılır?",

--- a/web/build/locales/uk.json
+++ b/web/build/locales/uk.json
@@ -77,7 +77,7 @@
   "download.chrome.source": "Сирці для Chrome",
   "download.firefox.name": "Firefox",
   "download.firefox.desc_html": "Manifest V2 · Firefox 109+",
-  "download.firefox.install": "Завантажити на Firefox Add-ons",
+  "download.firefox.install": "Завантажити на Firefox Add‑ons",
   "download.firefox.source": "Сирці для Firefox",
   "compare.label": "Чому WebBrain?",
   "compare.title": "Чим відрізняється WebBrain?",

--- a/web/build/template.html
+++ b/web/build/template.html
@@ -165,6 +165,7 @@
       backdrop-filter: blur(20px);
       background: var(--nav-bg);
       border-bottom: 1px solid var(--border);
+      overflow-x: clip;
     }
     .nav-inner {
       max-width: var(--max-w);
@@ -185,7 +186,7 @@
       -webkit-text-fill-color: transparent;
     }
     .nav-brand span.emoji { -webkit-text-fill-color: initial; font-size: 22px; }
-    .nav-links { display: flex; gap: 28px; align-items: center; }
+    .nav-links { display: flex; gap: 28px; align-items: center; margin-inline-start: auto; min-width: 0; }
     .nav-links a {
       color: var(--text-dim);
       font-size: 14px;
@@ -360,6 +361,7 @@
     .hero-visual {
       margin-top: 60px;
       position: relative;
+      overflow: hidden;
     }
     .browser-mockup {
       max-width: 820px;
@@ -388,12 +390,16 @@
     .browser-dots span:nth-child(3) { background: #34d399; }
     .browser-url {
       flex: 1;
+      min-width: 0;
       margin-inline-start: 12px;
       background: var(--url-bg);
       border-radius: 6px;
       padding: 5px 12px;
       font-size: 12px;
       color: var(--text-dim);
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
     }
     .browser-body {
       display: flex;
@@ -464,6 +470,7 @@
       font-size: 12px;
       line-height: 1.5;
       max-width: 90%;
+      overflow-wrap: anywhere;
       opacity: 0;
     }
     @keyframes fadeUp {
@@ -525,6 +532,7 @@
       grid-template-columns: minmax(0, 1fr);
       max-width: 820px;
       margin: 0 auto;
+      overflow: hidden;
     }
     .mockup-stack > .browser-mockup {
       grid-column: 1;
@@ -1033,13 +1041,23 @@
       gap: 10px;
       margin-top: auto;
     }
-    .download-card .btn { width: 100%; justify-content: center; }
-    /* Chrome is the more popular browser so the Chrome card gets ~25% more
-       horizontal real estate than Firefox via flex-grow. Both cards stay
+    .download-card .btn {
+      width: 100%;
+      justify-content: center;
+      line-height: 1.35;
+    }
+    .download-card .btn svg { flex: 0 0 auto; }
+    .download-card-firefox .btn-primary {
+      overflow-wrap: normal;
+      word-break: normal;
+      hyphens: none;
+    }
+    /* Chrome still gets a little extra emphasis, but keep the Firefox card
+       wide enough that its install CTA does not wrap awkwardly. Both cards stay
        on a single row at all desktop/tablet widths; the mobile breakpoint
        below stacks them. */
     .download-card-chrome {
-      flex-grow: 1.25;
+      flex-grow: 1.12;
       padding: 38px 32px;
       border-color: rgba(0, 212, 255, 0.45);
     }
@@ -1262,10 +1280,16 @@
        RESPONSIVE
        ================================================================ */
     @media (max-width: 768px) {
+      body { overflow-x: hidden; }
       .browser-body { flex-direction: column; }
       .side-panel { width: 100%; border-inline-start: none; border-top: 1px solid var(--border); min-height: 260px; }
       .modes-grid { grid-template-columns: 1fr; }
+      .nav-inner { width: 100%; padding: 12px 10px; gap: 8px; }
+      .nav-brand { min-width: 0; font-size: 17px; gap: 6px; }
+      .nav-links { gap: 8px; flex-shrink: 0; }
       .nav-links a:not(.nav-cta) { display: none; }
+      .nav-cta { padding: 8px 14px; font-size: 12px; }
+      .lang-dropdown { max-width: 42vw; }
       .gh-stars { display: none; }
       /* The theme toggle would overflow the 24px-padded header at phone
          widths. prefers-color-scheme still auto-picks the right theme
@@ -1792,7 +1816,7 @@
         </a>
       </div>
     </div>
-    <div class="download-card">
+    <div class="download-card download-card-firefox">
       <div class="browser-icon">🦊</div>
       <h3>{{t:download.firefox.name}}</h3>
       <p>{{t-html:download.firefox.desc_html}}</p>

--- a/web/es/index.html
+++ b/web/es/index.html
@@ -353,6 +353,7 @@
       backdrop-filter: blur(20px);
       background: var(--nav-bg);
       border-bottom: 1px solid var(--border);
+      overflow-x: clip;
     }
     .nav-inner {
       max-width: var(--max-w);
@@ -373,7 +374,7 @@
       -webkit-text-fill-color: transparent;
     }
     .nav-brand span.emoji { -webkit-text-fill-color: initial; font-size: 22px; }
-    .nav-links { display: flex; gap: 28px; align-items: center; }
+    .nav-links { display: flex; gap: 28px; align-items: center; margin-inline-start: auto; min-width: 0; }
     .nav-links a {
       color: var(--text-dim);
       font-size: 14px;
@@ -548,6 +549,7 @@
     .hero-visual {
       margin-top: 60px;
       position: relative;
+      overflow: hidden;
     }
     .browser-mockup {
       max-width: 820px;
@@ -576,12 +578,16 @@
     .browser-dots span:nth-child(3) { background: #34d399; }
     .browser-url {
       flex: 1;
+      min-width: 0;
       margin-inline-start: 12px;
       background: var(--url-bg);
       border-radius: 6px;
       padding: 5px 12px;
       font-size: 12px;
       color: var(--text-dim);
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
     }
     .browser-body {
       display: flex;
@@ -652,6 +658,7 @@
       font-size: 12px;
       line-height: 1.5;
       max-width: 90%;
+      overflow-wrap: anywhere;
       opacity: 0;
     }
     @keyframes fadeUp {
@@ -713,6 +720,7 @@
       grid-template-columns: minmax(0, 1fr);
       max-width: 820px;
       margin: 0 auto;
+      overflow: hidden;
     }
     .mockup-stack > .browser-mockup {
       grid-column: 1;
@@ -1221,13 +1229,23 @@
       gap: 10px;
       margin-top: auto;
     }
-    .download-card .btn { width: 100%; justify-content: center; }
-    /* Chrome is the more popular browser so the Chrome card gets ~25% more
-       horizontal real estate than Firefox via flex-grow. Both cards stay
+    .download-card .btn {
+      width: 100%;
+      justify-content: center;
+      line-height: 1.35;
+    }
+    .download-card .btn svg { flex: 0 0 auto; }
+    .download-card-firefox .btn-primary {
+      overflow-wrap: normal;
+      word-break: normal;
+      hyphens: none;
+    }
+    /* Chrome still gets a little extra emphasis, but keep the Firefox card
+       wide enough that its install CTA does not wrap awkwardly. Both cards stay
        on a single row at all desktop/tablet widths; the mobile breakpoint
        below stacks them. */
     .download-card-chrome {
-      flex-grow: 1.25;
+      flex-grow: 1.12;
       padding: 38px 32px;
       border-color: rgba(0, 212, 255, 0.45);
     }
@@ -1450,10 +1468,16 @@
        RESPONSIVE
        ================================================================ */
     @media (max-width: 768px) {
+      body { overflow-x: hidden; }
       .browser-body { flex-direction: column; }
       .side-panel { width: 100%; border-inline-start: none; border-top: 1px solid var(--border); min-height: 260px; }
       .modes-grid { grid-template-columns: 1fr; }
+      .nav-inner { width: 100%; padding: 12px 10px; gap: 8px; }
+      .nav-brand { min-width: 0; font-size: 17px; gap: 6px; }
+      .nav-links { gap: 8px; flex-shrink: 0; }
       .nav-links a:not(.nav-cta) { display: none; }
+      .nav-cta { padding: 8px 14px; font-size: 12px; }
+      .lang-dropdown { max-width: 42vw; }
       .gh-stars { display: none; }
       /* The theme toggle would overflow the 24px-padded header at phone
          widths. prefers-color-scheme still auto-picks the right theme
@@ -1980,14 +2004,14 @@
         </a>
       </div>
     </div>
-    <div class="download-card">
+    <div class="download-card download-card-firefox">
       <div class="browser-icon">🦊</div>
       <h3>Firefox</h3>
       <p>Manifest V2 · Firefox 109+</p>
       <div class="download-card-actions">
         <a href="https://addons.mozilla.org/en-US/firefox/addon/webbrain/" target="_blank" rel="noopener noreferrer" class="btn btn-primary" style="background: #ff9800;">
           <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" width="16" height="16"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>
-          Descargar desde Firefox Add-ons
+          Descargar desde Firefox Add‑ons
         </a>
         <a href="https://github.com/esokullu/webbrain/tree/main/src/firefox" target="_blank" rel="noopener noreferrer" class="btn btn-secondary">
           Ver código de Firefox

--- a/web/fr/index.html
+++ b/web/fr/index.html
@@ -353,6 +353,7 @@
       backdrop-filter: blur(20px);
       background: var(--nav-bg);
       border-bottom: 1px solid var(--border);
+      overflow-x: clip;
     }
     .nav-inner {
       max-width: var(--max-w);
@@ -373,7 +374,7 @@
       -webkit-text-fill-color: transparent;
     }
     .nav-brand span.emoji { -webkit-text-fill-color: initial; font-size: 22px; }
-    .nav-links { display: flex; gap: 28px; align-items: center; }
+    .nav-links { display: flex; gap: 28px; align-items: center; margin-inline-start: auto; min-width: 0; }
     .nav-links a {
       color: var(--text-dim);
       font-size: 14px;
@@ -548,6 +549,7 @@
     .hero-visual {
       margin-top: 60px;
       position: relative;
+      overflow: hidden;
     }
     .browser-mockup {
       max-width: 820px;
@@ -576,12 +578,16 @@
     .browser-dots span:nth-child(3) { background: #34d399; }
     .browser-url {
       flex: 1;
+      min-width: 0;
       margin-inline-start: 12px;
       background: var(--url-bg);
       border-radius: 6px;
       padding: 5px 12px;
       font-size: 12px;
       color: var(--text-dim);
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
     }
     .browser-body {
       display: flex;
@@ -652,6 +658,7 @@
       font-size: 12px;
       line-height: 1.5;
       max-width: 90%;
+      overflow-wrap: anywhere;
       opacity: 0;
     }
     @keyframes fadeUp {
@@ -713,6 +720,7 @@
       grid-template-columns: minmax(0, 1fr);
       max-width: 820px;
       margin: 0 auto;
+      overflow: hidden;
     }
     .mockup-stack > .browser-mockup {
       grid-column: 1;
@@ -1221,13 +1229,23 @@
       gap: 10px;
       margin-top: auto;
     }
-    .download-card .btn { width: 100%; justify-content: center; }
-    /* Chrome is the more popular browser so the Chrome card gets ~25% more
-       horizontal real estate than Firefox via flex-grow. Both cards stay
+    .download-card .btn {
+      width: 100%;
+      justify-content: center;
+      line-height: 1.35;
+    }
+    .download-card .btn svg { flex: 0 0 auto; }
+    .download-card-firefox .btn-primary {
+      overflow-wrap: normal;
+      word-break: normal;
+      hyphens: none;
+    }
+    /* Chrome still gets a little extra emphasis, but keep the Firefox card
+       wide enough that its install CTA does not wrap awkwardly. Both cards stay
        on a single row at all desktop/tablet widths; the mobile breakpoint
        below stacks them. */
     .download-card-chrome {
-      flex-grow: 1.25;
+      flex-grow: 1.12;
       padding: 38px 32px;
       border-color: rgba(0, 212, 255, 0.45);
     }
@@ -1450,10 +1468,16 @@
        RESPONSIVE
        ================================================================ */
     @media (max-width: 768px) {
+      body { overflow-x: hidden; }
       .browser-body { flex-direction: column; }
       .side-panel { width: 100%; border-inline-start: none; border-top: 1px solid var(--border); min-height: 260px; }
       .modes-grid { grid-template-columns: 1fr; }
+      .nav-inner { width: 100%; padding: 12px 10px; gap: 8px; }
+      .nav-brand { min-width: 0; font-size: 17px; gap: 6px; }
+      .nav-links { gap: 8px; flex-shrink: 0; }
       .nav-links a:not(.nav-cta) { display: none; }
+      .nav-cta { padding: 8px 14px; font-size: 12px; }
+      .lang-dropdown { max-width: 42vw; }
       .gh-stars { display: none; }
       /* The theme toggle would overflow the 24px-padded header at phone
          widths. prefers-color-scheme still auto-picks the right theme
@@ -1980,14 +2004,14 @@
         </a>
       </div>
     </div>
-    <div class="download-card">
+    <div class="download-card download-card-firefox">
       <div class="browser-icon">🦊</div>
       <h3>Firefox</h3>
       <p>Manifest V2 · Firefox 109+</p>
       <div class="download-card-actions">
         <a href="https://addons.mozilla.org/en-US/firefox/addon/webbrain/" target="_blank" rel="noopener noreferrer" class="btn btn-primary" style="background: #ff9800;">
           <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" width="16" height="16"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>
-          Télécharger sur Firefox Add-ons
+          Télécharger sur Firefox Add‑ons
         </a>
         <a href="https://github.com/esokullu/webbrain/tree/main/src/firefox" target="_blank" rel="noopener noreferrer" class="btn btn-secondary">
           Voir les sources Firefox

--- a/web/id/index.html
+++ b/web/id/index.html
@@ -353,6 +353,7 @@
       backdrop-filter: blur(20px);
       background: var(--nav-bg);
       border-bottom: 1px solid var(--border);
+      overflow-x: clip;
     }
     .nav-inner {
       max-width: var(--max-w);
@@ -373,7 +374,7 @@
       -webkit-text-fill-color: transparent;
     }
     .nav-brand span.emoji { -webkit-text-fill-color: initial; font-size: 22px; }
-    .nav-links { display: flex; gap: 28px; align-items: center; }
+    .nav-links { display: flex; gap: 28px; align-items: center; margin-inline-start: auto; min-width: 0; }
     .nav-links a {
       color: var(--text-dim);
       font-size: 14px;
@@ -548,6 +549,7 @@
     .hero-visual {
       margin-top: 60px;
       position: relative;
+      overflow: hidden;
     }
     .browser-mockup {
       max-width: 820px;
@@ -576,12 +578,16 @@
     .browser-dots span:nth-child(3) { background: #34d399; }
     .browser-url {
       flex: 1;
+      min-width: 0;
       margin-inline-start: 12px;
       background: var(--url-bg);
       border-radius: 6px;
       padding: 5px 12px;
       font-size: 12px;
       color: var(--text-dim);
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
     }
     .browser-body {
       display: flex;
@@ -652,6 +658,7 @@
       font-size: 12px;
       line-height: 1.5;
       max-width: 90%;
+      overflow-wrap: anywhere;
       opacity: 0;
     }
     @keyframes fadeUp {
@@ -713,6 +720,7 @@
       grid-template-columns: minmax(0, 1fr);
       max-width: 820px;
       margin: 0 auto;
+      overflow: hidden;
     }
     .mockup-stack > .browser-mockup {
       grid-column: 1;
@@ -1221,13 +1229,23 @@
       gap: 10px;
       margin-top: auto;
     }
-    .download-card .btn { width: 100%; justify-content: center; }
-    /* Chrome is the more popular browser so the Chrome card gets ~25% more
-       horizontal real estate than Firefox via flex-grow. Both cards stay
+    .download-card .btn {
+      width: 100%;
+      justify-content: center;
+      line-height: 1.35;
+    }
+    .download-card .btn svg { flex: 0 0 auto; }
+    .download-card-firefox .btn-primary {
+      overflow-wrap: normal;
+      word-break: normal;
+      hyphens: none;
+    }
+    /* Chrome still gets a little extra emphasis, but keep the Firefox card
+       wide enough that its install CTA does not wrap awkwardly. Both cards stay
        on a single row at all desktop/tablet widths; the mobile breakpoint
        below stacks them. */
     .download-card-chrome {
-      flex-grow: 1.25;
+      flex-grow: 1.12;
       padding: 38px 32px;
       border-color: rgba(0, 212, 255, 0.45);
     }
@@ -1450,10 +1468,16 @@
        RESPONSIVE
        ================================================================ */
     @media (max-width: 768px) {
+      body { overflow-x: hidden; }
       .browser-body { flex-direction: column; }
       .side-panel { width: 100%; border-inline-start: none; border-top: 1px solid var(--border); min-height: 260px; }
       .modes-grid { grid-template-columns: 1fr; }
+      .nav-inner { width: 100%; padding: 12px 10px; gap: 8px; }
+      .nav-brand { min-width: 0; font-size: 17px; gap: 6px; }
+      .nav-links { gap: 8px; flex-shrink: 0; }
       .nav-links a:not(.nav-cta) { display: none; }
+      .nav-cta { padding: 8px 14px; font-size: 12px; }
+      .lang-dropdown { max-width: 42vw; }
       .gh-stars { display: none; }
       /* The theme toggle would overflow the 24px-padded header at phone
          widths. prefers-color-scheme still auto-picks the right theme
@@ -1980,14 +2004,14 @@
         </a>
       </div>
     </div>
-    <div class="download-card">
+    <div class="download-card download-card-firefox">
       <div class="browser-icon">🦊</div>
       <h3>Firefox</h3>
       <p>Manifest V2 · Firefox 109+</p>
       <div class="download-card-actions">
         <a href="https://addons.mozilla.org/en-US/firefox/addon/webbrain/" target="_blank" rel="noopener noreferrer" class="btn btn-primary" style="background: #ff9800;">
           <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" width="16" height="16"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>
-          Unduh dari Firefox Add-ons
+          Unduh dari Firefox Add‑ons
         </a>
         <a href="https://github.com/esokullu/webbrain/tree/main/src/firefox" target="_blank" rel="noopener noreferrer" class="btn btn-secondary">
           Lihat sumber Firefox

--- a/web/index.html
+++ b/web/index.html
@@ -1229,13 +1229,23 @@
       gap: 10px;
       margin-top: auto;
     }
-    .download-card .btn { width: 100%; justify-content: center; }
-    /* Chrome is the more popular browser so the Chrome card gets ~25% more
-       horizontal real estate than Firefox via flex-grow. Both cards stay
+    .download-card .btn {
+      width: 100%;
+      justify-content: center;
+      line-height: 1.35;
+    }
+    .download-card .btn svg { flex: 0 0 auto; }
+    .download-card-firefox .btn-primary {
+      overflow-wrap: normal;
+      word-break: normal;
+      hyphens: none;
+    }
+    /* Chrome still gets a little extra emphasis, but keep the Firefox card
+       wide enough that its install CTA does not wrap awkwardly. Both cards stay
        on a single row at all desktop/tablet widths; the mobile breakpoint
        below stacks them. */
     .download-card-chrome {
-      flex-grow: 1.25;
+      flex-grow: 1.12;
       padding: 38px 32px;
       border-color: rgba(0, 212, 255, 0.45);
     }
@@ -1994,14 +2004,14 @@
         </a>
       </div>
     </div>
-    <div class="download-card">
+    <div class="download-card download-card-firefox">
       <div class="browser-icon">🦊</div>
       <h3>Firefox</h3>
       <p>Manifest V2 · Firefox 109+</p>
       <div class="download-card-actions">
         <a href="https://addons.mozilla.org/en-US/firefox/addon/webbrain/" target="_blank" rel="noopener noreferrer" class="btn btn-primary" style="background: #ff9800;">
           <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" width="16" height="16"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>
-          Download from Firefox Add-ons
+          Download from Firefox Add‑ons
         </a>
         <a href="https://github.com/esokullu/webbrain/tree/main/src/firefox" target="_blank" rel="noopener noreferrer" class="btn btn-secondary">
           View Firefox source

--- a/web/ja/index.html
+++ b/web/ja/index.html
@@ -353,6 +353,7 @@
       backdrop-filter: blur(20px);
       background: var(--nav-bg);
       border-bottom: 1px solid var(--border);
+      overflow-x: clip;
     }
     .nav-inner {
       max-width: var(--max-w);
@@ -373,7 +374,7 @@
       -webkit-text-fill-color: transparent;
     }
     .nav-brand span.emoji { -webkit-text-fill-color: initial; font-size: 22px; }
-    .nav-links { display: flex; gap: 28px; align-items: center; }
+    .nav-links { display: flex; gap: 28px; align-items: center; margin-inline-start: auto; min-width: 0; }
     .nav-links a {
       color: var(--text-dim);
       font-size: 14px;
@@ -548,6 +549,7 @@
     .hero-visual {
       margin-top: 60px;
       position: relative;
+      overflow: hidden;
     }
     .browser-mockup {
       max-width: 820px;
@@ -576,12 +578,16 @@
     .browser-dots span:nth-child(3) { background: #34d399; }
     .browser-url {
       flex: 1;
+      min-width: 0;
       margin-inline-start: 12px;
       background: var(--url-bg);
       border-radius: 6px;
       padding: 5px 12px;
       font-size: 12px;
       color: var(--text-dim);
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
     }
     .browser-body {
       display: flex;
@@ -652,6 +658,7 @@
       font-size: 12px;
       line-height: 1.5;
       max-width: 90%;
+      overflow-wrap: anywhere;
       opacity: 0;
     }
     @keyframes fadeUp {
@@ -713,6 +720,7 @@
       grid-template-columns: minmax(0, 1fr);
       max-width: 820px;
       margin: 0 auto;
+      overflow: hidden;
     }
     .mockup-stack > .browser-mockup {
       grid-column: 1;
@@ -1221,13 +1229,23 @@
       gap: 10px;
       margin-top: auto;
     }
-    .download-card .btn { width: 100%; justify-content: center; }
-    /* Chrome is the more popular browser so the Chrome card gets ~25% more
-       horizontal real estate than Firefox via flex-grow. Both cards stay
+    .download-card .btn {
+      width: 100%;
+      justify-content: center;
+      line-height: 1.35;
+    }
+    .download-card .btn svg { flex: 0 0 auto; }
+    .download-card-firefox .btn-primary {
+      overflow-wrap: normal;
+      word-break: normal;
+      hyphens: none;
+    }
+    /* Chrome still gets a little extra emphasis, but keep the Firefox card
+       wide enough that its install CTA does not wrap awkwardly. Both cards stay
        on a single row at all desktop/tablet widths; the mobile breakpoint
        below stacks them. */
     .download-card-chrome {
-      flex-grow: 1.25;
+      flex-grow: 1.12;
       padding: 38px 32px;
       border-color: rgba(0, 212, 255, 0.45);
     }
@@ -1450,10 +1468,16 @@
        RESPONSIVE
        ================================================================ */
     @media (max-width: 768px) {
+      body { overflow-x: hidden; }
       .browser-body { flex-direction: column; }
       .side-panel { width: 100%; border-inline-start: none; border-top: 1px solid var(--border); min-height: 260px; }
       .modes-grid { grid-template-columns: 1fr; }
+      .nav-inner { width: 100%; padding: 12px 10px; gap: 8px; }
+      .nav-brand { min-width: 0; font-size: 17px; gap: 6px; }
+      .nav-links { gap: 8px; flex-shrink: 0; }
       .nav-links a:not(.nav-cta) { display: none; }
+      .nav-cta { padding: 8px 14px; font-size: 12px; }
+      .lang-dropdown { max-width: 42vw; }
       .gh-stars { display: none; }
       /* The theme toggle would overflow the 24px-padded header at phone
          widths. prefers-color-scheme still auto-picks the right theme
@@ -1980,14 +2004,14 @@
         </a>
       </div>
     </div>
-    <div class="download-card">
+    <div class="download-card download-card-firefox">
       <div class="browser-icon">🦊</div>
       <h3>Firefox</h3>
       <p>Manifest V2 · Firefox 109+</p>
       <div class="download-card-actions">
         <a href="https://addons.mozilla.org/en-US/firefox/addon/webbrain/" target="_blank" rel="noopener noreferrer" class="btn btn-primary" style="background: #ff9800;">
           <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" width="16" height="16"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>
-          Firefox Add-ons でダウンロード
+          Firefox Add‑ons でダウンロード
         </a>
         <a href="https://github.com/esokullu/webbrain/tree/main/src/firefox" target="_blank" rel="noopener noreferrer" class="btn btn-secondary">
           Firefox 版ソースを見る

--- a/web/ko/index.html
+++ b/web/ko/index.html
@@ -353,6 +353,7 @@
       backdrop-filter: blur(20px);
       background: var(--nav-bg);
       border-bottom: 1px solid var(--border);
+      overflow-x: clip;
     }
     .nav-inner {
       max-width: var(--max-w);
@@ -373,7 +374,7 @@
       -webkit-text-fill-color: transparent;
     }
     .nav-brand span.emoji { -webkit-text-fill-color: initial; font-size: 22px; }
-    .nav-links { display: flex; gap: 28px; align-items: center; }
+    .nav-links { display: flex; gap: 28px; align-items: center; margin-inline-start: auto; min-width: 0; }
     .nav-links a {
       color: var(--text-dim);
       font-size: 14px;
@@ -548,6 +549,7 @@
     .hero-visual {
       margin-top: 60px;
       position: relative;
+      overflow: hidden;
     }
     .browser-mockup {
       max-width: 820px;
@@ -576,12 +578,16 @@
     .browser-dots span:nth-child(3) { background: #34d399; }
     .browser-url {
       flex: 1;
+      min-width: 0;
       margin-inline-start: 12px;
       background: var(--url-bg);
       border-radius: 6px;
       padding: 5px 12px;
       font-size: 12px;
       color: var(--text-dim);
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
     }
     .browser-body {
       display: flex;
@@ -652,6 +658,7 @@
       font-size: 12px;
       line-height: 1.5;
       max-width: 90%;
+      overflow-wrap: anywhere;
       opacity: 0;
     }
     @keyframes fadeUp {
@@ -713,6 +720,7 @@
       grid-template-columns: minmax(0, 1fr);
       max-width: 820px;
       margin: 0 auto;
+      overflow: hidden;
     }
     .mockup-stack > .browser-mockup {
       grid-column: 1;
@@ -1221,13 +1229,23 @@
       gap: 10px;
       margin-top: auto;
     }
-    .download-card .btn { width: 100%; justify-content: center; }
-    /* Chrome is the more popular browser so the Chrome card gets ~25% more
-       horizontal real estate than Firefox via flex-grow. Both cards stay
+    .download-card .btn {
+      width: 100%;
+      justify-content: center;
+      line-height: 1.35;
+    }
+    .download-card .btn svg { flex: 0 0 auto; }
+    .download-card-firefox .btn-primary {
+      overflow-wrap: normal;
+      word-break: normal;
+      hyphens: none;
+    }
+    /* Chrome still gets a little extra emphasis, but keep the Firefox card
+       wide enough that its install CTA does not wrap awkwardly. Both cards stay
        on a single row at all desktop/tablet widths; the mobile breakpoint
        below stacks them. */
     .download-card-chrome {
-      flex-grow: 1.25;
+      flex-grow: 1.12;
       padding: 38px 32px;
       border-color: rgba(0, 212, 255, 0.45);
     }
@@ -1450,10 +1468,16 @@
        RESPONSIVE
        ================================================================ */
     @media (max-width: 768px) {
+      body { overflow-x: hidden; }
       .browser-body { flex-direction: column; }
       .side-panel { width: 100%; border-inline-start: none; border-top: 1px solid var(--border); min-height: 260px; }
       .modes-grid { grid-template-columns: 1fr; }
+      .nav-inner { width: 100%; padding: 12px 10px; gap: 8px; }
+      .nav-brand { min-width: 0; font-size: 17px; gap: 6px; }
+      .nav-links { gap: 8px; flex-shrink: 0; }
       .nav-links a:not(.nav-cta) { display: none; }
+      .nav-cta { padding: 8px 14px; font-size: 12px; }
+      .lang-dropdown { max-width: 42vw; }
       .gh-stars { display: none; }
       /* The theme toggle would overflow the 24px-padded header at phone
          widths. prefers-color-scheme still auto-picks the right theme
@@ -1980,7 +2004,7 @@
         </a>
       </div>
     </div>
-    <div class="download-card">
+    <div class="download-card download-card-firefox">
       <div class="browser-icon">🦊</div>
       <h3>Firefox</h3>
       <p>Manifest V2 · Firefox 109+</p>

--- a/web/ms/index.html
+++ b/web/ms/index.html
@@ -353,6 +353,7 @@
       backdrop-filter: blur(20px);
       background: var(--nav-bg);
       border-bottom: 1px solid var(--border);
+      overflow-x: clip;
     }
     .nav-inner {
       max-width: var(--max-w);
@@ -373,7 +374,7 @@
       -webkit-text-fill-color: transparent;
     }
     .nav-brand span.emoji { -webkit-text-fill-color: initial; font-size: 22px; }
-    .nav-links { display: flex; gap: 28px; align-items: center; }
+    .nav-links { display: flex; gap: 28px; align-items: center; margin-inline-start: auto; min-width: 0; }
     .nav-links a {
       color: var(--text-dim);
       font-size: 14px;
@@ -548,6 +549,7 @@
     .hero-visual {
       margin-top: 60px;
       position: relative;
+      overflow: hidden;
     }
     .browser-mockup {
       max-width: 820px;
@@ -576,12 +578,16 @@
     .browser-dots span:nth-child(3) { background: #34d399; }
     .browser-url {
       flex: 1;
+      min-width: 0;
       margin-inline-start: 12px;
       background: var(--url-bg);
       border-radius: 6px;
       padding: 5px 12px;
       font-size: 12px;
       color: var(--text-dim);
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
     }
     .browser-body {
       display: flex;
@@ -652,6 +658,7 @@
       font-size: 12px;
       line-height: 1.5;
       max-width: 90%;
+      overflow-wrap: anywhere;
       opacity: 0;
     }
     @keyframes fadeUp {
@@ -713,6 +720,7 @@
       grid-template-columns: minmax(0, 1fr);
       max-width: 820px;
       margin: 0 auto;
+      overflow: hidden;
     }
     .mockup-stack > .browser-mockup {
       grid-column: 1;
@@ -1221,13 +1229,23 @@
       gap: 10px;
       margin-top: auto;
     }
-    .download-card .btn { width: 100%; justify-content: center; }
-    /* Chrome is the more popular browser so the Chrome card gets ~25% more
-       horizontal real estate than Firefox via flex-grow. Both cards stay
+    .download-card .btn {
+      width: 100%;
+      justify-content: center;
+      line-height: 1.35;
+    }
+    .download-card .btn svg { flex: 0 0 auto; }
+    .download-card-firefox .btn-primary {
+      overflow-wrap: normal;
+      word-break: normal;
+      hyphens: none;
+    }
+    /* Chrome still gets a little extra emphasis, but keep the Firefox card
+       wide enough that its install CTA does not wrap awkwardly. Both cards stay
        on a single row at all desktop/tablet widths; the mobile breakpoint
        below stacks them. */
     .download-card-chrome {
-      flex-grow: 1.25;
+      flex-grow: 1.12;
       padding: 38px 32px;
       border-color: rgba(0, 212, 255, 0.45);
     }
@@ -1450,10 +1468,16 @@
        RESPONSIVE
        ================================================================ */
     @media (max-width: 768px) {
+      body { overflow-x: hidden; }
       .browser-body { flex-direction: column; }
       .side-panel { width: 100%; border-inline-start: none; border-top: 1px solid var(--border); min-height: 260px; }
       .modes-grid { grid-template-columns: 1fr; }
+      .nav-inner { width: 100%; padding: 12px 10px; gap: 8px; }
+      .nav-brand { min-width: 0; font-size: 17px; gap: 6px; }
+      .nav-links { gap: 8px; flex-shrink: 0; }
       .nav-links a:not(.nav-cta) { display: none; }
+      .nav-cta { padding: 8px 14px; font-size: 12px; }
+      .lang-dropdown { max-width: 42vw; }
       .gh-stars { display: none; }
       /* The theme toggle would overflow the 24px-padded header at phone
          widths. prefers-color-scheme still auto-picks the right theme
@@ -1980,14 +2004,14 @@
         </a>
       </div>
     </div>
-    <div class="download-card">
+    <div class="download-card download-card-firefox">
       <div class="browser-icon">🦊</div>
       <h3>Firefox</h3>
       <p>Manifest V2 · Firefox 109+</p>
       <div class="download-card-actions">
         <a href="https://addons.mozilla.org/en-US/firefox/addon/webbrain/" target="_blank" rel="noopener noreferrer" class="btn btn-primary" style="background: #ff9800;">
           <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" width="16" height="16"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>
-          Muat turun dari Firefox Add-ons
+          Muat turun dari Firefox Add‑ons
         </a>
         <a href="https://github.com/esokullu/webbrain/tree/main/src/firefox" target="_blank" rel="noopener noreferrer" class="btn btn-secondary">
           Lihat sumber Firefox

--- a/web/ru/index.html
+++ b/web/ru/index.html
@@ -353,6 +353,7 @@
       backdrop-filter: blur(20px);
       background: var(--nav-bg);
       border-bottom: 1px solid var(--border);
+      overflow-x: clip;
     }
     .nav-inner {
       max-width: var(--max-w);
@@ -373,7 +374,7 @@
       -webkit-text-fill-color: transparent;
     }
     .nav-brand span.emoji { -webkit-text-fill-color: initial; font-size: 22px; }
-    .nav-links { display: flex; gap: 28px; align-items: center; }
+    .nav-links { display: flex; gap: 28px; align-items: center; margin-inline-start: auto; min-width: 0; }
     .nav-links a {
       color: var(--text-dim);
       font-size: 14px;
@@ -548,6 +549,7 @@
     .hero-visual {
       margin-top: 60px;
       position: relative;
+      overflow: hidden;
     }
     .browser-mockup {
       max-width: 820px;
@@ -576,12 +578,16 @@
     .browser-dots span:nth-child(3) { background: #34d399; }
     .browser-url {
       flex: 1;
+      min-width: 0;
       margin-inline-start: 12px;
       background: var(--url-bg);
       border-radius: 6px;
       padding: 5px 12px;
       font-size: 12px;
       color: var(--text-dim);
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
     }
     .browser-body {
       display: flex;
@@ -652,6 +658,7 @@
       font-size: 12px;
       line-height: 1.5;
       max-width: 90%;
+      overflow-wrap: anywhere;
       opacity: 0;
     }
     @keyframes fadeUp {
@@ -713,6 +720,7 @@
       grid-template-columns: minmax(0, 1fr);
       max-width: 820px;
       margin: 0 auto;
+      overflow: hidden;
     }
     .mockup-stack > .browser-mockup {
       grid-column: 1;
@@ -1221,13 +1229,23 @@
       gap: 10px;
       margin-top: auto;
     }
-    .download-card .btn { width: 100%; justify-content: center; }
-    /* Chrome is the more popular browser so the Chrome card gets ~25% more
-       horizontal real estate than Firefox via flex-grow. Both cards stay
+    .download-card .btn {
+      width: 100%;
+      justify-content: center;
+      line-height: 1.35;
+    }
+    .download-card .btn svg { flex: 0 0 auto; }
+    .download-card-firefox .btn-primary {
+      overflow-wrap: normal;
+      word-break: normal;
+      hyphens: none;
+    }
+    /* Chrome still gets a little extra emphasis, but keep the Firefox card
+       wide enough that its install CTA does not wrap awkwardly. Both cards stay
        on a single row at all desktop/tablet widths; the mobile breakpoint
        below stacks them. */
     .download-card-chrome {
-      flex-grow: 1.25;
+      flex-grow: 1.12;
       padding: 38px 32px;
       border-color: rgba(0, 212, 255, 0.45);
     }
@@ -1450,10 +1468,16 @@
        RESPONSIVE
        ================================================================ */
     @media (max-width: 768px) {
+      body { overflow-x: hidden; }
       .browser-body { flex-direction: column; }
       .side-panel { width: 100%; border-inline-start: none; border-top: 1px solid var(--border); min-height: 260px; }
       .modes-grid { grid-template-columns: 1fr; }
+      .nav-inner { width: 100%; padding: 12px 10px; gap: 8px; }
+      .nav-brand { min-width: 0; font-size: 17px; gap: 6px; }
+      .nav-links { gap: 8px; flex-shrink: 0; }
       .nav-links a:not(.nav-cta) { display: none; }
+      .nav-cta { padding: 8px 14px; font-size: 12px; }
+      .lang-dropdown { max-width: 42vw; }
       .gh-stars { display: none; }
       /* The theme toggle would overflow the 24px-padded header at phone
          widths. prefers-color-scheme still auto-picks the right theme
@@ -1980,14 +2004,14 @@
         </a>
       </div>
     </div>
-    <div class="download-card">
+    <div class="download-card download-card-firefox">
       <div class="browser-icon">🦊</div>
       <h3>Firefox</h3>
       <p>Manifest V2 · Firefox 109+</p>
       <div class="download-card-actions">
         <a href="https://addons.mozilla.org/en-US/firefox/addon/webbrain/" target="_blank" rel="noopener noreferrer" class="btn btn-primary" style="background: #ff9800;">
           <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" width="16" height="16"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>
-          Скачать на Firefox Add-ons
+          Скачать на Firefox Add‑ons
         </a>
         <a href="https://github.com/esokullu/webbrain/tree/main/src/firefox" target="_blank" rel="noopener noreferrer" class="btn btn-secondary">
           Исходники для Firefox

--- a/web/th/index.html
+++ b/web/th/index.html
@@ -353,6 +353,7 @@
       backdrop-filter: blur(20px);
       background: var(--nav-bg);
       border-bottom: 1px solid var(--border);
+      overflow-x: clip;
     }
     .nav-inner {
       max-width: var(--max-w);
@@ -373,7 +374,7 @@
       -webkit-text-fill-color: transparent;
     }
     .nav-brand span.emoji { -webkit-text-fill-color: initial; font-size: 22px; }
-    .nav-links { display: flex; gap: 28px; align-items: center; }
+    .nav-links { display: flex; gap: 28px; align-items: center; margin-inline-start: auto; min-width: 0; }
     .nav-links a {
       color: var(--text-dim);
       font-size: 14px;
@@ -548,6 +549,7 @@
     .hero-visual {
       margin-top: 60px;
       position: relative;
+      overflow: hidden;
     }
     .browser-mockup {
       max-width: 820px;
@@ -576,12 +578,16 @@
     .browser-dots span:nth-child(3) { background: #34d399; }
     .browser-url {
       flex: 1;
+      min-width: 0;
       margin-inline-start: 12px;
       background: var(--url-bg);
       border-radius: 6px;
       padding: 5px 12px;
       font-size: 12px;
       color: var(--text-dim);
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
     }
     .browser-body {
       display: flex;
@@ -652,6 +658,7 @@
       font-size: 12px;
       line-height: 1.5;
       max-width: 90%;
+      overflow-wrap: anywhere;
       opacity: 0;
     }
     @keyframes fadeUp {
@@ -713,6 +720,7 @@
       grid-template-columns: minmax(0, 1fr);
       max-width: 820px;
       margin: 0 auto;
+      overflow: hidden;
     }
     .mockup-stack > .browser-mockup {
       grid-column: 1;
@@ -1221,13 +1229,23 @@
       gap: 10px;
       margin-top: auto;
     }
-    .download-card .btn { width: 100%; justify-content: center; }
-    /* Chrome is the more popular browser so the Chrome card gets ~25% more
-       horizontal real estate than Firefox via flex-grow. Both cards stay
+    .download-card .btn {
+      width: 100%;
+      justify-content: center;
+      line-height: 1.35;
+    }
+    .download-card .btn svg { flex: 0 0 auto; }
+    .download-card-firefox .btn-primary {
+      overflow-wrap: normal;
+      word-break: normal;
+      hyphens: none;
+    }
+    /* Chrome still gets a little extra emphasis, but keep the Firefox card
+       wide enough that its install CTA does not wrap awkwardly. Both cards stay
        on a single row at all desktop/tablet widths; the mobile breakpoint
        below stacks them. */
     .download-card-chrome {
-      flex-grow: 1.25;
+      flex-grow: 1.12;
       padding: 38px 32px;
       border-color: rgba(0, 212, 255, 0.45);
     }
@@ -1450,10 +1468,16 @@
        RESPONSIVE
        ================================================================ */
     @media (max-width: 768px) {
+      body { overflow-x: hidden; }
       .browser-body { flex-direction: column; }
       .side-panel { width: 100%; border-inline-start: none; border-top: 1px solid var(--border); min-height: 260px; }
       .modes-grid { grid-template-columns: 1fr; }
+      .nav-inner { width: 100%; padding: 12px 10px; gap: 8px; }
+      .nav-brand { min-width: 0; font-size: 17px; gap: 6px; }
+      .nav-links { gap: 8px; flex-shrink: 0; }
       .nav-links a:not(.nav-cta) { display: none; }
+      .nav-cta { padding: 8px 14px; font-size: 12px; }
+      .lang-dropdown { max-width: 42vw; }
       .gh-stars { display: none; }
       /* The theme toggle would overflow the 24px-padded header at phone
          widths. prefers-color-scheme still auto-picks the right theme
@@ -1980,14 +2004,14 @@
         </a>
       </div>
     </div>
-    <div class="download-card">
+    <div class="download-card download-card-firefox">
       <div class="browser-icon">🦊</div>
       <h3>Firefox</h3>
       <p>Manifest V2 · Firefox 109+</p>
       <div class="download-card-actions">
         <a href="https://addons.mozilla.org/en-US/firefox/addon/webbrain/" target="_blank" rel="noopener noreferrer" class="btn btn-primary" style="background: #ff9800;">
           <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" width="16" height="16"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>
-          ดาวน์โหลดจาก Firefox Add-ons
+          ดาวน์โหลดจาก Firefox Add‑ons
         </a>
         <a href="https://github.com/esokullu/webbrain/tree/main/src/firefox" target="_blank" rel="noopener noreferrer" class="btn btn-secondary">
           ดูซอร์สโค้ดของเวอร์ชัน Firefox

--- a/web/tl/index.html
+++ b/web/tl/index.html
@@ -353,6 +353,7 @@
       backdrop-filter: blur(20px);
       background: var(--nav-bg);
       border-bottom: 1px solid var(--border);
+      overflow-x: clip;
     }
     .nav-inner {
       max-width: var(--max-w);
@@ -373,7 +374,7 @@
       -webkit-text-fill-color: transparent;
     }
     .nav-brand span.emoji { -webkit-text-fill-color: initial; font-size: 22px; }
-    .nav-links { display: flex; gap: 28px; align-items: center; }
+    .nav-links { display: flex; gap: 28px; align-items: center; margin-inline-start: auto; min-width: 0; }
     .nav-links a {
       color: var(--text-dim);
       font-size: 14px;
@@ -548,6 +549,7 @@
     .hero-visual {
       margin-top: 60px;
       position: relative;
+      overflow: hidden;
     }
     .browser-mockup {
       max-width: 820px;
@@ -576,12 +578,16 @@
     .browser-dots span:nth-child(3) { background: #34d399; }
     .browser-url {
       flex: 1;
+      min-width: 0;
       margin-inline-start: 12px;
       background: var(--url-bg);
       border-radius: 6px;
       padding: 5px 12px;
       font-size: 12px;
       color: var(--text-dim);
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
     }
     .browser-body {
       display: flex;
@@ -652,6 +658,7 @@
       font-size: 12px;
       line-height: 1.5;
       max-width: 90%;
+      overflow-wrap: anywhere;
       opacity: 0;
     }
     @keyframes fadeUp {
@@ -713,6 +720,7 @@
       grid-template-columns: minmax(0, 1fr);
       max-width: 820px;
       margin: 0 auto;
+      overflow: hidden;
     }
     .mockup-stack > .browser-mockup {
       grid-column: 1;
@@ -1221,13 +1229,23 @@
       gap: 10px;
       margin-top: auto;
     }
-    .download-card .btn { width: 100%; justify-content: center; }
-    /* Chrome is the more popular browser so the Chrome card gets ~25% more
-       horizontal real estate than Firefox via flex-grow. Both cards stay
+    .download-card .btn {
+      width: 100%;
+      justify-content: center;
+      line-height: 1.35;
+    }
+    .download-card .btn svg { flex: 0 0 auto; }
+    .download-card-firefox .btn-primary {
+      overflow-wrap: normal;
+      word-break: normal;
+      hyphens: none;
+    }
+    /* Chrome still gets a little extra emphasis, but keep the Firefox card
+       wide enough that its install CTA does not wrap awkwardly. Both cards stay
        on a single row at all desktop/tablet widths; the mobile breakpoint
        below stacks them. */
     .download-card-chrome {
-      flex-grow: 1.25;
+      flex-grow: 1.12;
       padding: 38px 32px;
       border-color: rgba(0, 212, 255, 0.45);
     }
@@ -1450,10 +1468,16 @@
        RESPONSIVE
        ================================================================ */
     @media (max-width: 768px) {
+      body { overflow-x: hidden; }
       .browser-body { flex-direction: column; }
       .side-panel { width: 100%; border-inline-start: none; border-top: 1px solid var(--border); min-height: 260px; }
       .modes-grid { grid-template-columns: 1fr; }
+      .nav-inner { width: 100%; padding: 12px 10px; gap: 8px; }
+      .nav-brand { min-width: 0; font-size: 17px; gap: 6px; }
+      .nav-links { gap: 8px; flex-shrink: 0; }
       .nav-links a:not(.nav-cta) { display: none; }
+      .nav-cta { padding: 8px 14px; font-size: 12px; }
+      .lang-dropdown { max-width: 42vw; }
       .gh-stars { display: none; }
       /* The theme toggle would overflow the 24px-padded header at phone
          widths. prefers-color-scheme still auto-picks the right theme
@@ -1980,14 +2004,14 @@
         </a>
       </div>
     </div>
-    <div class="download-card">
+    <div class="download-card download-card-firefox">
       <div class="browser-icon">🦊</div>
       <h3>Firefox</h3>
       <p>Manifest V2 · Firefox 109+</p>
       <div class="download-card-actions">
         <a href="https://addons.mozilla.org/en-US/firefox/addon/webbrain/" target="_blank" rel="noopener noreferrer" class="btn btn-primary" style="background: #ff9800;">
           <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" width="16" height="16"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>
-          I-download mula sa Firefox Add-ons
+          I-download mula sa Firefox Add‑ons
         </a>
         <a href="https://github.com/esokullu/webbrain/tree/main/src/firefox" target="_blank" rel="noopener noreferrer" class="btn btn-secondary">
           Tingnan ang Firefox source

--- a/web/tr/index.html
+++ b/web/tr/index.html
@@ -353,6 +353,7 @@
       backdrop-filter: blur(20px);
       background: var(--nav-bg);
       border-bottom: 1px solid var(--border);
+      overflow-x: clip;
     }
     .nav-inner {
       max-width: var(--max-w);
@@ -373,7 +374,7 @@
       -webkit-text-fill-color: transparent;
     }
     .nav-brand span.emoji { -webkit-text-fill-color: initial; font-size: 22px; }
-    .nav-links { display: flex; gap: 28px; align-items: center; }
+    .nav-links { display: flex; gap: 28px; align-items: center; margin-inline-start: auto; min-width: 0; }
     .nav-links a {
       color: var(--text-dim);
       font-size: 14px;
@@ -548,6 +549,7 @@
     .hero-visual {
       margin-top: 60px;
       position: relative;
+      overflow: hidden;
     }
     .browser-mockup {
       max-width: 820px;
@@ -576,12 +578,16 @@
     .browser-dots span:nth-child(3) { background: #34d399; }
     .browser-url {
       flex: 1;
+      min-width: 0;
       margin-inline-start: 12px;
       background: var(--url-bg);
       border-radius: 6px;
       padding: 5px 12px;
       font-size: 12px;
       color: var(--text-dim);
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
     }
     .browser-body {
       display: flex;
@@ -652,6 +658,7 @@
       font-size: 12px;
       line-height: 1.5;
       max-width: 90%;
+      overflow-wrap: anywhere;
       opacity: 0;
     }
     @keyframes fadeUp {
@@ -713,6 +720,7 @@
       grid-template-columns: minmax(0, 1fr);
       max-width: 820px;
       margin: 0 auto;
+      overflow: hidden;
     }
     .mockup-stack > .browser-mockup {
       grid-column: 1;
@@ -1221,13 +1229,23 @@
       gap: 10px;
       margin-top: auto;
     }
-    .download-card .btn { width: 100%; justify-content: center; }
-    /* Chrome is the more popular browser so the Chrome card gets ~25% more
-       horizontal real estate than Firefox via flex-grow. Both cards stay
+    .download-card .btn {
+      width: 100%;
+      justify-content: center;
+      line-height: 1.35;
+    }
+    .download-card .btn svg { flex: 0 0 auto; }
+    .download-card-firefox .btn-primary {
+      overflow-wrap: normal;
+      word-break: normal;
+      hyphens: none;
+    }
+    /* Chrome still gets a little extra emphasis, but keep the Firefox card
+       wide enough that its install CTA does not wrap awkwardly. Both cards stay
        on a single row at all desktop/tablet widths; the mobile breakpoint
        below stacks them. */
     .download-card-chrome {
-      flex-grow: 1.25;
+      flex-grow: 1.12;
       padding: 38px 32px;
       border-color: rgba(0, 212, 255, 0.45);
     }
@@ -1450,10 +1468,16 @@
        RESPONSIVE
        ================================================================ */
     @media (max-width: 768px) {
+      body { overflow-x: hidden; }
       .browser-body { flex-direction: column; }
       .side-panel { width: 100%; border-inline-start: none; border-top: 1px solid var(--border); min-height: 260px; }
       .modes-grid { grid-template-columns: 1fr; }
+      .nav-inner { width: 100%; padding: 12px 10px; gap: 8px; }
+      .nav-brand { min-width: 0; font-size: 17px; gap: 6px; }
+      .nav-links { gap: 8px; flex-shrink: 0; }
       .nav-links a:not(.nav-cta) { display: none; }
+      .nav-cta { padding: 8px 14px; font-size: 12px; }
+      .lang-dropdown { max-width: 42vw; }
       .gh-stars { display: none; }
       /* The theme toggle would overflow the 24px-padded header at phone
          widths. prefers-color-scheme still auto-picks the right theme
@@ -1980,14 +2004,14 @@
         </a>
       </div>
     </div>
-    <div class="download-card">
+    <div class="download-card download-card-firefox">
       <div class="browser-icon">🦊</div>
       <h3>Firefox</h3>
       <p>Manifest V2 · Firefox 109+</p>
       <div class="download-card-actions">
         <a href="https://addons.mozilla.org/en-US/firefox/addon/webbrain/" target="_blank" rel="noopener noreferrer" class="btn btn-primary" style="background: #ff9800;">
           <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" width="16" height="16"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>
-          Firefox Add-ons&#39;tan indir
+          Firefox Add‑ons&#39;tan indir
         </a>
         <a href="https://github.com/esokullu/webbrain/tree/main/src/firefox" target="_blank" rel="noopener noreferrer" class="btn btn-secondary">
           Firefox kaynağını gör

--- a/web/uk/index.html
+++ b/web/uk/index.html
@@ -353,6 +353,7 @@
       backdrop-filter: blur(20px);
       background: var(--nav-bg);
       border-bottom: 1px solid var(--border);
+      overflow-x: clip;
     }
     .nav-inner {
       max-width: var(--max-w);
@@ -373,7 +374,7 @@
       -webkit-text-fill-color: transparent;
     }
     .nav-brand span.emoji { -webkit-text-fill-color: initial; font-size: 22px; }
-    .nav-links { display: flex; gap: 28px; align-items: center; }
+    .nav-links { display: flex; gap: 28px; align-items: center; margin-inline-start: auto; min-width: 0; }
     .nav-links a {
       color: var(--text-dim);
       font-size: 14px;
@@ -548,6 +549,7 @@
     .hero-visual {
       margin-top: 60px;
       position: relative;
+      overflow: hidden;
     }
     .browser-mockup {
       max-width: 820px;
@@ -576,12 +578,16 @@
     .browser-dots span:nth-child(3) { background: #34d399; }
     .browser-url {
       flex: 1;
+      min-width: 0;
       margin-inline-start: 12px;
       background: var(--url-bg);
       border-radius: 6px;
       padding: 5px 12px;
       font-size: 12px;
       color: var(--text-dim);
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
     }
     .browser-body {
       display: flex;
@@ -652,6 +658,7 @@
       font-size: 12px;
       line-height: 1.5;
       max-width: 90%;
+      overflow-wrap: anywhere;
       opacity: 0;
     }
     @keyframes fadeUp {
@@ -713,6 +720,7 @@
       grid-template-columns: minmax(0, 1fr);
       max-width: 820px;
       margin: 0 auto;
+      overflow: hidden;
     }
     .mockup-stack > .browser-mockup {
       grid-column: 1;
@@ -1221,13 +1229,23 @@
       gap: 10px;
       margin-top: auto;
     }
-    .download-card .btn { width: 100%; justify-content: center; }
-    /* Chrome is the more popular browser so the Chrome card gets ~25% more
-       horizontal real estate than Firefox via flex-grow. Both cards stay
+    .download-card .btn {
+      width: 100%;
+      justify-content: center;
+      line-height: 1.35;
+    }
+    .download-card .btn svg { flex: 0 0 auto; }
+    .download-card-firefox .btn-primary {
+      overflow-wrap: normal;
+      word-break: normal;
+      hyphens: none;
+    }
+    /* Chrome still gets a little extra emphasis, but keep the Firefox card
+       wide enough that its install CTA does not wrap awkwardly. Both cards stay
        on a single row at all desktop/tablet widths; the mobile breakpoint
        below stacks them. */
     .download-card-chrome {
-      flex-grow: 1.25;
+      flex-grow: 1.12;
       padding: 38px 32px;
       border-color: rgba(0, 212, 255, 0.45);
     }
@@ -1450,10 +1468,16 @@
        RESPONSIVE
        ================================================================ */
     @media (max-width: 768px) {
+      body { overflow-x: hidden; }
       .browser-body { flex-direction: column; }
       .side-panel { width: 100%; border-inline-start: none; border-top: 1px solid var(--border); min-height: 260px; }
       .modes-grid { grid-template-columns: 1fr; }
+      .nav-inner { width: 100%; padding: 12px 10px; gap: 8px; }
+      .nav-brand { min-width: 0; font-size: 17px; gap: 6px; }
+      .nav-links { gap: 8px; flex-shrink: 0; }
       .nav-links a:not(.nav-cta) { display: none; }
+      .nav-cta { padding: 8px 14px; font-size: 12px; }
+      .lang-dropdown { max-width: 42vw; }
       .gh-stars { display: none; }
       /* The theme toggle would overflow the 24px-padded header at phone
          widths. prefers-color-scheme still auto-picks the right theme
@@ -1980,14 +2004,14 @@
         </a>
       </div>
     </div>
-    <div class="download-card">
+    <div class="download-card download-card-firefox">
       <div class="browser-icon">🦊</div>
       <h3>Firefox</h3>
       <p>Manifest V2 · Firefox 109+</p>
       <div class="download-card-actions">
         <a href="https://addons.mozilla.org/en-US/firefox/addon/webbrain/" target="_blank" rel="noopener noreferrer" class="btn btn-primary" style="background: #ff9800;">
           <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" width="16" height="16"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>
-          Завантажити на Firefox Add-ons
+          Завантажити на Firefox Add‑ons
         </a>
         <a href="https://github.com/esokullu/webbrain/tree/main/src/firefox" target="_blank" rel="noopener noreferrer" class="btn btn-secondary">
           Сирці для Firefox

--- a/web/zh/index.html
+++ b/web/zh/index.html
@@ -353,6 +353,7 @@
       backdrop-filter: blur(20px);
       background: var(--nav-bg);
       border-bottom: 1px solid var(--border);
+      overflow-x: clip;
     }
     .nav-inner {
       max-width: var(--max-w);
@@ -373,7 +374,7 @@
       -webkit-text-fill-color: transparent;
     }
     .nav-brand span.emoji { -webkit-text-fill-color: initial; font-size: 22px; }
-    .nav-links { display: flex; gap: 28px; align-items: center; }
+    .nav-links { display: flex; gap: 28px; align-items: center; margin-inline-start: auto; min-width: 0; }
     .nav-links a {
       color: var(--text-dim);
       font-size: 14px;
@@ -548,6 +549,7 @@
     .hero-visual {
       margin-top: 60px;
       position: relative;
+      overflow: hidden;
     }
     .browser-mockup {
       max-width: 820px;
@@ -576,12 +578,16 @@
     .browser-dots span:nth-child(3) { background: #34d399; }
     .browser-url {
       flex: 1;
+      min-width: 0;
       margin-inline-start: 12px;
       background: var(--url-bg);
       border-radius: 6px;
       padding: 5px 12px;
       font-size: 12px;
       color: var(--text-dim);
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
     }
     .browser-body {
       display: flex;
@@ -652,6 +658,7 @@
       font-size: 12px;
       line-height: 1.5;
       max-width: 90%;
+      overflow-wrap: anywhere;
       opacity: 0;
     }
     @keyframes fadeUp {
@@ -713,6 +720,7 @@
       grid-template-columns: minmax(0, 1fr);
       max-width: 820px;
       margin: 0 auto;
+      overflow: hidden;
     }
     .mockup-stack > .browser-mockup {
       grid-column: 1;
@@ -1221,13 +1229,23 @@
       gap: 10px;
       margin-top: auto;
     }
-    .download-card .btn { width: 100%; justify-content: center; }
-    /* Chrome is the more popular browser so the Chrome card gets ~25% more
-       horizontal real estate than Firefox via flex-grow. Both cards stay
+    .download-card .btn {
+      width: 100%;
+      justify-content: center;
+      line-height: 1.35;
+    }
+    .download-card .btn svg { flex: 0 0 auto; }
+    .download-card-firefox .btn-primary {
+      overflow-wrap: normal;
+      word-break: normal;
+      hyphens: none;
+    }
+    /* Chrome still gets a little extra emphasis, but keep the Firefox card
+       wide enough that its install CTA does not wrap awkwardly. Both cards stay
        on a single row at all desktop/tablet widths; the mobile breakpoint
        below stacks them. */
     .download-card-chrome {
-      flex-grow: 1.25;
+      flex-grow: 1.12;
       padding: 38px 32px;
       border-color: rgba(0, 212, 255, 0.45);
     }
@@ -1450,10 +1468,16 @@
        RESPONSIVE
        ================================================================ */
     @media (max-width: 768px) {
+      body { overflow-x: hidden; }
       .browser-body { flex-direction: column; }
       .side-panel { width: 100%; border-inline-start: none; border-top: 1px solid var(--border); min-height: 260px; }
       .modes-grid { grid-template-columns: 1fr; }
+      .nav-inner { width: 100%; padding: 12px 10px; gap: 8px; }
+      .nav-brand { min-width: 0; font-size: 17px; gap: 6px; }
+      .nav-links { gap: 8px; flex-shrink: 0; }
       .nav-links a:not(.nav-cta) { display: none; }
+      .nav-cta { padding: 8px 14px; font-size: 12px; }
+      .lang-dropdown { max-width: 42vw; }
       .gh-stars { display: none; }
       /* The theme toggle would overflow the 24px-padded header at phone
          widths. prefers-color-scheme still auto-picks the right theme
@@ -1980,7 +2004,7 @@
         </a>
       </div>
     </div>
-    <div class="download-card">
+    <div class="download-card download-card-firefox">
       <div class="browser-icon">🦊</div>
       <h3>Firefox</h3>
       <p>Manifest V2 · Firefox 109+</p>


### PR DESCRIPTION
### Motivation
- The Firefox install CTA was splitting awkwardly at the ordinary hyphen in "Add-ons" and the card had insufficient width causing poor wrapping on some locales and viewports. 
- The goal was to ensure the Firefox card CTA stays on a single readable line while keeping Chrome emphasis and overall layout intact. 
- While addressing the CTA, a few related layout constraints (header, hero mockup, and mockup stack) were hardened to avoid overflow/wrapping regressions across locales. 

### Description
- Added a dedicated class `download-card-firefox` and updated the download card markup in `web/build/template.html` so Firefox-specific styling can be applied. 
- Tightened button layout by changing `.download-card .btn` to include `line-height: 1.35` and prevented the SVG from shrinking with `.download-card .btn svg { flex: 0 0 auto; }`, and reduced Chrome card dominance by changing `.download-card-chrome` `flex-grow` from `1.25` to `1.12`. 
- Prevented CTA word-breaking by adding `.download-card-firefox .btn-primary { overflow-wrap: normal; word-break: normal; hyphens: none; }` and replaced the breakable hyphen in locale strings with a non-breaking hyphen (`Add‑ons`) in `web/build/locales/*.json`. 
- Regenerated the site so changes propagate to built pages (`web/*.html`) and also applied small layout fixes: `nav` `overflow-x: clip`, `nav-links` `margin-inline-start:auto` + `min-width:0`, `.hero-visual`/`.mockup-stack` `overflow: hidden`, `.browser-url` `min-width:0` + ellipsis, `.sp-msg` `overflow-wrap:anywhere`, and mobile `body { overflow-x: hidden; }`. 

### Testing
- Ran `npm run build:web` which rebuilt all localized pages successfully and wrote updated `web/*.html` files. 
- Ran the test suite via `npm test` with all tests passing (`195 passed, 0 failed`). 
- Verified locale replacements with a search for the new non-breaking hyphen (`rg -n "Add‑ons" web`) and confirmed generated pages include the `download-card-firefox` class. 
- Attempted `npx playwright install chromium` for a headless screenshot, but the Playwright CDN download failed with `403 Forbidden` in this environment so no browser-based screenshot was produced.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1a1ddc994c83279d0a3d0883c67bd3)