### PR TITLE
fix: make .one visible in nav brand on Chrome

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -1557,7 +1557,7 @@
 <nav>
   <div class="nav-inner">
     <a href="https://webbrain.one/" class="nav-brand" style="text-decoration:none;">
-      <span class="emoji">🧠</span> WebBrain<span style="opacity:0.5; font-weight:400;">.one</span>
+      <span class="emoji">🧠</span> WebBrain<span style="opacity:0.5; font-weight:400; -webkit-text-fill-color:currentColor;">.one</span>
     </a>
     <div class="nav-links">
       <a href="#features">Features</a>


### PR DESCRIPTION
The .one span inherited -webkit-text-fill-color:transparent from .nav-brand's gradient-text trick, but its own opacity creates a paint group that Chrome won't paint the clipped gradient behind, leaving it invisible. Set an explicit -webkit-text-fill-color so it renders.