### PR TITLE
fix(recorder): make Stop reliably end stuck/orphaned tab recordings

### DIFF
--- a/src/chrome/src/agent/agent.js
+++ b/src/chrome/src/agent/agent.js
@@ -3797,6 +3797,21 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
     if (name === 'stop_recording') {
       const r = await recorderStop();
       if (!r.ok) return { success: false, error: r.error };
+      // The stop may not have produced a file. recorderStop() force-clears a
+      // stuck/orphaned recording (service worker suspended, offscreen session
+      // evicted) and reports it with `cleared`, and reports a no-op stop with
+      // `alreadyStopped`. In neither case is there a filename — don't claim a
+      // phantom "saved as undefined".
+      if (r.alreadyStopped) {
+        return { success: true, note: 'No recording was active; nothing to stop.' };
+      }
+      if (r.cleared) {
+        return {
+          success: true,
+          cleared: true,
+          note: `The recording could not be finalized, so no file was saved (${r.warning || 'the recorder was no longer running'}). The stuck recording state has been cleared.`,
+        };
+      }
       return {
         success: true,
         filename: r.filename,

--- a/src/chrome/src/recorder/host.js
+++ b/src/chrome/src/recorder/host.js
@@ -168,8 +168,9 @@ export async function stopTabRecording() {
   if (!recordingState.active) {
     // Nothing active. Still broadcast 'stopped' so any sidepanel showing a
     // stale banner clears it, and report success — the user's goal (no active
-    // recording) is already met.
-    broadcast('stopped', { result: { ok: false, error: 'No active recording.' } });
+    // recording) is already met. This is benign (no failure to surface), so
+    // the broadcast carries ok:true and the UI clears silently.
+    broadcast('stopped', { result: { ok: true, alreadyStopped: true } });
     return { ok: true, alreadyStopped: true };
   }
   let res = null;

--- a/src/chrome/src/recorder/host.js
+++ b/src/chrome/src/recorder/host.js
@@ -166,16 +166,31 @@ export async function startTabRecording(tabId, options = {}) {
 export async function stopTabRecording() {
   await ensureRecordingStateLoaded();
   if (!recordingState.active) {
-    return { ok: false, error: 'No active recording.' };
+    // Nothing active. Still broadcast 'stopped' so any sidepanel showing a
+    // stale banner clears it, and report success — the user's goal (no active
+    // recording) is already met.
+    broadcast('stopped', { result: { ok: false, error: 'No active recording.' } });
+    return { ok: true, alreadyStopped: true };
   }
-  let res;
+  let res = null;
+  let stopError = null;
   try {
     res = await chrome.runtime.sendMessage({ type: 'recorder-stop' });
   } catch (e) {
-    return { ok: false, error: `recorder-stop dispatch failed: ${e.message}` };
+    stopError = `recorder-stop dispatch failed: ${e.message}`;
   }
-  if (!res?.ok) {
-    return { ok: false, error: res?.error || 'recorder failed to stop' };
+
+  // If the offscreen recorder is gone or refused to stop, the recording is no
+  // longer recoverable (e.g. the service worker was suspended for hours and the
+  // offscreen session was evicted, but recordingState.active stuck around in
+  // session storage). Force the state clear and tell the panel — otherwise the
+  // banner can tick forever with no way to dismiss it.
+  if (stopError || !res?.ok) {
+    const error = stopError || res?.error || 'recorder failed to stop';
+    recordingState = { active: false };
+    saveRecordingState();
+    broadcast('stopped', { result: { ok: false, error } });
+    return { ok: true, cleared: true, warning: error };
   }
 
   // Save webm to Downloads. The data URL is safe — recorder.js strips
@@ -188,6 +203,7 @@ export async function stopTabRecording() {
     .slice(0, 19);
   const filename = `webbrain-recording-${stamp}.webm`;
   let downloadId = null;
+  let saveError = null;
   try {
     downloadId = await chrome.downloads.download({
       url: res.dataUrl,
@@ -195,20 +211,23 @@ export async function stopTabRecording() {
       saveAs: false,
     });
   } catch (e) {
-    return { ok: false, error: `download failed: ${e.message}` };
+    saveError = `download failed: ${e.message}`;
   }
 
-  const wantTranscribe = recordingState.transcribeAfter;
+  const wantTranscribe = recordingState.transcribeAfter && !saveError;
   const final = {
-    ok: true,
-    filename,
+    ok: !saveError,
+    filename: saveError ? null : filename,
     downloadId,
+    error: saveError || undefined,
     sizeBytes: res.sizeBytes,
     durationMs: res.durationMs,
     mimeType: res.mimeType,
     transcribeAfter: wantTranscribe,
   };
 
+  // Always clear the recording state once the recorder has stopped, even if the
+  // download failed — the capture is over and the banner must not linger.
   recordingState = { active: false };
   saveRecordingState();
   broadcast('stopped', { result: final });

--- a/src/chrome/src/ui/sidepanel.js
+++ b/src/chrome/src/ui/sidepanel.js
@@ -931,7 +931,15 @@ chrome.runtime.onMessage.addListener((msg) => {
   } else if (msg.event === 'stopped') {
     setRecordingUI(false);
     lastRecordingResult = msg.result || null;
-    if (lastRecordingResult?.transcribeAfter) {
+    if (lastRecordingResult && lastRecordingResult.ok === false) {
+      // The recorder couldn't be finalized (lost/evicted recorder, or a
+      // MediaRecorder/download error). host.js still cleared the stuck state,
+      // but no .webm was saved — surface that instead of silently dropping it.
+      showRecordingStatus(
+        t('sp.record.error', { error: lastRecordingResult.error || 'unknown' }),
+        { autoHide: 8000 }
+      );
+    } else if (lastRecordingResult?.transcribeAfter) {
       showRecordingStatus(t('sp.record.transcribing'));
     } else if (lastRecordingResult?.filename) {
       showRecordingStatus(t('sp.record.saved', { filename: lastRecordingResult.filename }), { autoHide: 6000 });

--- a/src/chrome/src/ui/sidepanel.js
+++ b/src/chrome/src/ui/sidepanel.js
@@ -830,6 +830,11 @@ async function sendMessage() {
 
 let recordingTimerInterval = null;
 let recordingStartedAt = null;
+// Safety cap: auto-stop a recording that has run this long, so a forgotten or
+// orphaned recording can't tick on forever (and pile up memory in the
+// offscreen recorder). Enforced from the 1s banner timer below.
+const MAX_RECORDING_MS = 2 * 60 * 60 * 1000; // 2 hours
+let recordingAutoStopTriggered = false;
 
 function formatRecordTimer(ms) {
   const total = Math.max(0, Math.floor(ms / 1000));
@@ -841,10 +846,17 @@ function formatRecordTimer(ms) {
 function setRecordingUI(active) {
   if (recordingBanner) recordingBanner.classList.toggle('hidden', !active);
   if (active) {
+    recordingAutoStopTriggered = false;
     if (!recordingTimerInterval) {
       recordingTimerInterval = setInterval(() => {
         if (recordingStartedAt && recordingTimerEl) {
-          recordingTimerEl.textContent = formatRecordTimer(Date.now() - recordingStartedAt);
+          const elapsed = Date.now() - recordingStartedAt;
+          recordingTimerEl.textContent = formatRecordTimer(elapsed);
+          if (elapsed >= MAX_RECORDING_MS && !recordingAutoStopTriggered) {
+            // Hit the safety cap — stop the runaway recording.
+            recordingAutoStopTriggered = true;
+            stopRecording();
+          }
         }
       }, 1000);
     }
@@ -858,6 +870,7 @@ function setRecordingUI(active) {
     }
     if (recordingTimerEl) recordingTimerEl.textContent = '00:00';
     recordingStartedAt = null;
+    recordingAutoStopTriggered = false;
   }
 }
 
@@ -877,11 +890,17 @@ async function stopRecording() {
   if (recordingStopBtn) recordingStopBtn.disabled = true;
   try {
     const res = await sendToBackground('stop_tab_recording');
+    // Always tear down the banner. Whether the stop saved a file, cleared a
+    // stale/orphaned recording, or failed outright, the user pressed Stop —
+    // the banner must go away so they're never trapped (see the stuck-for-hours
+    // report). Errors are surfaced but no longer block the UI from clearing.
+    setRecordingUI(false);
     if (!res?.ok) {
       alert(t('sp.record.error', { error: res?.error || 'unknown' }));
-      return;
     }
+  } catch (e) {
     setRecordingUI(false);
+    alert(t('sp.record.error', { error: e?.message || 'unknown' }));
   } finally {
     if (recordingStopBtn) recordingStopBtn.disabled = false;
   }


### PR DESCRIPTION
@
## Problem

The tab-recording banner (the agent's "record tab" feature) could run **forever with no way to stop it** — reported stuck at **1139 minutes**, Stop button doing nothing.

In MV3, the background service worker is suspended after ~30s idle and the offscreen recording session can be evicted mid-recording, while `recordingState.active` stays `true` in `chrome.storage.session`. After that:

- `stopTabRecording()` messaged a recorder that no longer existed, got an error, and returned `{ok:false}` **without clearing the state**.
- The sidepanel `stopRecording()` saw `!ok`, showed an alert, and **`return`ed before clearing the banner**.

Result: a ghost banner that ticks indefinitely and can never be dismissed.

## Fix

- **`recorder/host.js` — `stopTabRecording()`**: force-clear `recordingState` and broadcast `stopped` whenever the recorder is gone or the stop/save fails; treat "no active recording" as a clean clear. Stop can always escape a ghost recording, even if the `.webm` download fails.
- **`ui/sidepanel.js` — `stopRecording()`**: always tear down the banner (success, stale-clear, or error). Errors are still surfaced but no longer trap the UI.
- **`ui/sidepanel.js`**: add a 2h `MAX_RECORDING_MS` safety cap that auto-stops a runaway recording from the banner timer.

## Notes

- **Is data lost?** A `.webm` is only written to Downloads on a successful Stop; a stuck/ghost banner was never writing to disk, so nothing saved is lost.
- **Scope:** Chrome-only — the Firefox build does not have the tab-recorder feature.
- Verified: `node --check` passes on both files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@