### PR TITLE
Remove obsolete Claude Pro/Max README warning

### DIFF
--- a/README.fr.md
+++ b/README.fr.md
@@ -225,7 +225,6 @@ La règle UI-d'abord par défaut existe parce que les actions API sont invisible
   - Les adaptateurs de sites, la détection par vision, la détection de boucle, la boucle de capture d'écran automatique et l'ensemble prompt/outils compact opt-in *sont* reflétés sur Firefox.
 - **Détection de navigation SPA dans Firefox.** Certaines applications monopages peuvent ne pas déclencher la réinjection du content-script après une navigation côté client.
 - **Module complémentaire temporaire Firefox** — Firefox exige que l'extension soit chargée en tant que module complémentaire temporaire pendant le développement, ce qui est supprimé au redémarrage.
-- **Le fournisseur Claude (abonnement Pro/Max) est en zone grise.** La connexion utilise le même flux OAuth que Claude Code (le CLI propre à Anthropic), y compris son client_id public. Les conditions d'Anthropic restreignent l'utilisation d'un abonnement Pro/Max avec des outils non-Anthropic, et Anthropic peut révoquer le client OAuth de son CLI à tout moment — auquel cas ce fournisseur cesse de fonctionner. Le prompt système est aussi automatiquement préfixé par `"You are Claude Code, Anthropic's official CLI for Claude."` car la passerelle OAuth d'Anthropic signale les requêtes qui l'omettent. Pour une utilisation en production, préférez le fournisseur Anthropic avec clé API.
 
 ## Nouveautés
 

--- a/README.md
+++ b/README.md
@@ -225,7 +225,6 @@ The default UI-first rule exists because API actions are invisible (you don't se
   - Site adapters, vision detection, loop detection, the auto-screenshot loop, and the opt-in compact prompt/tool set *are* mirrored to Firefox.
 - **SPA navigation detection in Firefox.** Some single-page applications may not trigger content-script re-injection after client-side navigation.
 - **Firefox temporary add-on** — Firefox requires the extension to be loaded as a temporary add-on during development, which is removed on restart.
-- **Claude (Pro/Max subscription) provider is grey-area.** Sign-in uses the same OAuth flow Claude Code (Anthropic's own CLI) ships, including its public client_id. Anthropic's terms restrict using a Pro/Max subscription with non-Anthropic tools, and Anthropic can revoke their CLI's OAuth client at any time — at which point this provider stops working. The system prompt is also auto-prefixed with `"You are Claude Code, Anthropic's official CLI for Claude."` because Anthropic's OAuth gate flags requests that omit it. For production use prefer the API-key Anthropic provider.
 
 ## What's New
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -225,7 +225,6 @@ WebBrain 接受作为输入框某行开头的斜杠命令。在面板内输入 `
   - 站点适配器、视觉检测、循环检测、自动截图循环以及可选的压缩提示/工具集 *确实* 已镜像到 Firefox。
 - **Firefox 中的 SPA 导航检测。** 某些单页应用在客户端导航后可能不会触发内容脚本重新注入。
 - **Firefox 临时附加组件** — Firefox 在开发期间要求扩展作为临时附加组件加载，重启后会被移除。
-- **Claude（Pro/Max 订阅）提供商属灰色地带。** 登录使用与 Claude Code（Anthropic 自家 CLI）相同的 OAuth 流程，包括其公开的 client_id。Anthropic 的条款限制将 Pro/Max 订阅用于非 Anthropic 工具，且 Anthropic 可随时撤销其 CLI 的 OAuth 客户端——届时此提供商将停止工作。系统提示也会自动前缀 `"You are Claude Code, Anthropic's official CLI for Claude."`，因为 Anthropic 的 OAuth 网关会标记省略它的请求。生产使用请优先选择使用 API 密钥的 Anthropic 提供商。
 
 ## 更新内容
 


### PR DESCRIPTION
### Motivation
- Remove an outdated warning about the Claude (Pro/Max) OAuth provider since that option is no longer available.

### Description
- Delete the Claude Pro/Max grey-area/OAuth warning paragraph from `README.md`, `README.fr.md`, and `README.zh-CN.md`.

### Testing
- Verified the paragraph was removed by running `rg -n "Claude \(Pro/Max subscription\) provider is grey-area|Le fournisseur Claude \(abonnement Pro/Max\) est en zone grise|Claude（Pro/Max 订阅）提供商属灰色地带|OAuth gate|public client_id" README.md README.fr.md README.zh-CN.md` which returned no matches and confirmed the three README files are modified in the working tree with `git status --short`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a21cd2e914483279fd6ed87c2843a96)