### PR TITLE
fix(firefox): grant downloads permission and expose AX tree in Ask mode

### DIFF
--- a/src/firefox/manifest.json
+++ b/src/firefox/manifest.json
@@ -9,6 +9,7 @@
     "unlimitedStorage",
     "tabs",
     "tabGroups",
+    "downloads",
     "clipboardWrite",
     "clipboardRead",
     "<all_urls>"

--- a/src/firefox/src/agent/tools.js
+++ b/src/firefox/src/agent/tools.js
@@ -634,7 +634,8 @@ export const AGENT_TOOLS = [
  * Read-only tools allowed in Ask mode.
  */
 export const ASK_ONLY_TOOLS = [
-  'read_page', 'read_pdf', 'screenshot', 'get_interactive_elements', 'scroll',
+  'get_accessibility_tree', 'read_page', 'read_pdf', 'screenshot',
+  'get_interactive_elements', 'scroll',
   'extract_data', 'get_selection', 'clarify', 'done',
   // wait_for_stable just polls — safe in Ask mode.
   'wait_for_stable',


### PR DESCRIPTION
## Summary

Two Firefox-only papercuts surfaced from a real agent run:

- **`download_files` failed** with `can't access property "download", browser.downloads is undefined`. Firefox's `manifest.json` was missing the `"downloads"` permission, so `browser.downloads.download / search / onChanged` at `src/firefox/src/network/network-tools.js:400,432,560,598` were all unreachable. Even when the model fell back to a `navigate` to the raw URL (and Firefox itself did download the file), the extension had no way to observe it.
- **AX tree was unavailable in Ask mode**. `src/firefox/src/agent/tools.js` `ASK_ONLY_TOOLS` didn't include `'get_accessibility_tree'`, while Chrome's `ASK_ONLY_TOOLS` lists it first. The system prompt explicitly calls AX tree "PREFERRED," so Ask-mode users on Firefox were being steered to a tool that wasn't on offer.

## Changes

- `src/firefox/manifest.json` — add `"downloads"` to the permissions array.
- `src/firefox/src/agent/tools.js` — add `'get_accessibility_tree'` to `ASK_ONLY_TOOLS` to mirror Chrome.

## Test plan

- [ ] Load the unpacked Firefox build and confirm `browser.downloads` is defined in the background console.
- [ ] In Act mode, run a task that triggers `download_files` against any reasonable file URL — expect success, not the "undefined" error.
- [ ] Switch to Ask mode on a page and confirm `get_accessibility_tree` shows up in the advertised tool list and the model uses it instead of falling back to `read_page`.
- [ ] Sanity-check `list_downloads` returns recent entries.
- [ ] Confirm AMO packaging accepts the new permission on the next submission build.