### PR TITLE
[codex] Improve scroll targeting for nested panes

### DIFF
--- a/src/chrome/src/agent/agent.js
+++ b/src/chrome/src/agent/agent.js
@@ -109,7 +109,7 @@ export class Agent {
     // Used to draw an outline onto verification screenshots in `done` so the
     // model can see which element it last touched. Lives for the tab's
     // lifetime; overwritten on each ax interaction, cleared on tab close.
-    this._lastInteractionRect = new Map(); // tabId -> { x, y, w, h, ts }
+    this._lastInteractionRect = new Map(); // tabId -> { x, y, w, h, ts, url }
     // Pending clarify() tool calls awaiting user input. Keyed by tabId →
     // (clarifyId → {resolve, reject}). The clarify tool returns a Promise
     // that resolves when the user submits a response via the side panel
@@ -4275,6 +4275,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
           // Snapshot existing tabs first so we can detect a target=_blank
           // link that spawns a background tab instead of navigating in-place
           // (see _redirectTargetBlankClick).
+          const clickUrl = await this._currentUrl(tabId);
           const beforeTabIdsText = new Set((await chrome.tabs.query({})).map(t => t.id));
           await new Promise(r => setTimeout(r, 100));
           await cdpClient.dispatchMouseEvent(tabId, 'mouseMoved', info.x, info.y);
@@ -4357,7 +4358,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
           }
           const clickX = Math.round(info.x);
           const clickY = Math.round(info.y);
-          this._lastInteractionRect.set(tabId, { x: clickX, y: clickY, w: 1, h: 1, ts: Date.now() });
+          this._lastInteractionRect.set(tabId, { x: clickX, y: clickY, w: 1, h: 1, ts: Date.now(), url: clickUrl });
           return {
             success: true,
             method: 'cdp-by-text',
@@ -4539,6 +4540,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
           const clickX = redir ? redir.x : args.x;
           const clickY = redir ? redir.y : args.y;
 
+          const clickUrl = await this._currentUrl(tabId);
           const beforeTabIdsCoord = new Set((await chrome.tabs.query({})).map(t => t.id));
           await cdpClient.dispatchMouseEvent(tabId, 'mouseMoved', clickX, clickY);
           await cdpClient.dispatchMouseEvent(tabId, 'mousePressed', clickX, clickY);
@@ -4584,6 +4586,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
             w: 1,
             h: 1,
             ts: Date.now(),
+            url: clickUrl,
           });
           return { success: true, method: 'cdp-coords', x: args.x, y: args.y };
         }
@@ -5015,8 +5018,13 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
       }
     } catch { /* tab lookup failures are non-fatal — fall through */ }
 
+    const interactionUrl = (
+      name === 'click' || name === 'click_ax' ||
+      name === 'type_ax' || name === 'set_field'
+    ) ? await this._currentUrl(tabId) : '';
+
     if (name === 'scroll') {
-      args = this._augmentScrollArgsWithLastInteraction(tabId, args);
+      args = await this._augmentScrollArgsWithLastInteraction(tabId, args);
     }
 
     try {
@@ -5025,7 +5033,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
         action,
         params: args,
       });
-      this._recordInteractionRect(tabId, name, response);
+      this._recordInteractionRect(tabId, name, response, interactionUrl);
       this._annotateCredentialField(name, response);
       return response;
     } catch (e) {
@@ -5043,7 +5051,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
           action,
           params: args,
         });
-        this._recordInteractionRect(tabId, name, response);
+        this._recordInteractionRect(tabId, name, response, interactionUrl);
         this._annotateCredentialField(name, response);
         return response;
       } catch (e2) {
@@ -5093,12 +5101,12 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
    * `done` verification screenshot can outline the last-touched element.
    * No-op for other tool responses or when the rect is missing/degenerate.
    */
-  _recordInteractionRect(tabId, toolName, response) {
+  _recordInteractionRect(tabId, toolName, response, url = '') {
     if (!response || !response.success) return;
     if (toolName !== 'click' && toolName !== 'click_ax' && toolName !== 'type_ax' && toolName !== 'set_field') return;
     const r = response.rect;
     if (r && r.w && r.h) {
-      this._lastInteractionRect.set(tabId, { x: r.x, y: r.y, w: r.w, h: r.h, ts: Date.now() });
+      this._lastInteractionRect.set(tabId, { x: r.x, y: r.y, w: r.w, h: r.h, ts: Date.now(), url });
       return;
     }
     if (Number.isFinite(Number(response.x)) && Number.isFinite(Number(response.y))) {
@@ -5108,14 +5116,21 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
         w: 1,
         h: 1,
         ts: Date.now(),
+        url,
       });
     }
   }
 
-  _augmentScrollArgsWithLastInteraction(tabId, args = {}) {
+  async _augmentScrollArgsWithLastInteraction(tabId, args = {}) {
     if (!args || args.ref_id != null || args.x != null || args.y != null) return args || {};
     const last = this._lastInteractionRect.get(tabId);
     if (!last || Date.now() - last.ts > 60000) return args;
+    const currentUrl = await this._currentUrl(tabId);
+    if (!last.url || !currentUrl) return args;
+    if (last.url !== currentUrl) {
+      this._lastInteractionRect.delete(tabId);
+      return args;
+    }
     return {
       ...args,
       x: Math.round(last.x + last.w / 2),

--- a/src/chrome/src/agent/agent.js
+++ b/src/chrome/src/agent/agent.js
@@ -4355,6 +4355,9 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
               hint: `The clicked link had target="_blank" and opened in a new tab. To keep the agent on one tab, the spawned tab was closed and this tab was navigated to ${redirectedText.url}. Take a screenshot or call read_page to see the destination.`,
             };
           }
+          const clickX = Math.round(info.x);
+          const clickY = Math.round(info.y);
+          this._lastInteractionRect.set(tabId, { x: clickX, y: clickY, w: 1, h: 1, ts: Date.now() });
           return {
             success: true,
             method: 'cdp-by-text',
@@ -4362,6 +4365,9 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
             tag: info.tag,
             text: info.text,
             matched: args.text,
+            x: clickX,
+            y: clickY,
+            rect: { x: clickX, y: clickY, w: 1, h: 1 },
             ...(warning ? { warning } : {}),
           };
         }
@@ -4572,6 +4578,13 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
               hint: `The clicked coordinate hit a target="_blank" link. The spawned tab was closed and this tab was navigated to ${redirectedCoord.url} so the agent stays on a single tab.`,
             };
           }
+          this._lastInteractionRect.set(tabId, {
+            x: Math.round(Number(args.x)),
+            y: Math.round(Number(args.y)),
+            w: 1,
+            h: 1,
+            ts: Date.now(),
+          });
           return { success: true, method: 'cdp-coords', x: args.x, y: args.y };
         }
         // index-based: fall through to content-script path which knows the
@@ -5002,6 +5015,10 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
       }
     } catch { /* tab lookup failures are non-fatal — fall through */ }
 
+    if (name === 'scroll') {
+      args = this._augmentScrollArgsWithLastInteraction(tabId, args);
+    }
+
     try {
       const response = await chrome.tabs.sendMessage(tabId, {
         target: 'content',
@@ -5078,10 +5095,33 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
    */
   _recordInteractionRect(tabId, toolName, response) {
     if (!response || !response.success) return;
-    if (toolName !== 'click_ax' && toolName !== 'type_ax' && toolName !== 'set_field') return;
+    if (toolName !== 'click' && toolName !== 'click_ax' && toolName !== 'type_ax' && toolName !== 'set_field') return;
     const r = response.rect;
-    if (!r || !r.w || !r.h) return;
-    this._lastInteractionRect.set(tabId, { x: r.x, y: r.y, w: r.w, h: r.h, ts: Date.now() });
+    if (r && r.w && r.h) {
+      this._lastInteractionRect.set(tabId, { x: r.x, y: r.y, w: r.w, h: r.h, ts: Date.now() });
+      return;
+    }
+    if (Number.isFinite(Number(response.x)) && Number.isFinite(Number(response.y))) {
+      this._lastInteractionRect.set(tabId, {
+        x: Math.round(Number(response.x)),
+        y: Math.round(Number(response.y)),
+        w: 1,
+        h: 1,
+        ts: Date.now(),
+      });
+    }
+  }
+
+  _augmentScrollArgsWithLastInteraction(tabId, args = {}) {
+    if (!args || args.ref_id != null || args.x != null || args.y != null) return args || {};
+    const last = this._lastInteractionRect.get(tabId);
+    if (!last || Date.now() - last.ts > 60000) return args;
+    return {
+      ...args,
+      x: Math.round(last.x + last.w / 2),
+      y: Math.round(last.y + last.h / 2),
+      origin: 'last_interaction',
+    };
   }
 
   /**

--- a/src/chrome/src/agent/tools.js
+++ b/src/chrome/src/agent/tools.js
@@ -238,7 +238,7 @@ export const AGENT_TOOLS = [
     type: 'function',
     function: {
       name: 'scroll',
-      description: 'Scroll the page in a given direction.',
+      description: 'Scroll in a given direction. By default, targets the nearest scrollable pane around the last interaction/focus when available, then falls back to the window. For split panes, sticky filters, dropdowns, or virtualized lists, pass ref_id from get_accessibility_tree or CSS-pixel x/y inside the pane so the correct container scrolls. The result reports movedWindow/movedContainer plus warnings when no movement or an almost-blank viewport suggests the wrong scroll surface.',
       parameters: {
         type: 'object',
         properties: {
@@ -248,6 +248,10 @@ export const AGENT_TOOLS = [
             description: 'Scroll direction',
           },
           amount: { type: 'number', description: 'Pixels to scroll (default: 500)' },
+          ref_id: { type: 'string', description: 'Optional ref_id for an element inside the pane/dropdown/list you intend to scroll.' },
+          x: { type: 'number', description: 'Optional CSS-pixel x coordinate inside the pane/dropdown/list you intend to scroll.' },
+          y: { type: 'number', description: 'Optional CSS-pixel y coordinate inside the pane/dropdown/list you intend to scroll.' },
+          alsoWindow: { type: 'boolean', description: 'If true, scroll the window too even when a nested container moved. Default false.' },
         },
       },
     },

--- a/src/chrome/src/content/content.js
+++ b/src/chrome/src/content/content.js
@@ -1050,7 +1050,7 @@
     const windowScrollable = document.documentElement.scrollHeight > window.innerHeight + 10;
 
     // Strategy 2: find the largest scrollable container on the page.
-    if (!target && (originEl || !windowScrollable)) {
+    if (!target) {
       let best = null;
       let bestArea = 0;
       const candidates = document.querySelectorAll('div, section, main, article, [role="main"], [role="dialog"]');

--- a/src/chrome/src/content/content.js
+++ b/src/chrome/src/content/content.js
@@ -1139,6 +1139,14 @@
       return max > 1 && canMove(el.scrollTop, max, dir);
     }
 
+    function scrollElementInstant(el, dir, px) {
+      const max = Math.max(0, el.scrollHeight - el.clientHeight);
+      if (dir === 'down') el.scrollTop = Math.min(max, el.scrollTop + px);
+      else if (dir === 'up') el.scrollTop = Math.max(0, el.scrollTop - px);
+      else if (dir === 'top') el.scrollTop = 0;
+      else if (dir === 'bottom') el.scrollTop = max;
+    }
+
     function isScrollableElement(el, allowHidden = false) {
       if (!el || el === document.body || el === document.documentElement) return false;
       if (el.scrollHeight <= el.clientHeight + 10) return false;
@@ -1257,10 +1265,7 @@
     let containerAfter = null;
     if (target) {
       containerBefore = target.scrollTop;
-      if (direction === 'down') target.scrollBy(0, amount);
-      else if (direction === 'up') target.scrollBy(0, -amount);
-      else if (direction === 'top') target.scrollTo(0, 0);
-      else if (direction === 'bottom') target.scrollTo(0, target.scrollHeight);
+      scrollElementInstant(target, direction, amount);
       containerAfter = target.scrollTop;
     }
 

--- a/src/chrome/src/content/content.js
+++ b/src/chrome/src/content/content.js
@@ -1230,7 +1230,7 @@
     let target = originEl ? findScrollableAncestor(originEl, direction, !windowScrollable) : null;
     let targetSource = target ? 'origin-ancestor' : 'none';
 
-    if (!target && (originEl || !windowScrollable)) {
+    if (!target && !windowScrollable) {
       let best = null;
       let bestArea = 0;
       const candidates = document.querySelectorAll('div, section, main, article, aside, [role="main"], [role="dialog"], [role="region"], [role="listbox"], [role="menu"]');

--- a/src/chrome/src/content/content.js
+++ b/src/chrome/src/content/content.js
@@ -1050,7 +1050,7 @@
     const windowScrollable = document.documentElement.scrollHeight > window.innerHeight + 10;
 
     // Strategy 2: find the largest scrollable container on the page.
-    if (!target) {
+    if (!target && (originEl || !windowScrollable)) {
       let best = null;
       let bestArea = 0;
       const candidates = document.querySelectorAll('div, section, main, article, [role="main"], [role="dialog"]');
@@ -1230,7 +1230,7 @@
     let target = originEl ? findScrollableAncestor(originEl, direction, !windowScrollable) : null;
     let targetSource = target ? 'origin-ancestor' : 'none';
 
-    if (!target) {
+    if (!target && (originEl || !windowScrollable)) {
       let best = null;
       let bestArea = 0;
       const candidates = document.querySelectorAll('div, section, main, article, aside, [role="main"], [role="dialog"], [role="region"], [role="listbox"], [role="menu"]');

--- a/src/chrome/src/content/content.js
+++ b/src/chrome/src/content/content.js
@@ -1229,10 +1229,11 @@
     }
 
     const windowScrollable = docScrollHeight() > window.innerHeight + 10;
+    const windowCanMove = canScrollWindow(direction);
     let target = originEl ? findScrollableAncestor(originEl, direction, !windowScrollable) : null;
     let targetSource = target ? 'origin-ancestor' : 'none';
 
-    if (!target && !windowScrollable) {
+    if (!target && !windowCanMove) {
       let best = null;
       let bestArea = 0;
       const candidates = document.querySelectorAll('div, section, main, article, aside, [role="main"], [role="dialog"], [role="region"], [role="listbox"], [role="menu"]');
@@ -1265,7 +1266,7 @@
 
     const movedContainer = target && Math.abs((containerAfter || 0) - (containerBefore || 0)) > 0.5;
     const shouldScrollWindow = params.alsoWindow === true || !movedContainer;
-    if (shouldScrollWindow && canScrollWindow(direction)) {
+    if (shouldScrollWindow && windowCanMove) {
       if (direction === 'down') window.scrollBy(0, amount);
       else if (direction === 'up') window.scrollBy(0, -amount);
       else if (direction === 'top') window.scrollTo(0, 0);

--- a/src/chrome/src/content/content.js
+++ b/src/chrome/src/content/content.js
@@ -1162,7 +1162,9 @@
     }
 
     function findScrollableAncestor(origin, dir, allowHidden = false) {
-      let el = origin;
+      const tag = origin?.tagName || '';
+      const skipOrigin = tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT' || origin?.isContentEditable;
+      let el = skipOrigin ? origin.parentElement : origin;
       while (el && el !== document.body && el !== document.documentElement) {
         if (isScrollableElement(el, allowHidden) && canScrollElement(el, dir)) return el;
         el = el.parentElement;

--- a/src/chrome/src/content/content.js
+++ b/src/chrome/src/content/content.js
@@ -125,6 +125,31 @@
     return false;
   }
 
+  let _lastInteractionPoint = null;
+
+  function rememberInteractionPoint(el, source = 'interaction') {
+    try {
+      if (!el || typeof el.getBoundingClientRect !== 'function') return null;
+      const r = el.getBoundingClientRect();
+      if (!Number.isFinite(r.left) || !Number.isFinite(r.top) || r.width < 1 || r.height < 1) return null;
+      const rect = {
+        x: Math.round(r.left),
+        y: Math.round(r.top),
+        w: Math.round(r.width),
+        h: Math.round(r.height),
+      };
+      _lastInteractionPoint = {
+        x: Math.round(r.left + r.width / 2),
+        y: Math.round(r.top + r.height / 2),
+        source,
+        ts: Date.now(),
+      };
+      return rect;
+    } catch {
+      return null;
+    }
+  }
+
   /**
    * Detect the topmost modal/overlay/dialog on the page. If one is found,
    * only elements inside it (and the backdrop) are "reachable" — everything
@@ -681,6 +706,7 @@
       } catch {}
     }
 
+    const clickedRect = rememberInteractionPoint(el, 'click');
     el.click();
 
     // Post-click SELECT detection: the click may have activated a <select>
@@ -709,7 +735,13 @@
       warning = 'Same element clicked again with no page change. Try click({x, y}) with coordinates from a screenshot, or click({index: N}) from get_interactive_elements.';
     }
     _lastClickIdent = ident;
-    return { success: true, tag: el.tagName, text: el.innerText?.slice(0, 50), ...(warning ? { warning } : {}) };
+    return {
+      success: true,
+      tag: el.tagName,
+      text: el.innerText?.slice(0, 50),
+      ...(clickedRect ? { rect: clickedRect } : {}),
+      ...(warning ? { warning } : {}),
+    };
   }
 
   let _lastTypeFieldIdent = null;
@@ -985,7 +1017,7 @@
   /**
    * Scroll the page.
    */
-  function scrollPage(params) {
+  function legacyScrollPage(params) {
     const amount = params.amount || 500;
     const direction = params.direction || 'down';
 
@@ -1072,6 +1104,223 @@
       viewportHeight: window.innerHeight,
       ...(target ? { scrolledContainer: true, containerScrollY: target.scrollTop, containerScrollHeight: target.scrollHeight } : {}),
     };
+  }
+
+  function smartScrollPage(params) {
+    params = params || {};
+    const rawAmount = Number(params.amount);
+    const amount = Number.isFinite(rawAmount) && rawAmount > 0 ? rawAmount : 500;
+    const direction = params.direction || 'down';
+    const scrollingElement = document.scrollingElement || document.documentElement || document.body;
+    const beforeWindowY = window.scrollY;
+
+    function docScrollHeight() {
+      return Math.max(
+        document.body?.scrollHeight || 0,
+        document.documentElement?.scrollHeight || 0,
+        scrollingElement?.scrollHeight || 0
+      );
+    }
+
+    function canMove(start, max, dir) {
+      if (dir === 'down' || dir === 'bottom') return start < max - 1;
+      if (dir === 'up' || dir === 'top') return start > 1;
+      return false;
+    }
+
+    function canScrollWindow(dir) {
+      const max = Math.max(0, docScrollHeight() - window.innerHeight);
+      return canMove(window.scrollY, max, dir);
+    }
+
+    function canScrollElement(el, dir) {
+      if (!el || el === document.body || el === document.documentElement) return false;
+      const max = Math.max(0, el.scrollHeight - el.clientHeight);
+      return max > 1 && canMove(el.scrollTop, max, dir);
+    }
+
+    function isScrollableElement(el, allowHidden = false) {
+      if (!el || el === document.body || el === document.documentElement) return false;
+      if (el.scrollHeight <= el.clientHeight + 10) return false;
+      const ov = window.getComputedStyle(el).overflowY;
+      return ov === 'auto' || ov === 'scroll' || ov === 'overlay' || (allowHidden && ov === 'hidden');
+    }
+
+    function elementSummary(el) {
+      if (!el) return null;
+      let rect = null;
+      try {
+        const r = el.getBoundingClientRect();
+        rect = { x: Math.round(r.x), y: Math.round(r.y), w: Math.round(r.width), h: Math.round(r.height) };
+      } catch {}
+      return {
+        tag: el.tagName ? el.tagName.toLowerCase() : '',
+        role: el.getAttribute?.('role') || '',
+        text: (el.innerText || el.getAttribute?.('aria-label') || '').trim().slice(0, 80),
+        rect,
+      };
+    }
+
+    function findScrollableAncestor(origin, dir, allowHidden = false) {
+      let el = origin;
+      while (el && el !== document.body && el !== document.documentElement) {
+        if (isScrollableElement(el, allowHidden) && canScrollElement(el, dir)) return el;
+        el = el.parentElement;
+      }
+      return null;
+    }
+
+    function visibleTextChars(limit = 2000) {
+      try {
+        if (!document.body) return 0;
+        let total = 0;
+        const walker = document.createTreeWalker(document.body, NodeFilter.SHOW_TEXT, {
+          acceptNode(node) {
+            const text = (node.nodeValue || '').trim();
+            if (!text) return NodeFilter.FILTER_REJECT;
+            const parent = node.parentElement;
+            if (!parent) return NodeFilter.FILTER_REJECT;
+            const style = window.getComputedStyle(parent);
+            if (style.display === 'none' || style.visibility === 'hidden' || parseFloat(style.opacity || '1') === 0) return NodeFilter.FILTER_REJECT;
+            const r = parent.getBoundingClientRect();
+            if (r.width < 1 || r.height < 1 || r.bottom < 0 || r.top > window.innerHeight || r.right < 0 || r.left > window.innerWidth) {
+              return NodeFilter.FILTER_REJECT;
+            }
+            return NodeFilter.FILTER_ACCEPT;
+          },
+        });
+        let node;
+        while ((node = walker.nextNode())) {
+          total += (node.nodeValue || '').trim().length;
+          if (total >= limit) return total;
+        }
+        return total;
+      } catch {
+        return null;
+      }
+    }
+
+    let originEl = null;
+    let origin = 'none';
+    if (typeof params.ref_id === 'string' && typeof window.__wb_ax_lookup === 'function') {
+      originEl = window.__wb_ax_lookup(params.ref_id);
+      origin = originEl ? `ref_id:${params.ref_id}` : `missing-ref_id:${params.ref_id}`;
+    }
+    if (!originEl && params.x != null && params.y != null) {
+      const x = Number(params.x);
+      const y = Number(params.y);
+      if (Number.isFinite(x) && Number.isFinite(y)) {
+        originEl = document.elementFromPoint(x, y);
+        origin = params.origin === 'last_interaction' ? 'last_interaction' : 'point';
+      }
+    }
+    if (!originEl) {
+      const active = document.activeElement;
+      if (active && active !== document.body && active !== document.documentElement) {
+        originEl = active;
+        origin = 'activeElement';
+      }
+    }
+    if (!originEl && _lastInteractionPoint && Date.now() - _lastInteractionPoint.ts < 60000) {
+      originEl = document.elementFromPoint(_lastInteractionPoint.x, _lastInteractionPoint.y);
+      origin = `last_interaction:${_lastInteractionPoint.source}`;
+    }
+
+    const windowScrollable = docScrollHeight() > window.innerHeight + 10;
+    let target = originEl ? findScrollableAncestor(originEl, direction, !windowScrollable) : null;
+    let targetSource = target ? 'origin-ancestor' : 'none';
+
+    if (!target && !originEl) {
+      let best = null;
+      let bestArea = 0;
+      const candidates = document.querySelectorAll('div, section, main, article, aside, [role="main"], [role="dialog"], [role="region"], [role="listbox"], [role="menu"]');
+      for (const el of candidates) {
+        if (!isScrollableElement(el, !windowScrollable) || !canScrollElement(el, direction)) continue;
+        const rect = el.getBoundingClientRect();
+        if (rect.width < 1 || rect.height < 1 || rect.bottom < 0 || rect.top > window.innerHeight || rect.right < 0 || rect.left > window.innerWidth) continue;
+        const area = rect.width * rect.height;
+        if (area > bestArea) {
+          bestArea = area;
+          best = el;
+        }
+      }
+      if (best && bestArea > window.innerWidth * window.innerHeight * 0.15) {
+        target = best;
+        targetSource = 'largest-visible-container';
+      }
+    }
+
+    let containerBefore = null;
+    let containerAfter = null;
+    if (target) {
+      containerBefore = target.scrollTop;
+      if (direction === 'down') target.scrollBy(0, amount);
+      else if (direction === 'up') target.scrollBy(0, -amount);
+      else if (direction === 'top') target.scrollTo(0, 0);
+      else if (direction === 'bottom') target.scrollTo(0, target.scrollHeight);
+      containerAfter = target.scrollTop;
+    }
+
+    const movedContainer = target && Math.abs((containerAfter || 0) - (containerBefore || 0)) > 0.5;
+    const shouldScrollWindow = params.alsoWindow === true || !movedContainer;
+    if (shouldScrollWindow && canScrollWindow(direction)) {
+      if (direction === 'down') window.scrollBy(0, amount);
+      else if (direction === 'up') window.scrollBy(0, -amount);
+      else if (direction === 'top') window.scrollTo(0, 0);
+      else if (direction === 'bottom') window.scrollTo(0, docScrollHeight());
+    }
+
+    const afterWindowY = window.scrollY;
+    const movedWindow = Math.abs(afterWindowY - beforeWindowY) > 0.5;
+    const textChars = visibleTextChars();
+    const totalTextChars = (document.body?.innerText || '').trim().length;
+    const warningParts = [];
+    if (!movedContainer && !movedWindow) {
+      warningParts.push('No scroll movement occurred; the current target may already be at its limit. Try the opposite direction, top/bottom, or pass ref_id/x/y for a different pane.');
+    }
+    if (movedContainer && !movedWindow && params.alsoWindow !== true) {
+      warningParts.push('Scrolled the nearest scrollable container only; the window was left in place to avoid split-pane/listing pages drifting away from the intended area.');
+    }
+    if (textChars !== null && textChars < 20 && totalTextChars > 200) {
+      warningParts.push('The viewport has almost no visible text after scrolling even though the document has text. The page may be lazy-rendered or between scroll panes; use get_accessibility_tree({filter:"visible"}) or scroll with ref_id/x/y instead of assuming the page is empty.');
+    }
+
+    return {
+      success: true,
+      scrollY: afterWindowY,
+      scrollHeight: docScrollHeight(),
+      viewportHeight: window.innerHeight,
+      moved: movedContainer || movedWindow,
+      movedWindow,
+      movedContainer: !!movedContainer,
+      origin,
+      ...(originEl ? { originElement: elementSummary(originEl) } : {}),
+      ...(target ? {
+        scrolledContainer: true,
+        targetSource,
+        targetElement: elementSummary(target),
+        containerScrollY: containerAfter,
+        containerScrollYBefore: containerBefore,
+        containerScrollHeight: target.scrollHeight,
+        containerClientHeight: target.clientHeight,
+      } : {}),
+      scrollYBefore: beforeWindowY,
+      visibleTextChars: textChars,
+      documentTextChars: totalTextChars,
+      ...(warningParts.length ? { warning: warningParts.join(' ') } : {}),
+    };
+  }
+
+  function scrollPage(params) {
+    try {
+      return smartScrollPage(params);
+    } catch (e) {
+      const fallback = legacyScrollPage(params || {});
+      return {
+        ...fallback,
+        warning: `Smart scroll targeting failed (${e && e.message || e}); fell back to legacy window/container scroll.`,
+      };
+    }
   }
 
   /**
@@ -1446,6 +1695,7 @@
           try { el.scrollIntoView({ block: 'center', inline: 'center' }); } catch {}
           try { el.focus({ preventScroll: true }); } catch {}
           const rect = el.getBoundingClientRect();
+          rememberInteractionPoint(el, 'click_ax');
           el.click();
           // If the model just clicked a text-entry element, its next call must
           // be type_ax on the same ref_id. Putting the directive in the tool

--- a/src/chrome/src/content/content.js
+++ b/src/chrome/src/content/content.js
@@ -1230,7 +1230,7 @@
     let target = originEl ? findScrollableAncestor(originEl, direction, !windowScrollable) : null;
     let targetSource = target ? 'origin-ancestor' : 'none';
 
-    if (!target && !originEl) {
+    if (!target) {
       let best = null;
       let bestArea = 0;
       const candidates = document.querySelectorAll('div, section, main, article, aside, [role="main"], [role="dialog"], [role="region"], [role="listbox"], [role="menu"]');

--- a/src/firefox/src/agent/tools.js
+++ b/src/firefox/src/agent/tools.js
@@ -225,7 +225,7 @@ export const AGENT_TOOLS = [
     type: 'function',
     function: {
       name: 'scroll',
-      description: 'Scroll the page in a given direction.',
+      description: 'Scroll in a given direction. By default, targets the nearest scrollable pane around the last interaction/focus when available, then falls back to the window. For split panes, sticky filters, dropdowns, or virtualized lists, pass ref_id from get_accessibility_tree or CSS-pixel x/y inside the pane so the correct container scrolls. The result reports movedWindow/movedContainer plus warnings when no movement or an almost-blank viewport suggests the wrong scroll surface.',
       parameters: {
         type: 'object',
         properties: {
@@ -235,6 +235,10 @@ export const AGENT_TOOLS = [
             description: 'Scroll direction',
           },
           amount: { type: 'number', description: 'Pixels to scroll (default: 500)' },
+          ref_id: { type: 'string', description: 'Optional ref_id for an element inside the pane/dropdown/list you intend to scroll.' },
+          x: { type: 'number', description: 'Optional CSS-pixel x coordinate inside the pane/dropdown/list you intend to scroll.' },
+          y: { type: 'number', description: 'Optional CSS-pixel y coordinate inside the pane/dropdown/list you intend to scroll.' },
+          alsoWindow: { type: 'boolean', description: 'If true, scroll the window too even when a nested container moved. Default false.' },
         },
       },
     },

--- a/src/firefox/src/content/content.js
+++ b/src/firefox/src/content/content.js
@@ -1415,10 +1415,11 @@
     }
 
     const windowScrollable = docScrollHeight() > window.innerHeight + 10;
+    const windowCanMove = canScrollWindow(direction);
     let target = originEl ? findScrollableAncestor(originEl, direction, !windowScrollable) : null;
     let targetSource = target ? 'origin-ancestor' : 'none';
 
-    if (!target && !windowScrollable) {
+    if (!target && !windowCanMove) {
       let best = null;
       let bestArea = 0;
       const candidates = document.querySelectorAll('div, section, main, article, aside, [role="main"], [role="dialog"], [role="region"], [role="listbox"], [role="menu"]');
@@ -1451,7 +1452,7 @@
 
     const movedContainer = target && Math.abs((containerAfter || 0) - (containerBefore || 0)) > 0.5;
     const shouldScrollWindow = params.alsoWindow === true || !movedContainer;
-    if (shouldScrollWindow && canScrollWindow(direction)) {
+    if (shouldScrollWindow && windowCanMove) {
       if (direction === 'down') window.scrollBy(0, amount);
       else if (direction === 'up') window.scrollBy(0, -amount);
       else if (direction === 'top') window.scrollTo(0, 0);

--- a/src/firefox/src/content/content.js
+++ b/src/firefox/src/content/content.js
@@ -1416,7 +1416,7 @@
     let target = originEl ? findScrollableAncestor(originEl, direction, !windowScrollable) : null;
     let targetSource = target ? 'origin-ancestor' : 'none';
 
-    if (!target && (originEl || !windowScrollable)) {
+    if (!target && !windowScrollable) {
       let best = null;
       let bestArea = 0;
       const candidates = document.querySelectorAll('div, section, main, article, aside, [role="main"], [role="dialog"], [role="region"], [role="listbox"], [role="menu"]');

--- a/src/firefox/src/content/content.js
+++ b/src/firefox/src/content/content.js
@@ -1325,6 +1325,14 @@
       return max > 1 && canMove(el.scrollTop, max, dir);
     }
 
+    function scrollElementInstant(el, dir, px) {
+      const max = Math.max(0, el.scrollHeight - el.clientHeight);
+      if (dir === 'down') el.scrollTop = Math.min(max, el.scrollTop + px);
+      else if (dir === 'up') el.scrollTop = Math.max(0, el.scrollTop - px);
+      else if (dir === 'top') el.scrollTop = 0;
+      else if (dir === 'bottom') el.scrollTop = max;
+    }
+
     function isScrollableElement(el, allowHidden = false) {
       if (!el || el === document.body || el === document.documentElement) return false;
       if (el.scrollHeight <= el.clientHeight + 10) return false;
@@ -1443,10 +1451,7 @@
     let containerAfter = null;
     if (target) {
       containerBefore = target.scrollTop;
-      if (direction === 'down') target.scrollBy(0, amount);
-      else if (direction === 'up') target.scrollBy(0, -amount);
-      else if (direction === 'top') target.scrollTo(0, 0);
-      else if (direction === 'bottom') target.scrollTo(0, target.scrollHeight);
+      scrollElementInstant(target, direction, amount);
       containerAfter = target.scrollTop;
     }
 

--- a/src/firefox/src/content/content.js
+++ b/src/firefox/src/content/content.js
@@ -1238,7 +1238,7 @@
     const windowScrollable = document.documentElement.scrollHeight > window.innerHeight + 10;
 
     // Strategy 2: find the largest scrollable container on the page.
-    if (!target) {
+    if (!target && (originEl || !windowScrollable)) {
       let best = null;
       let bestArea = 0;
       const candidates = document.querySelectorAll('div, section, main, article, [role="main"], [role="dialog"]');
@@ -1416,7 +1416,7 @@
     let target = originEl ? findScrollableAncestor(originEl, direction, !windowScrollable) : null;
     let targetSource = target ? 'origin-ancestor' : 'none';
 
-    if (!target) {
+    if (!target && (originEl || !windowScrollable)) {
       let best = null;
       let bestArea = 0;
       const candidates = document.querySelectorAll('div, section, main, article, aside, [role="main"], [role="dialog"], [role="region"], [role="listbox"], [role="menu"]');

--- a/src/firefox/src/content/content.js
+++ b/src/firefox/src/content/content.js
@@ -1238,7 +1238,7 @@
     const windowScrollable = document.documentElement.scrollHeight > window.innerHeight + 10;
 
     // Strategy 2: find the largest scrollable container on the page.
-    if (!target && (originEl || !windowScrollable)) {
+    if (!target) {
       let best = null;
       let bestArea = 0;
       const candidates = document.querySelectorAll('div, section, main, article, [role="main"], [role="dialog"]');

--- a/src/firefox/src/content/content.js
+++ b/src/firefox/src/content/content.js
@@ -1348,7 +1348,9 @@
     }
 
     function findScrollableAncestor(origin, dir, allowHidden = false) {
-      let el = origin;
+      const tag = origin?.tagName || '';
+      const skipOrigin = tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT' || origin?.isContentEditable;
+      let el = skipOrigin ? origin.parentElement : origin;
       while (el && el !== document.body && el !== document.documentElement) {
         if (isScrollableElement(el, allowHidden) && canScrollElement(el, dir)) return el;
         el = el.parentElement;

--- a/src/firefox/src/content/content.js
+++ b/src/firefox/src/content/content.js
@@ -1416,7 +1416,7 @@
     let target = originEl ? findScrollableAncestor(originEl, direction, !windowScrollable) : null;
     let targetSource = target ? 'origin-ancestor' : 'none';
 
-    if (!target && !originEl) {
+    if (!target) {
       let best = null;
       let bestArea = 0;
       const candidates = document.querySelectorAll('div, section, main, article, aside, [role="main"], [role="dialog"], [role="region"], [role="listbox"], [role="menu"]');

--- a/src/firefox/src/content/content.js
+++ b/src/firefox/src/content/content.js
@@ -245,6 +245,31 @@
     return false;
   }
 
+  let _lastInteractionPoint = null;
+
+  function rememberInteractionPoint(el, source = 'interaction') {
+    try {
+      if (!el || typeof el.getBoundingClientRect !== 'function') return null;
+      const r = el.getBoundingClientRect();
+      if (!Number.isFinite(r.left) || !Number.isFinite(r.top) || r.width < 1 || r.height < 1) return null;
+      const rect = {
+        x: Math.round(r.left),
+        y: Math.round(r.top),
+        w: Math.round(r.width),
+        h: Math.round(r.height),
+      };
+      _lastInteractionPoint = {
+        x: Math.round(r.left + r.width / 2),
+        y: Math.round(r.top + r.height / 2),
+        source,
+        ts: Date.now(),
+      };
+      return rect;
+    } catch {
+      return null;
+    }
+  }
+
   /**
    * Detect the topmost modal/overlay/dialog on the page. Returns the modal
    * container element, or null if no overlay is detected.
@@ -871,6 +896,7 @@
       } catch {}
     }
 
+    const clickedRect = rememberInteractionPoint(el, 'click');
     el.click();
 
     // Post-click SELECT detection: the click may have activated a <select>
@@ -899,7 +925,13 @@
       warning = 'Same element clicked again with no page change. Try click({x, y}) with coordinates from a screenshot, or click({index: N}) from get_interactive_elements.';
     }
     _lastClickIdent = ident;
-    return { success: true, tag: el.tagName, text: el.innerText?.slice(0, 50), ...(warning ? { warning } : {}) };
+    return {
+      success: true,
+      tag: el.tagName,
+      text: el.innerText?.slice(0, 50),
+      ...(clickedRect ? { rect: clickedRect } : {}),
+      ...(warning ? { warning } : {}),
+    };
   }
 
   let _lastTypeFieldIdent = null;
@@ -1173,7 +1205,7 @@
   /**
    * Scroll the page.
    */
-  function scrollPage(params) {
+  function legacyScrollPage(params) {
     const amount = params.amount || 500;
     const direction = params.direction || 'down';
 
@@ -1258,6 +1290,223 @@
       viewportHeight: window.innerHeight,
       ...(target ? { scrolledContainer: true, containerScrollY: target.scrollTop, containerScrollHeight: target.scrollHeight } : {}),
     };
+  }
+
+  function smartScrollPage(params) {
+    params = params || {};
+    const rawAmount = Number(params.amount);
+    const amount = Number.isFinite(rawAmount) && rawAmount > 0 ? rawAmount : 500;
+    const direction = params.direction || 'down';
+    const scrollingElement = document.scrollingElement || document.documentElement || document.body;
+    const beforeWindowY = window.scrollY;
+
+    function docScrollHeight() {
+      return Math.max(
+        document.body?.scrollHeight || 0,
+        document.documentElement?.scrollHeight || 0,
+        scrollingElement?.scrollHeight || 0
+      );
+    }
+
+    function canMove(start, max, dir) {
+      if (dir === 'down' || dir === 'bottom') return start < max - 1;
+      if (dir === 'up' || dir === 'top') return start > 1;
+      return false;
+    }
+
+    function canScrollWindow(dir) {
+      const max = Math.max(0, docScrollHeight() - window.innerHeight);
+      return canMove(window.scrollY, max, dir);
+    }
+
+    function canScrollElement(el, dir) {
+      if (!el || el === document.body || el === document.documentElement) return false;
+      const max = Math.max(0, el.scrollHeight - el.clientHeight);
+      return max > 1 && canMove(el.scrollTop, max, dir);
+    }
+
+    function isScrollableElement(el, allowHidden = false) {
+      if (!el || el === document.body || el === document.documentElement) return false;
+      if (el.scrollHeight <= el.clientHeight + 10) return false;
+      const ov = window.getComputedStyle(el).overflowY;
+      return ov === 'auto' || ov === 'scroll' || ov === 'overlay' || (allowHidden && ov === 'hidden');
+    }
+
+    function elementSummary(el) {
+      if (!el) return null;
+      let rect = null;
+      try {
+        const r = el.getBoundingClientRect();
+        rect = { x: Math.round(r.x), y: Math.round(r.y), w: Math.round(r.width), h: Math.round(r.height) };
+      } catch {}
+      return {
+        tag: el.tagName ? el.tagName.toLowerCase() : '',
+        role: el.getAttribute?.('role') || '',
+        text: (el.innerText || el.getAttribute?.('aria-label') || '').trim().slice(0, 80),
+        rect,
+      };
+    }
+
+    function findScrollableAncestor(origin, dir, allowHidden = false) {
+      let el = origin;
+      while (el && el !== document.body && el !== document.documentElement) {
+        if (isScrollableElement(el, allowHidden) && canScrollElement(el, dir)) return el;
+        el = el.parentElement;
+      }
+      return null;
+    }
+
+    function visibleTextChars(limit = 2000) {
+      try {
+        if (!document.body) return 0;
+        let total = 0;
+        const walker = document.createTreeWalker(document.body, NodeFilter.SHOW_TEXT, {
+          acceptNode(node) {
+            const text = (node.nodeValue || '').trim();
+            if (!text) return NodeFilter.FILTER_REJECT;
+            const parent = node.parentElement;
+            if (!parent) return NodeFilter.FILTER_REJECT;
+            const style = window.getComputedStyle(parent);
+            if (style.display === 'none' || style.visibility === 'hidden' || parseFloat(style.opacity || '1') === 0) return NodeFilter.FILTER_REJECT;
+            const r = parent.getBoundingClientRect();
+            if (r.width < 1 || r.height < 1 || r.bottom < 0 || r.top > window.innerHeight || r.right < 0 || r.left > window.innerWidth) {
+              return NodeFilter.FILTER_REJECT;
+            }
+            return NodeFilter.FILTER_ACCEPT;
+          },
+        });
+        let node;
+        while ((node = walker.nextNode())) {
+          total += (node.nodeValue || '').trim().length;
+          if (total >= limit) return total;
+        }
+        return total;
+      } catch {
+        return null;
+      }
+    }
+
+    let originEl = null;
+    let origin = 'none';
+    if (typeof params.ref_id === 'string' && typeof window.__wb_ax_lookup === 'function') {
+      originEl = window.__wb_ax_lookup(params.ref_id);
+      origin = originEl ? `ref_id:${params.ref_id}` : `missing-ref_id:${params.ref_id}`;
+    }
+    if (!originEl && params.x != null && params.y != null) {
+      const x = Number(params.x);
+      const y = Number(params.y);
+      if (Number.isFinite(x) && Number.isFinite(y)) {
+        originEl = document.elementFromPoint(x, y);
+        origin = params.origin === 'last_interaction' ? 'last_interaction' : 'point';
+      }
+    }
+    if (!originEl) {
+      const active = document.activeElement;
+      if (active && active !== document.body && active !== document.documentElement) {
+        originEl = active;
+        origin = 'activeElement';
+      }
+    }
+    if (!originEl && _lastInteractionPoint && Date.now() - _lastInteractionPoint.ts < 60000) {
+      originEl = document.elementFromPoint(_lastInteractionPoint.x, _lastInteractionPoint.y);
+      origin = `last_interaction:${_lastInteractionPoint.source}`;
+    }
+
+    const windowScrollable = docScrollHeight() > window.innerHeight + 10;
+    let target = originEl ? findScrollableAncestor(originEl, direction, !windowScrollable) : null;
+    let targetSource = target ? 'origin-ancestor' : 'none';
+
+    if (!target && !originEl) {
+      let best = null;
+      let bestArea = 0;
+      const candidates = document.querySelectorAll('div, section, main, article, aside, [role="main"], [role="dialog"], [role="region"], [role="listbox"], [role="menu"]');
+      for (const el of candidates) {
+        if (!isScrollableElement(el, !windowScrollable) || !canScrollElement(el, direction)) continue;
+        const rect = el.getBoundingClientRect();
+        if (rect.width < 1 || rect.height < 1 || rect.bottom < 0 || rect.top > window.innerHeight || rect.right < 0 || rect.left > window.innerWidth) continue;
+        const area = rect.width * rect.height;
+        if (area > bestArea) {
+          bestArea = area;
+          best = el;
+        }
+      }
+      if (best && bestArea > window.innerWidth * window.innerHeight * 0.15) {
+        target = best;
+        targetSource = 'largest-visible-container';
+      }
+    }
+
+    let containerBefore = null;
+    let containerAfter = null;
+    if (target) {
+      containerBefore = target.scrollTop;
+      if (direction === 'down') target.scrollBy(0, amount);
+      else if (direction === 'up') target.scrollBy(0, -amount);
+      else if (direction === 'top') target.scrollTo(0, 0);
+      else if (direction === 'bottom') target.scrollTo(0, target.scrollHeight);
+      containerAfter = target.scrollTop;
+    }
+
+    const movedContainer = target && Math.abs((containerAfter || 0) - (containerBefore || 0)) > 0.5;
+    const shouldScrollWindow = params.alsoWindow === true || !movedContainer;
+    if (shouldScrollWindow && canScrollWindow(direction)) {
+      if (direction === 'down') window.scrollBy(0, amount);
+      else if (direction === 'up') window.scrollBy(0, -amount);
+      else if (direction === 'top') window.scrollTo(0, 0);
+      else if (direction === 'bottom') window.scrollTo(0, docScrollHeight());
+    }
+
+    const afterWindowY = window.scrollY;
+    const movedWindow = Math.abs(afterWindowY - beforeWindowY) > 0.5;
+    const textChars = visibleTextChars();
+    const totalTextChars = (document.body?.innerText || '').trim().length;
+    const warningParts = [];
+    if (!movedContainer && !movedWindow) {
+      warningParts.push('No scroll movement occurred; the current target may already be at its limit. Try the opposite direction, top/bottom, or pass ref_id/x/y for a different pane.');
+    }
+    if (movedContainer && !movedWindow && params.alsoWindow !== true) {
+      warningParts.push('Scrolled the nearest scrollable container only; the window was left in place to avoid split-pane/listing pages drifting away from the intended area.');
+    }
+    if (textChars !== null && textChars < 20 && totalTextChars > 200) {
+      warningParts.push('The viewport has almost no visible text after scrolling even though the document has text. The page may be lazy-rendered or between scroll panes; use get_accessibility_tree({filter:"visible"}) or scroll with ref_id/x/y instead of assuming the page is empty.');
+    }
+
+    return {
+      success: true,
+      scrollY: afterWindowY,
+      scrollHeight: docScrollHeight(),
+      viewportHeight: window.innerHeight,
+      moved: movedContainer || movedWindow,
+      movedWindow,
+      movedContainer: !!movedContainer,
+      origin,
+      ...(originEl ? { originElement: elementSummary(originEl) } : {}),
+      ...(target ? {
+        scrolledContainer: true,
+        targetSource,
+        targetElement: elementSummary(target),
+        containerScrollY: containerAfter,
+        containerScrollYBefore: containerBefore,
+        containerScrollHeight: target.scrollHeight,
+        containerClientHeight: target.clientHeight,
+      } : {}),
+      scrollYBefore: beforeWindowY,
+      visibleTextChars: textChars,
+      documentTextChars: totalTextChars,
+      ...(warningParts.length ? { warning: warningParts.join(' ') } : {}),
+    };
+  }
+
+  function scrollPage(params) {
+    try {
+      return smartScrollPage(params);
+    } catch (e) {
+      const fallback = legacyScrollPage(params || {});
+      return {
+        ...fallback,
+        warning: `Smart scroll targeting failed (${e && e.message || e}); fell back to legacy window/container scroll.`,
+      };
+    }
   }
 
   /**
@@ -1450,6 +1699,7 @@
           try { el.scrollIntoView({ block: 'center', inline: 'center' }); } catch {}
           try { el.focus({ preventScroll: true }); } catch {}
           const rect = el.getBoundingClientRect();
+          rememberInteractionPoint(el, 'click_ax');
           el.click();
           const tag = el.tagName ? el.tagName.toLowerCase() : '';
           let isTextEntry = false;


### PR DESCRIPTION
## What changed

- Improves the `scroll` tool so it can target the nearest scrollable pane around a `ref_id`, CSS-pixel point, focused element, or recent interaction.
- Stops scrolling the window when a nested container actually moved, avoiding split-pane/listing pages drifting away from the intended area.
- Adds scroll diagnostics such as `movedWindow`, `movedContainer`, target/origin metadata, before/after positions, and warnings for no movement or almost-blank viewports.
- Updates Chrome CDP click handling to remember the last clicked point so a following plain `scroll()` can target nearby panes.
- Mirrors the tool schema and content-script behavior across Chrome and Firefox.

## Why

The trace showed the agent reaching Apple Certified Refurbished Mac pages, opening a filter, and then repeatedly using generic page scrolling while the viewport turned mostly blank. The root issue is general: pages with sticky filters, nested panes, dropdowns, or virtualized lists often need the inner scroll surface targeted instead of the window.

## Validation

- `npm test` passes: 196 passed, 0 failed.
- `node --check` passed for the edited JS files.
- `git diff --check` is clean.