### PR TITLE
[codex] Focus social media downloads on active media

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ Deeper docs live in [`docs/`](docs/): [architecture](docs/architecture.md), [sit
 | `research_url` | Yes | Yes | -- | Open a URL in a hidden tab, wait for JS rendering, return content |
 | `download_files` | -- | Yes | -- | Download one or more files (single url or array, max 3 concurrent) |
 | `download_resource_from_page` | -- | Yes | -- | Download an `<img>`/`<video>`/blob URL from the current page |
-| `download_social_media` | -- | Yes | Yes | One-shot media download from Facebook, Instagram, X, LinkedIn, Reddit, Pinterest, YouTube |
+| `download_social_media` | -- | Yes | Yes | One-shot social media download; DOM/CDN first, optional visible-media vision crop fallback |
 | `list_downloads` | Yes | Yes | -- | List recent downloads with status and source URLs |
 | `read_downloaded_file` | -- | Yes | -- | Re-fetch a downloaded file's content (text or base64) |
 | `iframe_read` / `iframe_click` / `iframe_type` | -- | Yes | -- | Read/click/type inside cross-origin iframes |

--- a/src/chrome/src/agent/agent.js
+++ b/src/chrome/src/agent/agent.js
@@ -2000,7 +2000,8 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
     const stamp = new Date().toISOString().replace(/[:.]/g, '-').slice(0, 19).replace('T', '_');
     let filename = String(args.filename || `webbrain-visible-media-${stamp}.png`).trim();
     filename = filename.split('/').pop().split('\\').pop();
-    if (!/\.(png|jpg|jpeg|webp)$/i.test(filename)) filename += '.png';
+    filename = filename.replace(/\.(jpe?g|webp)$/i, '.png');
+    if (!/\.png$/i.test(filename)) filename += '.png';
     const downloadId = await chrome.downloads.download({ url: crop.dataUrl, filename, saveAs: false });
 
     return {

--- a/src/chrome/src/agent/agent.js
+++ b/src/chrome/src/agent/agent.js
@@ -4258,12 +4258,13 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
           files: ['src/agent/social-media-downloader.js'],
           world: 'MAIN',
         });
+        const bulkSocialDownload = !!args.scroll || args.mode === 'all';
         const opts = {
           mode: args.mode || 'auto',
           all: !!args.scroll,
           limit: typeof args.limit === 'number' && args.limit > 0
             ? args.limit
-            : Number.MAX_SAFE_INTEGER,
+            : (bulkSocialDownload ? Number.MAX_SAFE_INTEGER : 1),
         };
         const results = await chrome.scripting.executeScript({
           target: { tabId },

--- a/src/chrome/src/agent/agent.js
+++ b/src/chrome/src/agent/agent.js
@@ -1768,6 +1768,262 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
     }
   }
 
+  static _extractFirstJsonObject(raw) {
+    const text = String(raw || '').trim();
+    if (!text) return null;
+    const candidates = [];
+    const fenced = text.match(/```(?:json)?\s*([\s\S]*?)```/i);
+    if (fenced) candidates.push(fenced[1].trim());
+    candidates.push(text);
+
+    for (const candidate of candidates) {
+      const start = candidate.indexOf('{');
+      if (start < 0) continue;
+      let depth = 0;
+      let inString = false;
+      let escaped = false;
+      for (let i = start; i < candidate.length; i++) {
+        const ch = candidate[i];
+        if (inString) {
+          if (escaped) {
+            escaped = false;
+          } else if (ch === '\\') {
+            escaped = true;
+          } else if (ch === '"') {
+            inString = false;
+          }
+          continue;
+        }
+        if (ch === '"') {
+          inString = true;
+        } else if (ch === '{') {
+          depth += 1;
+        } else if (ch === '}') {
+          depth -= 1;
+          if (depth === 0) {
+            try {
+              return JSON.parse(candidate.slice(start, i + 1));
+            } catch (_) {
+              break;
+            }
+          }
+        }
+      }
+    }
+    return null;
+  }
+
+  static _normalizeVisibleMediaLocation(raw, viewport = {}) {
+    const obj = typeof raw === 'string' ? Agent._extractFirstJsonObject(raw) : raw;
+    if (!obj || typeof obj !== 'object') return null;
+    if (obj.found === false || obj.noMedia === true || obj.no_media === true) return null;
+
+    const box = obj.bbox || obj.box || obj.rect || obj.crop || {};
+    let x = Number(obj.x ?? obj.left ?? box.x ?? box.left);
+    let y = Number(obj.y ?? obj.top ?? box.y ?? box.top);
+    let width = Number(obj.width ?? obj.w ?? box.width ?? box.w);
+    let height = Number(obj.height ?? obj.h ?? box.height ?? box.h);
+    const right = Number(obj.right ?? box.right);
+    const bottom = Number(obj.bottom ?? box.bottom);
+    if (!Number.isFinite(width) && Number.isFinite(right) && Number.isFinite(x)) width = right - x;
+    if (!Number.isFinite(height) && Number.isFinite(bottom) && Number.isFinite(y)) height = bottom - y;
+    if (![x, y, width, height].every(Number.isFinite)) return null;
+
+    const imageW = Math.max(1, Math.round(Number(viewport.width || viewport.w || 0)));
+    const imageH = Math.max(1, Math.round(Number(viewport.height || viewport.h || 0)));
+    if (!imageW || !imageH) return null;
+
+    if (x < 0) {
+      width += x;
+      x = 0;
+    }
+    if (y < 0) {
+      height += y;
+      y = 0;
+    }
+    width = Math.min(width, imageW - x);
+    height = Math.min(height, imageH - y);
+    if (width < 24 || height < 24) return null;
+
+    let confidence = Number(obj.confidence ?? obj.score ?? obj.probability ?? 0.75);
+    if (!Number.isFinite(confidence)) confidence = 0.75;
+    if (confidence > 1 && confidence <= 100) confidence /= 100;
+    confidence = Math.max(0, Math.min(1, confidence));
+
+    const mediaType = String(obj.mediaType || obj.media_type || obj.type || 'media').toLowerCase();
+    return {
+      found: true,
+      x: Math.round(x),
+      y: Math.round(y),
+      width: Math.round(width),
+      height: Math.round(height),
+      confidence,
+      mediaType: ['image', 'video', 'media'].includes(mediaType) ? mediaType : 'media',
+      reason: String(obj.reason || obj.notes || '').slice(0, 300),
+    };
+  }
+
+  async _captureVisibleMediaScreenshot(tabId) {
+    try {
+      await cdpClient.attach(tabId);
+      await cdpClient.sendCommand(tabId, 'Page.enable');
+      await this._bringToFrontForCapture(tabId);
+      const vp = await cdpClient.evaluate(tabId, '({w: window.innerWidth, h: window.innerHeight})');
+      const cssW = Math.max(1, Math.round(vp?.result?.value?.w || 1024));
+      const cssH = Math.max(1, Math.round(vp?.result?.value?.h || 768));
+      const shot = await this._withIndicatorsHidden(tabId, () =>
+        cdpClient.sendCommand(tabId, 'Page.captureScreenshot', {
+          format: 'png',
+          fromSurface: true,
+          clip: { x: 0, y: 0, width: cssW, height: cssH, scale: 1 },
+        })
+      );
+      if (!shot?.data) return null;
+      const cropDataUrl = `data:image/png;base64,${shot.data}`;
+      const dataUrl = await this._compressJpegToByteCeiling(cropDataUrl);
+      return { dataUrl, cropDataUrl, width: cssW, height: cssH, coordAligned: true };
+    } catch (_) {
+      const fallback = await this._captureAutoScreenshot(tabId, { coordAligned: true });
+      return fallback ? { ...fallback, cropDataUrl: fallback.dataUrl } : null;
+    }
+  }
+
+  async _locateVisibleMediaWithVision(tabId, screenshot, opts = {}) {
+    if (!screenshot?.dataUrl) {
+      return { success: false, error: 'visible media localization needs a screenshot.' };
+    }
+    const activeProvider = this.providerManager.getActive();
+    const visionProvider = await this.providerManager.getVisionProvider();
+    const vision = visionProvider || (activeProvider?.supportsVision ? activeProvider : null);
+    if (!vision) {
+      return {
+        success: false,
+        error: 'vision_unavailable',
+        message: 'No vision-capable active model or dedicated vision model is configured.',
+      };
+    }
+
+    const target = ['image', 'video', 'media'].includes(opts.target) ? opts.target : 'media';
+    const width = Math.max(1, Math.round(screenshot.width || 0));
+    const height = Math.max(1, Math.round(screenshot.height || 0));
+    const started = Date.now();
+    const runId = this.currentRunId.get(tabId);
+    const costState = opts.costState || this.currentCostState.get(tabId) || null;
+    const prompt = [
+      `Image size: ${width}x${height} pixels.`,
+      `Task: locate the single visible ${target} the user most likely means by "this image", "this video", or "this media" on the current page.`,
+      'Return JSON only with this exact shape:',
+      '{"found":true,"x":0,"y":0,"width":100,"height":100,"confidence":0.9,"mediaType":"image","reason":"largest central visible media"}',
+      'Coordinates must be image pixels. Use a tight box around only the visible media content, excluding captions, comments, buttons, browser UI, avatars, icons, and unrelated thumbnails. If there is no obvious single target, return {"found":false,"confidence":0,"reason":"..."} only.',
+    ].join('\n');
+
+    try {
+      const res = await this._chatWithCostAllowance(vision, [
+        { role: 'system', content: 'You are a precise viewport media localizer. Return one JSON object only; no prose, no markdown.' },
+        {
+          role: 'user',
+          content: [
+            { type: 'text', text: prompt },
+            { type: 'image_url', image_url: { url: screenshot.dataUrl } },
+          ],
+        },
+      ], {
+        maxTokens: 220,
+        temperature: 0,
+        extraBody: { chat_template_kwargs: { enable_thinking: false } },
+      }, costState);
+
+      const raw = res?.content || '';
+      const rect = Agent._normalizeVisibleMediaLocation(raw, { width, height });
+      if (!rect) throw new Error('vision model did not return a usable media box');
+      if (rect.confidence < 0.45) throw new Error(`vision confidence too low (${rect.confidence})`);
+      const latencyMs = Date.now() - started;
+      trace.recordVisionSubCall(runId, {
+        context: 'download_social_media_visible_media',
+        model: vision.config?.model || vision.model,
+        baseUrl: vision.config?.baseUrl || vision.baseUrl || null,
+        description: raw.slice(0, 1000),
+        latencyMs,
+      });
+      return {
+        success: true,
+        rect,
+        model: vision.config?.model || vision.model || null,
+        provider: vision.name || vision.config?.providerName || null,
+      };
+    } catch (e) {
+      trace.recordVisionSubCall(runId, {
+        context: 'download_social_media_visible_media',
+        model: vision.config?.model || vision.model,
+        baseUrl: vision.config?.baseUrl || vision.baseUrl || null,
+        latencyMs: Date.now() - started,
+        error: e?.message || String(e),
+      });
+      return { success: false, error: e?.message || String(e) };
+    }
+  }
+
+  async _cropDataUrl(dataUrl, rect, mimeType = 'image/png') {
+    const resp = await fetch(dataUrl);
+    const blob = await resp.blob();
+    const bmp = await createImageBitmap(blob);
+    const x = Math.max(0, Math.min(bmp.width - 1, Math.round(rect.x)));
+    const y = Math.max(0, Math.min(bmp.height - 1, Math.round(rect.y)));
+    const width = Math.max(1, Math.min(bmp.width - x, Math.round(rect.width)));
+    const height = Math.max(1, Math.min(bmp.height - y, Math.round(rect.height)));
+    const canvas = new OffscreenCanvas(width, height);
+    const ctx = canvas.getContext('2d');
+    ctx.drawImage(bmp, x, y, width, height, 0, 0, width, height);
+    const outBlob = await canvas.convertToBlob({ type: mimeType, quality: 0.95 });
+    const buf = await outBlob.arrayBuffer();
+    return {
+      dataUrl: Agent._bufferToDataUrl(buf, mimeType),
+      width,
+      height,
+      mimeType,
+      bytes: buf.byteLength,
+    };
+  }
+
+  async _saveVisibleMediaCrop(tabId, args = {}) {
+    const screenshot = await this._captureVisibleMediaScreenshot(tabId);
+    if (!screenshot) {
+      return { success: false, error: 'Could not capture the visible page for media localization.' };
+    }
+    const located = await this._locateVisibleMediaWithVision(tabId, screenshot, {
+      target: args.target,
+      costState: this.currentCostState.get(tabId) || null,
+    });
+    if (!located.success) return located;
+
+    const crop = await this._cropDataUrl(screenshot.cropDataUrl || screenshot.dataUrl, located.rect, 'image/png');
+    const stamp = new Date().toISOString().replace(/[:.]/g, '-').slice(0, 19).replace('T', '_');
+    let filename = String(args.filename || `webbrain-visible-media-${stamp}.png`).trim();
+    filename = filename.split('/').pop().split('\\').pop();
+    if (!/\.(png|jpg|jpeg|webp)$/i.test(filename)) filename += '.png';
+    const downloadId = await chrome.downloads.download({ url: crop.dataUrl, filename, saveAs: false });
+
+    return {
+      success: true,
+      method: 'vision_crop',
+      mode: 'vision',
+      site: 'visible_viewport',
+      count: 1,
+      triggeredCount: 1,
+      completedCount: 1,
+      openedInTabCount: 0,
+      failedCount: 0,
+      savedFile: { downloadId, filename, mimeType: crop.mimeType, bytes: crop.bytes },
+      visibleMedia: {
+        rect: located.rect,
+        cropSize: { width: crop.width, height: crop.height },
+        model: located.model,
+        provider: located.provider,
+      },
+      note: 'Saved a screenshot crop of the single visible media item. This is a visual fallback, not the original CDN asset.',
+    };
+  }
+
   /**
    * Lightweight pre-capture page-health probe. Runs alongside a screenshot
    * to give the agent a few numbers that explain what it's about to look at
@@ -4248,7 +4504,22 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
     }
 
     if (name === 'download_social_media') {
-      try {
+      const toolArgs = args || {};
+      const summarizeResult = (result) => {
+        if (!result) return null;
+        return {
+          success: result.success !== false,
+          method: result.method || null,
+          site: result.site || null,
+          count: result.count ?? null,
+          completedCount: result.completedCount ?? null,
+          openedInTabCount: result.openedInTabCount ?? null,
+          failedCount: result.failedCount ?? null,
+          error: result.error || null,
+          recommendationKind: result.recommendation?.kind || null,
+        };
+      };
+      const runDomDownloader = async () => {
         // Inject the SocialMediaDownloader library into the page's main
         // world so it shares fetch/XHR/cookies with page scripts — same
         // execution context the script's DevTools-console docs target.
@@ -4258,12 +4529,12 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
           files: ['src/agent/social-media-downloader.js'],
           world: 'MAIN',
         });
-        const bulkSocialDownload = !!args.scroll || args.mode === 'all';
+        const bulkSocialDownload = !!toolArgs.scroll || toolArgs.mode === 'all';
         const opts = {
-          mode: args.mode || 'auto',
-          all: !!args.scroll,
-          limit: typeof args.limit === 'number' && args.limit > 0
-            ? args.limit
+          mode: toolArgs.mode || 'auto',
+          all: !!toolArgs.scroll,
+          limit: typeof toolArgs.limit === 'number' && toolArgs.limit > 0
+            ? toolArgs.limit
             : (bulkSocialDownload ? Number.MAX_SAFE_INTEGER : 1),
         };
         const results = await chrome.scripting.executeScript({
@@ -4358,7 +4629,80 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
         if (!result) {
           return { success: false, error: 'download_social_media: no result returned (tab may have navigated away).' };
         }
-        return result;
+        return {
+          method: result.method || 'dom',
+          strategy: 'dom',
+          ...result,
+        };
+      };
+      const runVisionCrop = async () => {
+        try {
+          return await this._saveVisibleMediaCrop(tabId, toolArgs);
+        } catch (e) {
+          return { success: false, error: `vision crop failed: ${e.message}` };
+        }
+      };
+      const hasCompletedDownload = (result) => result && result.success !== false && Number(result.completedCount || 0) > 0;
+
+      try {
+        const strategy = ['auto', 'dom', 'vision'].includes(toolArgs.strategy) ? toolArgs.strategy : 'auto';
+        const bulkSocialDownload = !!toolArgs.scroll || toolArgs.mode === 'all';
+        const activeProvider = this.providerManager.getActive();
+        const visionProvider = await this.providerManager.getVisionProvider();
+        const visionAvailable = !!visionProvider || !!activeProvider?.supportsVision;
+
+        if (strategy === 'vision') {
+          if (visionAvailable && !bulkSocialDownload) {
+            const visionResult = await runVisionCrop();
+            if (visionResult.success) return visionResult;
+            const domResult = await runDomDownloader();
+            return {
+              ...domResult,
+              visionFallback: {
+                success: false,
+                error: visionResult.error || 'visible media crop failed',
+              },
+            };
+          }
+          const domResult = await runDomDownloader();
+          return {
+            ...domResult,
+            visionFallback: {
+              success: false,
+              error: visionAvailable
+                ? 'vision strategy is disabled for bulk social-media downloads; fell back to DOM extraction.'
+                : 'vision_unavailable',
+              message: visionAvailable
+                ? 'Bulk requests use DOM extraction so they do not crop one arbitrary visible item.'
+                : 'No vision-capable active model or dedicated vision model is configured, so download_social_media used DOM extraction instead.',
+            },
+          };
+        }
+
+        const domResult = await runDomDownloader();
+        if (strategy === 'dom' || bulkSocialDownload || hasCompletedDownload(domResult)) {
+          return domResult;
+        }
+        const recommendationKind = domResult?.recommendation?.kind || null;
+        if (recommendationKind && !['empty_result', 'unsupported_site'].includes(recommendationKind)) {
+          return domResult;
+        }
+        if (!visionAvailable) return domResult;
+
+        const visionResult = await runVisionCrop();
+        if (visionResult.success) {
+          return {
+            ...visionResult,
+            domFallback: summarizeResult(domResult),
+          };
+        }
+        return {
+          ...domResult,
+          visionFallback: {
+            success: false,
+            error: visionResult.error || 'visible media crop failed',
+          },
+        };
       } catch (e) {
         return { success: false, error: `download_social_media failed: ${e.message}` };
       }

--- a/src/chrome/src/agent/social-media-downloader.js
+++ b/src/chrome/src/agent/social-media-downloader.js
@@ -1309,6 +1309,11 @@ window.SocialMediaDownloader = (() => {
     return [...httpVideos, ...blobUrls, ...rest];
   };
 
+  const isVideoDownloadUrl = url =>
+    isHttpVideoUrl(url) ||
+    String(url || '').startsWith('blob:') ||
+    /v\.redd\.it/i.test(url || '');
+
   const focusedDownloadUrls = urls => {
     urls = videoFirstUrls(urls);
     const httpVideoUrl = urls.find(isHttpVideoUrl);
@@ -1683,9 +1688,7 @@ window.SocialMediaDownloader = (() => {
     };
     let i = 1;
     for (const url of selected) {
-      const isVideo = /\.(mp4|mov|m4v|webm|m3u8|ts)(\?|#|$)/i.test(url)
-        || url.startsWith('blob:')
-        || /v\.redd\.it/.test(url);
+      const isVideo = isVideoDownloadUrl(url);
       const ext = getExt(url) || (isVideo ? '.mp4' : '.jpg');
       const filename = `${filenameSafe(prefix)}_${isVideo ? 'video' : 'photo'}_${String(i).padStart(3, '0')}${ext}`;
       let r;

--- a/src/chrome/src/agent/social-media-downloader.js
+++ b/src/chrome/src/agent/social-media-downloader.js
@@ -6,9 +6,9 @@
  * --------------------------------------------------------------------
  * Quick start (paste into the page's DevTools console):
  *
- *   await SocialMediaDownloader.run()           // current view, main content
+ *   await SocialMediaDownloader.run()           // focused/open media item
  *   await SocialMediaDownloader.single()        // just the main photo/video
- *   await SocialMediaDownloader.run({ all:true })// scroll the feed, grab everything
+ *   await SocialMediaDownloader.run({ mode:"all", all:true }) // intentional bulk
  *   SocialMediaDownloader.list()                // print URLs, don't download
  *
  * For VIDEOS played through MediaSource Extensions (Facebook, IG reels,
@@ -20,12 +20,11 @@
  *   await SocialMediaDownloader.saveMse()       // download captured bytes
  *
  * Options for run():
- *   mode:    'auto' (default) — single-photo pages = main content only;
- *                              feeds/profiles = everything
- *            'main'           — force "main content" mode
- *            'all'            — force "everything on page" mode
- *   all:     true|false       — scroll-and-collect (only useful in 'all')
- *   limit:   N                — max downloads
+ *   mode:    'auto' (default) - focused/open/centered media item only
+ *            'main'           - force "main content" mode
+ *            'all'            - force "everything on page" mode
+ *   all:     true|false       - scroll-and-collect (only useful in 'all')
+ *   limit:   N                - max downloads
  *
  * --------------------------------------------------------------------
  * What's NEW in v4
@@ -215,6 +214,9 @@ window.SocialMediaDownloader = (() => {
         '[data-visualcompletion="media-vc-image"], ' +
         '[role="dialog"] [data-visualcompletion="media-vc-image"], ' +
         '[role="dialog"] img[data-imgperflogname]',  // FB tags the main photo
+      focusSel:
+        '[data-pagelet*="MediaViewer" i], ' +
+        '[role="dialog"]',
       // Each album thumbnail is a `<a href="/photo/?fbid=…">` wrapping an
       // `<img>`. Scoping to that link pattern excludes the page profile
       // pic, cover photo, nav avatars, ads, and the "Suggested for you"
@@ -278,6 +280,10 @@ window.SocialMediaDownloader = (() => {
         // role=presentation is the IG main-post marker on some layouts
         'main article[role="presentation"] img, ' +
         'main article[role="presentation"] video',
+      focusSel:
+        '[role="dialog"], ' +
+        'main article[role="presentation"], ' +
+        'main article:first-of-type',
       exclude: [
         'header', 'nav', 'aside',
         '[role="navigation"]',
@@ -307,6 +313,9 @@ window.SocialMediaDownloader = (() => {
         // Status page without modal — grab only the FIRST tweet's media
         'main article[data-testid="tweet"]:first-of-type [data-testid="tweetPhoto"] img, ' +
         'main article[data-testid="tweet"]:first-of-type [data-testid="videoPlayer"] video',
+      focusSel:
+        '[aria-modal="true"], ' +
+        'main article[data-testid="tweet"]:first-of-type',
       exclude: [
         'header', 'nav', 'aside',
         '[data-testid*="UserAvatar"]',
@@ -326,6 +335,10 @@ window.SocialMediaDownloader = (() => {
         '[data-test-id="post-content"] video, ' +
         '[slot="post-media-container"] img, ' +
         '[slot="post-media-container"] video',
+      focusSel:
+        'shreddit-post, ' +
+        '[data-test-id="post-content"], ' +
+        '[slot="post-media-container"]',
       exclude: [
         'header', 'nav', 'aside',
         'faceplate-tracker[noun="avatar"]',
@@ -343,6 +356,9 @@ window.SocialMediaDownloader = (() => {
         '[data-test-id="pin-closeup-image"] img, ' +
         '[data-test-id="visual-content-container"] img, ' +
         '[data-test-id="visual-content-container"] video',
+      focusSel:
+        '[data-test-id="pin-closeup-image"], ' +
+        '[data-test-id="visual-content-container"]',
       exclude: [
         'header', 'nav', 'aside',
         '[data-test-id="user-profile-thumbnail"]',
@@ -361,6 +377,9 @@ window.SocialMediaDownloader = (() => {
         '.feed-shared-image img, ' +
         '.feed-shared-linkedin-video video, ' +
         'article img, article video',
+      focusSel:
+        '.feed-shared-update-v2__content, ' +
+        'article',
       exclude: [
         'header', 'nav', 'aside',
         // Generic
@@ -395,6 +414,10 @@ window.SocialMediaDownloader = (() => {
         'ytd-player video, ytd-player img, ' +
         'ytd-watch-flexy video, ' +
         'ytd-reel-player-renderer video',
+      focusSel:
+        '#movie_player, ' +
+        'ytd-player, ' +
+        'ytd-reel-player-renderer',
       exclude: [
         'header', 'nav', 'aside',
         '#secondary',                              // right rail (up-next videos)
@@ -413,6 +436,7 @@ window.SocialMediaDownloader = (() => {
       match: () => true,
       isSingle: () => false,
       mainSel: 'main img, main video, article img, article video',
+      focusSel: 'main, article',
       exclude: ['header', 'nav', 'aside', 'svg', '[role="navigation"]']
     }
   };
@@ -489,6 +513,156 @@ window.SocialMediaDownloader = (() => {
       el = el.parentElement;
     }
     return false;
+  };
+
+  const viewportSize = () => ({
+    w: Math.max(document.documentElement.clientWidth || 0, window.innerWidth || 0),
+    h: Math.max(document.documentElement.clientHeight || 0, window.innerHeight || 0),
+  });
+
+  const visibleArea = rect => {
+    const vp = viewportSize();
+    const left = Math.max(0, rect.left);
+    const top = Math.max(0, rect.top);
+    const right = Math.min(vp.w, rect.right);
+    const bottom = Math.min(vp.h, rect.bottom);
+    return Math.max(0, right - left) * Math.max(0, bottom - top);
+  };
+
+  const isVisibleElement = el => {
+    if (!el || !el.getBoundingClientRect) return false;
+    const style = window.getComputedStyle ? window.getComputedStyle(el) : null;
+    if (style && (style.display === 'none' || style.visibility === 'hidden' || Number(style.opacity) === 0)) {
+      return false;
+    }
+    const rect = el.getBoundingClientRect();
+    if (rect.width < 24 || rect.height < 24) return false;
+    return visibleArea(rect) >= 1024;
+  };
+
+  const mediaBoxElement = el => {
+    if (!el) return null;
+    const tag = el.tagName;
+    if (tag === 'SOURCE') return el.closest('picture,video') || el.parentElement;
+    return el;
+  };
+
+  const addMediaCandidateUrls = (el, add) => {
+    if (!el) return;
+    const tag = el.tagName;
+    if (tag === 'IMG') {
+      [el.currentSrc, el.src,
+       el.getAttribute('src'), el.getAttribute('data-src'),
+       el.getAttribute('data-original'), el.getAttribute('data-url')]
+        .forEach(add);
+      parseSrcset(el.getAttribute('srcset')).forEach(add);
+      const picture = el.closest('picture');
+      if (picture) {
+        picture.querySelectorAll('source').forEach(s => {
+          [s.src, s.getAttribute('src'), s.getAttribute('srcset')]
+            .forEach(v => { parseSrcset(v).forEach(add); add(v); });
+        });
+      }
+      return;
+    }
+    if (tag === 'VIDEO') {
+      [el.currentSrc, el.src, el.poster,
+       el.getAttribute('src'), el.getAttribute('poster')]
+        .forEach(add);
+      el.querySelectorAll('source').forEach(s => {
+        [s.src, s.getAttribute('src'), s.getAttribute('srcset')]
+          .forEach(v => { parseSrcset(v).forEach(add); add(v); });
+      });
+      return;
+    }
+    if (tag === 'SOURCE') {
+      [el.src, el.getAttribute('src'), el.getAttribute('srcset')]
+        .forEach(v => { parseSrcset(v).forEach(add); add(v); });
+    }
+  };
+
+  const directMediaUrls = el => {
+    const urls = new Set();
+    const add = url => {
+      url = absoluteUrl(url);
+      if (isMediaUrl(url)) urls.add(url);
+    };
+    addMediaCandidateUrls(el, add);
+    return [...urls];
+  };
+
+  const mediaElementsIn = root => {
+    if (!root) return [];
+    const out = [];
+    if (root.matches && root.matches('img, video, source')) out.push(root);
+    if (root.querySelectorAll) {
+      root.querySelectorAll('img, video, source').forEach(el => out.push(el));
+    }
+    return out;
+  };
+
+  const mediaElementScore = el => {
+    const box = mediaBoxElement(el);
+    if (!box || !box.getBoundingClientRect) return -Infinity;
+    const rect = box.getBoundingClientRect();
+    const area = visibleArea(rect);
+    if (area <= 0) return -Infinity;
+    const vp = viewportSize();
+    const cx = rect.left + rect.width / 2;
+    const cy = rect.top + rect.height / 2;
+    const maxDist = Math.hypot(vp.w / 2, vp.h / 2) || 1;
+    const centered = 1 - Math.min(1, Math.hypot(cx - vp.w / 2, cy - vp.h / 2) / maxDist);
+    let score = area + centered * 50000;
+    if (box.closest('dialog[open], [aria-modal="true"], [role="dialog"]')) score += 1000000;
+    if (box.closest('[aria-selected="true"], [data-current="true"], [data-active="true"]')) score += 20000;
+    if (el.tagName === 'VIDEO' || box.tagName === 'VIDEO') score += 10000;
+    return score;
+  };
+
+  const bestFocusedMedia = (roots, excluded) => {
+    const candidates = [];
+    for (const root of roots || []) {
+      if (!root || isExcluded(root, excluded) || !isVisibleElement(root)) continue;
+      for (const el of mediaElementsIn(root)) {
+        const box = mediaBoxElement(el);
+        if (!box || isExcluded(box, excluded) || !isVisibleElement(box)) continue;
+        const rect = box.getBoundingClientRect();
+        const intrinsicW = el.naturalWidth || el.videoWidth || el.width || rect.width || 0;
+        const intrinsicH = el.naturalHeight || el.videoHeight || el.height || rect.height || 0;
+        if (intrinsicW < 120 || intrinsicH < 120) continue;
+        const urls = directMediaUrls(el);
+        if (!urls.length) continue;
+        candidates.push({ el, urls, score: mediaElementScore(el) });
+      }
+    }
+    candidates.sort((a, b) => b.score - a.score);
+    return candidates[0] || null;
+  };
+
+  const queryVisibleRoots = selector => {
+    const roots = [];
+    if (!selector) return roots;
+    try {
+      document.querySelectorAll(selector).forEach(el => {
+        if (isVisibleElement(el)) roots.push(el);
+      });
+    } catch { /* unsupported selector */ }
+    return roots;
+  };
+
+  const collectFocusedMedia = (profile, excluded) => {
+    const dialogRoots = queryVisibleRoots(
+      'dialog[open], [aria-modal="true"], [role="dialog"], ' +
+      '[data-pagelet*="MediaViewer" i], [data-testid*="lightbox" i]'
+    );
+    let best = bestFocusedMedia(dialogRoots, excluded);
+    if (best) return best.urls;
+
+    best = bestFocusedMedia(queryVisibleRoots(profile.focusSel), excluded);
+    if (best) return best.urls;
+
+    best = bestFocusedMedia([document.body || document.documentElement], excluded);
+    return best ? best.urls : [];
   };
 
   // Extract candidate media URLs from a given root (default: document)
@@ -1234,6 +1408,9 @@ window.SocialMediaDownloader = (() => {
     const profile = activeProfile();
     const excluded = buildExclusionSet(profile);
 
+    const focusedUrls = mode === 'auto'
+      ? collectFocusedMedia(profile, excluded)
+      : [];
     let useMain;
     if (mode === 'main') useMain = true;
     else if (mode === 'all') useMain = false;
@@ -1250,7 +1427,11 @@ window.SocialMediaDownloader = (() => {
       profile.isGallery();
 
     let urls;
-    if (useGallery) {
+    let sourceMode = useGallery ? 'gallery' : (useMain ? 'main' : 'all');
+    if (focusedUrls.length) {
+      urls = focusedUrls;
+      sourceMode = 'focused';
+    } else if (useGallery) {
       const galleryUrls = [];
       const galleryEls = document.querySelectorAll(profile.gallerySel);
       galleryEls.forEach(el => {
@@ -1338,8 +1519,9 @@ window.SocialMediaDownloader = (() => {
         try { return profile.urlFilter(u); } catch { return true; }
       });
     }
+    if (sourceMode === 'focused') finalUrls = finalUrls.slice(0, 1);
     return { urls: finalUrls, profile,
-             mode: useGallery ? 'gallery' : (useMain ? 'main' : 'all'),
+             mode: sourceMode,
              dashGroups: groups };
   };
 

--- a/src/chrome/src/agent/social-media-downloader.js
+++ b/src/chrome/src/agent/social-media-downloader.js
@@ -1284,9 +1284,15 @@ window.SocialMediaDownloader = (() => {
   };
 
   // ---------- Scoring & ranking ----------
+  const isHttpVideoUrl = url =>
+    /^https?:\/\//i.test(url || '') &&
+    (/\.(mp4|mov|m4v|webm|m3u8|mpd|ts)(\?|#|$)/i.test(url) ||
+     /googlevideo\.com\/videoplayback\b/i.test(url) ||
+     /[?&](?:mime|type)=video(?:%2f|\/)/i.test(url));
+
   const scoreUrl = url => {
     let s = 0;
-    if (/\.(mp4|mov|m4v|webm)(\?|#|$)/i.test(url)) s += 100;
+    if (isHttpVideoUrl(url)) s += 100;
     if (/\.(jpg|jpeg|png|webp)(\?|#|$)/i.test(url)) s += 50;
     if (url.includes("name=orig")) s += 20;
     if (url.includes("originals/")) s += 25;
@@ -1297,6 +1303,8 @@ window.SocialMediaDownloader = (() => {
   };
 
   const focusedDownloadUrls = urls => {
+    const httpVideoUrl = urls.find(isHttpVideoUrl);
+    if (httpVideoUrl) return [httpVideoUrl];
     const blobUrl = urls.find(u => u.startsWith("blob:"));
     return blobUrl ? [blobUrl] : urls.slice(0, 1);
   };

--- a/src/chrome/src/agent/social-media-downloader.js
+++ b/src/chrome/src/agent/social-media-downloader.js
@@ -1302,7 +1302,15 @@ window.SocialMediaDownloader = (() => {
     return s;
   };
 
+  const videoFirstUrls = urls => {
+    const httpVideos = urls.filter(isHttpVideoUrl);
+    const blobUrls = urls.filter(u => u.startsWith("blob:"));
+    const rest = urls.filter(u => !isHttpVideoUrl(u) && !u.startsWith("blob:"));
+    return [...httpVideos, ...blobUrls, ...rest];
+  };
+
   const focusedDownloadUrls = urls => {
+    urls = videoFirstUrls(urls);
     const httpVideoUrl = urls.find(isHttpVideoUrl);
     if (httpVideoUrl) return [httpVideoUrl];
     const blobUrl = urls.find(u => u.startsWith("blob:"));
@@ -1533,6 +1541,7 @@ window.SocialMediaDownloader = (() => {
       });
     }
     if (sourceMode === 'focused') finalUrls = focusedDownloadUrls(finalUrls);
+    else if (sourceMode === 'main') finalUrls = videoFirstUrls(finalUrls);
     return { urls: finalUrls, profile,
              mode: sourceMode,
              dashGroups: groups };

--- a/src/chrome/src/agent/social-media-downloader.js
+++ b/src/chrome/src/agent/social-media-downloader.js
@@ -1296,6 +1296,11 @@ window.SocialMediaDownloader = (() => {
     return s;
   };
 
+  const focusedDownloadUrls = urls => {
+    const blobUrl = urls.find(u => u.startsWith("blob:"));
+    return blobUrl ? [blobUrl] : urls.slice(0, 1);
+  };
+
   // ---------- HLS m3u8 stitching ----------
   const fetchText = async u =>
     (await fetch(u, { credentials: "include" })).text();
@@ -1519,7 +1524,7 @@ window.SocialMediaDownloader = (() => {
         try { return profile.urlFilter(u); } catch { return true; }
       });
     }
-    if (sourceMode === 'focused') finalUrls = finalUrls.slice(0, 1);
+    if (sourceMode === 'focused') finalUrls = focusedDownloadUrls(finalUrls);
     return { urls: finalUrls, profile,
              mode: sourceMode,
              dashGroups: groups };

--- a/src/chrome/src/agent/tools.js
+++ b/src/chrome/src/agent/tools.js
@@ -674,7 +674,7 @@ export const AGENT_TOOLS = [
           mode: {
             type: 'string',
             enum: ['auto', 'main', 'all'],
-            description: '"auto" (default): main media on single-content pages, everything on feeds. "main": force just the primary photo/video on the page. "all": every media item currently in the DOM.',
+            description: '"auto" (default): focused/open media only. "main": primary post media on single-content pages. "all": every media item currently in the DOM; use only for explicit bulk requests.',
           },
           scroll: {
             type: 'boolean',
@@ -682,7 +682,7 @@ export const AGENT_TOOLS = [
           },
           limit: {
             type: 'number',
-            description: 'Max number of files to download. Default unlimited.',
+            description: 'Max number of files to download. Default 1 for focused/main requests; unlimited only when mode:"all" or scroll:true is explicit.',
           },
         },
         required: [],

--- a/src/chrome/src/agent/tools.js
+++ b/src/chrome/src/agent/tools.js
@@ -671,6 +671,20 @@ export const AGENT_TOOLS = [
       parameters: {
         type: 'object',
         properties: {
+          strategy: {
+            type: 'string',
+            enum: ['auto', 'dom', 'vision'],
+            description: '"auto" (default): try the DOM/CDN social downloader first; if it cannot save the focused media and vision is available, crop the single visible media from a screenshot. "dom": never spend a vision call. "vision": crop exactly the visible media when vision is available; if not, automatically falls back to DOM.',
+          },
+          target: {
+            type: 'string',
+            enum: ['image', 'video', 'media'],
+            description: 'Hint for the vision crop path. Use "image" for "download this image", "video" for "download this video", otherwise omit.',
+          },
+          filename: {
+            type: 'string',
+            description: 'Optional filename for the screenshot-crop fallback. Directory components are ignored.',
+          },
           mode: {
             type: 'string',
             enum: ['auto', 'main', 'all'],
@@ -1114,7 +1128,7 @@ SCROLLING — read this:
 
 SOCIAL MEDIA DOWNLOADS — read this:
 - When the user asks to download images or videos from Facebook, Instagram, X/Twitter, LinkedIn, Reddit, Pinterest, or YouTube (thumbnails), call \`download_social_media\` — it is a SINGLE tool call that handles the per-site DOM, picks the right resolution, and saves to the Downloads folder. Do NOT inspect the page with \`get_accessibility_tree\` + \`download_files\` to figure it out yourself; the tool already knows.
-- Defaults: on single-content pages (e.g. /photo/, /p/, /reel/, /status/.../photo/, /pin/, /comments/) it grabs the main item; pass \`scroll:true\` to walk a feed/profile/timeline and capture everything that lazy-loads.
+- Defaults: strategy:"auto" tries the DOM/CDN path first (original asset quality, no extra LLM call). If that cannot save the focused media and vision is available, the same tool uses a screenshot+vision sub-call to crop the single visible image/video; if no vision model is configured, it falls back to DOM only. Pass strategy:"vision" only for "download this visible image/video" when a screenshot crop is acceptable; pass strategy:"dom" or scroll:true for bulk/original-asset requests.
 - After it returns, optionally call \`list_downloads\` to surface the saved filenames for the user. Some CDNs (notably media.licdn.com) block CORS and the tool will open the media in a new tab as fallback — that is expected behavior, not a failure.
 - The tool may return a \`recommendation\` field with shape \`{ kind, message }\`. This means SMD knowingly cannot handle the request well — most often YouTube full video (Widevine DRM + signatureCipher), an MSE blob the player hasn't loaded yet, or a site outside SMD's supported list. When it appears, RELAY \`recommendation.message\` to the user verbatim in your reply — it points them at the right external CLI tool (\`yt-dlp\` for video, \`gallery-dl\` for images) with a copy-pasteable command. Do NOT try to work around it with \`get_accessibility_tree\` or repeated tool calls — the recommendation exists precisely because those paths cannot help.
 
@@ -1181,7 +1195,7 @@ TOOLS — use ONLY these:
 - new_tab({url}): Open a URL in a new tab.
 - wait_for_element({selector}): Wait for an element to appear.
 - fetch_url({url}): Fetch a URL for its content.
-- download_social_media: Download images/videos from social sites.
+- download_social_media: Download images/videos from social sites. Use strategy:"vision" only when the user wants the single visible item cropped; without vision it falls back to DOM.
 - scratchpad_write({text}): Save notes that persist across steps.
 - done({summary}): Signal completion.
 
@@ -1244,7 +1258,7 @@ TOOLS — use only these:
 - wait_for_element({selector}) / wait_for_stable({quietMs}): wait for an element / for the page to go quiet after an action.
 - iframe_read / iframe_click / iframe_type ({urlFilter, selector, text}): interact inside cross-origin iframes (Stripe, payment widgets, embeds).
 - fetch_url({url}) / research_url({url}): read OTHER URLs (not the active tab). list_downloads, download_files, read_downloaded_file, upload_file({filePath, selector}): file workflows.
-- download_social_media: one-shot image/video download from supported social sites.
+- download_social_media: one-shot image/video download from supported social sites; strategy:"auto" uses DOM first, then vision crop only when needed and available.
 - verify_form: check a form's field values before submitting. scratchpad_write({text}): pin facts that survive context summarization.
 - clarify({question}): ask the user only when materially blocked/ambiguous (budget 1-2 per run). solve_captcha: once, only when CapSolver is configured.
 - record_tab / stop_recording: record the current tab (video + audio) when the user asks to "record".

--- a/src/firefox/src/agent/agent.js
+++ b/src/firefox/src/agent/agent.js
@@ -1593,7 +1593,8 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
     const stamp = new Date().toISOString().replace(/[:.]/g, '-').slice(0, 19).replace('T', '_');
     let filename = String(args.filename || `webbrain-visible-media-${stamp}.png`).trim();
     filename = filename.split('/').pop().split('\\').pop();
-    if (!/\.(png|jpg|jpeg|webp)$/i.test(filename)) filename += '.png';
+    filename = filename.replace(/\.(jpe?g|webp)$/i, '.png');
+    if (!/\.png$/i.test(filename)) filename += '.png';
     const downloadId = await browser.downloads.download({ url: crop.dataUrl, filename, saveAs: false });
 
     return {

--- a/src/firefox/src/agent/agent.js
+++ b/src/firefox/src/agent/agent.js
@@ -2855,12 +2855,13 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
         await browser.tabs.executeScript(tabId, {
           file: 'src/agent/social-media-downloader.js',
         });
+        const bulkSocialDownload = !!args.scroll || args.mode === 'all';
         const opts = {
           mode: args.mode || 'auto',
           all: !!args.scroll,
           limit: typeof args.limit === 'number' && args.limit > 0
             ? args.limit
-            : Number.MAX_SAFE_INTEGER,
+            : (bulkSocialDownload ? Number.MAX_SAFE_INTEGER : 1),
         };
         const code = `
           (async () => {

--- a/src/firefox/src/agent/agent.js
+++ b/src/firefox/src/agent/agent.js
@@ -1353,6 +1353,270 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
     }
   }
 
+  static _extractFirstJsonObject(raw) {
+    const text = String(raw || '').trim();
+    if (!text) return null;
+    const candidates = [];
+    const fenced = text.match(/```(?:json)?\s*([\s\S]*?)```/i);
+    if (fenced) candidates.push(fenced[1].trim());
+    candidates.push(text);
+
+    for (const candidate of candidates) {
+      const start = candidate.indexOf('{');
+      if (start < 0) continue;
+      let depth = 0;
+      let inString = false;
+      let escaped = false;
+      for (let i = start; i < candidate.length; i++) {
+        const ch = candidate[i];
+        if (inString) {
+          if (escaped) {
+            escaped = false;
+          } else if (ch === '\\') {
+            escaped = true;
+          } else if (ch === '"') {
+            inString = false;
+          }
+          continue;
+        }
+        if (ch === '"') {
+          inString = true;
+        } else if (ch === '{') {
+          depth += 1;
+        } else if (ch === '}') {
+          depth -= 1;
+          if (depth === 0) {
+            try {
+              return JSON.parse(candidate.slice(start, i + 1));
+            } catch (_) {
+              break;
+            }
+          }
+        }
+      }
+    }
+    return null;
+  }
+
+  static _normalizeVisibleMediaLocation(raw, viewport = {}) {
+    const obj = typeof raw === 'string' ? Agent._extractFirstJsonObject(raw) : raw;
+    if (!obj || typeof obj !== 'object') return null;
+    if (obj.found === false || obj.noMedia === true || obj.no_media === true) return null;
+
+    const box = obj.bbox || obj.box || obj.rect || obj.crop || {};
+    let x = Number(obj.x ?? obj.left ?? box.x ?? box.left);
+    let y = Number(obj.y ?? obj.top ?? box.y ?? box.top);
+    let width = Number(obj.width ?? obj.w ?? box.width ?? box.w);
+    let height = Number(obj.height ?? obj.h ?? box.height ?? box.h);
+    const right = Number(obj.right ?? box.right);
+    const bottom = Number(obj.bottom ?? box.bottom);
+    if (!Number.isFinite(width) && Number.isFinite(right) && Number.isFinite(x)) width = right - x;
+    if (!Number.isFinite(height) && Number.isFinite(bottom) && Number.isFinite(y)) height = bottom - y;
+    if (![x, y, width, height].every(Number.isFinite)) return null;
+
+    const imageW = Math.max(1, Math.round(Number(viewport.width || viewport.w || 0)));
+    const imageH = Math.max(1, Math.round(Number(viewport.height || viewport.h || 0)));
+    if (!imageW || !imageH) return null;
+
+    if (x < 0) {
+      width += x;
+      x = 0;
+    }
+    if (y < 0) {
+      height += y;
+      y = 0;
+    }
+    width = Math.min(width, imageW - x);
+    height = Math.min(height, imageH - y);
+    if (width < 24 || height < 24) return null;
+
+    let confidence = Number(obj.confidence ?? obj.score ?? obj.probability ?? 0.75);
+    if (!Number.isFinite(confidence)) confidence = 0.75;
+    if (confidence > 1 && confidence <= 100) confidence /= 100;
+    confidence = Math.max(0, Math.min(1, confidence));
+
+    const mediaType = String(obj.mediaType || obj.media_type || obj.type || 'media').toLowerCase();
+    return {
+      found: true,
+      x: Math.round(x),
+      y: Math.round(y),
+      width: Math.round(width),
+      height: Math.round(height),
+      confidence,
+      mediaType: ['image', 'video', 'media'].includes(mediaType) ? mediaType : 'media',
+      reason: String(obj.reason || obj.notes || '').slice(0, 300),
+    };
+  }
+
+  async _captureVisibleMediaScreenshot(tabId) {
+    try {
+      const tab = await browser.tabs.get(tabId);
+      if (!tab?.active) return null;
+      let width = 1024;
+      let height = 768;
+      try {
+        const dims = await browser.tabs.executeScript(tabId, {
+          code: 'JSON.stringify({w: window.innerWidth, h: window.innerHeight})',
+        });
+        if (dims && dims[0]) {
+          const parsed = JSON.parse(dims[0]);
+          width = Math.max(1, Math.round(parsed.w));
+          height = Math.max(1, Math.round(parsed.h));
+        }
+      } catch (_) {}
+      const cropDataUrl = await this._withIndicatorsHidden(tabId, () =>
+        browser.tabs.captureVisibleTab(tab.windowId, {
+          format: 'png',
+          scale: 1,
+        })
+      );
+      if (!cropDataUrl) return null;
+      const dataUrl = await this._compressJpegToByteCeiling(cropDataUrl);
+      return { dataUrl, cropDataUrl, width, height, coordAligned: true };
+    } catch (_) {
+      const fallback = await this._captureAutoScreenshot(tabId);
+      return fallback ? { ...fallback, cropDataUrl: fallback.dataUrl } : null;
+    }
+  }
+
+  async _locateVisibleMediaWithVision(tabId, screenshot, opts = {}) {
+    if (!screenshot?.dataUrl) {
+      return { success: false, error: 'visible media localization needs a screenshot.' };
+    }
+    const activeProvider = this.providerManager.getActive();
+    const visionProvider = await this.providerManager.getVisionProvider();
+    const vision = visionProvider || (activeProvider?.supportsVision ? activeProvider : null);
+    if (!vision) {
+      return {
+        success: false,
+        error: 'vision_unavailable',
+        message: 'No vision-capable active model or dedicated vision model is configured.',
+      };
+    }
+
+    const target = ['image', 'video', 'media'].includes(opts.target) ? opts.target : 'media';
+    const width = Math.max(1, Math.round(screenshot.width || 0));
+    const height = Math.max(1, Math.round(screenshot.height || 0));
+    const started = Date.now();
+    const runId = this.currentRunId.get(tabId);
+    const costState = opts.costState || this.currentCostState.get(tabId) || null;
+    const prompt = [
+      `Image size: ${width}x${height} pixels.`,
+      `Task: locate the single visible ${target} the user most likely means by "this image", "this video", or "this media" on the current page.`,
+      'Return JSON only with this exact shape:',
+      '{"found":true,"x":0,"y":0,"width":100,"height":100,"confidence":0.9,"mediaType":"image","reason":"largest central visible media"}',
+      'Coordinates must be image pixels. Use a tight box around only the visible media content, excluding captions, comments, buttons, browser UI, avatars, icons, and unrelated thumbnails. If there is no obvious single target, return {"found":false,"confidence":0,"reason":"..."} only.',
+    ].join('\n');
+
+    try {
+      const res = await this._chatWithCostAllowance(vision, [
+        { role: 'system', content: 'You are a precise viewport media localizer. Return one JSON object only; no prose, no markdown.' },
+        {
+          role: 'user',
+          content: [
+            { type: 'text', text: prompt },
+            { type: 'image_url', image_url: { url: screenshot.dataUrl } },
+          ],
+        },
+      ], {
+        maxTokens: 220,
+        temperature: 0,
+        extraBody: { chat_template_kwargs: { enable_thinking: false } },
+      }, costState);
+
+      const raw = res?.content || '';
+      const rect = Agent._normalizeVisibleMediaLocation(raw, { width, height });
+      if (!rect) throw new Error('vision model did not return a usable media box');
+      if (rect.confidence < 0.45) throw new Error(`vision confidence too low (${rect.confidence})`);
+      const latencyMs = Date.now() - started;
+      trace.recordVisionSubCall(runId, {
+        context: 'download_social_media_visible_media',
+        model: vision.config?.model || vision.model,
+        baseUrl: vision.config?.baseUrl || vision.baseUrl || null,
+        description: raw.slice(0, 1000),
+        latencyMs,
+      });
+      return {
+        success: true,
+        rect,
+        model: vision.config?.model || vision.model || null,
+        provider: vision.name || vision.config?.providerName || null,
+      };
+    } catch (e) {
+      trace.recordVisionSubCall(runId, {
+        context: 'download_social_media_visible_media',
+        model: vision.config?.model || vision.model,
+        baseUrl: vision.config?.baseUrl || vision.baseUrl || null,
+        latencyMs: Date.now() - started,
+        error: e?.message || String(e),
+      });
+      return { success: false, error: e?.message || String(e) };
+    }
+  }
+
+  async _cropDataUrl(dataUrl, rect, mimeType = 'image/png') {
+    const img = await this._loadImageFromDataUrl(dataUrl);
+    const sourceW = img.naturalWidth || img.width;
+    const sourceH = img.naturalHeight || img.height;
+    const x = Math.max(0, Math.min(sourceW - 1, Math.round(rect.x)));
+    const y = Math.max(0, Math.min(sourceH - 1, Math.round(rect.y)));
+    const width = Math.max(1, Math.min(sourceW - x, Math.round(rect.width)));
+    const height = Math.max(1, Math.min(sourceH - y, Math.round(rect.height)));
+    const canvas = document.createElement('canvas');
+    canvas.width = width;
+    canvas.height = height;
+    const ctx = canvas.getContext('2d');
+    ctx.drawImage(img, x, y, width, height, 0, 0, width, height);
+    const outBlob = await this._canvasToBlob(canvas, mimeType, 0.95);
+    const buf = await outBlob.arrayBuffer();
+    return {
+      dataUrl: Agent._bufferToDataUrl(buf, mimeType),
+      width,
+      height,
+      mimeType,
+      bytes: buf.byteLength,
+    };
+  }
+
+  async _saveVisibleMediaCrop(tabId, args = {}) {
+    const screenshot = await this._captureVisibleMediaScreenshot(tabId);
+    if (!screenshot) {
+      return { success: false, error: 'Could not capture the visible page for media localization.' };
+    }
+    const located = await this._locateVisibleMediaWithVision(tabId, screenshot, {
+      target: args.target,
+      costState: this.currentCostState.get(tabId) || null,
+    });
+    if (!located.success) return located;
+
+    const crop = await this._cropDataUrl(screenshot.cropDataUrl || screenshot.dataUrl, located.rect, 'image/png');
+    const stamp = new Date().toISOString().replace(/[:.]/g, '-').slice(0, 19).replace('T', '_');
+    let filename = String(args.filename || `webbrain-visible-media-${stamp}.png`).trim();
+    filename = filename.split('/').pop().split('\\').pop();
+    if (!/\.(png|jpg|jpeg|webp)$/i.test(filename)) filename += '.png';
+    const downloadId = await browser.downloads.download({ url: crop.dataUrl, filename, saveAs: false });
+
+    return {
+      success: true,
+      method: 'vision_crop',
+      mode: 'vision',
+      site: 'visible_viewport',
+      count: 1,
+      triggeredCount: 1,
+      completedCount: 1,
+      openedInTabCount: 0,
+      failedCount: 0,
+      savedFile: { downloadId, filename, mimeType: crop.mimeType, bytes: crop.bytes },
+      visibleMedia: {
+        rect: located.rect,
+        cropSize: { width: crop.width, height: crop.height },
+        model: located.model,
+        provider: located.provider,
+      },
+      note: 'Saved a screenshot crop of the single visible media item. This is a visual fallback, not the original CDN asset.',
+    };
+  }
+
   /**
    * Attach the current page's URL/title to every user message so deictic
    * phrases like "this page" resolve to the active tab, not an older page
@@ -2846,7 +3110,22 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
     }
 
     if (name === 'download_social_media') {
-      try {
+      const toolArgs = args || {};
+      const summarizeResult = (result) => {
+        if (!result) return null;
+        return {
+          success: result.success !== false,
+          method: result.method || null,
+          site: result.site || null,
+          count: result.count ?? null,
+          completedCount: result.completedCount ?? null,
+          openedInTabCount: result.openedInTabCount ?? null,
+          failedCount: result.failedCount ?? null,
+          error: result.error || null,
+          recommendationKind: result.recommendation?.kind || null,
+        };
+      };
+      const runDomDownloader = async () => {
         // Inject the SocialMediaDownloader library into the page (isolated
         // content-script world — Firefox MV2 has no MAIN-world option for
         // executeScript). The script defines window.SocialMediaDownloader,
@@ -2855,12 +3134,12 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
         await browser.tabs.executeScript(tabId, {
           file: 'src/agent/social-media-downloader.js',
         });
-        const bulkSocialDownload = !!args.scroll || args.mode === 'all';
+        const bulkSocialDownload = !!toolArgs.scroll || toolArgs.mode === 'all';
         const opts = {
-          mode: args.mode || 'auto',
-          all: !!args.scroll,
-          limit: typeof args.limit === 'number' && args.limit > 0
-            ? args.limit
+          mode: toolArgs.mode || 'auto',
+          all: !!toolArgs.scroll,
+          limit: typeof toolArgs.limit === 'number' && toolArgs.limit > 0
+            ? toolArgs.limit
             : (bulkSocialDownload ? Number.MAX_SAFE_INTEGER : 1),
         };
         const code = `
@@ -2940,7 +3219,80 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
         if (!result) {
           return { success: false, error: 'download_social_media: no result returned (tab may have navigated away).' };
         }
-        return result;
+        return {
+          method: result.method || 'dom',
+          strategy: 'dom',
+          ...result,
+        };
+      };
+      const runVisionCrop = async () => {
+        try {
+          return await this._saveVisibleMediaCrop(tabId, toolArgs);
+        } catch (e) {
+          return { success: false, error: `vision crop failed: ${e.message}` };
+        }
+      };
+      const hasCompletedDownload = (result) => result && result.success !== false && Number(result.completedCount || 0) > 0;
+
+      try {
+        const strategy = ['auto', 'dom', 'vision'].includes(toolArgs.strategy) ? toolArgs.strategy : 'auto';
+        const bulkSocialDownload = !!toolArgs.scroll || toolArgs.mode === 'all';
+        const activeProvider = this.providerManager.getActive();
+        const visionProvider = await this.providerManager.getVisionProvider();
+        const visionAvailable = !!visionProvider || !!activeProvider?.supportsVision;
+
+        if (strategy === 'vision') {
+          if (visionAvailable && !bulkSocialDownload) {
+            const visionResult = await runVisionCrop();
+            if (visionResult.success) return visionResult;
+            const domResult = await runDomDownloader();
+            return {
+              ...domResult,
+              visionFallback: {
+                success: false,
+                error: visionResult.error || 'visible media crop failed',
+              },
+            };
+          }
+          const domResult = await runDomDownloader();
+          return {
+            ...domResult,
+            visionFallback: {
+              success: false,
+              error: visionAvailable
+                ? 'vision strategy is disabled for bulk social-media downloads; fell back to DOM extraction.'
+                : 'vision_unavailable',
+              message: visionAvailable
+                ? 'Bulk requests use DOM extraction so they do not crop one arbitrary visible item.'
+                : 'No vision-capable active model or dedicated vision model is configured, so download_social_media used DOM extraction instead.',
+            },
+          };
+        }
+
+        const domResult = await runDomDownloader();
+        if (strategy === 'dom' || bulkSocialDownload || hasCompletedDownload(domResult)) {
+          return domResult;
+        }
+        const recommendationKind = domResult?.recommendation?.kind || null;
+        if (recommendationKind && !['empty_result', 'unsupported_site'].includes(recommendationKind)) {
+          return domResult;
+        }
+        if (!visionAvailable) return domResult;
+
+        const visionResult = await runVisionCrop();
+        if (visionResult.success) {
+          return {
+            ...visionResult,
+            domFallback: summarizeResult(domResult),
+          };
+        }
+        return {
+          ...domResult,
+          visionFallback: {
+            success: false,
+            error: visionResult.error || 'visible media crop failed',
+          },
+        };
       } catch (e) {
         return { success: false, error: `download_social_media failed: ${e.message}` };
       }

--- a/src/firefox/src/agent/social-media-downloader.js
+++ b/src/firefox/src/agent/social-media-downloader.js
@@ -1309,6 +1309,11 @@ window.SocialMediaDownloader = (() => {
     return [...httpVideos, ...blobUrls, ...rest];
   };
 
+  const isVideoDownloadUrl = url =>
+    isHttpVideoUrl(url) ||
+    String(url || '').startsWith('blob:') ||
+    /v\.redd\.it/i.test(url || '');
+
   const focusedDownloadUrls = urls => {
     urls = videoFirstUrls(urls);
     const httpVideoUrl = urls.find(isHttpVideoUrl);
@@ -1683,9 +1688,7 @@ window.SocialMediaDownloader = (() => {
     };
     let i = 1;
     for (const url of selected) {
-      const isVideo = /\.(mp4|mov|m4v|webm|m3u8|ts)(\?|#|$)/i.test(url)
-        || url.startsWith('blob:')
-        || /v\.redd\.it/.test(url);
+      const isVideo = isVideoDownloadUrl(url);
       const ext = getExt(url) || (isVideo ? '.mp4' : '.jpg');
       const filename = `${filenameSafe(prefix)}_${isVideo ? 'video' : 'photo'}_${String(i).padStart(3, '0')}${ext}`;
       let r;

--- a/src/firefox/src/agent/social-media-downloader.js
+++ b/src/firefox/src/agent/social-media-downloader.js
@@ -6,9 +6,9 @@
  * --------------------------------------------------------------------
  * Quick start (paste into the page's DevTools console):
  *
- *   await SocialMediaDownloader.run()           // current view, main content
+ *   await SocialMediaDownloader.run()           // focused/open media item
  *   await SocialMediaDownloader.single()        // just the main photo/video
- *   await SocialMediaDownloader.run({ all:true })// scroll the feed, grab everything
+ *   await SocialMediaDownloader.run({ mode:"all", all:true }) // intentional bulk
  *   SocialMediaDownloader.list()                // print URLs, don't download
  *
  * For VIDEOS played through MediaSource Extensions (Facebook, IG reels,
@@ -20,12 +20,11 @@
  *   await SocialMediaDownloader.saveMse()       // download captured bytes
  *
  * Options for run():
- *   mode:    'auto' (default) — single-photo pages = main content only;
- *                              feeds/profiles = everything
- *            'main'           — force "main content" mode
- *            'all'            — force "everything on page" mode
- *   all:     true|false       — scroll-and-collect (only useful in 'all')
- *   limit:   N                — max downloads
+ *   mode:    'auto' (default) - focused/open/centered media item only
+ *            'main'           - force "main content" mode
+ *            'all'            - force "everything on page" mode
+ *   all:     true|false       - scroll-and-collect (only useful in 'all')
+ *   limit:   N                - max downloads
  *
  * --------------------------------------------------------------------
  * What's NEW in v4
@@ -215,6 +214,9 @@ window.SocialMediaDownloader = (() => {
         '[data-visualcompletion="media-vc-image"], ' +
         '[role="dialog"] [data-visualcompletion="media-vc-image"], ' +
         '[role="dialog"] img[data-imgperflogname]',  // FB tags the main photo
+      focusSel:
+        '[data-pagelet*="MediaViewer" i], ' +
+        '[role="dialog"]',
       // Each album thumbnail is a `<a href="/photo/?fbid=…">` wrapping an
       // `<img>`. Scoping to that link pattern excludes the page profile
       // pic, cover photo, nav avatars, ads, and the "Suggested for you"
@@ -278,6 +280,10 @@ window.SocialMediaDownloader = (() => {
         // role=presentation is the IG main-post marker on some layouts
         'main article[role="presentation"] img, ' +
         'main article[role="presentation"] video',
+      focusSel:
+        '[role="dialog"], ' +
+        'main article[role="presentation"], ' +
+        'main article:first-of-type',
       exclude: [
         'header', 'nav', 'aside',
         '[role="navigation"]',
@@ -307,6 +313,9 @@ window.SocialMediaDownloader = (() => {
         // Status page without modal — grab only the FIRST tweet's media
         'main article[data-testid="tweet"]:first-of-type [data-testid="tweetPhoto"] img, ' +
         'main article[data-testid="tweet"]:first-of-type [data-testid="videoPlayer"] video',
+      focusSel:
+        '[aria-modal="true"], ' +
+        'main article[data-testid="tweet"]:first-of-type',
       exclude: [
         'header', 'nav', 'aside',
         '[data-testid*="UserAvatar"]',
@@ -326,6 +335,10 @@ window.SocialMediaDownloader = (() => {
         '[data-test-id="post-content"] video, ' +
         '[slot="post-media-container"] img, ' +
         '[slot="post-media-container"] video',
+      focusSel:
+        'shreddit-post, ' +
+        '[data-test-id="post-content"], ' +
+        '[slot="post-media-container"]',
       exclude: [
         'header', 'nav', 'aside',
         'faceplate-tracker[noun="avatar"]',
@@ -343,6 +356,9 @@ window.SocialMediaDownloader = (() => {
         '[data-test-id="pin-closeup-image"] img, ' +
         '[data-test-id="visual-content-container"] img, ' +
         '[data-test-id="visual-content-container"] video',
+      focusSel:
+        '[data-test-id="pin-closeup-image"], ' +
+        '[data-test-id="visual-content-container"]',
       exclude: [
         'header', 'nav', 'aside',
         '[data-test-id="user-profile-thumbnail"]',
@@ -361,6 +377,9 @@ window.SocialMediaDownloader = (() => {
         '.feed-shared-image img, ' +
         '.feed-shared-linkedin-video video, ' +
         'article img, article video',
+      focusSel:
+        '.feed-shared-update-v2__content, ' +
+        'article',
       exclude: [
         'header', 'nav', 'aside',
         // Generic
@@ -395,6 +414,10 @@ window.SocialMediaDownloader = (() => {
         'ytd-player video, ytd-player img, ' +
         'ytd-watch-flexy video, ' +
         'ytd-reel-player-renderer video',
+      focusSel:
+        '#movie_player, ' +
+        'ytd-player, ' +
+        'ytd-reel-player-renderer',
       exclude: [
         'header', 'nav', 'aside',
         '#secondary',                              // right rail (up-next videos)
@@ -413,6 +436,7 @@ window.SocialMediaDownloader = (() => {
       match: () => true,
       isSingle: () => false,
       mainSel: 'main img, main video, article img, article video',
+      focusSel: 'main, article',
       exclude: ['header', 'nav', 'aside', 'svg', '[role="navigation"]']
     }
   };
@@ -489,6 +513,156 @@ window.SocialMediaDownloader = (() => {
       el = el.parentElement;
     }
     return false;
+  };
+
+  const viewportSize = () => ({
+    w: Math.max(document.documentElement.clientWidth || 0, window.innerWidth || 0),
+    h: Math.max(document.documentElement.clientHeight || 0, window.innerHeight || 0),
+  });
+
+  const visibleArea = rect => {
+    const vp = viewportSize();
+    const left = Math.max(0, rect.left);
+    const top = Math.max(0, rect.top);
+    const right = Math.min(vp.w, rect.right);
+    const bottom = Math.min(vp.h, rect.bottom);
+    return Math.max(0, right - left) * Math.max(0, bottom - top);
+  };
+
+  const isVisibleElement = el => {
+    if (!el || !el.getBoundingClientRect) return false;
+    const style = window.getComputedStyle ? window.getComputedStyle(el) : null;
+    if (style && (style.display === 'none' || style.visibility === 'hidden' || Number(style.opacity) === 0)) {
+      return false;
+    }
+    const rect = el.getBoundingClientRect();
+    if (rect.width < 24 || rect.height < 24) return false;
+    return visibleArea(rect) >= 1024;
+  };
+
+  const mediaBoxElement = el => {
+    if (!el) return null;
+    const tag = el.tagName;
+    if (tag === 'SOURCE') return el.closest('picture,video') || el.parentElement;
+    return el;
+  };
+
+  const addMediaCandidateUrls = (el, add) => {
+    if (!el) return;
+    const tag = el.tagName;
+    if (tag === 'IMG') {
+      [el.currentSrc, el.src,
+       el.getAttribute('src'), el.getAttribute('data-src'),
+       el.getAttribute('data-original'), el.getAttribute('data-url')]
+        .forEach(add);
+      parseSrcset(el.getAttribute('srcset')).forEach(add);
+      const picture = el.closest('picture');
+      if (picture) {
+        picture.querySelectorAll('source').forEach(s => {
+          [s.src, s.getAttribute('src'), s.getAttribute('srcset')]
+            .forEach(v => { parseSrcset(v).forEach(add); add(v); });
+        });
+      }
+      return;
+    }
+    if (tag === 'VIDEO') {
+      [el.currentSrc, el.src, el.poster,
+       el.getAttribute('src'), el.getAttribute('poster')]
+        .forEach(add);
+      el.querySelectorAll('source').forEach(s => {
+        [s.src, s.getAttribute('src'), s.getAttribute('srcset')]
+          .forEach(v => { parseSrcset(v).forEach(add); add(v); });
+      });
+      return;
+    }
+    if (tag === 'SOURCE') {
+      [el.src, el.getAttribute('src'), el.getAttribute('srcset')]
+        .forEach(v => { parseSrcset(v).forEach(add); add(v); });
+    }
+  };
+
+  const directMediaUrls = el => {
+    const urls = new Set();
+    const add = url => {
+      url = absoluteUrl(url);
+      if (isMediaUrl(url)) urls.add(url);
+    };
+    addMediaCandidateUrls(el, add);
+    return [...urls];
+  };
+
+  const mediaElementsIn = root => {
+    if (!root) return [];
+    const out = [];
+    if (root.matches && root.matches('img, video, source')) out.push(root);
+    if (root.querySelectorAll) {
+      root.querySelectorAll('img, video, source').forEach(el => out.push(el));
+    }
+    return out;
+  };
+
+  const mediaElementScore = el => {
+    const box = mediaBoxElement(el);
+    if (!box || !box.getBoundingClientRect) return -Infinity;
+    const rect = box.getBoundingClientRect();
+    const area = visibleArea(rect);
+    if (area <= 0) return -Infinity;
+    const vp = viewportSize();
+    const cx = rect.left + rect.width / 2;
+    const cy = rect.top + rect.height / 2;
+    const maxDist = Math.hypot(vp.w / 2, vp.h / 2) || 1;
+    const centered = 1 - Math.min(1, Math.hypot(cx - vp.w / 2, cy - vp.h / 2) / maxDist);
+    let score = area + centered * 50000;
+    if (box.closest('dialog[open], [aria-modal="true"], [role="dialog"]')) score += 1000000;
+    if (box.closest('[aria-selected="true"], [data-current="true"], [data-active="true"]')) score += 20000;
+    if (el.tagName === 'VIDEO' || box.tagName === 'VIDEO') score += 10000;
+    return score;
+  };
+
+  const bestFocusedMedia = (roots, excluded) => {
+    const candidates = [];
+    for (const root of roots || []) {
+      if (!root || isExcluded(root, excluded) || !isVisibleElement(root)) continue;
+      for (const el of mediaElementsIn(root)) {
+        const box = mediaBoxElement(el);
+        if (!box || isExcluded(box, excluded) || !isVisibleElement(box)) continue;
+        const rect = box.getBoundingClientRect();
+        const intrinsicW = el.naturalWidth || el.videoWidth || el.width || rect.width || 0;
+        const intrinsicH = el.naturalHeight || el.videoHeight || el.height || rect.height || 0;
+        if (intrinsicW < 120 || intrinsicH < 120) continue;
+        const urls = directMediaUrls(el);
+        if (!urls.length) continue;
+        candidates.push({ el, urls, score: mediaElementScore(el) });
+      }
+    }
+    candidates.sort((a, b) => b.score - a.score);
+    return candidates[0] || null;
+  };
+
+  const queryVisibleRoots = selector => {
+    const roots = [];
+    if (!selector) return roots;
+    try {
+      document.querySelectorAll(selector).forEach(el => {
+        if (isVisibleElement(el)) roots.push(el);
+      });
+    } catch { /* unsupported selector */ }
+    return roots;
+  };
+
+  const collectFocusedMedia = (profile, excluded) => {
+    const dialogRoots = queryVisibleRoots(
+      'dialog[open], [aria-modal="true"], [role="dialog"], ' +
+      '[data-pagelet*="MediaViewer" i], [data-testid*="lightbox" i]'
+    );
+    let best = bestFocusedMedia(dialogRoots, excluded);
+    if (best) return best.urls;
+
+    best = bestFocusedMedia(queryVisibleRoots(profile.focusSel), excluded);
+    if (best) return best.urls;
+
+    best = bestFocusedMedia([document.body || document.documentElement], excluded);
+    return best ? best.urls : [];
   };
 
   // Extract candidate media URLs from a given root (default: document)
@@ -1003,6 +1177,7 @@ window.SocialMediaDownloader = (() => {
         return null; // bytes saved — nothing to recommend
       }
       if (mseSavedFiles !== null || mseSaveError) {
+        // New caller invoked saveMse, but it returned nothing or threw.
         const errBit = mseSaveError ? ' (' + mseSaveError + ')' : '';
         return {
           kind: 'mse_save_failed',
@@ -1233,6 +1408,9 @@ window.SocialMediaDownloader = (() => {
     const profile = activeProfile();
     const excluded = buildExclusionSet(profile);
 
+    const focusedUrls = mode === 'auto'
+      ? collectFocusedMedia(profile, excluded)
+      : [];
     let useMain;
     if (mode === 'main') useMain = true;
     else if (mode === 'all') useMain = false;
@@ -1249,7 +1427,11 @@ window.SocialMediaDownloader = (() => {
       profile.isGallery();
 
     let urls;
-    if (useGallery) {
+    let sourceMode = useGallery ? 'gallery' : (useMain ? 'main' : 'all');
+    if (focusedUrls.length) {
+      urls = focusedUrls;
+      sourceMode = 'focused';
+    } else if (useGallery) {
       const galleryUrls = [];
       const galleryEls = document.querySelectorAll(profile.gallerySel);
       galleryEls.forEach(el => {
@@ -1337,8 +1519,9 @@ window.SocialMediaDownloader = (() => {
         try { return profile.urlFilter(u); } catch { return true; }
       });
     }
+    if (sourceMode === 'focused') finalUrls = finalUrls.slice(0, 1);
     return { urls: finalUrls, profile,
-             mode: useGallery ? 'gallery' : (useMain ? 'main' : 'all'),
+             mode: sourceMode,
              dashGroups: groups };
   };
 

--- a/src/firefox/src/agent/social-media-downloader.js
+++ b/src/firefox/src/agent/social-media-downloader.js
@@ -1284,9 +1284,15 @@ window.SocialMediaDownloader = (() => {
   };
 
   // ---------- Scoring & ranking ----------
+  const isHttpVideoUrl = url =>
+    /^https?:\/\//i.test(url || '') &&
+    (/\.(mp4|mov|m4v|webm|m3u8|mpd|ts)(\?|#|$)/i.test(url) ||
+     /googlevideo\.com\/videoplayback\b/i.test(url) ||
+     /[?&](?:mime|type)=video(?:%2f|\/)/i.test(url));
+
   const scoreUrl = url => {
     let s = 0;
-    if (/\.(mp4|mov|m4v|webm)(\?|#|$)/i.test(url)) s += 100;
+    if (isHttpVideoUrl(url)) s += 100;
     if (/\.(jpg|jpeg|png|webp)(\?|#|$)/i.test(url)) s += 50;
     if (url.includes("name=orig")) s += 20;
     if (url.includes("originals/")) s += 25;
@@ -1297,6 +1303,8 @@ window.SocialMediaDownloader = (() => {
   };
 
   const focusedDownloadUrls = urls => {
+    const httpVideoUrl = urls.find(isHttpVideoUrl);
+    if (httpVideoUrl) return [httpVideoUrl];
     const blobUrl = urls.find(u => u.startsWith("blob:"));
     return blobUrl ? [blobUrl] : urls.slice(0, 1);
   };

--- a/src/firefox/src/agent/social-media-downloader.js
+++ b/src/firefox/src/agent/social-media-downloader.js
@@ -1302,7 +1302,15 @@ window.SocialMediaDownloader = (() => {
     return s;
   };
 
+  const videoFirstUrls = urls => {
+    const httpVideos = urls.filter(isHttpVideoUrl);
+    const blobUrls = urls.filter(u => u.startsWith("blob:"));
+    const rest = urls.filter(u => !isHttpVideoUrl(u) && !u.startsWith("blob:"));
+    return [...httpVideos, ...blobUrls, ...rest];
+  };
+
   const focusedDownloadUrls = urls => {
+    urls = videoFirstUrls(urls);
     const httpVideoUrl = urls.find(isHttpVideoUrl);
     if (httpVideoUrl) return [httpVideoUrl];
     const blobUrl = urls.find(u => u.startsWith("blob:"));
@@ -1533,6 +1541,7 @@ window.SocialMediaDownloader = (() => {
       });
     }
     if (sourceMode === 'focused') finalUrls = focusedDownloadUrls(finalUrls);
+    else if (sourceMode === 'main') finalUrls = videoFirstUrls(finalUrls);
     return { urls: finalUrls, profile,
              mode: sourceMode,
              dashGroups: groups };

--- a/src/firefox/src/agent/social-media-downloader.js
+++ b/src/firefox/src/agent/social-media-downloader.js
@@ -1296,6 +1296,11 @@ window.SocialMediaDownloader = (() => {
     return s;
   };
 
+  const focusedDownloadUrls = urls => {
+    const blobUrl = urls.find(u => u.startsWith("blob:"));
+    return blobUrl ? [blobUrl] : urls.slice(0, 1);
+  };
+
   // ---------- HLS m3u8 stitching ----------
   const fetchText = async u =>
     (await fetch(u, { credentials: "include" })).text();
@@ -1519,7 +1524,7 @@ window.SocialMediaDownloader = (() => {
         try { return profile.urlFilter(u); } catch { return true; }
       });
     }
-    if (sourceMode === 'focused') finalUrls = finalUrls.slice(0, 1);
+    if (sourceMode === 'focused') finalUrls = focusedDownloadUrls(finalUrls);
     return { urls: finalUrls, profile,
              mode: sourceMode,
              dashGroups: groups };

--- a/src/firefox/src/agent/tools.js
+++ b/src/firefox/src/agent/tools.js
@@ -619,7 +619,7 @@ export const AGENT_TOOLS = [
           mode: {
             type: 'string',
             enum: ['auto', 'main', 'all'],
-            description: '"auto" (default): main media on single-content pages, everything on feeds. "main": force just the primary photo/video on the page. "all": every media item currently in the DOM.',
+            description: '"auto" (default): focused/open media only. "main": primary post media on single-content pages. "all": every media item currently in the DOM; use only for explicit bulk requests.',
           },
           scroll: {
             type: 'boolean',
@@ -627,7 +627,7 @@ export const AGENT_TOOLS = [
           },
           limit: {
             type: 'number',
-            description: 'Max number of files to download. Default unlimited.',
+            description: 'Max number of files to download. Default 1 for focused/main requests; unlimited only when mode:"all" or scroll:true is explicit.',
           },
         },
         required: [],

--- a/src/firefox/src/agent/tools.js
+++ b/src/firefox/src/agent/tools.js
@@ -616,6 +616,20 @@ export const AGENT_TOOLS = [
       parameters: {
         type: 'object',
         properties: {
+          strategy: {
+            type: 'string',
+            enum: ['auto', 'dom', 'vision'],
+            description: '"auto" (default): try the DOM/CDN social downloader first; if it cannot save the focused media and vision is available, crop the single visible media from a screenshot. "dom": never spend a vision call. "vision": crop exactly the visible media when vision is available; if not, automatically falls back to DOM.',
+          },
+          target: {
+            type: 'string',
+            enum: ['image', 'video', 'media'],
+            description: 'Hint for the vision crop path. Use "image" for "download this image", "video" for "download this video", otherwise omit.',
+          },
+          filename: {
+            type: 'string',
+            description: 'Optional filename for the screenshot-crop fallback. Directory components are ignored.',
+          },
           mode: {
             type: 'string',
             enum: ['auto', 'main', 'all'],
@@ -783,7 +797,7 @@ TOOLS - use only these:
 - new_tab({url}): Open a URL in a new tab.
 - wait_for_element({selector}): Wait for an element to appear.
 - fetch_url({url}): Fetch other URLs for reading only; do not use it to re-read the active tab.
-- download_social_media: Download images/videos from supported social sites.
+- download_social_media: Download images/videos from supported social sites. Use strategy:"vision" only when the user wants the single visible item cropped; without vision it falls back to DOM.
 - scratchpad_write({text}): Save notes that persist across steps.
 - clarify({question}): Ask the user only when materially blocked or ambiguous.
 - solve_captcha: Try once only when CapSolver is configured.
@@ -1012,7 +1026,7 @@ SCROLLING — read this:
 
 SOCIAL MEDIA DOWNLOADS — read this:
 - When the user asks to download images or videos from Facebook, Instagram, X/Twitter, LinkedIn, Reddit, Pinterest, or YouTube (thumbnails), call \`download_social_media\` — it is a SINGLE tool call that handles the per-site DOM, picks the right resolution, and saves to the Downloads folder. Do NOT inspect the page with \`get_interactive_elements\` + \`execute_js\` + \`download_file\` to figure it out yourself; the tool already knows.
-- Defaults: on single-content pages (e.g. /photo/, /p/, /reel/, /status/.../photo/, /pin/, /comments/) it grabs the main item; pass \`scroll:true\` to walk a feed/profile/timeline and capture everything that lazy-loads.
+- Defaults: strategy:"auto" tries the DOM/CDN path first (original asset quality, no extra LLM call). If that cannot save the focused media and vision is available, the same tool uses a screenshot+vision sub-call to crop the single visible image/video; if no vision model is configured, it falls back to DOM only. Pass strategy:"vision" only for "download this visible image/video" when a screenshot crop is acceptable; pass strategy:"dom" or scroll:true for bulk/original-asset requests.
 - After it returns, optionally call \`list_downloads\` to surface the saved filenames for the user. Some CDNs (notably media.licdn.com) block CORS and the tool will open the media in a new tab as fallback — that is expected behavior, not a failure.
 - The tool may return a \`recommendation\` field with shape \`{ kind, message }\`. This means SMD knowingly cannot handle the request well — most often YouTube full video (Widevine DRM + signatureCipher), an MSE blob the player hasn't loaded yet, or a site outside SMD's supported list. When it appears, RELAY \`recommendation.message\` to the user verbatim in your reply — it points them at the right external CLI tool (\`yt-dlp\` for video, \`gallery-dl\` for images) with a copy-pasteable command. Do NOT try to work around it with \`execute_js\` or repeated tool calls — the recommendation exists precisely because those paths cannot help. Exception: \`kind: "mse_capture_available"\` is the one case where you SHOULD follow up — it means the MSE recorder buffered bytes while the page was open, and the message tells you to call \`await SocialMediaDownloader.saveMse()\` via \`execute_js\` to download them.
 
@@ -1081,7 +1095,7 @@ TOOLS — use only these:
 - wait_for_element({selector}) / wait_for_stable({quietMs}): wait for an element / for the page to go quiet after an action.
 - iframe_read / iframe_click / iframe_type ({urlFilter, selector, text}): interact inside cross-origin iframes (Stripe, payment widgets, embeds).
 - fetch_url({url}) / research_url({url}): read OTHER URLs (not the active tab). list_downloads, download_files, read_downloaded_file: file workflows.
-- download_social_media: one-shot image/video download from supported social sites.
+- download_social_media: one-shot image/video download from supported social sites; strategy:"auto" uses DOM first, then vision crop only when needed and available.
 - verify_form: check a form's field values before submitting. scratchpad_write({text}): pin facts that survive context summarization.
 - clarify({question}): ask the user only when materially blocked/ambiguous (budget 1-2 per run). solve_captcha: once, only when CapSolver is configured.
 - done({summary}): signal completion — verify success first.

--- a/test/fixtures/run.mjs
+++ b/test/fixtures/run.mjs
@@ -20,6 +20,7 @@ import path from 'node:path';
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const root = path.resolve(__dirname, '..', '..');
 const contentJsPath = path.join(root, 'src', 'chrome', 'src', 'content', 'content.js');
+const smdJsPath = path.join(root, 'src', 'chrome', 'src', 'agent', 'social-media-downloader.js');
 
 function fixtureUrl(name) {
   return 'file://' + path.join(__dirname, name);
@@ -57,6 +58,27 @@ async function call(page, action, params) {
 
 async function clickedSentinel(page) {
   return page.evaluate(() => window.__clicked);
+}
+
+async function setupSmd(page, url, html) {
+  const u = new URL(url);
+  await page.route(`${u.origin}/**`, route => {
+    if (route.request().resourceType() === 'document') {
+      return route.fulfill({ body: html, contentType: 'text/html' });
+    }
+    return route.fulfill({ body: '', contentType: 'text/plain' });
+  });
+  await page.goto(url, { waitUntil: 'domcontentloaded' });
+  const src = await readFile(smdJsPath, 'utf-8');
+  await page.addScriptTag({ content: src });
+  await page.waitForFunction(() => typeof window.SocialMediaDownloader === 'object');
+}
+
+async function collectSmd(page, mode = 'auto') {
+  return page.evaluate((m) => {
+    const r = window.SocialMediaDownloader._collect(m);
+    return { urls: r.urls, mode: r.mode, profile: r.profile.name };
+  }, mode);
 }
 
 const tests = [];
@@ -124,6 +146,68 @@ test('ambiguity: two Cancels return rich candidates with ancestor', async (page)
 });
 
 // ─── main ─────────────────────────────────────────────────────────────────
+// Social media downloader focus safety
+test('SMD: Instagram auto mode downloads the open dialog image, not the feed', async (page) => {
+  await setupSmd(page, 'https://www.instagram.com/natgeo/', `<!doctype html>
+    <style>
+      body { margin: 0; }
+      main { display: grid; grid-template-columns: repeat(3, 220px); gap: 12px; }
+      main img { width: 220px; height: 220px; object-fit: cover; }
+      [role="dialog"] { position: fixed; inset: 0; display: grid; place-items: center; background: rgba(0,0,0,.8); }
+      [role="dialog"] img { width: 640px; height: 640px; object-fit: contain; }
+    </style>
+    <main>
+      <article>
+        ${Array.from({ length: 9 }, (_, i) =>
+          `<img width="220" height="220" src="https://cdninstagram.com/feed-${i}.jpg">`
+        ).join('')}
+      </article>
+    </main>
+    <div role="dialog" aria-modal="true">
+      <img width="640" height="640" src="https://cdninstagram.com/open-dialog-current.jpg">
+    </div>`);
+
+  const auto = await collectSmd(page, 'auto');
+  if (auto.profile !== 'instagram') throw new Error(`expected instagram profile, got ${auto.profile}`);
+  if (auto.mode !== 'focused') throw new Error(`expected focused mode, got ${auto.mode}`);
+  if (auto.urls.length !== 1) throw new Error(`expected one focused URL, got ${auto.urls.length}: ${auto.urls.join(', ')}`);
+  if (!/open-dialog-current\.jpg/.test(auto.urls[0])) {
+    throw new Error(`expected dialog image, got ${auto.urls[0]}`);
+  }
+
+  const all = await collectSmd(page, 'all');
+  if (all.urls.length <= 1) throw new Error(`explicit all mode should still expose bulk media, got ${all.urls.length}`);
+});
+
+test('SMD: X photo modal wins over background timeline media', async (page) => {
+  await setupSmd(page, 'https://x.com/NASA/status/123/photo/1', `<!doctype html>
+    <style>
+      body { margin: 0; }
+      main article img { width: 300px; height: 300px; display: block; margin: 16px; }
+      [aria-modal="true"] { position: fixed; inset: 0; display: grid; place-items: center; background: #000; }
+      [aria-modal="true"] img { width: 720px; height: 480px; object-fit: contain; }
+    </style>
+    <main>
+      <article data-testid="tweet">
+        <div data-testid="tweetPhoto"><img width="300" height="300" src="https://pbs.twimg.com/media/background-one.jpg?name=small"></div>
+        <div data-testid="tweetPhoto"><img width="300" height="300" src="https://pbs.twimg.com/media/background-two.jpg?name=small"></div>
+      </article>
+    </main>
+    <div aria-modal="true" role="dialog">
+      <div data-testid="tweetPhoto">
+        <img width="720" height="480" src="https://pbs.twimg.com/media/current-photo.jpg?name=small">
+      </div>
+    </div>`);
+
+  const auto = await collectSmd(page, 'auto');
+  if (auto.profile !== 'twitter') throw new Error(`expected twitter profile, got ${auto.profile}`);
+  if (auto.mode !== 'focused') throw new Error(`expected focused mode, got ${auto.mode}`);
+  if (auto.urls.length !== 1) throw new Error(`expected one focused URL, got ${auto.urls.length}: ${auto.urls.join(', ')}`);
+  if (!/current-photo\.jpg\?name=orig/.test(auto.urls[0])) {
+    throw new Error(`expected upgraded modal photo URL, got ${auto.urls[0]}`);
+  }
+});
+
 (async () => {
   const browser = await chromium.launch();
   const context = await browser.newContext();

--- a/test/fixtures/run.mjs
+++ b/test/fixtures/run.mjs
@@ -205,6 +205,29 @@ test('SMD: Instagram focused video keeps blob URL ahead of poster image', async 
   }
 });
 
+test('SMD: main mode orders focused video before poster when caller limits to one', async (page) => {
+  await setupSmd(page, 'https://www.instagram.com/p/video123/', `<!doctype html>
+    <style>
+      body { margin: 0; }
+      main article video { width: 640px; height: 640px; background: #000; }
+    </style>
+    <main>
+      <article>
+        <video width="640" height="640"
+          src="blob:https://www.instagram.com/main-post-video"
+          poster="https://cdninstagram.com/main-post-poster.jpg"></video>
+      </article>
+    </main>`);
+
+  const main = await collectSmd(page, 'main');
+  if (main.profile !== 'instagram') throw new Error(`expected instagram profile, got ${main.profile}`);
+  if (main.mode !== 'main') throw new Error(`expected main mode, got ${main.mode}`);
+  if (!main.urls.length) throw new Error('expected main-mode URLs');
+  if (!main.urls[0].startsWith('blob:https://www.instagram.com/main-post-video')) {
+    throw new Error(`expected main-mode video before poster, got ${main.urls[0]}`);
+  }
+});
+
 test('SMD: YouTube focused video prefers signed HTTP video over blob and poster', async (page) => {
   await setupSmd(page, 'https://www.youtube.com/watch?v=abc123', `<!doctype html>
     <script>

--- a/test/fixtures/run.mjs
+++ b/test/fixtures/run.mjs
@@ -205,6 +205,37 @@ test('SMD: Instagram focused video keeps blob URL ahead of poster image', async 
   }
 });
 
+test('SMD: YouTube focused video prefers signed HTTP video over blob and poster', async (page) => {
+  await setupSmd(page, 'https://www.youtube.com/watch?v=abc123', `<!doctype html>
+    <script>
+      window.ytInitialPlayerResponse = {
+        streamingData: {
+          formats: [
+            { url: 'https://rr1---sn.googlevideo.com/videoplayback?expire=999&mime=video%2Fmp4&itag=18' }
+          ]
+        }
+      };
+    </script>
+    <style>
+      body { margin: 0; }
+      #movie_player { width: 960px; height: 540px; }
+      #movie_player video { width: 960px; height: 540px; background: #000; }
+    </style>
+    <div id="movie_player">
+      <video width="960" height="540"
+        src="blob:https://www.youtube.com/focused-player-video"
+        poster="https://i.ytimg.com/vi/abc123/hqdefault.jpg"></video>
+    </div>`);
+
+  const auto = await collectSmd(page, 'auto');
+  if (auto.profile !== 'youtube') throw new Error(`expected youtube profile, got ${auto.profile}`);
+  if (auto.mode !== 'focused') throw new Error(`expected focused mode, got ${auto.mode}`);
+  if (auto.urls.length !== 1) throw new Error(`expected one focused URL, got ${auto.urls.length}: ${auto.urls.join(', ')}`);
+  if (!/googlevideo\.com\/videoplayback/.test(auto.urls[0])) {
+    throw new Error(`expected signed HTTP video before blob/poster, got ${auto.urls[0]}`);
+  }
+});
+
 test('SMD: X photo modal wins over background timeline media', async (page) => {
   await setupSmd(page, 'https://x.com/NASA/status/123/photo/1', `<!doctype html>
     <style>

--- a/test/fixtures/run.mjs
+++ b/test/fixtures/run.mjs
@@ -179,6 +179,32 @@ test('SMD: Instagram auto mode downloads the open dialog image, not the feed', a
   if (all.urls.length <= 1) throw new Error(`explicit all mode should still expose bulk media, got ${all.urls.length}`);
 });
 
+test('SMD: Instagram focused video keeps blob URL ahead of poster image', async (page) => {
+  await setupSmd(page, 'https://www.instagram.com/reel/abc123/', `<!doctype html>
+    <style>
+      body { margin: 0; }
+      main img { width: 220px; height: 220px; display: block; }
+      [role="dialog"] { position: fixed; inset: 0; display: grid; place-items: center; background: rgba(0,0,0,.85); }
+      video { width: 540px; height: 720px; background: #000; }
+    </style>
+    <main>
+      <img width="220" height="220" src="https://cdninstagram.com/feed-still.jpg">
+    </main>
+    <div role="dialog" aria-modal="true">
+      <video width="540" height="720"
+        src="blob:https://www.instagram.com/focused-reel-video"
+        poster="https://cdninstagram.com/focused-reel-poster.jpg"></video>
+    </div>`);
+
+  const auto = await collectSmd(page, 'auto');
+  if (auto.profile !== 'instagram') throw new Error(`expected instagram profile, got ${auto.profile}`);
+  if (auto.mode !== 'focused') throw new Error(`expected focused mode, got ${auto.mode}`);
+  if (auto.urls.length !== 1) throw new Error(`expected one focused URL, got ${auto.urls.length}: ${auto.urls.join(', ')}`);
+  if (!auto.urls[0].startsWith('blob:https://www.instagram.com/focused-reel-video')) {
+    throw new Error(`expected focused blob video before poster, got ${auto.urls[0]}`);
+  }
+});
+
 test('SMD: X photo modal wins over background timeline media', async (page) => {
   await setupSmd(page, 'https://x.com/NASA/status/123/photo/1', `<!doctype html>
     <style>

--- a/test/run.js
+++ b/test/run.js
@@ -8,6 +8,7 @@
  */
 
 import { strict as assert } from 'node:assert';
+import fs from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import path from 'node:path';
 
@@ -1449,6 +1450,30 @@ test('download_social_media exposes merged DOM/vision strategy in act tiers only
       assert.deepEqual(props.target.enum, ['image', 'video', 'media']);
       assert.match(props.strategy.description, /falls back to DOM/i);
     }
+  }
+});
+
+test('social media downloader copies stay in sync', () => {
+  const chrome = fs.readFileSync(path.join(ROOT, 'src/chrome/src/agent/social-media-downloader.js'), 'utf8');
+  const firefox = fs.readFileSync(path.join(ROOT, 'src/firefox/src/agent/social-media-downloader.js'), 'utf8');
+  const fixture = fs.readFileSync(path.join(ROOT, 'test/smd-tests/social-media-downloader.js'), 'utf8');
+
+  assert.equal(firefox, chrome);
+  assert.equal(fixture, chrome);
+});
+
+test('social media downloader names extensionless HTTP videos as videos', () => {
+  const downloaderPaths = [
+    'src/chrome/src/agent/social-media-downloader.js',
+    'src/firefox/src/agent/social-media-downloader.js',
+    'test/smd-tests/social-media-downloader.js',
+  ];
+
+  for (const relPath of downloaderPaths) {
+    const source = fs.readFileSync(path.join(ROOT, relPath), 'utf8');
+    assert.match(source, /const isHttpVideoUrl = url =>[\s\S]*googlevideo\\.com\\\/videoplayback\\b[\s\S]*mime\|type\)=video/);
+    assert.match(source, /const isVideoDownloadUrl = url =>\s*isHttpVideoUrl\(url\) \|\|[\s\S]*v\\.redd\\.it/);
+    assert.match(source, /const isVideo = isVideoDownloadUrl\(url\);/);
   }
 });
 

--- a/test/run.js
+++ b/test/run.js
@@ -643,6 +643,30 @@ test('4K and 1440p converge to the same max-budget dims', () => {
   assert.equal(h1440, h4k);
 });
 
+test('visible media localization parser accepts fenced JSON and clamps to viewport', () => {
+  const raw = '```json\n{"found":true,"x":-10,"y":20,"right":330,"bottom":220,"confidence":87,"mediaType":"image"}\n```';
+  for (const AgentClass of [AgentCh, AgentFx]) {
+    const rect = AgentClass._normalizeVisibleMediaLocation(raw, { width: 300, height: 200 });
+    assert.deepEqual(rect, {
+      found: true,
+      x: 0,
+      y: 20,
+      width: 300,
+      height: 180,
+      confidence: 0.87,
+      mediaType: 'image',
+      reason: '',
+    });
+  }
+});
+
+test('visible media localization parser rejects no-target and tiny boxes', () => {
+  for (const AgentClass of [AgentCh, AgentFx]) {
+    assert.equal(AgentClass._normalizeVisibleMediaLocation('{"found":false}', { width: 300, height: 200 }), null);
+    assert.equal(AgentClass._normalizeVisibleMediaLocation('{"found":true,"x":10,"y":10,"width":10,"height":10}', { width: 300, height: 200 }), null);
+  }
+});
+
 test('tall portrait caps the long side at maxTargetPx', () => {
   // A 1920×8000 full-page capture — the long side here is height.
   const [w, h] = fitImageDimensions(1920, 8000);
@@ -1408,6 +1432,23 @@ test('getToolsForMode: compact flag does not shrink ask mode', () => {
       getTools('ask', { compact: true }).map(t => t.function.name).sort(),
       getTools('ask').map(t => t.function.name).sort(),
     );
+  }
+});
+
+test('download_social_media exposes merged DOM/vision strategy in act tiers only', () => {
+  for (const [label, getTools] of [
+    ['chrome', getToolsForModeCh],
+    ['firefox', getToolsForModeFx],
+  ]) {
+    assert.equal(getTools('ask').some(t => t.function.name === 'download_social_media'), false, `[${label}] ask mode should not expose downloads`);
+    for (const opts of [{}, { tier: 'mid' }, { tier: 'compact' }]) {
+      const tool = getTools('act', opts).find(t => t.function.name === 'download_social_media');
+      assert.ok(tool, `[${label}] download_social_media missing for ${JSON.stringify(opts)}`);
+      const props = tool.function.parameters.properties;
+      assert.deepEqual(props.strategy.enum, ['auto', 'dom', 'vision']);
+      assert.deepEqual(props.target.enum, ['image', 'video', 'media']);
+      assert.match(props.strategy.description, /falls back to DOM/i);
+    }
   }
 });
 

--- a/test/smd-tests/README.md
+++ b/test/smd-tests/README.md
@@ -47,7 +47,7 @@ If the runner falls back to (3) when you expected (2), it'll be because Chrome s
 |---|---|---|
 | Pinterest | profile=pinterest, ≥10 pinimg URLs, ≥1 upgraded to /originals/ | (same) |
 | Reddit | profile=reddit, ≥3 redd.it URLs | (same) |
-| Instagram | profile=instagram | + ≥5 cdninstagram/fbcdn URLs |
+| Instagram | profile=instagram | + focused cdninstagram/fbcdn URL (auto mode is intentionally single-item) |
 | X/Twitter | profile=twitter | + ≥1 twimg URL with name=orig |
 | Facebook | profile=facebook | + click into single photo, main-mode returns 1–5 URLs (no avatar leak) |
 | LinkedIn | profile=linkedin | + ≥1 licdn URL after avatar exclusion |

--- a/test/smd-tests/sites.py
+++ b/test/smd-tests/sites.py
@@ -128,10 +128,10 @@ def test_instagram(page, js_path, sdir):
     r.sample_urls = [u[:90] for u in urls[:3]]; r.needs_login = logged_out
     r.assertions = [
         f"profile == 'instagram' (got: {r.profile_detected})",
-        "logged in: cdninstagram/fbcdn URLs >= 5" if not logged_out else "logged out: profile detection only",
+        "logged in: focused cdninstagram/fbcdn URL >= 1" if not logged_out else "logged out: profile detection only",
     ]
     if r.profile_detected != "instagram": r.failures.append("wrong profile")
-    if not logged_out and len(ig) < 5:   r.failures.append("too few IG URLs (logged in)")
+    if not logged_out and len(ig) < 1:   r.failures.append("no focused IG URL (logged in)")
     r.passed = not r.failures and not logged_out
     if logged_out: r.notes = "Use CDP attach or --setup for full coverage."
     if not r.passed and not logged_out: r.screenshot_path = _screenshot(page, sdir, "instagram")

--- a/test/smd-tests/social-media-downloader.js
+++ b/test/smd-tests/social-media-downloader.js
@@ -6,9 +6,9 @@
  * --------------------------------------------------------------------
  * Quick start (paste into the page's DevTools console):
  *
- *   await SocialMediaDownloader.run()           // current view, main content
+ *   await SocialMediaDownloader.run()           // focused/open media item
  *   await SocialMediaDownloader.single()        // just the main photo/video
- *   await SocialMediaDownloader.run({ all:true })// scroll the feed, grab everything
+ *   await SocialMediaDownloader.run({ mode:"all", all:true }) // intentional bulk
  *   SocialMediaDownloader.list()                // print URLs, don't download
  *
  * For VIDEOS played through MediaSource Extensions (Facebook, IG reels,
@@ -20,12 +20,11 @@
  *   await SocialMediaDownloader.saveMse()       // download captured bytes
  *
  * Options for run():
- *   mode:    'auto' (default) — single-photo pages = main content only;
- *                              feeds/profiles = everything
- *            'main'           — force "main content" mode
- *            'all'            — force "everything on page" mode
- *   all:     true|false       — scroll-and-collect (only useful in 'all')
- *   limit:   N                — max downloads
+ *   mode:    'auto' (default) - focused/open/centered media item only
+ *            'main'           - force "main content" mode
+ *            'all'            - force "everything on page" mode
+ *   all:     true|false       - scroll-and-collect (only useful in 'all')
+ *   limit:   N                - max downloads
  *
  * --------------------------------------------------------------------
  * What's NEW in v4
@@ -215,6 +214,9 @@ window.SocialMediaDownloader = (() => {
         '[data-visualcompletion="media-vc-image"], ' +
         '[role="dialog"] [data-visualcompletion="media-vc-image"], ' +
         '[role="dialog"] img[data-imgperflogname]',  // FB tags the main photo
+      focusSel:
+        '[data-pagelet*="MediaViewer" i], ' +
+        '[role="dialog"]',
       // Each album thumbnail is a `<a href="/photo/?fbid=…">` wrapping an
       // `<img>`. Scoping to that link pattern excludes the page profile
       // pic, cover photo, nav avatars, ads, and the "Suggested for you"
@@ -278,6 +280,10 @@ window.SocialMediaDownloader = (() => {
         // role=presentation is the IG main-post marker on some layouts
         'main article[role="presentation"] img, ' +
         'main article[role="presentation"] video',
+      focusSel:
+        '[role="dialog"], ' +
+        'main article[role="presentation"], ' +
+        'main article:first-of-type',
       exclude: [
         'header', 'nav', 'aside',
         '[role="navigation"]',
@@ -307,6 +313,9 @@ window.SocialMediaDownloader = (() => {
         // Status page without modal — grab only the FIRST tweet's media
         'main article[data-testid="tweet"]:first-of-type [data-testid="tweetPhoto"] img, ' +
         'main article[data-testid="tweet"]:first-of-type [data-testid="videoPlayer"] video',
+      focusSel:
+        '[aria-modal="true"], ' +
+        'main article[data-testid="tweet"]:first-of-type',
       exclude: [
         'header', 'nav', 'aside',
         '[data-testid*="UserAvatar"]',
@@ -326,6 +335,10 @@ window.SocialMediaDownloader = (() => {
         '[data-test-id="post-content"] video, ' +
         '[slot="post-media-container"] img, ' +
         '[slot="post-media-container"] video',
+      focusSel:
+        'shreddit-post, ' +
+        '[data-test-id="post-content"], ' +
+        '[slot="post-media-container"]',
       exclude: [
         'header', 'nav', 'aside',
         'faceplate-tracker[noun="avatar"]',
@@ -343,6 +356,9 @@ window.SocialMediaDownloader = (() => {
         '[data-test-id="pin-closeup-image"] img, ' +
         '[data-test-id="visual-content-container"] img, ' +
         '[data-test-id="visual-content-container"] video',
+      focusSel:
+        '[data-test-id="pin-closeup-image"], ' +
+        '[data-test-id="visual-content-container"]',
       exclude: [
         'header', 'nav', 'aside',
         '[data-test-id="user-profile-thumbnail"]',
@@ -361,6 +377,9 @@ window.SocialMediaDownloader = (() => {
         '.feed-shared-image img, ' +
         '.feed-shared-linkedin-video video, ' +
         'article img, article video',
+      focusSel:
+        '.feed-shared-update-v2__content, ' +
+        'article',
       exclude: [
         'header', 'nav', 'aside',
         // Generic
@@ -395,6 +414,10 @@ window.SocialMediaDownloader = (() => {
         'ytd-player video, ytd-player img, ' +
         'ytd-watch-flexy video, ' +
         'ytd-reel-player-renderer video',
+      focusSel:
+        '#movie_player, ' +
+        'ytd-player, ' +
+        'ytd-reel-player-renderer',
       exclude: [
         'header', 'nav', 'aside',
         '#secondary',                              // right rail (up-next videos)
@@ -413,6 +436,7 @@ window.SocialMediaDownloader = (() => {
       match: () => true,
       isSingle: () => false,
       mainSel: 'main img, main video, article img, article video',
+      focusSel: 'main, article',
       exclude: ['header', 'nav', 'aside', 'svg', '[role="navigation"]']
     }
   };
@@ -489,6 +513,156 @@ window.SocialMediaDownloader = (() => {
       el = el.parentElement;
     }
     return false;
+  };
+
+  const viewportSize = () => ({
+    w: Math.max(document.documentElement.clientWidth || 0, window.innerWidth || 0),
+    h: Math.max(document.documentElement.clientHeight || 0, window.innerHeight || 0),
+  });
+
+  const visibleArea = rect => {
+    const vp = viewportSize();
+    const left = Math.max(0, rect.left);
+    const top = Math.max(0, rect.top);
+    const right = Math.min(vp.w, rect.right);
+    const bottom = Math.min(vp.h, rect.bottom);
+    return Math.max(0, right - left) * Math.max(0, bottom - top);
+  };
+
+  const isVisibleElement = el => {
+    if (!el || !el.getBoundingClientRect) return false;
+    const style = window.getComputedStyle ? window.getComputedStyle(el) : null;
+    if (style && (style.display === 'none' || style.visibility === 'hidden' || Number(style.opacity) === 0)) {
+      return false;
+    }
+    const rect = el.getBoundingClientRect();
+    if (rect.width < 24 || rect.height < 24) return false;
+    return visibleArea(rect) >= 1024;
+  };
+
+  const mediaBoxElement = el => {
+    if (!el) return null;
+    const tag = el.tagName;
+    if (tag === 'SOURCE') return el.closest('picture,video') || el.parentElement;
+    return el;
+  };
+
+  const addMediaCandidateUrls = (el, add) => {
+    if (!el) return;
+    const tag = el.tagName;
+    if (tag === 'IMG') {
+      [el.currentSrc, el.src,
+       el.getAttribute('src'), el.getAttribute('data-src'),
+       el.getAttribute('data-original'), el.getAttribute('data-url')]
+        .forEach(add);
+      parseSrcset(el.getAttribute('srcset')).forEach(add);
+      const picture = el.closest('picture');
+      if (picture) {
+        picture.querySelectorAll('source').forEach(s => {
+          [s.src, s.getAttribute('src'), s.getAttribute('srcset')]
+            .forEach(v => { parseSrcset(v).forEach(add); add(v); });
+        });
+      }
+      return;
+    }
+    if (tag === 'VIDEO') {
+      [el.currentSrc, el.src, el.poster,
+       el.getAttribute('src'), el.getAttribute('poster')]
+        .forEach(add);
+      el.querySelectorAll('source').forEach(s => {
+        [s.src, s.getAttribute('src'), s.getAttribute('srcset')]
+          .forEach(v => { parseSrcset(v).forEach(add); add(v); });
+      });
+      return;
+    }
+    if (tag === 'SOURCE') {
+      [el.src, el.getAttribute('src'), el.getAttribute('srcset')]
+        .forEach(v => { parseSrcset(v).forEach(add); add(v); });
+    }
+  };
+
+  const directMediaUrls = el => {
+    const urls = new Set();
+    const add = url => {
+      url = absoluteUrl(url);
+      if (isMediaUrl(url)) urls.add(url);
+    };
+    addMediaCandidateUrls(el, add);
+    return [...urls];
+  };
+
+  const mediaElementsIn = root => {
+    if (!root) return [];
+    const out = [];
+    if (root.matches && root.matches('img, video, source')) out.push(root);
+    if (root.querySelectorAll) {
+      root.querySelectorAll('img, video, source').forEach(el => out.push(el));
+    }
+    return out;
+  };
+
+  const mediaElementScore = el => {
+    const box = mediaBoxElement(el);
+    if (!box || !box.getBoundingClientRect) return -Infinity;
+    const rect = box.getBoundingClientRect();
+    const area = visibleArea(rect);
+    if (area <= 0) return -Infinity;
+    const vp = viewportSize();
+    const cx = rect.left + rect.width / 2;
+    const cy = rect.top + rect.height / 2;
+    const maxDist = Math.hypot(vp.w / 2, vp.h / 2) || 1;
+    const centered = 1 - Math.min(1, Math.hypot(cx - vp.w / 2, cy - vp.h / 2) / maxDist);
+    let score = area + centered * 50000;
+    if (box.closest('dialog[open], [aria-modal="true"], [role="dialog"]')) score += 1000000;
+    if (box.closest('[aria-selected="true"], [data-current="true"], [data-active="true"]')) score += 20000;
+    if (el.tagName === 'VIDEO' || box.tagName === 'VIDEO') score += 10000;
+    return score;
+  };
+
+  const bestFocusedMedia = (roots, excluded) => {
+    const candidates = [];
+    for (const root of roots || []) {
+      if (!root || isExcluded(root, excluded) || !isVisibleElement(root)) continue;
+      for (const el of mediaElementsIn(root)) {
+        const box = mediaBoxElement(el);
+        if (!box || isExcluded(box, excluded) || !isVisibleElement(box)) continue;
+        const rect = box.getBoundingClientRect();
+        const intrinsicW = el.naturalWidth || el.videoWidth || el.width || rect.width || 0;
+        const intrinsicH = el.naturalHeight || el.videoHeight || el.height || rect.height || 0;
+        if (intrinsicW < 120 || intrinsicH < 120) continue;
+        const urls = directMediaUrls(el);
+        if (!urls.length) continue;
+        candidates.push({ el, urls, score: mediaElementScore(el) });
+      }
+    }
+    candidates.sort((a, b) => b.score - a.score);
+    return candidates[0] || null;
+  };
+
+  const queryVisibleRoots = selector => {
+    const roots = [];
+    if (!selector) return roots;
+    try {
+      document.querySelectorAll(selector).forEach(el => {
+        if (isVisibleElement(el)) roots.push(el);
+      });
+    } catch { /* unsupported selector */ }
+    return roots;
+  };
+
+  const collectFocusedMedia = (profile, excluded) => {
+    const dialogRoots = queryVisibleRoots(
+      'dialog[open], [aria-modal="true"], [role="dialog"], ' +
+      '[data-pagelet*="MediaViewer" i], [data-testid*="lightbox" i]'
+    );
+    let best = bestFocusedMedia(dialogRoots, excluded);
+    if (best) return best.urls;
+
+    best = bestFocusedMedia(queryVisibleRoots(profile.focusSel), excluded);
+    if (best) return best.urls;
+
+    best = bestFocusedMedia([document.body || document.documentElement], excluded);
+    return best ? best.urls : [];
   };
 
   // Extract candidate media URLs from a given root (default: document)
@@ -1110,9 +1284,15 @@ window.SocialMediaDownloader = (() => {
   };
 
   // ---------- Scoring & ranking ----------
+  const isHttpVideoUrl = url =>
+    /^https?:\/\//i.test(url || '') &&
+    (/\.(mp4|mov|m4v|webm|m3u8|mpd|ts)(\?|#|$)/i.test(url) ||
+     /googlevideo\.com\/videoplayback\b/i.test(url) ||
+     /[?&](?:mime|type)=video(?:%2f|\/)/i.test(url));
+
   const scoreUrl = url => {
     let s = 0;
-    if (/\.(mp4|mov|m4v|webm)(\?|#|$)/i.test(url)) s += 100;
+    if (isHttpVideoUrl(url)) s += 100;
     if (/\.(jpg|jpeg|png|webp)(\?|#|$)/i.test(url)) s += 50;
     if (url.includes("name=orig")) s += 20;
     if (url.includes("originals/")) s += 25;
@@ -1120,6 +1300,21 @@ window.SocialMediaDownloader = (() => {
     if (url.startsWith("blob:")) s -= 50;
     if (/preview\.redd\.it/.test(url)) s -= 5;
     return s;
+  };
+
+  const videoFirstUrls = urls => {
+    const httpVideos = urls.filter(isHttpVideoUrl);
+    const blobUrls = urls.filter(u => u.startsWith("blob:"));
+    const rest = urls.filter(u => !isHttpVideoUrl(u) && !u.startsWith("blob:"));
+    return [...httpVideos, ...blobUrls, ...rest];
+  };
+
+  const focusedDownloadUrls = urls => {
+    urls = videoFirstUrls(urls);
+    const httpVideoUrl = urls.find(isHttpVideoUrl);
+    if (httpVideoUrl) return [httpVideoUrl];
+    const blobUrl = urls.find(u => u.startsWith("blob:"));
+    return blobUrl ? [blobUrl] : urls.slice(0, 1);
   };
 
   // ---------- HLS m3u8 stitching ----------
@@ -1234,6 +1429,9 @@ window.SocialMediaDownloader = (() => {
     const profile = activeProfile();
     const excluded = buildExclusionSet(profile);
 
+    const focusedUrls = mode === 'auto'
+      ? collectFocusedMedia(profile, excluded)
+      : [];
     let useMain;
     if (mode === 'main') useMain = true;
     else if (mode === 'all') useMain = false;
@@ -1250,7 +1448,11 @@ window.SocialMediaDownloader = (() => {
       profile.isGallery();
 
     let urls;
-    if (useGallery) {
+    let sourceMode = useGallery ? 'gallery' : (useMain ? 'main' : 'all');
+    if (focusedUrls.length) {
+      urls = focusedUrls;
+      sourceMode = 'focused';
+    } else if (useGallery) {
       const galleryUrls = [];
       const galleryEls = document.querySelectorAll(profile.gallerySel);
       galleryEls.forEach(el => {
@@ -1338,8 +1540,10 @@ window.SocialMediaDownloader = (() => {
         try { return profile.urlFilter(u); } catch { return true; }
       });
     }
+    if (sourceMode === 'focused') finalUrls = focusedDownloadUrls(finalUrls);
+    else if (sourceMode === 'main') finalUrls = videoFirstUrls(finalUrls);
     return { urls: finalUrls, profile,
-             mode: useGallery ? 'gallery' : (useMain ? 'main' : 'all'),
+             mode: sourceMode,
              dashGroups: groups };
   };
 

--- a/test/smd-tests/social-media-downloader.js
+++ b/test/smd-tests/social-media-downloader.js
@@ -1309,6 +1309,11 @@ window.SocialMediaDownloader = (() => {
     return [...httpVideos, ...blobUrls, ...rest];
   };
 
+  const isVideoDownloadUrl = url =>
+    isHttpVideoUrl(url) ||
+    String(url || '').startsWith('blob:') ||
+    /v\.redd\.it/i.test(url || '');
+
   const focusedDownloadUrls = urls => {
     urls = videoFirstUrls(urls);
     const httpVideoUrl = urls.find(isHttpVideoUrl);
@@ -1683,9 +1688,7 @@ window.SocialMediaDownloader = (() => {
     };
     let i = 1;
     for (const url of selected) {
-      const isVideo = /\.(mp4|mov|m4v|webm|m3u8|ts)(\?|#|$)/i.test(url)
-        || url.startsWith('blob:')
-        || /v\.redd\.it/.test(url);
+      const isVideo = isVideoDownloadUrl(url);
       const ext = getExt(url) || (isVideo ? '.mp4' : '.jpg');
       const filename = `${filenameSafe(prefix)}_${isVideo ? 'video' : 'photo'}_${String(i).padStart(3, '0')}${ext}`;
       let r;


### PR DESCRIPTION
## Summary
- make `download_social_media` default to the focused/open media item instead of sweeping whole social feeds
- add focused media scoring for dialogs, lightboxes, single posts, and centered viewport media in both Chrome and Firefox builds
- keep explicit bulk downloads available via `mode:"all"` or `scroll:true`, and default extension-triggered focused requests to `limit: 1`
- preserve video intent by preferring signed HTTP video URLs, then focused/main `blob:` video URLs, then image/poster fallback
- keep the live SMD test-runner copy synced with the Chrome implementation
- add deterministic fixtures for Instagram, YouTube, and X modal-vs-feed behavior

## Validation
- `npm test` (`236 passed, 0 failed`)
- `npm run test:fixtures` (`10 passed, 0 failed`)
- `node --check` on changed JS/MJS files including `test/smd-tests/social-media-downloader.js`
- `git diff --check`
- `py test/smd-tests/test_smd.py --site recommendation_builder --headless`
- SHA-256 equality check between `src/chrome/src/agent/social-media-downloader.js` and `test/smd-tests/social-media-downloader.js`