### PR TITLE
[codex] Retry blank screenshot captures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ This changelog was generated from the repository Git history and release tags. V
 
 ## [Unreleased]
 
+## [13.0.1] - 2026-06-12
+
+### Fixed
+- Screenshot capture now mechanically detects near-blank frames and retries after 500ms, 1000ms, and 1500ms before handing the image to a vision model (Chrome + Firefox). This helps recover from compositor / lazy-load races on media-heavy pages such as Instagram, where the DOM already contains content but the first viewport capture can be all white or all black.
+
+### Changed
+- Screenshot probes now include image counts, and screenshot results/traces include `blankFrameRetry` metadata when a blank-frame retry path ran.
+
+### Tests
+- Added Chrome + Firefox unit coverage for blank-frame retry gating, successful recovery, and the no-content/no-retry case.
+
 ## [13.0.0] - 2026-06-10
 
 ### Added

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "WebBrain",
-  "version": "13.0.0",
+  "version": "13.0.1",
   "description": "Open-source AI browser agent — chat with pages, automate tasks, multi-provider LLM support.",
   "permissions": [
     "sidePanel",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "webbrain",
-  "version": "13.0.0",
+  "version": "13.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "webbrain",
-      "version": "13.0.0",
+      "version": "13.0.1",
       "license": "MIT",
       "devDependencies": {
         "playwright": "^1.48.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webbrain",
-  "version": "13.0.0",
+  "version": "13.0.1",
   "description": "Open-source AI browser agent — chat with pages, automate tasks, multi-provider LLM support.",
   "private": true,
   "type": "module",

--- a/src/chrome/ARCHITECTURE.md
+++ b/src/chrome/ARCHITECTURE.md
@@ -1,6 +1,6 @@
 # WebBrain Chrome Extension — Architecture
 
-> Version 13.0.0 · Manifest V3 · Service Worker background
+> Version 13.0.1 · Manifest V3 · Service Worker background
 
 ## High-Level Overview
 

--- a/src/chrome/manifest.json
+++ b/src/chrome/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "WebBrain",
-  "version": "13.0.0",
+  "version": "13.0.1",
   "description": "Open-source AI browser agent — chat with pages, automate tasks, multi-provider LLM support.",
   "permissions": [
     "sidePanel",

--- a/src/chrome/src/agent/agent.js
+++ b/src/chrome/src/agent/agent.js
@@ -1378,7 +1378,15 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
 
           if (pushed) {
             onUpdate('tool_call', { name: 'auto_screenshot', args: {} });
-            onUpdate('tool_result', { name: 'auto_screenshot', result: { success: true, bytes: shot.dataUrl.length, elements: visible.length } });
+            onUpdate('tool_result', {
+              name: 'auto_screenshot',
+              result: {
+                success: true,
+                bytes: shot.dataUrl.length,
+                elements: visible.length,
+                blankFrameRetry: shot.blankFrameRetry || undefined,
+              },
+            });
             const _runIdForShot = this.currentRunId.get(tabId);
             if (_runIdForShot) {
               trace.recordScreenshot(_runIdForShot, null, shot.dataUrl, 'auto-screenshot after tool batch');
@@ -1681,6 +1689,167 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
     }
   }
 
+  static BLANK_SCREENSHOT_RETRY_DELAYS_MS = [500, 1000, 1500];
+
+  static _summarizeBlankness(info) {
+    if (!info) return null;
+    return {
+      blank: !!info.blank,
+      reason: info.reason || '',
+      meanLuma: Math.round(info.meanLuma * 10) / 10,
+      lumaStdDev: Math.round(info.lumaStdDev * 10) / 10,
+      whiteRatio: Math.round(info.whiteRatio * 10000) / 10000,
+      blackRatio: Math.round(info.blackRatio * 10000) / 10000,
+    };
+  }
+
+  /**
+   * Detect compositor/lazy-load races where CDP returns an all-white/all-black
+   * frame even though the DOM has content. Sampling a 96px thumbnail keeps this
+   * cheap enough to run on every screenshot path.
+   */
+  async _analyzeScreenshotBlankness(dataUrl) {
+    try {
+      if (!dataUrl) return null;
+      const resp = await fetch(dataUrl);
+      const blob = await resp.blob();
+      const bmp = await createImageBitmap(blob);
+      const sampleW = Math.min(96, bmp.width);
+      const sampleH = Math.min(96, bmp.height);
+      if (!sampleW || !sampleH) return null;
+
+      const canvas = new OffscreenCanvas(sampleW, sampleH);
+      const ctx = canvas.getContext('2d', { willReadFrequently: true });
+      if (!ctx) return null;
+      ctx.imageSmoothingEnabled = true;
+      ctx.imageSmoothingQuality = 'high';
+      ctx.drawImage(bmp, 0, 0, bmp.width, bmp.height, 0, 0, sampleW, sampleH);
+      const pixels = ctx.getImageData(0, 0, sampleW, sampleH).data;
+      const count = sampleW * sampleH;
+      let sum = 0;
+      let sumSq = 0;
+      let sumR = 0;
+      let sumG = 0;
+      let sumB = 0;
+      let sumRSq = 0;
+      let sumGSq = 0;
+      let sumBSq = 0;
+      let white = 0;
+      let black = 0;
+
+      for (let i = 0; i < pixels.length; i += 4) {
+        const r = pixels[i];
+        const g = pixels[i + 1];
+        const b = pixels[i + 2];
+        const luma = 0.2126 * r + 0.7152 * g + 0.0722 * b;
+        sum += luma;
+        sumSq += luma * luma;
+        sumR += r;
+        sumG += g;
+        sumB += b;
+        sumRSq += r * r;
+        sumGSq += g * g;
+        sumBSq += b * b;
+        if (r >= 248 && g >= 248 && b >= 248) white++;
+        if (r <= 7 && g <= 7 && b <= 7) black++;
+      }
+
+      const meanLuma = sum / count;
+      const lumaVariance = Math.max(0, (sumSq / count) - (meanLuma * meanLuma));
+      const lumaStdDev = Math.sqrt(lumaVariance);
+      const rMean = sumR / count;
+      const gMean = sumG / count;
+      const bMean = sumB / count;
+      const rStdDev = Math.sqrt(Math.max(0, (sumRSq / count) - (rMean * rMean)));
+      const gStdDev = Math.sqrt(Math.max(0, (sumGSq / count) - (gMean * gMean)));
+      const bStdDev = Math.sqrt(Math.max(0, (sumBSq / count) - (bMean * bMean)));
+      const maxChannelStdDev = Math.max(rStdDev, gStdDev, bStdDev);
+      const whiteRatio = white / count;
+      const blackRatio = black / count;
+
+      let blank = false;
+      let reason = '';
+      if (whiteRatio >= 0.995 && lumaStdDev < 4) {
+        blank = true;
+        reason = 'near-all-white frame';
+      } else if (blackRatio >= 0.995 && lumaStdDev < 4) {
+        blank = true;
+        reason = 'near-all-black frame';
+      } else if (lumaStdDev < 1.5 && maxChannelStdDev < 1.5) {
+        blank = true;
+        reason = 'near-uniform frame';
+      }
+
+      return {
+        blank,
+        reason,
+        meanLuma,
+        lumaStdDev,
+        maxChannelStdDev,
+        whiteRatio,
+        blackRatio,
+        width: bmp.width,
+        height: bmp.height,
+      };
+    } catch {
+      return null;
+    }
+  }
+
+  _pageSignalsContentBehindBlank(probe) {
+    if (!probe) return true;
+    const textChars = Number(probe.documentTextChars || 0);
+    const visibleTextChars = Number(probe.visibleTextChars || 0);
+    const domNodes = Number(probe.domNodes || 0);
+    const imageCount = Number(probe.imageCount || 0);
+    const scrollHeight = Number(probe.scrollHeight || 0);
+    const innerHeight = Number(probe.innerHeight || 0);
+    return (
+      probe.readyState !== 'complete' ||
+      textChars > 20 ||
+      visibleTextChars > 20 ||
+      imageCount > 0 ||
+      domNodes > 150 ||
+      (innerHeight > 0 && scrollHeight > innerHeight + 200)
+    );
+  }
+
+  async _retryBlankScreenshotCapture(firstShot, captureOnce, { probe = null } = {}) {
+    if (!firstShot?.dataUrl || typeof captureOnce !== 'function') return firstShot;
+    let shot = firstShot;
+    let blankness = await this._analyzeScreenshotBlankness(shot.dataUrl);
+    if (!blankness?.blank || !this._pageSignalsContentBehindBlank(probe)) return shot;
+
+    const meta = {
+      detected: true,
+      retries: 0,
+      delaysMs: [],
+      recovered: false,
+      finalBlank: true,
+      firstBlankness: Agent._summarizeBlankness(blankness),
+      finalBlankness: Agent._summarizeBlankness(blankness),
+    };
+
+    for (const delayMs of Agent.BLANK_SCREENSHOT_RETRY_DELAYS_MS) {
+      await new Promise((r) => setTimeout(r, delayMs));
+      const next = await captureOnce();
+      if (!next?.dataUrl) continue;
+
+      shot = next;
+      meta.retries++;
+      meta.delaysMs.push(delayMs);
+      blankness = await this._analyzeScreenshotBlankness(shot.dataUrl);
+      meta.finalBlank = !!blankness?.blank;
+      meta.finalBlankness = Agent._summarizeBlankness(blankness);
+      if (!blankness?.blank) {
+        meta.recovered = true;
+        break;
+      }
+    }
+
+    return { ...shot, blankFrameRetry: meta };
+  }
+
   async _captureAutoScreenshot(tabId, { coordAligned = false } = {}) {
     try {
       await cdpClient.attach(tabId);
@@ -1690,9 +1859,9 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
       // Probe the CSS viewport first so we can either (a) clip exactly
       // to it for pixel-accurate captures, or (b) compute a budget-aware
       // CDP-side scale that downsizes during capture rather than after.
-      const vp = await cdpClient.evaluate(tabId, '({w: window.innerWidth, h: window.innerHeight})');
-      const cssW = Math.max(1, Math.round(vp?.result?.value?.w || 1024));
-      const cssH = Math.max(1, Math.round(vp?.result?.value?.h || 768));
+      const probe = await this._captureViewportProbe(tabId);
+      const cssW = Math.max(1, Math.round(probe?.innerWidth || 1024));
+      const cssH = Math.max(1, Math.round(probe?.innerHeight || 768));
 
       if (coordAligned) {
         // Pixel-accuracy mode: image pixels must equal CSS pixels so the
@@ -1701,17 +1870,21 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
         // We DO still run the byte-ceiling fallback afterwards: if the
         // CSS viewport happens to be huge, we'd rather lose some JPEG
         // quality than overflow the provider's image cap.
-        const shot = await this._withIndicatorsHidden(tabId, () =>
-          cdpClient.sendCommand(tabId, 'Page.captureScreenshot', {
-            format: 'jpeg',
-            quality: 60,
-            clip: { x: 0, y: 0, width: cssW, height: cssH, scale: 1 },
-          })
-        );
-        if (!shot?.data) return null;
-        const rawDataUrl = `data:image/jpeg;base64,${shot.data}`;
-        const shrunk = await this._compressJpegToByteCeiling(rawDataUrl);
-        return { dataUrl: shrunk, width: cssW, height: cssH, coordAligned: true };
+        const captureOnce = async () => {
+          const shot = await this._withIndicatorsHidden(tabId, () =>
+            cdpClient.sendCommand(tabId, 'Page.captureScreenshot', {
+              format: 'jpeg',
+              quality: 60,
+              clip: { x: 0, y: 0, width: cssW, height: cssH, scale: 1 },
+            })
+          );
+          if (!shot?.data) return null;
+          const rawDataUrl = `data:image/jpeg;base64,${shot.data}`;
+          const shrunk = await this._compressJpegToByteCeiling(rawDataUrl);
+          return { dataUrl: shrunk, width: cssW, height: cssH, coordAligned: true };
+        };
+        const first = await captureOnce();
+        return await this._retryBlankScreenshotCapture(first, captureOnce, { probe });
       }
 
       // Non-coord-aligned mode: pre-compute target dims via the budget
@@ -1720,27 +1893,31 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
       // then have to decode and resize in the service worker.
       const [targetW, targetH] = Agent._fitImageDimensions(cssW, cssH);
       const scale = targetW < cssW ? targetW / cssW : 1;
-      const shot = await this._withIndicatorsHidden(tabId, () =>
-        cdpClient.sendCommand(tabId, 'Page.captureScreenshot', {
-          format: 'jpeg',
-          quality: Math.round(Agent.IMAGE_BUDGET.initialJpegQuality * 100),
-          fromSurface: true,
-          clip: { x: 0, y: 0, width: cssW, height: cssH, scale },
-        })
-      );
-      if (!shot?.data) return null;
-      const rawDataUrl = `data:image/jpeg;base64,${shot.data}`;
+      const captureOnce = async () => {
+        const shot = await this._withIndicatorsHidden(tabId, () =>
+          cdpClient.sendCommand(tabId, 'Page.captureScreenshot', {
+            format: 'jpeg',
+            quality: Math.round(Agent.IMAGE_BUDGET.initialJpegQuality * 100),
+            fromSurface: true,
+            clip: { x: 0, y: 0, width: cssW, height: cssH, scale },
+          })
+        );
+        if (!shot?.data) return null;
+        const rawDataUrl = `data:image/jpeg;base64,${shot.data}`;
 
-      // CDP-side resize + JPEG q=75 usually fits. Iterative quality
-      // downgrade is the safety net for high-DPR screens where the
-      // captured image can still exceed the base64 ceiling.
-      const shrunk = await this._compressJpegToByteCeiling(rawDataUrl);
-      return {
-        dataUrl: shrunk,
-        width: targetW,
-        height: targetH,
-        coordAligned: false,
+        // CDP-side resize + JPEG q=75 usually fits. Iterative quality
+        // downgrade is the safety net for high-DPR screens where the
+        // captured image can still exceed the base64 ceiling.
+        const shrunk = await this._compressJpegToByteCeiling(rawDataUrl);
+        return {
+          dataUrl: shrunk,
+          width: targetW,
+          height: targetH,
+          coordAligned: false,
+        };
       };
+      const first = await captureOnce();
+      return await this._retryBlankScreenshotCapture(first, captureOnce, { probe });
     } catch (e) {
       return null;
     }
@@ -2114,6 +2291,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
             readyState: document.readyState,
             visibility: document.visibilityState,
             domNodes: document.getElementsByTagName('*').length,
+            imageCount: document.images ? document.images.length : 0,
             iframes: document.getElementsByTagName('iframe').length,
             scrollX: Math.round(window.scrollX || 0),
             scrollY: Math.round(window.scrollY || 0),
@@ -3739,6 +3917,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
         let description = '';
         let probe = null;
         let coordAligned = false;
+        let blankFrameRetry = null;
         try {
           await cdpClient.attach(tabId);
           await cdpClient.sendCommand(tabId, 'Page.enable');
@@ -3748,22 +3927,26 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
           const cssW = Math.max(1, Math.round(probe?.innerWidth || 1024));
           const cssH = Math.max(1, Math.round(probe?.innerHeight || 768));
 
-          if (coordAligned) {
-            // Pixel-accuracy mode: image pixels must equal CSS pixels so
-            // click({x,y}) off the screenshot lands on the real element.
-            // PNG (lossless, no quality knob) so no artifacts at glyph edges.
-            const screenshot = await this._withIndicatorsHidden(tabId, () =>
-              cdpClient.sendCommand(tabId, 'Page.captureScreenshot', {
-                format: 'png',
-                fromSurface: true,
-                clip: { x: 0, y: 0, width: cssW, height: cssH, scale: 1 },
-              })
-            );
-            dataUrl = `data:image/png;base64,${screenshot.data}`;
-            description = `Screenshot captured via CDP (${screenshot.data.length} bytes, CSS-pixel aligned for pixel clicks)`;
-            // Byte-ceiling fallback only — we don't resize in coord mode.
-            dataUrl = await this._compressJpegToByteCeiling(dataUrl);
-          } else {
+          const captureOnce = async () => {
+            if (coordAligned) {
+              // Pixel-accuracy mode: image pixels must equal CSS pixels so
+              // click({x,y}) off the screenshot lands on the real element.
+              // PNG (lossless, no quality knob) so no artifacts at glyph edges.
+              const screenshot = await this._withIndicatorsHidden(tabId, () =>
+                cdpClient.sendCommand(tabId, 'Page.captureScreenshot', {
+                  format: 'png',
+                  fromSurface: true,
+                  clip: { x: 0, y: 0, width: cssW, height: cssH, scale: 1 },
+                })
+              );
+              if (!screenshot?.data) return null;
+              const rawUrl = `data:image/png;base64,${screenshot.data}`;
+              return {
+                dataUrl: await this._compressJpegToByteCeiling(rawUrl),
+                description: `Screenshot captured via CDP (${screenshot.data.length} bytes, CSS-pixel aligned for pixel clicks)`,
+              };
+            }
+
             // Budget-aware mode (default): pick target dims via binary
             // search, ask CDP to capture + scale in one pass, then run
             // the iterative-quality fallback if bytes are still over.
@@ -3777,11 +3960,19 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
                 clip: { x: 0, y: 0, width: cssW, height: cssH, scale },
               })
             );
+            if (!screenshot?.data) return null;
             const rawUrl = `data:image/jpeg;base64,${screenshot.data}`;
-            dataUrl = await this._compressJpegToByteCeiling(rawUrl);
             const resized = scale < 1 ? ` (resized ${cssW}×${cssH} → ${targetW}×${targetH} for vision-token budget)` : '';
-            description = `Screenshot captured via CDP (${screenshot.data.length} bytes, JPEG)${resized}`;
-          }
+            return {
+              dataUrl: await this._compressJpegToByteCeiling(rawUrl),
+              description: `Screenshot captured via CDP (${screenshot.data.length} bytes, JPEG)${resized}`,
+            };
+          };
+          const captured = await this._retryBlankScreenshotCapture(await captureOnce(), captureOnce, { probe });
+          if (!captured?.dataUrl) throw new Error('CDP returned an empty screenshot');
+          dataUrl = captured.dataUrl;
+          description = captured.description || '';
+          blankFrameRetry = captured.blankFrameRetry || null;
         } catch {
           const tab = await chrome.tabs.get(tabId);
           if (!tab?.active) {
@@ -3792,17 +3983,33 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
           }
           // Tabs API fallback: no clip/scale available. Capture full, then
           // decode + resize + recompress via OffscreenCanvas to fit budget.
-          const rawUrl = await chrome.tabs.captureVisibleTab(tab.windowId, { format: 'png', quality: 80 });
-          if (!coordAligned) {
-            const cssW = Math.max(1, Math.round(probe?.innerWidth || 1024));
-            const cssH = Math.max(1, Math.round(probe?.innerHeight || 768));
-            const shrunk = await this._shrinkImageForBudget(rawUrl, cssW, cssH);
-            dataUrl = shrunk.dataUrl;
-            description = `Screenshot captured via tabs API (${dataUrl.length} bytes base64, resized to ${shrunk.width}×${shrunk.height})`;
-          } else {
-            dataUrl = await this._compressJpegToByteCeiling(rawUrl);
-            description = `Screenshot captured via tabs API (${dataUrl.length} bytes base64)`;
-          }
+          const captureOnce = async () => {
+            const rawUrl = await chrome.tabs.captureVisibleTab(tab.windowId, { format: 'png', quality: 80 });
+            if (!coordAligned) {
+              const cssW = Math.max(1, Math.round(probe?.innerWidth || 1024));
+              const cssH = Math.max(1, Math.round(probe?.innerHeight || 768));
+              const shrunk = await this._shrinkImageForBudget(rawUrl, cssW, cssH);
+              return {
+                dataUrl: shrunk.dataUrl,
+                description: `Screenshot captured via tabs API (${shrunk.dataUrl.length} bytes base64, resized to ${shrunk.width}×${shrunk.height})`,
+              };
+            }
+            const compressed = await this._compressJpegToByteCeiling(rawUrl);
+            return {
+              dataUrl: compressed,
+              description: `Screenshot captured via tabs API (${compressed.length} bytes base64)`,
+            };
+          };
+          const captured = await this._retryBlankScreenshotCapture(await captureOnce(), captureOnce, { probe });
+          dataUrl = captured?.dataUrl || null;
+          description = captured?.description || '';
+          blankFrameRetry = captured?.blankFrameRetry || null;
+        }
+        if (!dataUrl) {
+          return {
+            success: false,
+            error: 'Screenshot failed: no image data was captured.',
+          };
         }
 
         // If the user asked to save this screenshot to Downloads, do it
@@ -3850,6 +4057,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
               description: `[Screenshot described by vision model ${desc.model}]\n${desc.text}`,
               page: probe || undefined,
               coordAligned,
+              blankFrameRetry: blankFrameRetry || undefined,
               savedFile: savedFile || undefined,
             };
           }
@@ -3868,6 +4076,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
             description,
             page: probe || undefined,
             coordAligned,
+            blankFrameRetry: blankFrameRetry || undefined,
             savedFile: savedFile || undefined,
             _attachImage: dataUrl,
           };
@@ -3882,6 +4091,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
             savedFile,
             page: probe || undefined,
             coordAligned,
+            blankFrameRetry: blankFrameRetry || undefined,
           };
         }
 

--- a/src/chrome/src/ui/settings.js
+++ b/src/chrome/src/ui/settings.js
@@ -8,7 +8,7 @@ import { CAPABILITY_LABEL } from '../agent/permission-gate.js';
 
 // Version shown in the subtitle. Kept here so it only needs one update per
 // release; the subtitle string itself is translated.
-const EXT_VERSION = '13.0.0';
+const EXT_VERSION = '13.0.1';
 
 const providersContainer = document.getElementById('providers');
 const verboseToggle = document.getElementById('toggle-verbose');

--- a/src/firefox/ARCHITECTURE.md
+++ b/src/firefox/ARCHITECTURE.md
@@ -1,6 +1,6 @@
 # WebBrain Firefox Extension — Architecture
 
-> Version 13.0.0 · Manifest V2 · Background Page
+> Version 13.0.1 · Manifest V2 · Background Page
 
 ## How Firefox Differs from Chrome
 

--- a/src/firefox/manifest.json
+++ b/src/firefox/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "WebBrain",
-  "version": "13.0.0",
+  "version": "13.0.1",
   "description": "Open-source AI browser agent — chat with pages, automate tasks, multi-provider LLM support.",
   "permissions": [
     "activeTab",

--- a/src/firefox/src/agent/agent.js
+++ b/src/firefox/src/agent/agent.js
@@ -949,7 +949,15 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
 
           if (pushed) {
             onUpdate('tool_call', { name: 'auto_screenshot', args: {} });
-            onUpdate('tool_result', { name: 'auto_screenshot', result: { success: true, bytes: shot.dataUrl.length, elements: visible.length } });
+            onUpdate('tool_result', {
+              name: 'auto_screenshot',
+              result: {
+                success: true,
+                bytes: shot.dataUrl.length,
+                elements: visible.length,
+                blankFrameRetry: shot.blankFrameRetry || undefined,
+              },
+            });
             try {
               const runIdForShot = this.currentRunId.get(tabId);
               if (runIdForShot) {
@@ -1246,6 +1254,214 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
     }
   }
 
+  async _captureViewportProbe(tabId) {
+    try {
+      const probeCode = `
+        (() => {
+          let documentTextChars = 0;
+          let visibleTextChars = 0;
+          try { documentTextChars = (document.body && document.body.innerText || '').length; } catch (e) {}
+          try {
+            const sels = 'p, h1, h2, h3, h4, h5, h6, li, td, blockquote, article, section, [role="article"]';
+            const els = document.querySelectorAll(sels);
+            const vw = window.innerWidth, vh = window.innerHeight;
+            for (let i = 0; i < els.length; i++) {
+              const r = els[i].getBoundingClientRect();
+              if (r.bottom < 0 || r.top > vh) continue;
+              if (r.right < 0 || r.left > vw) continue;
+              if (r.width === 0 || r.height === 0) continue;
+              visibleTextChars += (els[i].innerText || '').length;
+              if (visibleTextChars > 20000) break;
+            }
+          } catch (e) {}
+          return {
+            url: location.href,
+            title: document.title || '',
+            readyState: document.readyState,
+            visibility: document.visibilityState,
+            domNodes: document.getElementsByTagName('*').length,
+            imageCount: document.images ? document.images.length : 0,
+            iframes: document.getElementsByTagName('iframe').length,
+            scrollX: Math.round(window.scrollX || 0),
+            scrollY: Math.round(window.scrollY || 0),
+            innerWidth: window.innerWidth,
+            innerHeight: window.innerHeight,
+            scrollHeight: Math.round((document.documentElement && document.documentElement.scrollHeight) || document.body.scrollHeight || 0),
+            documentTextChars,
+            visibleTextChars,
+          };
+        })()
+      `;
+      const results = await browser.tabs.executeScript(tabId, { code: probeCode });
+      return (results && results[0]) || null;
+    } catch {
+      return null;
+    }
+  }
+
+  static BLANK_SCREENSHOT_RETRY_DELAYS_MS = [500, 1000, 1500];
+
+  static _summarizeBlankness(info) {
+    if (!info) return null;
+    return {
+      blank: !!info.blank,
+      reason: info.reason || '',
+      meanLuma: Math.round(info.meanLuma * 10) / 10,
+      lumaStdDev: Math.round(info.lumaStdDev * 10) / 10,
+      whiteRatio: Math.round(info.whiteRatio * 10000) / 10000,
+      blackRatio: Math.round(info.blackRatio * 10000) / 10000,
+    };
+  }
+
+  /**
+   * Detect compositor/lazy-load races where the browser returns an all-white or
+   * all-black frame even though the DOM has content. Sampling a 96px thumbnail
+   * keeps this cheap enough to run on every screenshot path.
+   */
+  async _analyzeScreenshotBlankness(dataUrl) {
+    try {
+      if (!dataUrl) return null;
+      const img = await this._loadImageFromDataUrl(dataUrl);
+      const width = img.naturalWidth || img.width;
+      const height = img.naturalHeight || img.height;
+      const sampleW = Math.min(96, width);
+      const sampleH = Math.min(96, height);
+      if (!sampleW || !sampleH) return null;
+
+      const canvas = document.createElement('canvas');
+      canvas.width = sampleW;
+      canvas.height = sampleH;
+      const ctx = canvas.getContext('2d', { willReadFrequently: true });
+      if (!ctx) return null;
+      ctx.imageSmoothingEnabled = true;
+      ctx.imageSmoothingQuality = 'high';
+      ctx.drawImage(img, 0, 0, width, height, 0, 0, sampleW, sampleH);
+      const pixels = ctx.getImageData(0, 0, sampleW, sampleH).data;
+      const count = sampleW * sampleH;
+      let sum = 0;
+      let sumSq = 0;
+      let sumR = 0;
+      let sumG = 0;
+      let sumB = 0;
+      let sumRSq = 0;
+      let sumGSq = 0;
+      let sumBSq = 0;
+      let white = 0;
+      let black = 0;
+
+      for (let i = 0; i < pixels.length; i += 4) {
+        const r = pixels[i];
+        const g = pixels[i + 1];
+        const b = pixels[i + 2];
+        const luma = 0.2126 * r + 0.7152 * g + 0.0722 * b;
+        sum += luma;
+        sumSq += luma * luma;
+        sumR += r;
+        sumG += g;
+        sumB += b;
+        sumRSq += r * r;
+        sumGSq += g * g;
+        sumBSq += b * b;
+        if (r >= 248 && g >= 248 && b >= 248) white++;
+        if (r <= 7 && g <= 7 && b <= 7) black++;
+      }
+
+      const meanLuma = sum / count;
+      const lumaVariance = Math.max(0, (sumSq / count) - (meanLuma * meanLuma));
+      const lumaStdDev = Math.sqrt(lumaVariance);
+      const rMean = sumR / count;
+      const gMean = sumG / count;
+      const bMean = sumB / count;
+      const rStdDev = Math.sqrt(Math.max(0, (sumRSq / count) - (rMean * rMean)));
+      const gStdDev = Math.sqrt(Math.max(0, (sumGSq / count) - (gMean * gMean)));
+      const bStdDev = Math.sqrt(Math.max(0, (sumBSq / count) - (bMean * bMean)));
+      const maxChannelStdDev = Math.max(rStdDev, gStdDev, bStdDev);
+      const whiteRatio = white / count;
+      const blackRatio = black / count;
+
+      let blank = false;
+      let reason = '';
+      if (whiteRatio >= 0.995 && lumaStdDev < 4) {
+        blank = true;
+        reason = 'near-all-white frame';
+      } else if (blackRatio >= 0.995 && lumaStdDev < 4) {
+        blank = true;
+        reason = 'near-all-black frame';
+      } else if (lumaStdDev < 1.5 && maxChannelStdDev < 1.5) {
+        blank = true;
+        reason = 'near-uniform frame';
+      }
+
+      return {
+        blank,
+        reason,
+        meanLuma,
+        lumaStdDev,
+        maxChannelStdDev,
+        whiteRatio,
+        blackRatio,
+        width,
+        height,
+      };
+    } catch {
+      return null;
+    }
+  }
+
+  _pageSignalsContentBehindBlank(probe) {
+    if (!probe) return true;
+    const textChars = Number(probe.documentTextChars || 0);
+    const visibleTextChars = Number(probe.visibleTextChars || 0);
+    const domNodes = Number(probe.domNodes || 0);
+    const imageCount = Number(probe.imageCount || 0);
+    const scrollHeight = Number(probe.scrollHeight || 0);
+    const innerHeight = Number(probe.innerHeight || 0);
+    return (
+      probe.readyState !== 'complete' ||
+      textChars > 20 ||
+      visibleTextChars > 20 ||
+      imageCount > 0 ||
+      domNodes > 150 ||
+      (innerHeight > 0 && scrollHeight > innerHeight + 200)
+    );
+  }
+
+  async _retryBlankScreenshotCapture(firstShot, captureOnce, { probe = null } = {}) {
+    if (!firstShot?.dataUrl || typeof captureOnce !== 'function') return firstShot;
+    let shot = firstShot;
+    let blankness = await this._analyzeScreenshotBlankness(shot.dataUrl);
+    if (!blankness?.blank || !this._pageSignalsContentBehindBlank(probe)) return shot;
+
+    const meta = {
+      detected: true,
+      retries: 0,
+      delaysMs: [],
+      recovered: false,
+      finalBlank: true,
+      firstBlankness: Agent._summarizeBlankness(blankness),
+      finalBlankness: Agent._summarizeBlankness(blankness),
+    };
+
+    for (const delayMs of Agent.BLANK_SCREENSHOT_RETRY_DELAYS_MS) {
+      await new Promise((r) => setTimeout(r, delayMs));
+      const next = await captureOnce();
+      if (!next?.dataUrl) continue;
+
+      shot = next;
+      meta.retries++;
+      meta.delaysMs.push(delayMs);
+      blankness = await this._analyzeScreenshotBlankness(shot.dataUrl);
+      meta.finalBlank = !!blankness?.blank;
+      meta.finalBlankness = Agent._summarizeBlankness(blankness);
+      if (!blankness?.blank) {
+        meta.recovered = true;
+        break;
+      }
+    }
+
+    return { ...shot, blankFrameRetry: meta };
+  }
+
   /**
    * Capture a viewport screenshot via the WebExtension tabs API. Firefox
    * supports `scale: 1` on captureVisibleTab to force a CSS-pixel-aligned
@@ -1263,36 +1479,30 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
       // and feed misleading visual context to the model. Skip in that case;
       // the model will plan from text only this turn.
       if (!tab.active) return null;
-      // Get the actual viewport dimensions from the page so we can include
-      // them in the prompt accompanying the screenshot.
-      let w = 1024, h = 768;
-      try {
-        const dims = await browser.tabs.executeScript(tabId, {
-          code: 'JSON.stringify({w: window.innerWidth, h: window.innerHeight})',
-        });
-        if (dims && dims[0]) {
-          const parsed = JSON.parse(dims[0]);
-          w = Math.max(1, Math.round(parsed.w));
-          h = Math.max(1, Math.round(parsed.h));
-        }
-      } catch (e) { /* fall back to defaults */ }
-      // scale: 1 forces 1 image pixel per CSS pixel (Firefox-specific option,
-      // ignored by Chrome but Chrome path uses CDP anyway).
-      const rawDataUrl = await this._withIndicatorsHidden(tabId, () =>
-        browser.tabs.captureVisibleTab(tab.windowId, {
-          format: 'jpeg',
-          quality: 60,
-          scale: 1,
-        })
-      );
-      if (!rawDataUrl) return null;
+      const probe = await this._captureViewportProbe(tabId);
+      const w = Math.max(1, Math.round(probe?.innerWidth || 1024));
+      const h = Math.max(1, Math.round(probe?.innerHeight || 768));
+      const captureOnce = async () => {
+        // scale: 1 forces 1 image pixel per CSS pixel (Firefox-specific option,
+        // ignored by Chrome but Chrome path uses CDP anyway).
+        const rawDataUrl = await this._withIndicatorsHidden(tabId, () =>
+          browser.tabs.captureVisibleTab(tab.windowId, {
+            format: 'jpeg',
+            quality: 60,
+            scale: 1,
+          })
+        );
+        if (!rawDataUrl) return null;
 
-      // Firefox's captureVisibleTab doesn't take a clip/scale in a way that
-      // lets us downsize during capture (scale:1 is viewport-lock, not a
-      // factor). So we capture at CSS size and shrink via DOM canvas to
-      // the token budget. On small viewports this is a no-op fast-exit.
-      const shrunk = await this._shrinkImageForBudget(rawDataUrl, w, h);
-      return { dataUrl: shrunk.dataUrl, width: shrunk.width, height: shrunk.height };
+        // Firefox's captureVisibleTab doesn't take a clip/scale in a way that
+        // lets us downsize during capture (scale:1 is viewport-lock, not a
+        // factor). So we capture at CSS size and shrink via DOM canvas to
+        // the token budget. On small viewports this is a no-op fast-exit.
+        const shrunk = await this._shrinkImageForBudget(rawDataUrl, w, h);
+        return { dataUrl: shrunk.dataUrl, width: shrunk.width, height: shrunk.height };
+      };
+      const first = await captureOnce();
+      return await this._retryBlankScreenshotCapture(first, captureOnce, { probe });
     } catch (e) {
       return null;
     }
@@ -2883,60 +3093,34 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
             error: 'Cannot capture screenshot: this tab is not the active tab in its window. Switch to the tab to take a screenshot, or use a different tool.',
           };
         }
-        // Probe the page for layout + text-volume hints BEFORE capture.
-        // documentTextChars + visibleTextChars let the model detect cases
-        // where a JPEG looks blank (mid-lazy-load) but the page actually
-        // has thousands of chars of text — the trace where scroll'd CNN
-        // misread "blank screenshot" as "page is empty".
-        let probe = null;
-        try {
-          const probeCode = `
-            (() => {
-              let documentTextChars = 0;
-              let visibleTextChars = 0;
-              try { documentTextChars = (document.body && document.body.innerText || '').length; } catch (e) {}
-              try {
-                const sels = 'p, h1, h2, h3, h4, h5, h6, li, td, blockquote, article, section, [role="article"]';
-                const els = document.querySelectorAll(sels);
-                const vw = window.innerWidth, vh = window.innerHeight;
-                for (let i = 0; i < els.length; i++) {
-                  const r = els[i].getBoundingClientRect();
-                  if (r.bottom < 0 || r.top > vh) continue;
-                  if (r.right < 0 || r.left > vw) continue;
-                  if (r.width === 0 || r.height === 0) continue;
-                  visibleTextChars += (els[i].innerText || '').length;
-                  if (visibleTextChars > 20000) break;
-                }
-              } catch (e) {}
-              return {
-                url: location.href,
-                title: document.title || '',
-                readyState: document.readyState,
-                scrollX: Math.round(window.scrollX || 0),
-                scrollY: Math.round(window.scrollY || 0),
-                innerWidth: window.innerWidth,
-                innerHeight: window.innerHeight,
-                scrollHeight: Math.round((document.documentElement && document.documentElement.scrollHeight) || document.body.scrollHeight || 0),
-                documentTextChars,
-                visibleTextChars,
-              };
-            })()
-          `;
-          const probeResults = await browser.tabs.executeScript(tabId, { code: probeCode });
-          probe = (probeResults && probeResults[0]) || null;
-        } catch (_) { /* probe failures are non-fatal */ }
-        const rawUrl = await this._withIndicatorsHidden(tabId, () =>
-          browser.tabs.captureVisibleTab(tab.windowId, {
-            format: 'png',
-            quality: 80,
-          })
-        );
-        // Shrink to the vision budget before handing the image to the
-        // model. Same two-stage dance as Chrome: decode → pick target dims
-        // → draw at target → iterative JPEG quality until bytes fit.
-        const shrunk = await this._shrinkImageForBudget(rawUrl, 0, 0);
-        const dataUrl = shrunk.dataUrl;
-        const description = `Screenshot captured (${dataUrl.length} base64 chars, ${shrunk.width}×${shrunk.height})`;
+        const probe = await this._captureViewportProbe(tabId);
+        const captureOnce = async () => {
+          const rawUrl = await this._withIndicatorsHidden(tabId, () =>
+            browser.tabs.captureVisibleTab(tab.windowId, {
+              format: 'png',
+              quality: 80,
+            })
+          );
+          if (!rawUrl) return null;
+          // Shrink to the vision budget before handing the image to the
+          // model. Same two-stage dance as Chrome: decode → pick target dims
+          // → draw at target → iterative JPEG quality until bytes fit.
+          const shrunk = await this._shrinkImageForBudget(rawUrl, 0, 0);
+          return {
+            dataUrl: shrunk.dataUrl,
+            description: `Screenshot captured (${shrunk.dataUrl.length} base64 chars, ${shrunk.width}×${shrunk.height})`,
+          };
+        };
+        const captured = await this._retryBlankScreenshotCapture(await captureOnce(), captureOnce, { probe });
+        if (!captured?.dataUrl) {
+          return {
+            success: false,
+            error: 'Screenshot failed: no image data was captured.',
+          };
+        }
+        const dataUrl = captured.dataUrl;
+        const description = captured.description || '';
+        const blankFrameRetry = captured.blankFrameRetry || null;
 
         // Route the image through whichever vision path is actually wired up.
         // Returning a bare `{image: dataUrl}` blob looks like success but
@@ -2954,6 +3138,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
               method: 'vision_describe',
               description: `[Screenshot described by vision model ${desc.model}]\n${desc.text}`,
               page: probe || undefined,
+              blankFrameRetry: blankFrameRetry || undefined,
             };
           }
         }
@@ -2966,6 +3151,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
             method: 'image_attach',
             description,
             page: probe || undefined,
+            blankFrameRetry: blankFrameRetry || undefined,
             _attachImage: dataUrl,
           };
         }

--- a/src/firefox/src/ui/settings.js
+++ b/src/firefox/src/ui/settings.js
@@ -8,7 +8,7 @@ import { CAPABILITY_LABEL } from '../agent/permission-gate.js';
 
 // Version shown in the subtitle. Kept here so it only needs one update per
 // release; the subtitle string itself is translated.
-const EXT_VERSION = '13.0.0';
+const EXT_VERSION = '13.0.1';
 
 const providersContainer = document.getElementById('providers');
 const verboseToggle = document.getElementById('toggle-verbose');

--- a/test/run.js
+++ b/test/run.js
@@ -748,6 +748,107 @@ test('existing dims under caps stay within the monotonic bound', () => {
   }
 });
 
+test('blank screenshot retry: page-content probe gates retries', () => {
+  const emptyProbe = {
+    readyState: 'complete',
+    documentTextChars: 0,
+    visibleTextChars: 0,
+    domNodes: 20,
+    imageCount: 0,
+    scrollHeight: 800,
+    innerHeight: 800,
+  };
+  for (const AgentClass of [AgentCh, AgentFx]) {
+    const agent = new AgentClass({});
+    assert.equal(agent._pageSignalsContentBehindBlank(emptyProbe), false);
+    assert.equal(agent._pageSignalsContentBehindBlank({ ...emptyProbe, imageCount: 1 }), true);
+    assert.equal(agent._pageSignalsContentBehindBlank({ ...emptyProbe, documentTextChars: 21 }), true);
+    assert.equal(agent._pageSignalsContentBehindBlank({ ...emptyProbe, readyState: 'loading' }), true);
+  }
+});
+
+test('blank screenshot retry: retries and reports recovery', async () => {
+  for (const AgentClass of [AgentCh, AgentFx]) {
+    const agent = new AgentClass({});
+    const delays = AgentClass.BLANK_SCREENSHOT_RETRY_DELAYS_MS;
+    AgentClass.BLANK_SCREENSHOT_RETRY_DELAYS_MS = [0];
+    agent._analyzeScreenshotBlankness = async (dataUrl) => ({
+      blank: dataUrl === 'blank',
+      reason: dataUrl === 'blank' ? 'near-all-white frame' : '',
+      meanLuma: dataUrl === 'blank' ? 255 : 120,
+      lumaStdDev: dataUrl === 'blank' ? 0 : 35,
+      whiteRatio: dataUrl === 'blank' ? 1 : 0.2,
+      blackRatio: 0,
+    });
+    let recaptures = 0;
+    try {
+      const recovered = await agent._retryBlankScreenshotCapture(
+        { dataUrl: 'blank', description: 'first' },
+        async () => {
+          recaptures++;
+          return { dataUrl: 'real', description: 'retry' };
+        },
+        {
+          probe: {
+            readyState: 'complete',
+            documentTextChars: 0,
+            visibleTextChars: 0,
+            domNodes: 20,
+            imageCount: 1,
+            scrollHeight: 800,
+            innerHeight: 800,
+          },
+        }
+      );
+      assert.equal(recovered.dataUrl, 'real');
+      assert.equal(recovered.description, 'retry');
+      assert.equal(recaptures, 1);
+      assert.equal(recovered.blankFrameRetry.detected, true);
+      assert.equal(recovered.blankFrameRetry.retries, 1);
+      assert.equal(recovered.blankFrameRetry.recovered, true);
+      assert.equal(recovered.blankFrameRetry.finalBlank, false);
+    } finally {
+      AgentClass.BLANK_SCREENSHOT_RETRY_DELAYS_MS = delays;
+    }
+  }
+});
+
+test('blank screenshot retry: skips retry when a blank page has no content signals', async () => {
+  for (const AgentClass of [AgentCh, AgentFx]) {
+    const agent = new AgentClass({});
+    agent._analyzeScreenshotBlankness = async () => ({
+      blank: true,
+      reason: 'near-all-white frame',
+      meanLuma: 255,
+      lumaStdDev: 0,
+      whiteRatio: 1,
+      blackRatio: 0,
+    });
+    let recaptures = 0;
+    const result = await agent._retryBlankScreenshotCapture(
+      { dataUrl: 'blank', description: 'first' },
+      async () => {
+        recaptures++;
+        return { dataUrl: 'real', description: 'retry' };
+      },
+      {
+        probe: {
+          readyState: 'complete',
+          documentTextChars: 0,
+          visibleTextChars: 0,
+          domNodes: 20,
+          imageCount: 0,
+          scrollHeight: 800,
+          innerHeight: 800,
+        },
+      }
+    );
+    assert.equal(result.dataUrl, 'blank');
+    assert.equal(result.blankFrameRetry, undefined);
+    assert.equal(recaptures, 0);
+  }
+});
+
 // ────────────────────────────────────────────────────────────────────────
 // Markdown link sanitizer
 // ────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Adds a mechanical blank-frame detector around screenshot capture in both Chrome and Firefox builds. When a captured frame is near-all-white, near-all-black, or near-uniform while the page probe says content likely exists, WebBrain retries after 500ms, 1000ms, and 1500ms before handing the image to a vision model.

## Why

Instagram-style lazy rendering and browser compositor timing can produce blank viewport captures even when the DOM already contains images/text. In the traced failure, the model treated those blank captures as an unrecoverable Instagram lazy-load problem. This moves the first recovery step into deterministic tooling instead of relying on the model to infer and retry.

## Changes

- Add pixel-stat blank-frame detection and retry metadata to Chrome screenshots.
- Add the same retry path to Firefox screenshots using Firefox's DOM/canvas background-page APIs.
- Include `imageCount` in screenshot probes and expose `blankFrameRetry` in screenshot results/traces.
- Add Chrome + Firefox unit coverage for retry gating, recovery, and no-content/no-retry behavior.
- Bump version to `13.0.1` and update `CHANGELOG.md`.

## Validation

- `node --check src/chrome/src/agent/agent.js src/firefox/src/agent/agent.js test/run.js`
- `git diff --check`
- `npm test` -> 267 passed, plus 59/59 security checks