### PR TITLE
[codex] Add YouTube transcript guidance

### DIFF
--- a/src/chrome/src/agent/adapters.js
+++ b/src/chrome/src/agent/adapters.js
@@ -185,11 +185,14 @@ const ADAPTERS = [
   {
     name: 'youtube',
     category: 'general',
-    match: (url) => /^https?:\/\/(www\.)?youtube\.com\//.test(url),
+    match: (url) => /^https?:\/\/((www|m)\.)?youtube\.com\//.test(url) || /^https?:\/\/youtu\.be\//.test(url),
     notes: `
 - The video player is a custom element. Keyboard shortcuts: space=play/pause, k=play/pause, j/l=±10s, ←/→=±5s, m=mute.
+- For questions about the current video's content, read the transcript first when available and ground the answer in it; if no transcript is exposed, say so and fall back to visible title/description/comments.
+- Tool path for transcript: get_accessibility_tree({filter:"visible"}) → expand description ("..." / "more") with click_ax/click → click "Show transcript" → read the transcript panel with get_accessibility_tree or read_page; scroll the panel/page for more segments.
+- Do NOT invent transcript URLs. Only use fetch_url for captions if the page exposes a real YouTube captionTracks/baseUrl; otherwise use the visible transcript UI.
+- Transcript text is timestamped/segmented and may be auto-generated or auto-translated; collect enough segments before summarizing or answering, and do not infer from the title alone when transcript is reachable.
 - Comments load lazily AFTER you scroll past the video — they're not in the initial DOM.
-- "Show transcript" lives in the description "..." menu, not a top-level button.
 - The subscribe button has a bell icon next to it for notification preferences; they're separate clicks.`,
   },
   {

--- a/src/firefox/src/agent/adapters.js
+++ b/src/firefox/src/agent/adapters.js
@@ -185,11 +185,14 @@ const ADAPTERS = [
   {
     name: 'youtube',
     category: 'general',
-    match: (url) => /^https?:\/\/(www\.)?youtube\.com\//.test(url),
+    match: (url) => /^https?:\/\/((www|m)\.)?youtube\.com\//.test(url) || /^https?:\/\/youtu\.be\//.test(url),
     notes: `
 - The video player is a custom element. Keyboard shortcuts: space=play/pause, k=play/pause, j/l=±10s, ←/→=±5s, m=mute.
+- For questions about the current video's content, read the transcript first when available and ground the answer in it; if no transcript is exposed, say so and fall back to visible title/description/comments.
+- Tool path for transcript: get_accessibility_tree({filter:"visible"}) → expand description ("..." / "more") with click_ax/click → click "Show transcript" → read the transcript panel with get_accessibility_tree or read_page; scroll the panel/page for more segments.
+- Do NOT invent transcript URLs. Only use fetch_url for captions if the page exposes a real YouTube captionTracks/baseUrl; otherwise use the visible transcript UI.
+- Transcript text is timestamped/segmented and may be auto-generated or auto-translated; collect enough segments before summarizing or answering, and do not infer from the title alone when transcript is reachable.
 - Comments load lazily AFTER you scroll past the video — they're not in the initial DOM.
-- "Show transcript" lives in the description "..." menu, not a top-level button.
 - The subscribe button has a bell icon next to it for notification preferences; they're separate clicks.`,
   },
   {

--- a/test/run.js
+++ b/test/run.js
@@ -298,6 +298,17 @@ test('matches twitter.com and x.com', () => {
   assert.equal(getActiveAdapter('https://x.com/elonmusk')?.name, 'twitter');
 });
 
+test('matches youtube video URLs and includes transcript guidance', () => {
+  const a = getActiveAdapter('https://www.youtube.com/watch?v=dQw4w9WgXcQ');
+  assert.equal(a?.name, 'youtube');
+  assert.equal(getActiveAdapter('https://m.youtube.com/watch?v=dQw4w9WgXcQ')?.name, 'youtube');
+  assert.equal(getActiveAdapter('https://youtu.be/dQw4w9WgXcQ')?.name, 'youtube');
+  assert.match(a?.notes || '', /transcript/i);
+  assert.match(a?.notes || '', /ground the answer/i);
+  assert.match(a?.notes || '', /get_accessibility_tree/i);
+  assert.match(a?.notes || '', /Do NOT invent transcript URLs/i);
+});
+
 test('matches apple store pages', () => {
   assert.equal(getActiveAdapter('https://www.apple.com/shop/buy-mac/macbook-air')?.name, 'apple');
   assert.equal(getActiveAdapter('https://www.apple.com/uk/shop/refurbished')?.name, 'apple');


### PR DESCRIPTION
## Summary
- Update the YouTube site adapter to prioritize reading video transcripts for content questions.
- Add a concrete tool path using `get_accessibility_tree`, `click_ax`/`click`, `read_page`, and scrolling to find and read transcript segments.
- Extend YouTube matching to `m.youtube.com` and `youtu.be` URLs.
- Add regression coverage for YouTube matching and transcript guidance.

## Why
When the agent answers questions about a YouTube video, the transcript is a stronger source than the title, description, or comments. The adapter now teaches the agent to use the visible transcript UI when available and to avoid inventing unsupported transcript URLs.

## Validation
- `npm test`