### PR TITLE
[codex] Fix audit findings in tests and web copy source

### DIFF
--- a/test/anonymous/run.mjs
+++ b/test/anonymous/run.mjs
@@ -27,7 +27,7 @@ const args = process.argv.slice(2);
 const only = args.find(a => a.startsWith('--scenario='))?.split('=')[1];
 const setupOnly = args.includes('--setup');
 const hasInteractiveTerminal = process.stdin.isTTY && process.stdout.isTTY && !process.env.CI;
-const interactiveSetup = setupOnly && hasInteractiveTerminal;
+const interactiveSetup = hasInteractiveTerminal;
 
 async function main() {
   const scenarios = JSON.parse(await readFile(scenariosPath, 'utf-8'));

--- a/test/anonymous/run.mjs
+++ b/test/anonymous/run.mjs
@@ -78,6 +78,7 @@ async function main() {
     if (interactiveSetup) {
       console.log('  Waiting for the browser to close...');
       await context.waitForEvent('close', { timeout: 0 });
+      if (!setupOnly) process.exitCode = 2;
     } else {
       console.log('  Non-interactive run detected; exiting instead of waiting forever.');
       console.log('  Run `npm run test:anonymous -- --setup` from a desktop terminal to configure the test profile.');

--- a/test/anonymous/run.mjs
+++ b/test/anonymous/run.mjs
@@ -26,7 +26,8 @@ const scenariosPath = path.join(__dirname, 'scenarios.json');
 const args = process.argv.slice(2);
 const only = args.find(a => a.startsWith('--scenario='))?.split('=')[1];
 const setupOnly = args.includes('--setup');
-const interactiveSetup = setupOnly || (process.stdin.isTTY && process.stdout.isTTY && !process.env.CI);
+const hasInteractiveTerminal = process.stdin.isTTY && process.stdout.isTTY && !process.env.CI;
+const interactiveSetup = setupOnly && hasInteractiveTerminal;
 
 async function main() {
   const scenarios = JSON.parse(await readFile(scenariosPath, 'utf-8'));

--- a/test/anonymous/run.mjs
+++ b/test/anonymous/run.mjs
@@ -26,6 +26,7 @@ const scenariosPath = path.join(__dirname, 'scenarios.json');
 const args = process.argv.slice(2);
 const only = args.find(a => a.startsWith('--scenario='))?.split('=')[1];
 const setupOnly = args.includes('--setup');
+const interactiveSetup = setupOnly || (process.stdin.isTTY && process.stdout.isTTY && !process.env.CI);
 
 async function main() {
   const scenarios = JSON.parse(await readFile(scenariosPath, 'utf-8'));
@@ -36,13 +37,21 @@ async function main() {
   }
 
   console.log(`launching chromium with extension at ${extensionPath}`);
-  const context = await chromium.launchPersistentContext(profileDir, {
-    headless: false,
-    args: [
-      `--disable-extensions-except=${extensionPath}`,
-      `--load-extension=${extensionPath}`,
-    ],
-  });
+  let context;
+  try {
+    context = await chromium.launchPersistentContext(profileDir, {
+      headless: false,
+      args: [
+        `--disable-extensions-except=${extensionPath}`,
+        `--load-extension=${extensionPath}`,
+      ],
+    });
+  } catch (e) {
+    console.error('\n  Failed to launch Chromium for anonymous scenarios.');
+    console.error(`  Profile: ${profileDir}`);
+    console.error('  If a previous run was interrupted, close any Chromium window using this profile and retry.');
+    throw e;
+  }
 
   // Grab the extension's service worker — spin-wait up to 10s for MV3 to boot.
   let sw = context.serviceWorkers()[0];
@@ -65,9 +74,14 @@ async function main() {
     console.log(`\n  No active provider configured (${providerCheck.reason}).`);
     console.log(`  Opening Settings — enable a provider, set it active, then close the browser and re-run.`);
     await context.newPage().then(p => p.goto(`chrome-extension://${extensionId}/src/ui/settings.html`));
-    if (!setupOnly) {
-      // Keep the window open so you can configure.
-      await new Promise(() => {});
+    if (interactiveSetup) {
+      console.log('  Waiting for the browser to close...');
+      await context.waitForEvent('close', { timeout: 0 });
+    } else {
+      console.log('  Non-interactive run detected; exiting instead of waiting forever.');
+      console.log('  Run `npm run test:anonymous -- --setup` from a desktop terminal to configure the test profile.');
+      await context.close();
+      process.exit(2);
     }
     return;
   }

--- a/web/build/locales/en.json
+++ b/web/build/locales/en.json
@@ -91,7 +91,7 @@
   "features.token_conscious.desc": "Screenshots are resized and iteratively JPEG-compressed before they leave your machine, keeping image tokens small. Smart context trimming and tool-output caps keep cloud bills predictable — no surprise spend on long sessions.",
   "providers.label": "LLM Providers",
   "providers.title": "Bring your own AI",
-  "providers.subtitle": "Connect to any OpenAI-compatible API or run a local model. Switch providers anytime from the extension settings.",
+  "providers.subtitle": "Connect to any OpenAI-compatible API or run a local model. Switch providers anytime from the extension settings. For local models, give them at least a 16k-token context window (8k works with Compact mode) — WebBrain auto-compacts the conversation as it nears the limit.",
   "modes.label": "Interaction Modes",
   "modes.title": "Ask or Act",
   "modes.subtitle": "Two modes for different needs. Read-only by default, full agent power when you need it.",


### PR DESCRIPTION
## Summary
- make the anonymous-site E2E runner fail fast in non-interactive environments when no provider is configured, instead of waiting forever
- add a clearer Chromium launch failure message that points at the persistent test profile
- preserve the homepage provider context-window copy in the English locale source so `npm run build:web` stays stable

## Validation
- `npm test` (`236 passed, 0 failed`)
- `npm run test:fixtures` (`5 passed, 0 failed`)
- `npm run build:web`
- `npm run build:blog`
- `npm run build:zip` (zips restored afterward to avoid timestamp/binary churn)
- `node --check` over JS/MJS source excluding vendor/test profile
- `git diff --check`

## Note
`npm run test:anonymous` now exits quickly with setup instructions in this non-interactive environment because no provider is configured in the ignored Playwright profile. Run `npm run test:anonymous -- --setup` from a desktop terminal to configure that profile before running live anonymous-site scenarios.