### PR TITLE
Fix 6 bugs across Chrome and Firefox builds

### DIFF
--- a/TODOs.md
+++ b/TODOs.md
@@ -84,11 +84,13 @@ Recently closed Firefox parity items:
 
 ---
 
-## 3. Trace recorder: tool events missing step number
+## 3. Trace recorder: tool events missing step number — RESOLVED
 
-When inspecting any trace JSON, `kind: "tool"` events have `data.step === null` even though the surrounding `llm_request` / `llm_response` events carry the right step (1, 2, 3, …). The Compare view in the Traces page would benefit from step numbers on tool rows; currently the timeline still renders fine because `traces.js` falls back to `''` when step is missing.
-
-**Where to fix:** [`src/chrome/src/trace/recorder.js`](src/chrome/src/trace/recorder.js) — the tool-call recording path needs to pull the current step number from the agent loop the same way `llm_request` does. Quick fix; just hasn't been done.
+`kind: "tool"` events previously stored `data.step === null` even though the
+surrounding `llm_request` / `llm_response` events carried the right step. Fixed
+by threading the loop's `steps` counter through `_executeToolBatch` (new `step`
+parameter) to the `trace.recordToolCall` call in both the Chrome and Firefox
+agent loops. Tool rows in the Traces Compare view now carry their step number.
 
 ---
 
@@ -208,15 +210,14 @@ agent implementation drifts.
 
 ## 10. Keep streaming and non-streaming provider behavior in sync
 
-`OpenAICompatibleProvider.chat()` supports `options.extraBody`, but
-`chatStream()` does not. If a local or OpenAI-compatible provider needs extra
-request fields, non-streaming and streaming runs can behave differently.
+The original gap — `OpenAICompatibleProvider.chat()` applying `options.extraBody`
+while `chatStream()` did not — is **already resolved**: both methods now apply
+`extraBody` in `src/chrome/src/providers/openai.js` and the Firefox copy. The
+remaining (lower-priority) work is breadth:
 
 **Concrete next steps:**
-1. Apply `options.extraBody` in every streaming provider path where the
-   non-streaming path supports it.
-2. Add provider-level tests or small request-shape probes for OpenAI-compatible,
+1. Add provider-level tests or small request-shape probes for OpenAI-compatible,
    llama.cpp, and Anthropic providers.
-3. Document which provider-specific request fields are intentionally supported.
+2. Document which provider-specific request fields are intentionally supported.
 
 ---

--- a/src/chrome/src/agent/agent.js
+++ b/src/chrome/src/agent/agent.js
@@ -983,7 +983,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
    *   { action: 'return',   value: string }   → caller should return immediately
    *   { action: 'abort' }                     → user requested abort mid-batch
    */
-  async _executeToolBatch(tabId, toolCalls, messages, onUpdate, provider, partialAssistantText = null) {
+  async _executeToolBatch(tabId, toolCalls, messages, onUpdate, provider, partialAssistantText = null, step = null) {
     let didStateChange = false;
     // Set of tools whose side effect can navigate the page. We snapshot the
     // URL before these and re-check after, so we can warn the model when an
@@ -1093,7 +1093,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
       onUpdate('tool_result', { name: fnName, result: toolResult });
       const _runIdForTool = this.currentRunId.get(tabId);
       if (_runIdForTool) {
-        trace.recordToolCall(_runIdForTool, null, {
+        trace.recordToolCall(_runIdForTool, step, {
           name: fnName, args: fnArgs, result: toolResult, latencyMs: _toolLatency,
         });
       }
@@ -3298,6 +3298,14 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
     const scratchpadMsg = scratchpadIdx >= 0 ? messages[scratchpadIdx] : null;
     const keepLast = 6; // keep only 6 most recent messages
     const recent = messages.slice(-keepLast).filter(m => !this._isScratchpadMessage(m));
+
+    // Drop any leading `tool` messages whose requesting assistant turn fell
+    // outside the kept window. Both OpenAI-compatible and Anthropic APIs reject
+    // a `tool` message that isn't preceded by the assistant turn that requested
+    // it — same guard _manageContext applies. Without this, the emergency-trim
+    // retry re-sends a malformed conversation and the run dies instead of
+    // recovering, defeating the whole point of the fallback.
+    while (recent.length && recent[0].role === 'tool') recent.shift();
 
     // Also truncate any huge tool results in remaining messages
     for (const msg of recent) {
@@ -6824,7 +6832,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
         }
 
         const batchResult = await this._executeToolBatch(
-          tabId, result.toolCalls, messages, onUpdate, provider, result.content
+          tabId, result.toolCalls, messages, onUpdate, provider, result.content, steps
         );
         if (batchResult.action === 'return') {
           finalResponse = batchResult.value;
@@ -7038,7 +7046,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
           });
 
           const batchResult = await this._executeToolBatch(
-            tabId, toolCalls, messages, onUpdate, provider, fullText
+            tabId, toolCalls, messages, onUpdate, provider, fullText, steps
           );
           if (batchResult.action === 'return') {
             return batchResult.value;

--- a/src/chrome/src/agent/social-media-downloader.js
+++ b/src/chrome/src/agent/social-media-downloader.js
@@ -761,7 +761,11 @@ window.SocialMediaDownloader = (() => {
   // 128-bit big-endian unsigned integer (left-zero-padded).
   const _ivFromSequence = seq => {
     const iv = new Uint8Array(16);
-    let n = BigInt(seq | 0);
+    // A bitwise `| 0` here would coerce to a signed 32-bit int, returning an
+    // all-zero IV for any media sequence ≥ 2^31 (which long-running live HLS
+    // streams routinely exceed) and breaking AES-128 segment decryption.
+    // Coerce defensively to a non-negative integer, then go straight to BigInt.
+    let n = BigInt(Math.max(0, Math.trunc(Number(seq)) || 0));
     for (let i = 15; i >= 0 && n > 0n; i--) {
       iv[i] = Number(n & 0xffn);
       n >>= 8n;

--- a/src/chrome/src/offscreen/recorder.js
+++ b/src/chrome/src/offscreen/recorder.js
@@ -127,35 +127,50 @@
     // re-pipe it to the speaker so the user can still hear the call.
     // Without the passthrough, tabCapture mutes the tab and the user
     // can't follow the conversation — a known footgun.
-    const audioContext = new AudioContext();
-    const mixDest = audioContext.createMediaStreamDestination();
+    // Everything from here through the MediaRecorder construction can throw
+    // (AudioContext under autoplay policy, createMediaStreamSource, or the
+    // MediaRecorder constructor on an unsupported config). `session` isn't set
+    // yet, so a throw here would otherwise strand the already-acquired tab/mic
+    // streams (tab left captured + muted) with no way for stop() to release
+    // them. Release everything we acquired before rethrowing.
+    let audioContext = null;
+    let recorder;
+    try {
+      audioContext = new AudioContext();
+      const mixDest = audioContext.createMediaStreamDestination();
 
-    const tabAudioSource = audioContext.createMediaStreamSource(
-      new MediaStream(tabStream.getAudioTracks())
-    );
-    tabAudioSource.connect(mixDest);          // into the recording
-    tabAudioSource.connect(audioContext.destination); // out to user's speaker
+      const tabAudioSource = audioContext.createMediaStreamSource(
+        new MediaStream(tabStream.getAudioTracks())
+      );
+      tabAudioSource.connect(mixDest);          // into the recording
+      tabAudioSource.connect(audioContext.destination); // out to user's speaker
 
-    if (micStream) {
-      const micSource = audioContext.createMediaStreamSource(micStream);
-      micSource.connect(mixDest); // into the recording (do NOT loop to speaker — feedback)
+      if (micStream) {
+        const micSource = audioContext.createMediaStreamSource(micStream);
+        micSource.connect(mixDest); // into the recording (do NOT loop to speaker — feedback)
+      }
+
+      // 4. Build the final stream the recorder consumes.
+      const finalStream = new MediaStream();
+      if (video) {
+        for (const t of tabStream.getVideoTracks()) finalStream.addTrack(t);
+      }
+      for (const t of mixDest.stream.getAudioTracks()) finalStream.addTrack(t);
+
+      // 5. MediaRecorder. Collect dataavailable chunks. Pass a timeslice so
+      // partial data survives a crash and gives us progress estimates.
+      recorder = new MediaRecorder(finalStream, {
+        mimeType: chosenMime,
+        // ~256 kbps audio is plenty for speech; the rest is video budget.
+        audioBitsPerSecond: 192_000,
+        videoBitsPerSecond: 2_500_000,
+      });
+    } catch (e) {
+      try { for (const t of tabStream.getTracks()) t.stop(); } catch {}
+      if (micStream) { try { for (const t of micStream.getTracks()) t.stop(); } catch {} }
+      if (audioContext) { try { audioContext.close(); } catch {} }
+      throw new Error(`Failed to start recorder: ${e.message || e}`);
     }
-
-    // 4. Build the final stream the recorder consumes.
-    const finalStream = new MediaStream();
-    if (video) {
-      for (const t of tabStream.getVideoTracks()) finalStream.addTrack(t);
-    }
-    for (const t of mixDest.stream.getAudioTracks()) finalStream.addTrack(t);
-
-    // 5. MediaRecorder. Collect dataavailable chunks. Pass a timeslice so
-    // partial data survives a crash and gives us progress estimates.
-    const recorder = new MediaRecorder(finalStream, {
-      mimeType: chosenMime,
-      // ~256 kbps audio is plenty for speech; the rest is video budget.
-      audioBitsPerSecond: 192_000,
-      videoBitsPerSecond: 2_500_000,
-    });
     const chunks = [];
     let bytes = 0;
     recorder.ondataavailable = (e) => {
@@ -224,11 +239,24 @@
 
     // Finalize the recorder, wait for the last dataavailable + the stop event.
     await new Promise((resolve) => {
-      const onStop = () => {
+      // An already-inactive recorder will never emit 'stop' again — resolve
+      // immediately instead of waiting forever.
+      if (s.recorder.state === 'inactive') { resolve(); return; }
+      let settled = false;
+      let timer = null;
+      const finish = () => {
+        if (settled) return;
+        settled = true;
+        if (timer) clearTimeout(timer);
         s.recorder.removeEventListener('stop', onStop);
         resolve();
       };
+      const onStop = () => finish();
       s.recorder.addEventListener('stop', onStop);
+      // Safety net: a recorder wedged in a bad state may never fire 'stop'.
+      // Without this timeout stop() hangs forever, the recorder-stop message
+      // never returns, and the recording banner gets stuck with no recovery.
+      timer = setTimeout(finish, 5000);
       try { s.recorder.requestData(); } catch {}
       try { s.recorder.stop(); } catch {}
     });

--- a/src/chrome/src/ui/sidepanel.js
+++ b/src/chrome/src/ui/sidepanel.js
@@ -1681,7 +1681,9 @@ function formatMarkdown(text) {
   // 5. Restore inline code
   inlineCodes.forEach((code, i) => {
     const escaped = code.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
-    text = text.replace(`__INLINE_${i}__`, `<code>${escaped}</code>`);
+    // Function replacer: a string replacement would interpret `$&`, `$\``, etc.
+    // in code that contains literal `$` sequences (shell, jQuery, regex), mangling it.
+    text = text.replace(`__INLINE_${i}__`, () => `<code>${escaped}</code>`);
   });
 
   // 6. Restore fenced code blocks with copy button
@@ -1692,7 +1694,7 @@ function formatMarkdown(text) {
     const header = `<div class="code-block-header">${langLabel}${copyBtn}</div>`;
     text = text.replace(
       `__CODEBLOCK_${i}__`,
-      `<div class="code-block-wrapper">${header}<pre><code>${escaped}</code></pre></div>`
+      () => `<div class="code-block-wrapper">${header}<pre><code>${escaped}</code></pre></div>`
     );
   });
 

--- a/src/firefox/src/agent/agent.js
+++ b/src/firefox/src/agent/agent.js
@@ -630,7 +630,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
    * Shared tool-batch executor used by both processMessage and
    * processMessageStream so they can't drift.
    */
-  async _executeToolBatch(tabId, toolCalls, messages, onUpdate, provider, partialAssistantText = null, allowedToolNames = AGENT_TOOL_NAMES) {
+  async _executeToolBatch(tabId, toolCalls, messages, onUpdate, provider, partialAssistantText = null, allowedToolNames = AGENT_TOOL_NAMES, step = null) {
     let didStateChange = false;
     const NAV_PRONE_TOOLS = new Set(['click', 'navigate', 'execute_js', 'iframe_click']);
     const navNotices = [];
@@ -744,7 +744,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
       try {
         const runId = this.currentRunId.get(tabId);
         if (runId) {
-          await trace.recordToolCall(runId, null, {
+          await trace.recordToolCall(runId, step, {
             name: fnName, args: fnArgs, result: toolResult,
             latencyMs: Date.now() - _toolStart,
           });
@@ -2529,6 +2529,14 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
     const keepLast = 6; // keep only 6 most recent messages
     const recent = messages.slice(-keepLast).filter(m => !this._isScratchpadMessage(m));
 
+    // Drop any leading `tool` messages whose requesting assistant turn fell
+    // outside the kept window. Both OpenAI-compatible and Anthropic APIs reject
+    // a `tool` message that isn't preceded by the assistant turn that requested
+    // it — same guard _manageContext applies. Without this, the emergency-trim
+    // retry re-sends a malformed conversation and the run dies instead of
+    // recovering, defeating the whole point of the fallback.
+    while (recent.length && recent[0].role === 'tool') recent.shift();
+
     // Also truncate any huge tool results in remaining messages
     for (const msg of recent) {
       if (msg.role === 'tool' && msg.content && msg.content.length > 2000) {
@@ -4022,7 +4030,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
         }
 
         const batchResult = await this._executeToolBatch(
-          tabId, result.toolCalls, messages, onUpdate, provider, result.content, allowedToolNames
+          tabId, result.toolCalls, messages, onUpdate, provider, result.content, allowedToolNames, steps
         );
         if (batchResult.action === 'return') {
           finalResponse = batchResult.value;
@@ -4222,7 +4230,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
             tool_calls: toolCalls,
           });
           const batchResult = await this._executeToolBatch(
-            tabId, toolCalls, messages, onUpdate, provider, fullText, allowedToolNames
+            tabId, toolCalls, messages, onUpdate, provider, fullText, allowedToolNames, steps
           );
           if (batchResult.action === 'return') {
             return batchResult.value;

--- a/src/firefox/src/agent/social-media-downloader.js
+++ b/src/firefox/src/agent/social-media-downloader.js
@@ -761,7 +761,11 @@ window.SocialMediaDownloader = (() => {
   // 128-bit big-endian unsigned integer (left-zero-padded).
   const _ivFromSequence = seq => {
     const iv = new Uint8Array(16);
-    let n = BigInt(seq | 0);
+    // A bitwise `| 0` here would coerce to a signed 32-bit int, returning an
+    // all-zero IV for any media sequence ≥ 2^31 (which long-running live HLS
+    // streams routinely exceed) and breaking AES-128 segment decryption.
+    // Coerce defensively to a non-negative integer, then go straight to BigInt.
+    let n = BigInt(Math.max(0, Math.trunc(Number(seq)) || 0));
     for (let i = 15; i >= 0 && n > 0n; i--) {
       iv[i] = Number(n & 0xffn);
       n >>= 8n;

--- a/src/firefox/src/ui/sidepanel.js
+++ b/src/firefox/src/ui/sidepanel.js
@@ -1305,7 +1305,9 @@ function formatMarkdown(text) {
   // 5. Restore inline code
   inlineCodes.forEach((code, i) => {
     const escaped = code.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
-    text = text.replace(`__INLINE_${i}__`, `<code>${escaped}</code>`);
+    // Function replacer: a string replacement would interpret `$&`, `$\``, etc.
+    // in code that contains literal `$` sequences (shell, jQuery, regex), mangling it.
+    text = text.replace(`__INLINE_${i}__`, () => `<code>${escaped}</code>`);
   });
 
   // 6. Restore fenced code blocks with copy button
@@ -1316,7 +1318,7 @@ function formatMarkdown(text) {
     const header = `<div class="code-block-header">${langLabel}${copyBtn}</div>`;
     text = text.replace(
       `__CODEBLOCK_${i}__`,
-      `<div class="code-block-wrapper">${header}<pre><code>${escaped}</code></pre></div>`
+      () => `<div class="code-block-wrapper">${header}<pre><code>${escaped}</code></pre></div>`
     );
   });
 

--- a/test/run.js
+++ b/test/run.js
@@ -1477,6 +1477,23 @@ test('social media downloader names extensionless HTTP videos as videos', () => 
   }
 });
 
+test('HLS implicit-IV derivation does not 32-bit-truncate the media sequence', () => {
+  // RFC 8216 §5.2 implicit IV = media-sequence number as a 128-bit big-endian
+  // integer. A `BigInt(seq | 0)` truncates to signed 32-bit, yielding an
+  // all-zero IV for sequences ≥ 2^31 and breaking AES-128 decryption on long
+  // live streams. Guard all three byte-identical copies against the regression.
+  const downloaderPaths = [
+    'src/chrome/src/agent/social-media-downloader.js',
+    'src/firefox/src/agent/social-media-downloader.js',
+    'test/smd-tests/social-media-downloader.js',
+  ];
+  for (const relPath of downloaderPaths) {
+    const source = fs.readFileSync(path.join(ROOT, relPath), 'utf8');
+    assert.doesNotMatch(source, /BigInt\(seq \| 0\)/);
+    assert.match(source, /let n = BigInt\(Math\.max\(0, Math\.trunc\(Number\(seq\)\) \|\| 0\)\);/);
+  }
+});
+
 test('compact act prompt exists in both browser builds', () => {
   assert.match(SYSTEM_PROMPT_ACT_COMPACT_CH, /untrusted/i);
   assert.match(SYSTEM_PROMPT_ACT_COMPACT_FX, /untrusted/i);

--- a/test/smd-tests/social-media-downloader.js
+++ b/test/smd-tests/social-media-downloader.js
@@ -761,7 +761,11 @@ window.SocialMediaDownloader = (() => {
   // 128-bit big-endian unsigned integer (left-zero-padded).
   const _ivFromSequence = seq => {
     const iv = new Uint8Array(16);
-    let n = BigInt(seq | 0);
+    // A bitwise `| 0` here would coerce to a signed 32-bit int, returning an
+    // all-zero IV for any media sequence ≥ 2^31 (which long-running live HLS
+    // streams routinely exceed) and breaking AES-128 segment decryption.
+    // Coerce defensively to a non-negative integer, then go straight to BigInt.
+    let n = BigInt(Math.max(0, Math.trunc(Number(seq)) || 0));
     for (let i = 15; i >= 0 && n > 0n; i--) {
       iv[i] = Number(n & 0xffn);
       n >>= 8n;


### PR DESCRIPTION
## Summary

A bug-hunting pass (full test suite + parallel deep-review across every major subsystem) that fixes **6 distinct real bugs**, each in both the Chrome and Firefox builds where applicable.

| # | Bug | Impact |
|---|-----|--------|
| 1 | Trace tool events lost their step number (`_executeToolBatch` passed `null` to `recordToolCall`) | Trace Compare view showed no step on tool rows |
| 2 | `_emergencyTrim` could emit an orphaned `tool` message (slice starts mid-turn) | On context overflow, the recovery retry re-sent a conversation OpenAI/Anthropic reject — the run died instead of recovering |
| 3 | Offscreen recorder leaked tab/mic capture if `start()` threw before `session` was set | Tab left captured + muted with no way to recover |
| 4 | Recorder `stop()` awaited the `stop` event with no timeout | A wedged recorder hung the stop message and stuck the recording banner |
| 5 | Markdown code restored via `String.replace(str, str)` interpreted `$&` / `` $` `` / `$'` in snippets | Garbled code blocks + corrupted copy output (shell, jQuery, regex) |
| 6 | HLS implicit IV `BigInt(seq \| 0)` truncated to signed 32-bit | All-zero IV for media sequences ≥ 2^31 → AES-128 segments decrypt to garbage on long live streams |

## Notes
- #5 and #6 fixed in all byte-identical copies; #6 adds a regression test.
- TODOs #3 (resolved) and #10 (the streaming `extraBody` gap was already implemented) updated to match reality.
- 242/242 tests pass; all edited files syntax-clean; downloader byte-identity sync test still green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
