### PR TITLE
Add context-aware actions and recorder recovery

### DIFF
--- a/src/chrome/src/content/content.js
+++ b/src/chrome/src/content/content.js
@@ -48,6 +48,41 @@
     };
   }
 
+  function getActiveEditableSummary() {
+    let el = document.activeElement;
+    if (!el || el === document.body || el === document.documentElement) return null;
+    if (!el.isContentEditable && el.closest) {
+      const editableRoot = el.closest('input:not([type="hidden"]), textarea, [role="textbox"], [role="searchbox"], [contenteditable=""], [contenteditable="true"], [contenteditable="plaintext-only"]');
+      if (editableRoot) el = editableRoot;
+    }
+
+    const tag = (el.tagName || '').toLowerCase();
+    const role = el.getAttribute?.('role') || '';
+    const type = tag === 'input' ? String(el.type || 'text').toLowerCase() : tag;
+    const editable =
+      el.isContentEditable ||
+      tag === 'textarea' ||
+      (tag === 'input' && !['button', 'checkbox', 'color', 'date', 'file', 'hidden', 'image', 'radio', 'range', 'reset', 'submit'].includes(type)) ||
+      /^(textbox|searchbox)$/i.test(role);
+    if (!editable) return null;
+
+    const textPreview = tag === 'textarea' || el.isContentEditable
+      ? String(el.value || el.innerText || el.textContent || '').trim().slice(0, 160)
+      : '';
+    return {
+      tag,
+      type,
+      role,
+      name: el.name || '',
+      id: el.id || '',
+      placeholder: el.getAttribute?.('placeholder') || '',
+      ariaLabel: el.getAttribute?.('aria-label') || '',
+      label: _getFieldLabel(el) || '',
+      editable: !!el.isContentEditable,
+      textPreview,
+    };
+  }
+
   /**
    * Get page metadata.
    */
@@ -58,6 +93,7 @@
       description: document.querySelector('meta[name="description"]')?.content || '',
       text: getPageText(),
       media: getPageMediaSummary(),
+      activeElement: getActiveEditableSummary(),
       links: Array.from(document.querySelectorAll('a[href]')).slice(0, 100).map(a => ({
         text: a.innerText.trim().slice(0, 100),
         href: a.href,
@@ -1549,6 +1585,7 @@
       isArticlePage,
       includeChrome,
       media: getPageMediaSummary(),
+      activeElement: getActiveEditableSummary(),
       links: Array.from(document.querySelectorAll('a[href]')).slice(0, 100).map(a => ({
         text: a.innerText.trim().slice(0, 100),
         href: a.href,

--- a/src/chrome/src/offscreen/recorder.js
+++ b/src/chrome/src/offscreen/recorder.js
@@ -54,6 +54,14 @@
 
   async function start({ streamId, tabId, options }) {
     if (session) {
+      const state = session.recorder?.state || '';
+      if (state === 'inactive') {
+        log('discarding stale inactive session before start');
+        try { await releaseSession(session); } catch {}
+        session = null;
+      }
+    }
+    if (session) {
       throw new Error('A recording is already in progress.');
     }
     const { video = true, mic = true, mimeType: requestedMime } = options || {};
@@ -192,6 +200,7 @@
       micStream,
       audioContext,
       chunks,
+      stopping: false,
       get bytes() { return bytes; },
     };
 
@@ -223,6 +232,7 @@
     return {
       recording: session.recorder.state === 'recording',
       paused: session.recorder.state === 'paused',
+      stopping: !!session.stopping,
       tabId: session.tabId,
       startedAt: session.startedAt,
       mimeType: session.mimeType,
@@ -236,64 +246,78 @@
   async function stop() {
     if (!session) throw new Error('No active recording.');
     const s = session;
+    s.stopping = true;
 
-    // Finalize the recorder, wait for the last dataavailable + the stop event.
-    await new Promise((resolve) => {
-      // An already-inactive recorder will never emit 'stop' again — resolve
-      // immediately instead of waiting forever.
-      if (s.recorder.state === 'inactive') { resolve(); return; }
-      let settled = false;
-      let timer = null;
+    try {
+      // Finalize the recorder, wait for the last dataavailable + the stop event.
+      await waitForRecorderStop(s);
+
+      // Release the streams + AudioContext.
+      await releaseSession(s);
+
+      // IMPORTANT: strip the codecs= parameter from the blob's type before
+      // serializing to a data URL. MediaRecorder gives us something like
+      // "video/webm;codecs=vp9,opus" — that comma inside the parameter
+      // value makes the resulting `data:video/webm;codecs=vp9,opus;base64,XXX`
+      // URL ambiguous, and chrome.downloads.download's URL parser
+      // mis-segments it. The base64 payload ends up partially treated as
+      // mediatype params, so what hits disk is corrupted bytes and the
+      // .webm fails to play ("Invalid data found").
+      //
+      // The bare type ("video/webm") is enough — the codec is also encoded
+      // inside the WebM track header, so players auto-detect it without
+      // the param hint. We still return the FULL mimeType in the metadata
+      // for callers that want it (e.g. transcription).
+      const bareType = (s.mimeType || 'video/webm').split(';')[0];
+      const blob = new Blob(s.chunks, { type: bareType });
+      const dataUrl = await blobToDataUrl(blob);
+
+      return {
+        ok: true,
+        mimeType: s.mimeType,        // original, with codecs param
+        blobType: bareType,          // what the data URL actually carries
+        sizeBytes: blob.size,
+        durationMs: Date.now() - s.startedAt,
+        dataUrl,
+      };
+    } finally {
+      if (session === s) session = null;
+    }
+  }
+
+  function waitForRecorderStop(s) {
+    if (!s?.recorder || s.recorder.state === 'inactive') return Promise.resolve();
+    return new Promise((resolve) => {
+      let done = false;
+      let timeout = null;
       const finish = () => {
-        if (settled) return;
-        settled = true;
-        if (timer) clearTimeout(timer);
-        s.recorder.removeEventListener('stop', onStop);
+        if (done) return;
+        done = true;
+        if (timeout) clearTimeout(timeout);
+        try { s.recorder.removeEventListener('stop', finish); } catch {}
         resolve();
       };
-      const onStop = () => finish();
-      s.recorder.addEventListener('stop', onStop);
-      // Safety net: a recorder wedged in a bad state may never fire 'stop'.
-      // Without this timeout stop() hangs forever, the recorder-stop message
-      // never returns, and the recording banner gets stuck with no recovery.
-      timer = setTimeout(finish, 5000);
+      try { s.recorder.addEventListener('stop', finish); } catch {}
       try { s.recorder.requestData(); } catch {}
-      try { s.recorder.stop(); } catch {}
+      timeout = setTimeout(() => {
+        log('timed out waiting for MediaRecorder stop event; finalizing with collected chunks');
+        finish();
+      }, 5000);
+      try {
+        if (s.recorder.state === 'inactive') finish();
+        else s.recorder.stop();
+      } catch {
+        finish();
+      }
     });
+  }
 
-    // Release the streams + AudioContext.
-    try { for (const t of s.tabStream.getTracks()) t.stop(); } catch {}
-    if (s.micStream) {
-      try { for (const t of s.micStream.getTracks()) t.stop(); } catch {}
-    }
-    try { await s.audioContext.close(); } catch {}
-
-    // IMPORTANT: strip the codecs= parameter from the blob's type before
-    // serializing to a data URL. MediaRecorder gives us something like
-    // "video/webm;codecs=vp9,opus" — that comma inside the parameter
-    // value makes the resulting `data:video/webm;codecs=vp9,opus;base64,XXX`
-    // URL ambiguous, and chrome.downloads.download's URL parser
-    // mis-segments it. The base64 payload ends up partially treated as
-    // mediatype params, so what hits disk is corrupted bytes and the
-    // .webm fails to play ("Invalid data found").
-    //
-    // The bare type ("video/webm") is enough — the codec is also encoded
-    // inside the WebM track header, so players auto-detect it without
-    // the param hint. We still return the FULL mimeType in the metadata
-    // for callers that want it (e.g. transcription).
-    const bareType = (s.mimeType || 'video/webm').split(';')[0];
-    const blob = new Blob(s.chunks, { type: bareType });
-    const dataUrl = await blobToDataUrl(blob);
-
-    session = null;
-    return {
-      ok: true,
-      mimeType: s.mimeType,        // original, with codecs param
-      blobType: bareType,          // what the data URL actually carries
-      sizeBytes: blob.size,
-      durationMs: Date.now() - s.startedAt,
-      dataUrl,
-    };
+  async function releaseSession(s) {
+    try { for (const t of s.tabStream?.getTracks?.() || []) t.stop(); } catch {}
+    try { for (const t of s.micStream?.getTracks?.() || []) t.stop(); } catch {}
+    try {
+      if (s.audioContext && s.audioContext.state !== 'closed') await s.audioContext.close();
+    } catch {}
   }
 
   // ─── runtime.onMessage router ─────────────────────────────────────

--- a/src/chrome/src/recorder/host.js
+++ b/src/chrome/src/recorder/host.js
@@ -59,6 +59,9 @@ function saveRecordingState() {
 
 export async function getRecordingStateFresh() {
   await ensureRecordingStateLoaded();
+  if (recordingState.active) {
+    await reconcileStaleRecordingState({ finalizeInactiveSession: true });
+  }
   return recordingState;
 }
 
@@ -71,6 +74,35 @@ function broadcast(event, payload = {}) {
       ...payload,
     }).catch(() => {});
   } catch {}
+}
+
+async function readOffscreenRecorderState() {
+  try {
+    await ensureOffscreen();
+    return await chrome.runtime.sendMessage({ type: 'recorder-state' });
+  } catch {
+    return null;
+  }
+}
+
+async function reconcileStaleRecordingState({ finalizeInactiveSession = false } = {}) {
+  const offscreenState = await readOffscreenRecorderState();
+  if (!offscreenState || offscreenState.recording || offscreenState.paused || offscreenState.stopping) return false;
+  if (offscreenState.tabId && finalizeInactiveSession) {
+    await stopTabRecording();
+    return recordingState.active === false;
+  }
+  if (offscreenState.tabId) return false;
+  recordingState = { active: false };
+  saveRecordingState();
+  broadcast('stopped', {
+    result: {
+      ok: true,
+      alreadyStopped: true,
+      staleCleared: true,
+    },
+  });
+  return true;
 }
 
 /**
@@ -87,6 +119,8 @@ function broadcast(event, payload = {}) {
 export async function startTabRecording(tabId, options = {}) {
   await ensureRecordingStateLoaded();
   if (recordingState.active) {
+    const cleared = await reconcileStaleRecordingState({ finalizeInactiveSession: true });
+    if (cleared) return startTabRecording(tabId, options);
     return {
       ok: false,
       error: `A recording is already in progress on tab ${recordingState.tabId}.`,

--- a/src/chrome/src/ui/recommended-actions.js
+++ b/src/chrome/src/ui/recommended-actions.js
@@ -5,6 +5,14 @@ const SHOPPING_HOST_RE = /(^|\.)(amazon\.[a-z.]+|ebay\.[a-z.]+|etsy\.com|walmart
 const PRODUCT_PATH_RE = /\/(dp|gp\/product|itm|p|product|products|prod|item|listing|ilan|urun)\b/i;
 const RELEASES_PATH_RE = /^\/[^/]+\/[^/]+\/releases(?:\/|$)/i;
 const SEARCH_INPUT_RE = /^(search|q|query|keyword|keywords|s)$/i;
+const EMAIL_HOST_RE = /(^|\.)(mail\.google\.com|gmail\.com|outlook\.live\.com|outlook\.office\.com|outlook\.office365\.com|mail\.yahoo\.com|icloud\.com|proton\.me|protonmail\.com|fastmail\.com|hey\.com|mail\.zoho\.com)$/i;
+const DM_HOST_RE = /(^|\.)(instagram\.com|x\.com|twitter\.com|facebook\.com|messenger\.com|threads\.net|reddit\.com|linkedin\.com|discord\.com|slack\.com|web\.whatsapp\.com|messages\.google\.com|web\.telegram\.org)$/i;
+const DM_PATH_RE = /(?:^|[/?#])(direct|messages?|messaging|inbox|chat|chats|dm|conversation|conversations|t|channels)(?:\b|[/?#])/i;
+const COMPOSE_FIELD_RE = /\b(compose|reply|message|comment|post|tweet|share|caption|body|editor|write|what'?s happening|start a post|add a comment|write a reply|email)\b/i;
+const X_PROFILE_RESERVED_PATH_RE = /^\/(home|explore|notifications|messages?|i|search|settings|compose|login|signup|jobs|communities|lists|hashtag|intent|share|privacy|tos)(?:\/|$)/i;
+const WP_ADMIN_RE = /\/wp-admin(?:\/|$)/i;
+const WP_TEMPLATE_ROUTE_RE = /\/wp-admin\/(?:site-editor\.php|themes\.php|customize\.php|widgets\.php|theme-editor\.php)(?:[/?#]|$)|post_type=wp_template|page=gutenberg-edit-site/i;
+const WP_TEMPLATE_TITLE_RE = /\b(template|templates|template part|site editor|theme editor|customize|patterns)\b/i;
 
 function hostFromUrl(url) {
   try {
@@ -61,6 +69,68 @@ function hasCartOrPriceSignal(pageInfo = {}) {
   return /\b(add to cart|buy now|checkout|basket|cart|price|discount|sale|shipping|₺|\$|€|£)\b/i.test(haystack);
 }
 
+function communicationSignal(pageInfo = {}, { includeUrl = true } = {}) {
+  return [
+    includeUrl ? pageInfo.url : null,
+    pageInfo.title,
+    pageInfo.description,
+    String(pageInfo.text || '').slice(0, 3000),
+    ...(pageInfo.links || []).slice(0, 40).flatMap((link) => [link?.text, link?.href]),
+    ...(pageInfo.forms || []).slice(0, 10).flatMap((form) => (form?.inputs || []).flatMap((input) => [input?.type, input?.name, input?.id, input?.placeholder])),
+  ].filter(Boolean).join(' ');
+}
+
+function hasEmailThreadSignal(pageInfo = {}) {
+  const signal = communicationSignal(pageInfo, { includeUrl: false });
+  return /\b(reply|reply all|respond|conversation|thread|subject|wrote)\b/i.test(signal) ||
+    (/\bfrom\b/i.test(signal) && /\b(subject|sent)\b/i.test(signal));
+}
+
+function isCommunicationThread(pageInfo = {}, host = '', path = '/') {
+  const signal = communicationSignal(pageInfo);
+  const route = `${pageInfo.url || ''} ${path}`;
+  if (EMAIL_HOST_RE.test(host)) {
+    return hasEmailThreadSignal(pageInfo);
+  }
+  if (DM_HOST_RE.test(host)) {
+    return DM_PATH_RE.test(route) || /\b(reply|respond|conversation|thread|direct message|dm|chat)\b/i.test(signal);
+  }
+  return false;
+}
+
+function hasFocusedComposeBox(pageInfo = {}) {
+  const active = pageInfo.activeElement || null;
+  if (!active || typeof active !== 'object') return false;
+  const tag = String(active.tag || '').toLowerCase();
+  const type = String(active.type || '').toLowerCase();
+  const role = String(active.role || '').toLowerCase();
+  const fieldName = [active.name, active.id, active.placeholder, active.ariaLabel, active.label].filter(Boolean).join(' ').trim();
+  if (type === 'search' || role === 'searchbox' || SEARCH_INPUT_RE.test(fieldName)) return false;
+  const textPreview = String(active.textPreview || '').trim();
+  const signal = `${fieldName} ${textPreview}`;
+  const isMultilineOrRich = tag === 'textarea' || active.editable === true || active.isContentEditable === true || (role === 'textbox' && tag !== 'input');
+  const isSingleLineCompose = tag === 'input' && COMPOSE_FIELD_RE.test(signal);
+  return (isMultilineOrRich && (COMPOSE_FIELD_RE.test(signal) || textPreview.length >= 8)) || isSingleLineCompose;
+}
+
+function isPersonProfilePage(host = '', path = '/') {
+  const isLinkedIn = host === 'linkedin.com' || host.endsWith('.linkedin.com');
+  if (isLinkedIn) return /^\/in\/[^/?#]+(?:\/|$)/i.test(path);
+  const isX = host === 'x.com' || host === 'twitter.com' || host.endsWith('.x.com') || host.endsWith('.twitter.com');
+  return isX && /^\/[^/?#]+\/?$/i.test(path) && !X_PROFILE_RESERVED_PATH_RE.test(path);
+}
+
+function isWordPressAdmin(pageInfo = {}, path = '/') {
+  return WP_ADMIN_RE.test(path) || WP_ADMIN_RE.test(String(pageInfo.url || ''));
+}
+
+function isWordPressTemplatePage(pageInfo = {}, path = '/') {
+  const route = `${path} ${pageInfo.url || ''}`;
+  if (WP_TEMPLATE_ROUTE_RE.test(route)) return true;
+  const pageLocalSignal = `${pageInfo.title || ''} ${pageInfo.description || ''}`;
+  return WP_TEMPLATE_TITLE_RE.test(pageLocalSignal);
+}
+
 function isLongArticle(pageInfo = {}) {
   const textLen = String(pageInfo.text || '').trim().length;
   const url = String(pageInfo.url || '');
@@ -91,6 +161,57 @@ export function buildRecommendedActions(pageInfo = {}, options = {}) {
       prompt: 'Create a new GitHub release for this repository. Ask me for the tag, title, and release notes if needed.',
       mode: 'act',
     });
+  }
+
+  if (hasFocusedComposeBox(pageInfo)) {
+    addUnique(actions, {
+      id: 'rewrite-focused-draft',
+      label: 'Rewrite this draft',
+      prompt: 'Rewrite the text in the currently focused compose box in three versions: softer, shorter, and more formal. Do not type, send, or publish anything unless I ask.',
+    });
+  }
+
+  if (isCommunicationThread(pageInfo, host, path)) {
+    addUnique(actions, {
+      id: 'draft-reply',
+      label: 'Draft a reply',
+      prompt: 'Draft a concise, helpful reply to the currently open email or message. Do not send it or type it into the page unless I ask.',
+    });
+    addUnique(actions, {
+      id: 'summarize-thread',
+      label: 'Summarize this thread',
+      prompt: 'Summarize the currently open email or message thread, including key points, decisions, and unanswered questions.',
+    });
+    addUnique(actions, {
+      id: 'find-followups',
+      label: 'Find follow-ups',
+      prompt: 'Extract action items, deadlines, people to follow up with, and open questions from this conversation.',
+    });
+  }
+
+  if (isPersonProfilePage(host, path)) {
+    addUnique(actions, {
+      id: 'research-person',
+      label: 'Research this person',
+      prompt: 'Research the person shown on this profile. Find likely public profiles on other social/web sources, summarize what is known, include links or sources, and clearly label anything uncertain.',
+    });
+  }
+
+  if (isWordPressAdmin(pageInfo, path)) {
+    addUnique(actions, {
+      id: 'draft-wp-post',
+      label: 'Draft a post',
+      prompt: 'Draft a WordPress post for this site. Ask me for the topic, audience, and tone before changing the page.',
+      mode: 'act',
+    });
+    if (isWordPressTemplatePage(pageInfo, path)) {
+      addUnique(actions, {
+        id: 'change-wp-template',
+        label: 'Change template',
+        prompt: 'Help change this WordPress template or theme setting. First inspect the current editor/page and ask what template change I want before applying it.',
+        mode: 'act',
+      });
+    }
   }
 
   if (DATING_HOST_RE.test(host) && /\b(profile|discover|app|match|likes?)\b/i.test(`${path} ${pageInfo.title || ''}`)) {

--- a/src/firefox/src/content/content.js
+++ b/src/firefox/src/content/content.js
@@ -126,6 +126,41 @@
     };
   }
 
+  function getActiveEditableSummary() {
+    let el = document.activeElement;
+    if (!el || el === document.body || el === document.documentElement) return null;
+    if (!el.isContentEditable && el.closest) {
+      const editableRoot = el.closest('input:not([type="hidden"]), textarea, [role="textbox"], [role="searchbox"], [contenteditable=""], [contenteditable="true"], [contenteditable="plaintext-only"]');
+      if (editableRoot) el = editableRoot;
+    }
+
+    const tag = (el.tagName || '').toLowerCase();
+    const role = el.getAttribute?.('role') || '';
+    const type = tag === 'input' ? String(el.type || 'text').toLowerCase() : tag;
+    const editable =
+      el.isContentEditable ||
+      tag === 'textarea' ||
+      (tag === 'input' && !['button', 'checkbox', 'color', 'date', 'file', 'hidden', 'image', 'radio', 'range', 'reset', 'submit'].includes(type)) ||
+      /^(textbox|searchbox)$/i.test(role);
+    if (!editable) return null;
+
+    const textPreview = tag === 'textarea' || el.isContentEditable
+      ? String(el.value || el.innerText || el.textContent || '').trim().slice(0, 160)
+      : '';
+    return {
+      tag,
+      type,
+      role,
+      name: el.name || '',
+      id: el.id || '',
+      placeholder: el.getAttribute?.('placeholder') || '',
+      ariaLabel: el.getAttribute?.('aria-label') || '',
+      label: _getFieldLabel(el) || '',
+      editable: !!el.isContentEditable,
+      textPreview,
+    };
+  }
+
   /**
    * Get page metadata.
    */
@@ -140,6 +175,7 @@
       isArticlePage: t.isArticlePage,
       includeChrome: !!(params && params.includeChrome),
       media: getPageMediaSummary(),
+      activeElement: getActiveEditableSummary(),
       links: Array.from(document.querySelectorAll('a[href]')).slice(0, 100).map(a => ({
         text: a.innerText.trim().slice(0, 100),
         href: a.href,
@@ -187,6 +223,7 @@
       isArticlePage: t.isArticlePage,
       includeChrome: !!(params && params.includeChrome),
       media: getPageMediaSummary(),
+      activeElement: getActiveEditableSummary(),
       links: Array.from(document.querySelectorAll('a[href]')).slice(0, 100).map(a => ({
         text: a.innerText.trim().slice(0, 100),
         href: a.href,

--- a/src/firefox/src/ui/recommended-actions.js
+++ b/src/firefox/src/ui/recommended-actions.js
@@ -4,6 +4,14 @@ const SHOPPING_HOST_RE = /(^|\.)(amazon\.[a-z.]+|ebay\.[a-z.]+|etsy\.com|walmart
 const PRODUCT_PATH_RE = /\/(dp|gp\/product|itm|p|product|products|prod|item|listing|ilan|urun)\b/i;
 const RELEASES_PATH_RE = /^\/[^/]+\/[^/]+\/releases(?:\/|$)/i;
 const SEARCH_INPUT_RE = /^(search|q|query|keyword|keywords|s)$/i;
+const EMAIL_HOST_RE = /(^|\.)(mail\.google\.com|gmail\.com|outlook\.live\.com|outlook\.office\.com|outlook\.office365\.com|mail\.yahoo\.com|icloud\.com|proton\.me|protonmail\.com|fastmail\.com|hey\.com|mail\.zoho\.com)$/i;
+const DM_HOST_RE = /(^|\.)(instagram\.com|x\.com|twitter\.com|facebook\.com|messenger\.com|threads\.net|reddit\.com|linkedin\.com|discord\.com|slack\.com|web\.whatsapp\.com|messages\.google\.com|web\.telegram\.org)$/i;
+const DM_PATH_RE = /(?:^|[/?#])(direct|messages?|messaging|inbox|chat|chats|dm|conversation|conversations|t|channels)(?:\b|[/?#])/i;
+const COMPOSE_FIELD_RE = /\b(compose|reply|message|comment|post|tweet|share|caption|body|editor|write|what'?s happening|start a post|add a comment|write a reply|email)\b/i;
+const X_PROFILE_RESERVED_PATH_RE = /^\/(home|explore|notifications|messages?|i|search|settings|compose|login|signup|jobs|communities|lists|hashtag|intent|share|privacy|tos)(?:\/|$)/i;
+const WP_ADMIN_RE = /\/wp-admin(?:\/|$)/i;
+const WP_TEMPLATE_ROUTE_RE = /\/wp-admin\/(?:site-editor\.php|themes\.php|customize\.php|widgets\.php|theme-editor\.php)(?:[/?#]|$)|post_type=wp_template|page=gutenberg-edit-site/i;
+const WP_TEMPLATE_TITLE_RE = /\b(template|templates|template part|site editor|theme editor|customize|patterns)\b/i;
 
 function hostFromUrl(url) {
   try {
@@ -60,6 +68,68 @@ function hasCartOrPriceSignal(pageInfo = {}) {
   return /\b(add to cart|buy now|checkout|basket|cart|price|discount|sale|shipping|₺|\$|€|£)\b/i.test(haystack);
 }
 
+function communicationSignal(pageInfo = {}, { includeUrl = true } = {}) {
+  return [
+    includeUrl ? pageInfo.url : null,
+    pageInfo.title,
+    pageInfo.description,
+    String(pageInfo.text || '').slice(0, 3000),
+    ...(pageInfo.links || []).slice(0, 40).flatMap((link) => [link?.text, link?.href]),
+    ...(pageInfo.forms || []).slice(0, 10).flatMap((form) => (form?.inputs || []).flatMap((input) => [input?.type, input?.name, input?.id, input?.placeholder])),
+  ].filter(Boolean).join(' ');
+}
+
+function hasEmailThreadSignal(pageInfo = {}) {
+  const signal = communicationSignal(pageInfo, { includeUrl: false });
+  return /\b(reply|reply all|respond|conversation|thread|subject|wrote)\b/i.test(signal) ||
+    (/\bfrom\b/i.test(signal) && /\b(subject|sent)\b/i.test(signal));
+}
+
+function isCommunicationThread(pageInfo = {}, host = '', path = '/') {
+  const signal = communicationSignal(pageInfo);
+  const route = `${pageInfo.url || ''} ${path}`;
+  if (EMAIL_HOST_RE.test(host)) {
+    return hasEmailThreadSignal(pageInfo);
+  }
+  if (DM_HOST_RE.test(host)) {
+    return DM_PATH_RE.test(route) || /\b(reply|respond|conversation|thread|direct message|dm|chat)\b/i.test(signal);
+  }
+  return false;
+}
+
+function hasFocusedComposeBox(pageInfo = {}) {
+  const active = pageInfo.activeElement || null;
+  if (!active || typeof active !== 'object') return false;
+  const tag = String(active.tag || '').toLowerCase();
+  const type = String(active.type || '').toLowerCase();
+  const role = String(active.role || '').toLowerCase();
+  const fieldName = [active.name, active.id, active.placeholder, active.ariaLabel, active.label].filter(Boolean).join(' ').trim();
+  if (type === 'search' || role === 'searchbox' || SEARCH_INPUT_RE.test(fieldName)) return false;
+  const textPreview = String(active.textPreview || '').trim();
+  const signal = `${fieldName} ${textPreview}`;
+  const isMultilineOrRich = tag === 'textarea' || active.editable === true || active.isContentEditable === true || (role === 'textbox' && tag !== 'input');
+  const isSingleLineCompose = tag === 'input' && COMPOSE_FIELD_RE.test(signal);
+  return (isMultilineOrRich && (COMPOSE_FIELD_RE.test(signal) || textPreview.length >= 8)) || isSingleLineCompose;
+}
+
+function isPersonProfilePage(host = '', path = '/') {
+  const isLinkedIn = host === 'linkedin.com' || host.endsWith('.linkedin.com');
+  if (isLinkedIn) return /^\/in\/[^/?#]+(?:\/|$)/i.test(path);
+  const isX = host === 'x.com' || host === 'twitter.com' || host.endsWith('.x.com') || host.endsWith('.twitter.com');
+  return isX && /^\/[^/?#]+\/?$/i.test(path) && !X_PROFILE_RESERVED_PATH_RE.test(path);
+}
+
+function isWordPressAdmin(pageInfo = {}, path = '/') {
+  return WP_ADMIN_RE.test(path) || WP_ADMIN_RE.test(String(pageInfo.url || ''));
+}
+
+function isWordPressTemplatePage(pageInfo = {}, path = '/') {
+  const route = `${path} ${pageInfo.url || ''}`;
+  if (WP_TEMPLATE_ROUTE_RE.test(route)) return true;
+  const pageLocalSignal = `${pageInfo.title || ''} ${pageInfo.description || ''}`;
+  return WP_TEMPLATE_TITLE_RE.test(pageLocalSignal);
+}
+
 function isLongArticle(pageInfo = {}) {
   const textLen = String(pageInfo.text || '').trim().length;
   const url = String(pageInfo.url || '');
@@ -81,6 +151,57 @@ export function buildRecommendedActions(pageInfo = {}, options = {}) {
       prompt: 'Create a new GitHub release for this repository. Ask me for the tag, title, and release notes if needed.',
       mode: 'act',
     });
+  }
+
+  if (hasFocusedComposeBox(pageInfo)) {
+    addUnique(actions, {
+      id: 'rewrite-focused-draft',
+      label: 'Rewrite this draft',
+      prompt: 'Rewrite the text in the currently focused compose box in three versions: softer, shorter, and more formal. Do not type, send, or publish anything unless I ask.',
+    });
+  }
+
+  if (isCommunicationThread(pageInfo, host, path)) {
+    addUnique(actions, {
+      id: 'draft-reply',
+      label: 'Draft a reply',
+      prompt: 'Draft a concise, helpful reply to the currently open email or message. Do not send it or type it into the page unless I ask.',
+    });
+    addUnique(actions, {
+      id: 'summarize-thread',
+      label: 'Summarize this thread',
+      prompt: 'Summarize the currently open email or message thread, including key points, decisions, and unanswered questions.',
+    });
+    addUnique(actions, {
+      id: 'find-followups',
+      label: 'Find follow-ups',
+      prompt: 'Extract action items, deadlines, people to follow up with, and open questions from this conversation.',
+    });
+  }
+
+  if (isPersonProfilePage(host, path)) {
+    addUnique(actions, {
+      id: 'research-person',
+      label: 'Research this person',
+      prompt: 'Research the person shown on this profile. Find likely public profiles on other social/web sources, summarize what is known, include links or sources, and clearly label anything uncertain.',
+    });
+  }
+
+  if (isWordPressAdmin(pageInfo, path)) {
+    addUnique(actions, {
+      id: 'draft-wp-post',
+      label: 'Draft a post',
+      prompt: 'Draft a WordPress post for this site. Ask me for the topic, audience, and tone before changing the page.',
+      mode: 'act',
+    });
+    if (isWordPressTemplatePage(pageInfo, path)) {
+      addUnique(actions, {
+        id: 'change-wp-template',
+        label: 'Change template',
+        prompt: 'Help change this WordPress template or theme setting. First inspect the current editor/page and ask what template change I want before applying it.',
+        mode: 'act',
+      });
+    }
   }
 
   if (DATING_HOST_RE.test(host) && /\b(profile|discover|app|match|likes?)\b/i.test(`${path} ${pageInfo.title || ''}`)) {

--- a/test/run.js
+++ b/test/run.js
@@ -1360,6 +1360,14 @@ test('recommended actions match issue scenarios', () => {
       'Fill this form with my saved profile info',
     ],
     [
+      { url: 'https://mail.google.com/mail/u/0/#inbox/FMfc123', title: 'Gmail - Project update', text: 'From Ada Subject Project update Reply' },
+      'Draft a reply',
+    ],
+    [
+      { url: 'https://www.instagram.com/direct/t/123456', title: 'Instagram Direct', text: 'New message Reply' },
+      'Draft a reply',
+    ],
+    [
       { url: 'https://meet.google.com/abc-defg-hij', title: 'Team meeting' },
       'Record this meeting',
     ],
@@ -1379,6 +1387,14 @@ test('recommended actions match issue scenarios', () => {
       { url: 'https://www.amazon.com/dp/B000000', title: 'Product', description: 'Price $19.99 Add to Cart' },
       'Compare this price with other stores',
     ],
+    [
+      { url: 'https://x.com/karpathy', title: 'Andrej Karpathy (@karpathy) / X' },
+      'Research this person',
+    ],
+    [
+      { url: 'https://example.com/wp-admin/post-new.php', title: 'Add New Post - WordPress' },
+      'Draft a post',
+    ],
   ];
 
   for (const [pageInfo, label] of cases) {
@@ -1394,6 +1410,7 @@ test('actionable recommendations opt into Act mode', () => {
     { url: 'https://tinder.com/app/recs', title: 'Profile' },
     { url: 'https://www.instagram.com/p/abc/', title: 'Post', media: { imageCount: 1, videoCount: 0 } },
     { url: 'https://checkout.example.com/', title: 'Checkout', forms: [{ inputs: [{ type: 'email', name: 'email' }, { type: 'text', name: 'name' }] }] },
+    { url: 'https://example.com/wp-admin/site-editor.php', title: 'Editor - WordPress', text: 'Templates' },
   ];
   const readOnlyPage = { url: 'https://news.example.com/article/story', title: 'Long article', text: 'word '.repeat(500) };
 
@@ -1402,6 +1419,93 @@ test('actionable recommendations opt into Act mode', () => {
     assert.ok(actions.some((action) => action.mode === 'act'), `expected an Act-mode action for ${pageInfo.url}`);
   }
   assert.equal(buildRecommendedActionsCh(readOnlyPage).find((a) => a.id === 'summarize-page')?.mode, undefined);
+});
+
+test('communication threads get reply, summary, and follow-up suggestions', () => {
+  const pages = [
+    { url: 'https://mail.google.com/mail/u/0/#inbox/FMfc123', title: 'Gmail - Thread', text: 'From Ada Subject Launch Reply' },
+    { url: 'https://x.com/messages/123-456', title: 'Messages / X', text: 'Direct message conversation' },
+  ];
+  for (const buildRecommendedActions of [buildRecommendedActionsCh, buildRecommendedActionsFx]) {
+    for (const pageInfo of pages) {
+      const actions = buildRecommendedActions(pageInfo);
+      const labels = actions.map((a) => a.label);
+      assert.ok(labels.includes('Draft a reply'), `expected reply draft for ${pageInfo.url}; got ${labels.join(', ')}`);
+      assert.ok(labels.includes('Summarize this thread'), `expected thread summary for ${pageInfo.url}; got ${labels.join(', ')}`);
+      assert.ok(labels.includes('Find follow-ups'), `expected follow-ups for ${pageInfo.url}; got ${labels.join(', ')}`);
+      assert.equal(actions.find((a) => a.id === 'draft-reply')?.mode, undefined);
+    }
+    const inboxActions = buildRecommendedActions({
+      url: 'https://mail.google.com/mail/u/0/#inbox',
+      title: 'Inbox - Gmail',
+      text: 'Primary Promotions Social Updates',
+    });
+    assert.equal(inboxActions.some((a) => a.id === 'draft-reply'), false);
+  }
+});
+
+test('focused compose boxes get rewrite suggestions', () => {
+  const composePage = {
+    url: 'https://x.com/compose/post',
+    title: 'Post / X',
+    activeElement: {
+      tag: 'div',
+      role: 'textbox',
+      editable: true,
+      ariaLabel: 'Post text',
+      textPreview: 'This update is too blunt and needs a calmer tone.',
+    },
+  };
+  const searchPage = {
+    url: 'https://x.com/search',
+    title: 'Search / X',
+    activeElement: {
+      tag: 'input',
+      type: 'search',
+      role: 'searchbox',
+      placeholder: 'Search',
+      textPreview: 'launch plan',
+    },
+  };
+  for (const buildRecommendedActions of [buildRecommendedActionsCh, buildRecommendedActionsFx]) {
+    const composeActions = buildRecommendedActions(composePage);
+    assert.ok(composeActions.some((a) => a.id === 'rewrite-focused-draft'), 'expected rewrite action for focused compose box');
+    assert.equal(composeActions.find((a) => a.id === 'rewrite-focused-draft')?.mode, undefined);
+    assert.equal(buildRecommendedActions(searchPage).some((a) => a.id === 'rewrite-focused-draft'), false);
+  }
+});
+
+test('X and LinkedIn profile pages get a person research suggestion', () => {
+  const pages = [
+    { url: 'https://x.com/karpathy', title: 'Andrej Karpathy (@karpathy) / X' },
+    { url: 'https://www.linkedin.com/in/ada-lovelace/', title: 'Ada Lovelace - LinkedIn' },
+  ];
+  for (const buildRecommendedActions of [buildRecommendedActionsCh, buildRecommendedActionsFx]) {
+    for (const pageInfo of pages) {
+      const actions = buildRecommendedActions(pageInfo);
+      const research = actions.find((a) => a.id === 'research-person');
+      assert.equal(research?.label, 'Research this person', `expected person research for ${pageInfo.url}`);
+      assert.equal(research?.mode, undefined);
+    }
+    assert.equal(buildRecommendedActions({ url: 'https://x.com/messages/123', title: 'Messages' }).some((a) => a.id === 'research-person'), false);
+  }
+});
+
+test('WordPress admin pages get drafting and template suggestions', () => {
+  const dashboard = { url: 'https://example.com/wp-admin/index.php', title: 'Dashboard - WordPress', text: 'Posts Appearance Themes Settings' };
+  const siteEditor = { url: 'https://example.com/wp-admin/site-editor.php', title: 'Editor - WordPress', text: 'Templates' };
+  for (const buildRecommendedActions of [buildRecommendedActionsCh, buildRecommendedActionsFx]) {
+    const dashboardActions = buildRecommendedActions(dashboard);
+    const draft = dashboardActions.find((a) => a.id === 'draft-wp-post');
+    assert.equal(draft?.label, 'Draft a post');
+    assert.equal(draft?.mode, 'act');
+    assert.equal(dashboardActions.some((a) => a.id === 'change-wp-template'), false);
+
+    const editorActions = buildRecommendedActions(siteEditor);
+    const template = editorActions.find((a) => a.id === 'change-wp-template');
+    assert.equal(template?.label, 'Change template');
+    assert.equal(template?.mode, 'act');
+  }
 });
 
 test('firefox recommended actions match chrome', () => {


### PR DESCRIPTION
## Summary
- Add focused-compose recommended actions for rewriting drafts in softer, shorter, and more formal versions.
- Add profile research suggestions on X/Twitter and LinkedIn profiles, plus WordPress admin suggestions for drafting posts and changing templates.
- Harden Chrome tab recording recovery so stale background/offscreen recorder state does not block a later recording.

## Root Cause
The recorder could leave either `recordingState.active` in session storage or an inactive offscreen recorder session behind after a stop/finalize edge case. A later `record_tab` call then saw the stale state and reported that recording was still in progress. Follow-up review also caught state-refresh and concurrent finalization races, now covered by reconciling inactive sessions on refresh and treating offscreen `stopping` as in-progress.

## Validation
- `node --check` on touched Chrome recorder/content/UI modules and Firefox content/UI modules
- `npm test` -> 250 passed, 0 failed