### PR TITLE
Fix agent reporting a stopped recording as still in progress

### DIFF
--- a/src/chrome/src/agent/agent.js
+++ b/src/chrome/src/agent/agent.js
@@ -851,10 +851,21 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
     try {
       const rec = await recorderStateFresh();
       const recActive = !!(rec && rec.active);
-      const startedRecording = messages.some(
-        (m) => m.role === 'assistant' && Array.isArray(m.tool_calls) &&
-          m.tool_calls.some((tc) => tc?.function?.name === 'record_tab')
-      );
+      // Did this conversation ever start a recording? Check structured
+      // tool_calls AND text content. Once context compaction runs, the
+      // structured record_tab turn is collapsed into a "- record_tab → ..."
+      // summary line (the tool name survives via toolNameById), so a
+      // tool_calls-only scan would miss long conversations and skip the
+      // correction exactly when stale memory is most likely to mislead.
+      const refersToRecording = (m) => {
+        if (m.role === 'assistant' && Array.isArray(m.tool_calls) &&
+            m.tool_calls.some((tc) => tc?.function?.name === 'record_tab')) return true;
+        const c = m.content;
+        if (typeof c === 'string') return c.includes('record_tab');
+        if (Array.isArray(c)) return c.some((b) => typeof b?.text === 'string' && b.text.includes('record_tab'));
+        return false;
+      };
+      const startedRecording = messages.some(refersToRecording);
       if (recActive) {
         const since = rec.startedAt ? ` (started ${new Date(rec.startedAt).toISOString()})` : '';
         contextLine += `[Recording status: a tab recording is currently ACTIVE${since}. Call stop_recording to end it; do not start another.]\n\n`;

--- a/src/chrome/src/agent/agent.js
+++ b/src/chrome/src/agent/agent.js
@@ -23,6 +23,7 @@ import { solveCaptcha, detectCaptcha, injectToken } from './captcha-solver.js';
 import {
   startTabRecording as recorderStart,
   stopTabRecording as recorderStop,
+  getRecordingStateFresh as recorderStateFresh,
 } from '../recorder/host.js';
 import { Capability, CAPABILITY_LABEL, capabilitiesFor, requiredHosts, frameHostMatches, isNetworkMutation, PermissionManager, UNTRUSTED_CONTENT_TOOLS } from './permission-gate.js';
 
@@ -838,6 +839,29 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
     let contextLine = url
       ? `[Current page context — applies to this user message and supersedes older page context for phrases like "this page". URL: ${safeField(url)}${title ? ` — Title: ${safeField(title)}` : ''}]\n\n`
       : '';
+
+    // Recording status (ground truth). The tab recorder can be stopped
+    // out-of-band — the sidebar/toolbar Stop button, the safety-cap auto-stop,
+    // or stale-state reconciliation — none of which write to this conversation.
+    // So the history can hold a "Recording started" with no matching stop and
+    // fool the model into thinking a capture is still running. Inject the live
+    // state on every turn so it supersedes the stale memory. Only emit when
+    // there's something to say: a recording is active now, or one was started
+    // earlier in this conversation (and thus may need correcting).
+    try {
+      const rec = await recorderStateFresh();
+      const recActive = !!(rec && rec.active);
+      const startedRecording = messages.some(
+        (m) => m.role === 'assistant' && Array.isArray(m.tool_calls) &&
+          m.tool_calls.some((tc) => tc?.function?.name === 'record_tab')
+      );
+      if (recActive) {
+        const since = rec.startedAt ? ` (started ${new Date(rec.startedAt).toISOString()})` : '';
+        contextLine += `[Recording status: a tab recording is currently ACTIVE${since}. Call stop_recording to end it; do not start another.]\n\n`;
+      } else if (startedRecording) {
+        contextLine += `[Recording status: no recording is currently active. Any earlier "recording started" in this conversation has since been stopped (for example via the sidebar Stop button). It is safe to start a new recording if the user asks.]\n\n`;
+      }
+    } catch (e) { /* recorder state unavailable — skip the status note */ }
 
     // API mutation override: prepend a strong note when the user has set
     // /allow-api for this tab. Inject only once per "allowed run" to avoid

--- a/src/chrome/src/recorder/host.js
+++ b/src/chrome/src/recorder/host.js
@@ -76,23 +76,57 @@ function broadcast(event, payload = {}) {
   } catch {}
 }
 
+// Probe the offscreen recorder for its live state. The return value is a
+// discriminated verdict the reconciler can act on safely:
+//   • { absent: true }  — no offscreen document exists (couldn't be created, or
+//     it's confirmed gone). Nothing can be recording, so a stale active flag is
+//     safe to clear.
+//   • null              — a document exists but didn't answer (transient
+//     failure). Ambiguous: it MIGHT be hosting a live recording, so the
+//     reconciler must NOT clear on this.
+//   • the recorder's state object on success.
 async function readOffscreenRecorderState() {
   try {
     await ensureOffscreen();
-    return await chrome.runtime.sendMessage({ type: 'recorder-state' });
   } catch {
-    return null;
+    // The offscreen document can't even be established — definitively no
+    // MediaRecorder running anywhere.
+    return { absent: true };
+  }
+  try {
+    const state = await chrome.runtime.sendMessage({ type: 'recorder-state' });
+    return state || null;
+  } catch {
+    // The document didn't answer. Tell a truly-gone document (evicted — safe to
+    // treat as no recorder) apart from a transient message failure on a live
+    // document (ambiguous — must not clear a recording out from under the user).
+    let exists = true;
+    try { exists = await chrome.offscreen.hasDocument(); } catch {}
+    return exists ? null : { absent: true };
   }
 }
 
 async function reconcileStaleRecordingState({ finalizeInactiveSession = false } = {}) {
   const offscreenState = await readOffscreenRecorderState();
-  if (!offscreenState || offscreenState.recording || offscreenState.paused || offscreenState.stopping) return false;
+  // Couldn't reach a verdict (document exists but didn't answer). Stay
+  // conservative and leave the flag as-is rather than risk tearing down a live
+  // recording on a transient message failure.
+  if (offscreenState === null) return false;
+  // A genuinely live recording — never clear it out from under the user.
+  if (offscreenState.recording || offscreenState.paused || offscreenState.stopping) return false;
+  // The offscreen recorder still holds a finished-but-unflushed session (its
+  // MediaRecorder stopped before the Stop message landed). Finalize it so the
+  // captured bytes are saved instead of dropped.
   if (offscreenState.tabId && finalizeInactiveSession) {
     await stopTabRecording();
     return recordingState.active === false;
   }
   if (offscreenState.tabId) return false;
+  // Either the offscreen recorder reports idle (no session) or it's absent
+  // entirely ({ absent: true }) — the document that would host a capture is
+  // gone. In both cases no live recording can be relying on the flag, so clear
+  // the stuck active state instead of leaving the banner/agent to believe a
+  // capture is still running.
   recordingState = { active: false };
   saveRecordingState();
   broadcast('stopped', {

--- a/test/run.js
+++ b/test/run.js
@@ -2485,6 +2485,19 @@ test('Agent enrich: corrects stale "recording started" once no recording is acti
   assert.match(enriched.content, /record again$/);
 });
 
+test('Agent enrich: correction survives context compaction (record_tab in summary, not tool_calls)', async () => {
+  const agent = new AgentCh({});
+  // After _manageContext compacts, the structured record_tab tool_calls turn is
+  // gone — collapsed into a "- record_tab → ..." line inside a summary message.
+  // A tool_calls-only scan would miss this and skip the correction.
+  const messages = [
+    { role: 'user', content: '[Context window was trimmed to stay within budget. Previous conversation summary:\n- User asked: Record this meeting\n- record_tab → Recording started at 2026-06-01T09:32:10.733Z.]' },
+    { role: 'assistant', content: 'Recording started.' },
+  ];
+  const enriched = await agent._enrichUserMessageWithCurrentPage(999, messages, 'record again');
+  assert.match(enriched.content, /Recording status: no recording is currently active/i);
+});
+
 test('Agent enrich: no recording status note when the conversation never recorded', async () => {
   const agent = new AgentCh({});
   const messages = [

--- a/test/run.js
+++ b/test/run.js
@@ -2465,6 +2465,36 @@ test('record_tab (tab + microphone capture) is gated in Chrome and absent in Fir
   assert.equal(capabilityFor('record_tab', {}), null);
 });
 
+// The tab recorder can be stopped out-of-band (sidebar/toolbar Stop button,
+// safety-cap auto-stop) — none of which write to the conversation. Without a
+// ground-truth status note, history keeps a lone "Recording started" and the
+// model wrongly reports a recording is still in progress. _enrichUserMessage
+// injects the live status so the fresh state supersedes the stale memory.
+test('Agent enrich: corrects stale "recording started" once no recording is active', async () => {
+  const agent = new AgentCh({});
+  const messages = [
+    { role: 'user', content: 'Record this meeting and transcribe it when the recording stops.' },
+    { role: 'assistant', tool_calls: [{ id: 't1', function: { name: 'record_tab' } }] },
+    { role: 'tool', tool_call_id: 't1', content: 'Recording started at 2026-06-01T09:32:10.733Z.' },
+  ];
+  // Under Node the recorder reports inactive (no offscreen session), which is
+  // exactly the post-Stop state the model gets confused by.
+  const enriched = await agent._enrichUserMessageWithCurrentPage(999, messages, 'record again');
+  assert.equal(enriched.role, 'user');
+  assert.match(enriched.content, /Recording status: no recording is currently active/i);
+  assert.match(enriched.content, /record again$/);
+});
+
+test('Agent enrich: no recording status note when the conversation never recorded', async () => {
+  const agent = new AgentCh({});
+  const messages = [
+    { role: 'user', content: 'hello' },
+    { role: 'assistant', content: 'hi' },
+  ];
+  const enriched = await agent._enrichUserMessageWithCurrentPage(999, messages, 'summarize this page');
+  assert.doesNotMatch(enriched.content, /Recording status/i);
+});
+
 test('resize_window is gated as a browser-window action', () => {
   assert.equal(capabilityFor('resize_window', { width: 1280, height: 720 }), Capability.WINDOW);
   assert.equal(capabilityForCh('resize_window', { width: 1280, height: 720 }), CapabilityCh.WINDOW);


### PR DESCRIPTION
## Problem

When a tab recording is stopped **out-of-band** — the sidebar/toolbar Stop button, the safety-cap auto-stop, or stale-state reconciliation — nothing writes to the conversation. The history keeps a lone `record_tab → "Recording started"` tool result with no matching stop, so on the next turn the model reads its memory and wrongly reports a recording is *still in progress* (the "already recording" duplicate the user hit).

In the reported traces, the follow-up run made **zero tool calls** — it answered "Recording is already in progress" purely from the stale chat history, never consulting the recorder's actual flag. So this is fundamentally a conversation-memory bug, with a recorder-state dependency.

## Fix (two layers)

**1. Inject ground-truth recording status into each user turn.**
`_enrichUserMessageWithCurrentPage` now reads `getRecordingStateFresh()` and, alongside the existing page-context note that already supersedes stale history, emits:
- `[Recording status: a tab recording is currently ACTIVE …]` when a capture is live, or
- `[Recording status: no recording is currently active …]` when one was started earlier in the conversation but has since stopped.

Nothing is emitted for conversations that never recorded (detected by scanning history for a `record_tab` tool call — durable across service-worker restarts), so unrelated turns stay clean.

**2. Harden the recorder-state reconciler the status line trusts.**
The Option-1 note is only correct if `getRecordingStateFresh()` is truthful. `readOffscreenRecorderState()` now returns a *discriminated* verdict so the reconciler can tell:
- `{ absent: true }` — offscreen document can't be established or is confirmed gone (`chrome.offscreen.hasDocument()` → false) → **safe to clear** the stuck `active` flag;
- `null` — document exists but didn't answer (transient) → **ambiguous, leave alone** (unchanged conservative behavior, so a hiccup can't tear down a live recording and orphan its bytes).

A definitively-absent document now self-heals the stale flag instead of leaving it, closing the last path that could feed the status line a false "ACTIVE." This extends the reconcile logic added in #117.

## Scope / notes
- **Chrome-only** — Firefox has no recorder (`src/firefox` has no `recorder/host.js`, and `record_tab` is gated-absent there).
- No conflict with #117 (merged); this builds on its `reconcileStaleRecordingState`.
- Adds regression tests for the stale-memory correction and the no-op case. Full suite: 253/253 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)