### PR TITLE
feat: add go_back / go_forward history navigation tools (#168)

### DIFF
--- a/src/chrome/src/agent/agent.js
+++ b/src/chrome/src/agent/agent.js
@@ -822,9 +822,9 @@ export class Agent {
 
   // Tools whose successful completion should trigger an auto-screenshot when
   // the corresponding mode is active.
-  static NAV_TOOLS = new Set(['navigate', 'new_tab']);
-  static STATE_CHANGE_TOOLS = new Set(['navigate', 'new_tab', 'click', 'click_ax', 'type_text', 'type_ax', 'set_field', 'press_keys', 'scroll', 'hover', 'drag_drop']);
-  static NAV_PRONE_TOOLS = new Set(['click', 'click_ax', 'navigate', 'iframe_click']);
+  static NAV_TOOLS = new Set(['navigate', 'new_tab', 'go_back', 'go_forward']);
+  static STATE_CHANGE_TOOLS = new Set(['navigate', 'new_tab', 'go_back', 'go_forward', 'click', 'click_ax', 'type_text', 'type_ax', 'set_field', 'press_keys', 'scroll', 'hover', 'drag_drop']);
+  static NAV_PRONE_TOOLS = new Set(['click', 'click_ax', 'navigate', 'go_back', 'go_forward', 'iframe_click']);
 
   // System prompt for the dedicated "vision model" sub-call. Kept terse and
   // format-oriented so the description is actually useful to the planning
@@ -1101,6 +1101,55 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
   }
 
   /**
+   * Shared unsaved-changes guard for tools that leave the current page
+   * (navigate / go_back / go_forward). Leaving discards in-progress form state
+   * — attached files reset, filled fields clear — so before navigating away we
+   * probe the live DOM and block unless the caller passed force:true.
+   *
+   * Probes via chrome.scripting (NOT CDP): these tools are commonly reached
+   * after content-script-only actions (set_field / type_ax / click) that never
+   * attach a debugger, where a CDP evaluate would throw "Not attached" and the
+   * catch would silently allow the navigation — defeating the guard in exactly
+   * the form-filling case it exists for. scripting.executeScript works
+   * regardless of attach state and shows no debugger banner.
+   *
+   * Returns a blocking tool result ({ success:false, blockedUnsavedChanges })
+   * when there is meaningful unsaved state, or null when it's safe to proceed.
+   */
+  async _probeUnsavedChanges(tabId, toolName = 'navigate') {
+    try {
+      const probeResults = await chrome.scripting.executeScript({
+        target: { tabId },
+        func: () => {
+          let attachedFiles = 0;
+          for (const inp of document.querySelectorAll('input[type=file]')) {
+            if (inp.files && inp.files.length) attachedFiles += inp.files.length;
+          }
+          let dirtyFields = 0;
+          for (const el of document.querySelectorAll('input, textarea')) {
+            const t = (el.type || '').toLowerCase();
+            if (['file','hidden','submit','button','reset','search','checkbox','radio'].includes(t)) continue;
+            if (el.value && el.value !== el.defaultValue) dirtyFields++;
+          }
+          return { attachedFiles, dirtyFields };
+        },
+      });
+      const d = probeResults?.[0]?.result || {};
+      if (d.attachedFiles > 0 || d.dirtyFields >= 2) {
+        const parts = [];
+        if (d.attachedFiles > 0) parts.push(`${d.attachedFiles} attached file(s)`);
+        if (d.dirtyFields > 0) parts.push(`${d.dirtyFields} filled field(s)`);
+        const detail = parts.join(', ');
+        const error = toolName === 'navigate'
+          ? `Navigation blocked: the current page has unsaved changes (${detail}) that leaving will discard. Re-navigating resets forms like GitHub's "New release" page — you would lose the tag, title, and attached binaries, then have to start over. Finish the current action first (e.g. click "Publish release"). If discarding is genuinely intended, call navigate again with force:true.`
+          : `${toolName} blocked: the current page has unsaved changes (${detail}) that leaving will discard. Finish the current action first, or call ${toolName} again with force:true to discard them intentionally.`;
+        return { success: false, blockedUnsavedChanges: true, error };
+      }
+    } catch { /* injection failed (chrome:// / PDF viewer / no host perm) — nothing to protect there, allow navigation */ }
+    return null;
+  }
+
+  /**
    * Execute one assistant turn's worth of tool calls. Both the non-streaming
    * and streaming paths call this so they share identical loop-detection,
    * persistence, and auto-screenshot behavior.
@@ -1267,10 +1316,11 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
         const beforeNorm = this._normalizeUrl(beforeUrl);
         const afterNorm = this._normalizeUrl(afterUrl);
         if (beforeNorm && afterNorm && beforeNorm !== afterNorm) {
-          // The `navigate` tool intentionally goes somewhere — don't warn.
-          // For everything else (click, execute_js, iframe_click) the nav
-          // is a side effect the model may not have anticipated.
-          if (fnName !== 'navigate') {
+          // Explicit navigation tools (navigate / go_back / go_forward)
+          // intentionally go somewhere — don't warn. For everything else
+          // (click, execute_js, iframe_click) the nav is a side effect the
+          // model may not have anticipated.
+          if (!Agent.NAV_TOOLS.has(fnName)) {
             navNotices.push({ before: beforeUrl, after: afterUrl, viaTool: fnName });
           }
         }
@@ -4406,6 +4456,13 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
         if (parsed.url) return `now on ${this._truncate(parsed.url, 110)}`;
         break;
       }
+      case 'go_back':
+      case 'go_forward': {
+        if (parsed.blockedUnsavedChanges) return `${name} blocked: unsaved changes on current page (use force:true to discard)`;
+        if (parsed.success === false) return `${name} failed: ${this._truncate(parsed.error || '', 110)}`;
+        if (parsed.url) return `went ${parsed.direction || (name === 'go_back' ? 'back' : 'forward')} to ${this._truncate(parsed.url, 110)}`;
+        break;
+      }
       case 'upload_file': {
         if (parsed.success === false) return `upload failed: ${this._truncate(parsed.error || '', 110)}`;
         if (parsed.attached) return `uploaded ${this._truncate(parsed.attached.name || '', 60)} (${parsed.attached.size} bytes)`;
@@ -4855,42 +4912,8 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
       // can't tell its uploads landed will renavigate and destroy its own
       // progress. Detect meaningful unsaved state and block unless forced.
       if (!args.force) {
-        try {
-          // Probe via chrome.scripting, NOT CDP: navigate is often reached
-          // after only content-script tools (set_field / type_ax / click via
-          // the content path), which never attach a debugger session. A CDP
-          // evaluate would then throw "Not attached" and the catch would
-          // silently allow the navigation — defeating the guard exactly in
-          // the common form-filling case. scripting.executeScript works
-          // regardless of attach state and shows no debugger banner.
-          const probeResults = await chrome.scripting.executeScript({
-            target: { tabId },
-            func: () => {
-              let attachedFiles = 0;
-              for (const inp of document.querySelectorAll('input[type=file]')) {
-                if (inp.files && inp.files.length) attachedFiles += inp.files.length;
-              }
-              let dirtyFields = 0;
-              for (const el of document.querySelectorAll('input, textarea')) {
-                const t = (el.type || '').toLowerCase();
-                if (['file','hidden','submit','button','reset','search','checkbox','radio'].includes(t)) continue;
-                if (el.value && el.value !== el.defaultValue) dirtyFields++;
-              }
-              return { attachedFiles, dirtyFields };
-            },
-          });
-          const d = probeResults?.[0]?.result || {};
-          if (d.attachedFiles > 0 || d.dirtyFields >= 2) {
-            const parts = [];
-            if (d.attachedFiles > 0) parts.push(`${d.attachedFiles} attached file(s)`);
-            if (d.dirtyFields > 0) parts.push(`${d.dirtyFields} filled field(s)`);
-            return {
-              success: false,
-              blockedUnsavedChanges: true,
-              error: `Navigation blocked: the current page has unsaved changes (${parts.join(', ')}) that leaving will discard. Re-navigating resets forms like GitHub's "New release" page — you would lose the tag, title, and attached binaries, then have to start over. Finish the current action first (e.g. click "Publish release"). If discarding is genuinely intended, call navigate again with force:true.`,
-            };
-          }
-        } catch { /* injection failed (chrome:// / PDF viewer / no host perm) — nothing to protect there, allow navigation */ }
+        const blocked = await this._probeUnsavedChanges(tabId, 'navigate');
+        if (blocked) return blocked;
       }
 
       await chrome.tabs.update(tabId, { url: rawUrl });
@@ -4903,6 +4926,76 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
         if (tab && tab.url) finalUrl = tab.url;
       } catch {}
       return { success: true, url: finalUrl, requestedUrl: rawUrl };
+    }
+
+    if (name === 'go_back' || name === 'go_forward') {
+      const direction = name === 'go_back' ? 'back' : 'forward';
+      // Clamp steps to a sane range; default to a single entry.
+      let steps = Math.floor(Number(args.steps));
+      if (!Number.isFinite(steps) || steps < 1) steps = 1;
+      if (steps > 10) steps = 10;
+
+      let beforeUrl = '';
+      try {
+        const tab = await chrome.tabs.get(tabId);
+        beforeUrl = tab?.url || '';
+      } catch {}
+
+      // Internal pages (chrome://, about:, extension/view-source) have no
+      // meaningful web session history to walk.
+      if (/^(chrome|edge|brave|about|chrome-extension|moz-extension|view-source|data):/i.test(beforeUrl)) {
+        return { success: false, error: `${name}: history navigation is not available on internal pages (${beforeUrl || 'unknown'}).` };
+      }
+
+      // Same unsaved-changes guard as navigate — going back/forward leaves the
+      // current page and discards attached files / filled fields.
+      if (!args.force) {
+        const blocked = await this._probeUnsavedChanges(tabId, name);
+        if (blocked) return blocked;
+      }
+
+      // Drive history from the page's own context via scripting.executeScript
+      // (the extension's injected function, NOT page eval) so it works even
+      // where execute_js is CSP-blocked.
+      let probe = null;
+      try {
+        const delta = direction === 'back' ? -steps : steps;
+        const results = await chrome.scripting.executeScript({
+          target: { tabId },
+          args: [delta],
+          func: (d) => {
+            const before = location.href;
+            history.go(d);
+            return { before };
+          },
+        });
+        probe = results?.[0]?.result || null;
+      } catch (e) {
+        return { success: false, error: `${name}: cannot navigate history on this page (${e.message}).` };
+      }
+      if (!probe) {
+        return { success: false, error: `${name}: history navigation did not run on this page.` };
+      }
+
+      // history.go() commits asynchronously (including bfcache restores), so
+      // wait briefly, then confirm the URL actually changed. If it didn't,
+      // there was no entry in that direction — report failure rather than a
+      // misleading success the model would build on.
+      await new Promise(r => setTimeout(r, 1500));
+      let afterUrl = probe.before;
+      try {
+        const tab = await chrome.tabs.get(tabId);
+        if (tab?.url) afterUrl = tab.url;
+      } catch {}
+
+      if (this._normalizeUrl(afterUrl) === this._normalizeUrl(probe.before)) {
+        const dirWord = direction === 'back' ? 'earlier' : 'later';
+        return {
+          success: false,
+          error: `${name}: no ${dirWord} entry in this tab's history (the page did not change).`,
+        };
+      }
+      return { success: true, url: afterUrl, previousUrl: probe.before, direction, steps };
     }
 
     if (name === 'new_tab') {

--- a/src/chrome/src/agent/permission-gate.js
+++ b/src/chrome/src/agent/permission-gate.js
@@ -22,7 +22,7 @@
  */
 
 export const Capability = {
-  NAVIGATE: 'navigate',          // navigate / new_tab to a host
+  NAVIGATE: 'navigate',          // navigate / new_tab / go_back / go_forward to a host
   CLICK: 'click',                // click / click_ax / iframe_click / drag_drop / Enter / submit
   TYPE: 'type',                  // type_text / type_ax / iframe_type / set_field (no submit)
   EXECUTE_JS: 'execute_js',      // execute_js
@@ -128,6 +128,8 @@ export function isNetworkMutation(name, args) {
 const TOOL_CAPABILITY = {
   navigate: Capability.NAVIGATE,
   new_tab: Capability.NAVIGATE,
+  go_back: Capability.NAVIGATE,
+  go_forward: Capability.NAVIGATE,
   click: Capability.CLICK,
   click_ax: Capability.CLICK,
   iframe_click: Capability.CLICK,

--- a/src/chrome/src/agent/tools.js
+++ b/src/chrome/src/agent/tools.js
@@ -319,6 +319,34 @@ export const AGENT_TOOLS = [
   {
     type: 'function',
     function: {
+      name: 'go_back',
+      description: 'Go back one entry in the current tab\'s session history, like the browser Back button. Use this for "go back" / "return to the previous page" rather than trying to run history.back() yourself (page scripts are CSP-blocked on many sites). Returns {success, url} on success, or {success:false, error} when there is no earlier entry or the page is internal (the URL is verified to actually change). Leaving a page with unsaved changes is blocked unless force:true.',
+      parameters: {
+        type: 'object',
+        properties: {
+          steps: { type: 'number', description: 'How many entries to go back. Default 1; clamped to 1–10.' },
+          force: { type: 'boolean', description: 'Set true to leave even when the current page has unsaved changes (attached files / filled fields). Default false.' },
+        },
+      },
+    },
+  },
+  {
+    type: 'function',
+    function: {
+      name: 'go_forward',
+      description: 'Go forward one entry in the current tab\'s session history, like the browser Forward button — reverses a previous go_back. Returns {success, url} on success, or {success:false, error} when there is no later entry or the page is internal. Leaving a page with unsaved changes is blocked unless force:true.',
+      parameters: {
+        type: 'object',
+        properties: {
+          steps: { type: 'number', description: 'How many entries to go forward. Default 1; clamped to 1–10.' },
+          force: { type: 'boolean', description: 'Set true to leave even when the current page has unsaved changes (attached files / filled fields). Default false.' },
+        },
+      },
+    },
+  },
+  {
+    type: 'function',
+    function: {
       name: 'extract_data',
       description: 'Extract structured data from the page (tables, headings, or images).',
       parameters: {
@@ -1371,7 +1399,7 @@ PATTERN:
 export const MID_TOOL_NAMES = new Set([
   'get_accessibility_tree', 'click_ax', 'type_ax', 'set_field',
   'read_page', 'read_pdf', 'screenshot', 'get_window_info', 'resize_window', 'get_interactive_elements',
-  'click', 'type_text', 'press_keys', 'scroll', 'navigate',
+  'click', 'type_text', 'press_keys', 'scroll', 'navigate', 'go_back', 'go_forward',
   'extract_data', 'inspect_element_styles', 'wait_for_element', 'wait_for_stable', 'get_selection',
   'new_tab', 'done', 'clarify', 'schedule_resume', 'schedule_task',
   'iframe_read', 'iframe_click', 'iframe_type',
@@ -1405,7 +1433,7 @@ UNTRUSTED PAGE CONTENT:
 TOOLS — use only these:
 - get_accessibility_tree: PREFERRED read. Flat-text tree with roles, names, and stable ref_ids. Use filter:"visible" by default.
 - click_ax({ref_id}) / type_ax({ref_id, text}) / set_field({ref_id, text, submit}): act on nodes by ref_id. set_field is preferred for text fields.
-- read_page: prose fallback for long articles. screenshot: see the visible page. get_window_info / resize_window: inspect or resize the browser window for recording/layout tasks. scroll, navigate({url}), new_tab({url}).
+- read_page: prose fallback for long articles. screenshot: see the visible page. get_window_info / resize_window: inspect or resize the browser window for recording/layout tasks. scroll, navigate({url}), new_tab({url}), go_back()/go_forward(): walk the tab's history.
 - get_interactive_elements: legacy indexed element list (use when the tree misses elements). click({text}) / type_text({text}) / press_keys({key}): legacy fallbacks.
 - extract_data: tables/headings/images/links. inspect_element_styles: live computed CSS/box model. get_selection: highlighted text. read_pdf: read a PDF.
 - wait_for_element({selector}) / wait_for_stable({quietMs}): wait for an element / for the page to go quiet after an action.

--- a/src/chrome/src/ui/locales/en.js
+++ b/src/chrome/src/ui/locales/en.js
@@ -193,6 +193,8 @@ export default {
   'tool.type_text': 'Typing',
   'tool.scroll': 'Scrolling',
   'tool.navigate': 'Navigating',
+  'tool.go_back': 'Going back',
+  'tool.go_forward': 'Going forward',
   'tool.extract_data': 'Extracting data',
   'tool.inspect_element_styles': 'Inspecting styles',
   'tool.read_page_source': 'Reading page source',

--- a/src/chrome/src/ui/sidepanel.js
+++ b/src/chrome/src/ui/sidepanel.js
@@ -591,6 +591,8 @@ const TOOL_KEYS = {
   type_text: 'tool.type_text',
   scroll: 'tool.scroll',
   navigate: 'tool.navigate',
+  go_back: 'tool.go_back',
+  go_forward: 'tool.go_forward',
   extract_data: 'tool.extract_data',
   inspect_element_styles: 'tool.inspect_element_styles',
   read_page_source: 'tool.read_page_source',

--- a/src/firefox/src/agent/agent.js
+++ b/src/firefox/src/agent/agent.js
@@ -570,9 +570,9 @@ export class Agent {
     return { kind: 'nudge', warning };
   }
 
-  static NAV_TOOLS = new Set(['navigate', 'new_tab']);
-  static STATE_CHANGE_TOOLS = new Set(['navigate', 'new_tab', 'click', 'click_ax', 'type_text', 'type_ax', 'set_field', 'press_keys', 'scroll', 'hover', 'drag_drop']);
-  static NAV_PRONE_TOOLS = new Set(['click', 'click_ax', 'navigate', 'execute_js', 'iframe_click']);
+  static NAV_TOOLS = new Set(['navigate', 'new_tab', 'go_back', 'go_forward']);
+  static STATE_CHANGE_TOOLS = new Set(['navigate', 'new_tab', 'go_back', 'go_forward', 'click', 'click_ax', 'type_text', 'type_ax', 'set_field', 'press_keys', 'scroll', 'hover', 'drag_drop']);
+  static NAV_PRONE_TOOLS = new Set(['click', 'click_ax', 'navigate', 'go_back', 'go_forward', 'execute_js', 'iframe_click']);
 
   // System prompt for the dedicated "vision model" sub-call. Kept terse and
   // format-oriented so the description is actually useful to the planning
@@ -652,6 +652,48 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
       const u = new URL(url);
       return u.origin + u.pathname;
     } catch (e) { return url; }
+  }
+
+  /**
+   * Shared unsaved-changes guard for tools that leave the current page
+   * (navigate / go_back / go_forward). Leaving discards in-progress form state
+   * — attached files reset, filled fields clear — so before navigating away we
+   * probe the live DOM and block unless the caller passed force:true.
+   *
+   * Returns a blocking tool result ({ success:false, blockedUnsavedChanges })
+   * when there is meaningful unsaved state, or null when it's safe to proceed.
+   */
+  async _probeUnsavedChanges(tabId, toolName = 'navigate') {
+    try {
+      const probeCode = `
+        (() => {
+          let attachedFiles = 0;
+          for (const inp of document.querySelectorAll('input[type=file]')) {
+            if (inp.files && inp.files.length) attachedFiles += inp.files.length;
+          }
+          let dirtyFields = 0;
+          for (const el of document.querySelectorAll('input, textarea')) {
+            const t = (el.type || '').toLowerCase();
+            if (['file','hidden','submit','button','reset','search','checkbox','radio'].includes(t)) continue;
+            if (el.value && el.value !== el.defaultValue) dirtyFields++;
+          }
+          return { attachedFiles, dirtyFields };
+        })()
+      `;
+      const probeResults = await browser.tabs.executeScript(tabId, { code: probeCode });
+      const d = (probeResults && probeResults[0]) || {};
+      if (d.attachedFiles > 0 || d.dirtyFields >= 2) {
+        const parts = [];
+        if (d.attachedFiles > 0) parts.push(`${d.attachedFiles} attached file(s)`);
+        if (d.dirtyFields > 0) parts.push(`${d.dirtyFields} filled field(s)`);
+        const detail = parts.join(', ');
+        const error = toolName === 'navigate'
+          ? `Navigation blocked: the current page has unsaved changes (${detail}) that leaving will discard. Re-navigating resets forms like GitHub's "New release" page — you would lose the tag, title, and attached binaries, then have to start over. Finish the current action first (e.g. click "Publish release"). If discarding is genuinely intended, call navigate again with force:true.`
+          : `${toolName} blocked: the current page has unsaved changes (${detail}) that leaving will discard. Finish the current action first, or call ${toolName} again with force:true to discard them intentionally.`;
+        return { success: false, blockedUnsavedChanges: true, error };
+      }
+    } catch { /* probe failed (e.g. privileged page) — nothing to protect, allow navigation */ }
+    return null;
   }
 
   async _getVisibleInteractiveElements(tabId) {
@@ -877,7 +919,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
         const afterUrl = await this._currentUrl(tabId);
         const beforeNorm = this._normalizeUrl(beforeUrl);
         const afterNorm = this._normalizeUrl(afterUrl);
-        if (beforeNorm && afterNorm && beforeNorm !== afterNorm && fnName !== 'navigate') {
+        if (beforeNorm && afterNorm && beforeNorm !== afterNorm && !Agent.NAV_TOOLS.has(fnName)) {
           navNotices.push({ before: beforeUrl, after: afterUrl, viaTool: fnName });
         }
       }
@@ -3655,6 +3697,13 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
         if (parsed.url) return `now on ${this._truncate(parsed.url, 110)}`;
         break;
       }
+      case 'go_back':
+      case 'go_forward': {
+        if (parsed.blockedUnsavedChanges) return `${name} blocked: unsaved changes on current page (use force:true to discard)`;
+        if (parsed.success === false) return `${name} failed: ${this._truncate(parsed.error || '', 110)}`;
+        if (parsed.url) return `went ${parsed.direction || (name === 'go_back' ? 'back' : 'forward')} to ${this._truncate(parsed.url, 110)}`;
+        break;
+      }
       case 'upload_file': {
         if (parsed.success === false) return `upload failed: ${this._truncate(parsed.error || '', 110)}`;
         if (parsed.attached) return `uploaded ${this._truncate(parsed.attached.name || '', 60)} (${parsed.attached.size} bytes)`;
@@ -4026,41 +4075,82 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
       // can't tell its uploads landed will renavigate and destroy its own
       // progress. Detect meaningful unsaved state and block unless forced.
       if (!args.force) {
-        try {
-          const probeCode = `
-            (() => {
-              let attachedFiles = 0;
-              for (const inp of document.querySelectorAll('input[type=file]')) {
-                if (inp.files && inp.files.length) attachedFiles += inp.files.length;
-              }
-              let dirtyFields = 0;
-              for (const el of document.querySelectorAll('input, textarea')) {
-                const t = (el.type || '').toLowerCase();
-                if (['file','hidden','submit','button','reset','search','checkbox','radio'].includes(t)) continue;
-                if (el.value && el.value !== el.defaultValue) dirtyFields++;
-              }
-              return { attachedFiles, dirtyFields };
-            })()
-          `;
-          const probeResults = await browser.tabs.executeScript(tabId, { code: probeCode });
-          const d = (probeResults && probeResults[0]) || {};
-          if (d.attachedFiles > 0 || d.dirtyFields >= 2) {
-            const parts = [];
-            if (d.attachedFiles > 0) parts.push(`${d.attachedFiles} attached file(s)`);
-            if (d.dirtyFields > 0) parts.push(`${d.dirtyFields} filled field(s)`);
-            return {
-              success: false,
-              blockedUnsavedChanges: true,
-              error: `Navigation blocked: the current page has unsaved changes (${parts.join(', ')}) that leaving will discard. Re-navigating resets forms like GitHub's "New release" page — you would lose the tag, title, and attached binaries, then have to start over. Finish the current action first (e.g. click "Publish release"). If discarding is genuinely intended, call navigate again with force:true.`,
-            };
-          }
-        } catch { /* probe failed (e.g. privileged page) — allow navigation */ }
+        const blocked = await this._probeUnsavedChanges(tabId, 'navigate');
+        if (blocked) return blocked;
       }
 
       await browser.tabs.update(tabId, { url: args.url });
       // Wait a moment for navigation
       await new Promise(r => setTimeout(r, 2000));
       return { success: true, url: args.url };
+    }
+
+    if (name === 'go_back' || name === 'go_forward') {
+      const direction = name === 'go_back' ? 'back' : 'forward';
+      // Clamp steps to a sane range; default to a single entry.
+      let steps = Math.floor(Number(args.steps));
+      if (!Number.isFinite(steps) || steps < 1) steps = 1;
+      if (steps > 10) steps = 10;
+
+      let beforeUrl = '';
+      try {
+        const tab = await browser.tabs.get(tabId);
+        beforeUrl = tab?.url || '';
+      } catch {}
+
+      // Internal pages (about:, view-source, extension) have no meaningful
+      // web session history to walk.
+      if (/^(about|moz-extension|view-source|data|chrome):/i.test(beforeUrl)) {
+        return { success: false, error: `${name}: history navigation is not available on internal pages (${beforeUrl || 'unknown'}).` };
+      }
+
+      // Same unsaved-changes guard as navigate — going back/forward leaves the
+      // current page and discards attached files / filled fields.
+      if (!args.force) {
+        const blocked = await this._probeUnsavedChanges(tabId, name);
+        if (blocked) return blocked;
+      }
+
+      // Drive history from the page context (CSP-safe; this is the extension's
+      // injected code, not page eval).
+      let probe = null;
+      try {
+        const delta = direction === 'back' ? -steps : steps;
+        const code = `
+          (() => {
+            const before = location.href;
+            history.go(${delta});
+            return { before };
+          })()
+        `;
+        const results = await browser.tabs.executeScript(tabId, { code });
+        probe = (results && results[0]) || null;
+      } catch (e) {
+        return { success: false, error: `${name}: cannot navigate history on this page (${e.message}).` };
+      }
+      if (!probe) {
+        return { success: false, error: `${name}: history navigation did not run on this page.` };
+      }
+
+      // history.go() commits asynchronously (including bfcache restores), so
+      // wait briefly, then confirm the URL actually changed. If it didn't,
+      // there was no entry in that direction — report failure rather than a
+      // misleading success the model would build on.
+      await new Promise(r => setTimeout(r, 1500));
+      let afterUrl = probe.before;
+      try {
+        const tab = await browser.tabs.get(tabId);
+        if (tab?.url) afterUrl = tab.url;
+      } catch {}
+
+      if (this._normalizeUrl(afterUrl) === this._normalizeUrl(probe.before)) {
+        const dirWord = direction === 'back' ? 'earlier' : 'later';
+        return {
+          success: false,
+          error: `${name}: no ${dirWord} entry in this tab's history (the page did not change).`,
+        };
+      }
+      return { success: true, url: afterUrl, previousUrl: probe.before, direction, steps };
     }
 
     if (name === 'new_tab') {

--- a/src/firefox/src/agent/permission-gate.js
+++ b/src/firefox/src/agent/permission-gate.js
@@ -22,7 +22,7 @@
  */
 
 export const Capability = {
-  NAVIGATE: 'navigate',          // navigate / new_tab to a host
+  NAVIGATE: 'navigate',          // navigate / new_tab / go_back / go_forward to a host
   CLICK: 'click',                // click / click_ax / iframe_click / drag_drop / Enter / submit
   TYPE: 'type',                  // type_text / type_ax / iframe_type / set_field (no submit)
   EXECUTE_JS: 'execute_js',      // execute_js
@@ -127,6 +127,8 @@ export function isNetworkMutation(name, args) {
 const TOOL_CAPABILITY = {
   navigate: Capability.NAVIGATE,
   new_tab: Capability.NAVIGATE,
+  go_back: Capability.NAVIGATE,
+  go_forward: Capability.NAVIGATE,
   click: Capability.CLICK,
   click_ax: Capability.CLICK,
   iframe_click: Capability.CLICK,

--- a/src/firefox/src/agent/tools.js
+++ b/src/firefox/src/agent/tools.js
@@ -306,6 +306,34 @@ export const AGENT_TOOLS = [
   {
     type: 'function',
     function: {
+      name: 'go_back',
+      description: 'Go back one entry in the current tab\'s session history, like the browser Back button. Use this for "go back" / "return to the previous page" rather than trying to run history.back() yourself (page scripts are CSP-blocked on many sites). Returns {success, url} on success, or {success:false, error} when there is no earlier entry or the page is internal (the URL is verified to actually change). Leaving a page with unsaved changes is blocked unless force:true.',
+      parameters: {
+        type: 'object',
+        properties: {
+          steps: { type: 'number', description: 'How many entries to go back. Default 1; clamped to 1–10.' },
+          force: { type: 'boolean', description: 'Set true to leave even when the current page has unsaved changes (attached files / filled fields). Default false.' },
+        },
+      },
+    },
+  },
+  {
+    type: 'function',
+    function: {
+      name: 'go_forward',
+      description: 'Go forward one entry in the current tab\'s session history, like the browser Forward button — reverses a previous go_back. Returns {success, url} on success, or {success:false, error} when there is no later entry or the page is internal. Leaving a page with unsaved changes is blocked unless force:true.',
+      parameters: {
+        type: 'object',
+        properties: {
+          steps: { type: 'number', description: 'How many entries to go forward. Default 1; clamped to 1–10.' },
+          force: { type: 'boolean', description: 'Set true to leave even when the current page has unsaved changes (attached files / filled fields). Default false.' },
+        },
+      },
+    },
+  },
+  {
+    type: 'function',
+    function: {
       name: 'extract_data',
       description: 'Extract structured data from the page (tables, headings, or images).',
       parameters: {
@@ -1208,7 +1236,7 @@ LISTINGS & PAGINATION — read this:
 export const MID_TOOL_NAMES = new Set([
   'get_accessibility_tree', 'click_ax', 'type_ax', 'set_field',
   'read_page', 'read_pdf', 'screenshot', 'get_window_info', 'resize_window', 'get_interactive_elements',
-  'click', 'type_text', 'press_keys', 'scroll', 'navigate',
+  'click', 'type_text', 'press_keys', 'scroll', 'navigate', 'go_back', 'go_forward',
   'extract_data', 'inspect_element_styles', 'wait_for_element', 'wait_for_stable', 'get_selection',
   'new_tab', 'done', 'clarify', 'schedule_resume', 'schedule_task',
   'iframe_read', 'iframe_click', 'iframe_type',
@@ -1241,7 +1269,7 @@ UNTRUSTED PAGE CONTENT:
 TOOLS — use only these:
 - get_accessibility_tree: PREFERRED read. Flat-text tree with roles, names, and stable ref_ids. Use filter:"visible" by default.
 - click_ax({ref_id}) / type_ax({ref_id, text}) / set_field({ref_id, text, submit}): act on nodes by ref_id. set_field is preferred for text fields.
-- read_page: prose fallback for long articles. screenshot: see the visible page. get_window_info / resize_window: inspect or resize the browser window for recording/layout tasks. scroll, navigate({url}), new_tab({url}).
+- read_page: prose fallback for long articles. screenshot: see the visible page. get_window_info / resize_window: inspect or resize the browser window for recording/layout tasks. scroll, navigate({url}), new_tab({url}), go_back()/go_forward(): walk the tab's history.
 - get_interactive_elements: legacy indexed element list (use when the tree misses elements). click({text}) / type_text({text}) / press_keys({key}): legacy fallbacks.
 - extract_data: tables/headings/images/links. inspect_element_styles: live computed CSS/box model. get_selection: highlighted text. read_pdf: read a PDF.
 - wait_for_element({selector}) / wait_for_stable({quietMs}): wait for an element / for the page to go quiet after an action.

--- a/src/firefox/src/ui/locales/en.js
+++ b/src/firefox/src/ui/locales/en.js
@@ -183,6 +183,8 @@ export default {
   'tool.type_text': 'Typing',
   'tool.scroll': 'Scrolling',
   'tool.navigate': 'Navigating',
+  'tool.go_back': 'Going back',
+  'tool.go_forward': 'Going forward',
   'tool.extract_data': 'Extracting data',
   'tool.inspect_element_styles': 'Inspecting styles',
   'tool.read_page_source': 'Reading page source',

--- a/src/firefox/src/ui/sidepanel.js
+++ b/src/firefox/src/ui/sidepanel.js
@@ -458,6 +458,8 @@ const TOOL_KEYS = {
   type_text: 'tool.type_text',
   scroll: 'tool.scroll',
   navigate: 'tool.navigate',
+  go_back: 'tool.go_back',
+  go_forward: 'tool.go_forward',
   extract_data: 'tool.extract_data',
   inspect_element_styles: 'tool.inspect_element_styles',
   read_page_source: 'tool.read_page_source',

--- a/test/llm/scenarios/030.json
+++ b/test/llm/scenarios/030.json
@@ -7,7 +7,7 @@
     "url": "https://example.com/page",
     "title": "Example"
   },
-  "description": "execute_js to read history.length blocked. Just answer without it — not critical.",
+  "description": "execute_js history.back() is CSP-blocked. The agent has a dedicated go_back tool — it should use that instead of giving up.",
   "seed": [
     {
       "role": "user",
@@ -36,17 +36,19 @@
   ],
   "expected": {
     "idealNextToolCall": {
-      "name": "done",
-      "args": {
-        "summary": "I can't use execute_js on this site (CSP), and I don't have a back-button tool. Press the browser's Back button (or Cmd/Ctrl+[) to go back."
-      }
+      "name": "go_back",
+      "args": {}
     },
     "antiPatterns": [
       {
         "match": "execute_js({code:\"history.back()\"})",
-        "reason": "Same block."
+        "reason": "Same CSP block — execute_js can't drive history here."
+      },
+      {
+        "match": "done(...)",
+        "reason": "Don't give up and tell the user to press Back manually; the go_back tool exists for exactly this."
       }
     ],
-    "successRubric": "Honestly report the limitation. There is no back tool in the schema; execute_js is blocked. Tell the user to use the browser."
+    "successRubric": "Recover from the CSP-blocked execute_js by calling the dedicated go_back tool (no url/steps needed for a single step back). Do NOT retry history.back() via execute_js, and do NOT punt to the user with a manual Back-button instruction."
   }
 }

--- a/test/llm/scenarios/030.json
+++ b/test/llm/scenarios/030.json
@@ -45,7 +45,7 @@
         "reason": "Same CSP block — execute_js can't drive history here."
       },
       {
-        "match": "done(...)",
+        "match": "done({summary:\"...\"})",
         "reason": "Don't give up and tell the user to press Back manually; the go_back tool exists for exactly this."
       }
     ],

--- a/test/run.js
+++ b/test/run.js
@@ -1910,6 +1910,31 @@ test('scheduled tools are exposed only in full and mid act tiers', () => {
   }
 });
 
+test('history tools (go_back/go_forward) are exposed in full and mid tiers but not compact/ask', () => {
+  // The maintainer's one caveat on this feature: more tools = more small-model
+  // hallucination. So go_back/go_forward stay out of the leanest compact tier
+  // (those models keep navigate); mid+ models that handle real tasks get them.
+  for (const [label, getTools, midPrompt, compactPrompt] of [
+    ['chrome', getToolsForModeCh, SYSTEM_PROMPT_ACT_MID_CH, SYSTEM_PROMPT_ACT_COMPACT_CH],
+    ['firefox', getToolsForModeFx, SYSTEM_PROMPT_ACT_MID_FX, SYSTEM_PROMPT_ACT_COMPACT_FX],
+  ]) {
+    const full = getTools('act').map(t => t.function.name);
+    const mid = getTools('act', { tier: 'mid' }).map(t => t.function.name);
+    const compact = getTools('act', { tier: 'compact' }).map(t => t.function.name);
+    const ask = getTools('ask').map(t => t.function.name);
+
+    for (const tool of ['go_back', 'go_forward']) {
+      assert.equal(full.includes(tool), true, `[${label}] full act should expose ${tool}`);
+      assert.equal(mid.includes(tool), true, `[${label}] mid act should expose ${tool}`);
+      assert.equal(compact.includes(tool), false, `[${label}] compact act must not expose ${tool}`);
+      assert.equal(ask.includes(tool), false, `[${label}] ask mode must not expose ${tool} (read-only)`);
+    }
+
+    assert.match(midPrompt, /go_back/, `[${label}] mid prompt should mention go_back`);
+    assert.doesNotMatch(compactPrompt, /go_back/, `[${label}] compact prompt must not mention go_back`);
+  }
+});
+
 test('sidepanel exposes schedule slash commands in both builds', () => {
   for (const [label, panelRel, localeRel] of [
     ['chrome', 'src/chrome/src/ui/sidepanel.js', 'src/chrome/src/ui/locales/en.js'],
@@ -6503,6 +6528,8 @@ test('capabilityFor: screenshot is read-only, but save:true is a download', () =
 test('capabilityFor: state-changing tools map to capabilities', () => {
   assert.equal(capabilityFor('navigate', { url: 'https://x.com' }), Capability.NAVIGATE);
   assert.equal(capabilityFor('new_tab', { url: 'https://x.com' }), Capability.NAVIGATE);
+  assert.equal(capabilityFor('go_back', {}), Capability.NAVIGATE);
+  assert.equal(capabilityFor('go_forward', { steps: 2 }), Capability.NAVIGATE);
   assert.equal(capabilityFor('click', {}), Capability.CLICK);
   assert.equal(capabilityFor('click_ax', { ref_id: 'ref_1' }), Capability.CLICK); // ref_id, no label needed
   assert.equal(capabilityFor('type_text', {}), Capability.TYPE);
@@ -8572,6 +8599,9 @@ test('hostForCapability: navigate/network use target URL, others use current pag
   assert.equal(hostForCapability(Capability.NETWORK, { url: 'https://api.dest.com' }, 'https://cur.com'), 'api.dest.com');
   assert.equal(hostForCapability(Capability.CLICK, { ref_id: 'ref_1' }, 'https://cur.com'), 'cur.com');
   assert.equal(hostForCapability(Capability.TYPE, {}, 'https://cur.com'), 'cur.com');
+  // go_back / go_forward carry no url arg, so they charge the current tab host.
+  assert.equal(hostForCapability(Capability.NAVIGATE, {}, 'https://cur.com', 'go_back'), 'cur.com');
+  assert.equal(hostForCapability(Capability.NAVIGATE, { steps: 2 }, 'https://cur.com', 'go_forward'), 'cur.com');
 });
 
 test('hostForCapability: URL-target scheduled tasks use the scheduled host', () => {


### PR DESCRIPTION
Closes #168.

Adds two Act-only history-navigation tools so the agent can walk the current tab's session history — the approach you approved in the issue, with the small-model caveat baked in.

## Why
There was no history tool in the schema. Models that needed "go back" tried `execute_js({code:"history.back()"})`, which is **CSP-blocked on Chrome MV3**, so the only fallback was telling the user to press Back manually (that's literally what `test/llm/scenarios/030.json` expected). This closes a real gap, not just convenience.

## What
- **`go_back` / `go_forward`** (Option A from the issue) — Act-only, each with optional:
  - `steps` (default `1`, clamped `1–10`) → `history.go(±n)`
  - `force` (default `false`) → same unsaved-changes guard as `navigate`
- **Handler** drives `history.go()` via `chrome.scripting.executeScript` / `browser.tabs.executeScript` (the extension's own injected function, **CSP-safe** — works where `execute_js` is blocked). It:
  - reuses `navigate`'s unsaved-changes guard, now extracted into a shared `_probeUnsavedChanges()` helper (no duplication / drift),
  - refuses internal pages (`chrome://`, `about:`, extension, `view-source:`),
  - waits, then **verifies the URL actually changed** — returns `success:false` instead of a misleading success when there's no entry in that direction.
- **Classification / security**: added to `NAV_TOOLS` / `STATE_CHANGE_TOOLS` / `NAV_PRONE_TOOLS`, mapped to `Capability.NAVIGATE` in `permission-gate.js` (charged to the current tab origin). The "unintended navigation" notice now excludes all explicit nav tools so back/forward don't spam a false warning.
- **Firefox mirror** + i18n labels (`tool.go_back` / `tool.go_forward`) + side-panel `TOOL_KEYS`.

## On your caveat — "more tools = more small-model hallucination"
Took this seriously:
- The tools are exposed in the **full and mid tiers only**, **not the leanest compact tier** (compact models keep `navigate`).
- I **deliberately skipped** the optional `get_history_state` read helper from my issue write-up to keep the tool surface minimal.
- Names are intentionally unambiguous (`go_back` / `go_forward`) over a single enum tool, which small models confuse less.

Happy to move them to compact too (or pull them back to full-only) if you'd prefer a different cut — it's a one-line set change.

## Tests
- Updated `test/llm/scenarios/030.json`: ideal next action is now `go_back` (no longer "give up and tell the user").
- Added unit tests: capability mapping, current-tab host charging, and tier exposure (full+mid yes, compact+ask no) across both builds.
- `npm test` → **430 passed, 0 failed**; untrusted-content corpus 59/59.

No new manifest permissions (`scripting` + `tabs` already granted).