### PR TITLE
Feature/mutation api observer

### DIFF
--- a/src/chrome/manifest.json
+++ b/src/chrome/manifest.json
@@ -12,6 +12,7 @@
     "scripting",
     "storage",
     "webNavigation",
+    "webRequest",
     "debugger",
     "downloads",
     "alarms",

--- a/src/chrome/src/agent/agent.js
+++ b/src/chrome/src/agent/agent.js
@@ -553,6 +553,42 @@ export class Agent {
   }
 
   /**
+   * Issue #189 — mutation API observer shortcutter. When _checkLoop flags a
+   * repeated click (e.g. "Next Page" clicked 3x), check whether each click
+   * fired the same background XHR/fetch (captured by the webRequest
+   * listener in background.js). If so, surface the URL/method so the model
+   * can call fetch_url directly instead of clicking again.
+   *
+   * Strict matching only: same tab, exact url+method repeated, request must
+   * land within WINDOW_MS after the click that triggered it. No fuzzy
+   * param-pattern matching.
+   */
+  _detectApiShortcut(tabId, loop, buf) {
+    if (loop.type !== 'repeat') return null;
+    if (!['click', 'click_ax'].includes(loop.name)) return null;
+    const apiRequests = globalThis.__webbrainApiRequests?.get(tabId);
+    if (!apiRequests || apiRequests.length === 0) return null;
+
+    const clickTimes = buf.filter(e => e.key === loop.key).map(e => e.ts);
+    if (clickTimes.length < 2) return null;
+
+    const WINDOW_MS = 3000;
+    let candidate = null;
+    let matches = 0;
+    for (const clickTs of clickTimes) {
+      const hit = apiRequests.find(r =>
+        r.ts >= clickTs && r.ts <= clickTs + WINDOW_MS &&
+        (!candidate || (r.url === candidate.url && r.method === candidate.method))
+      );
+      if (!hit) continue;
+      if (!candidate) candidate = { url: hit.url, method: hit.method };
+      matches++;
+    }
+    if (!candidate || matches < 2) return null;
+    return { url: candidate.url, method: candidate.method, occurrences: matches };
+  }
+
+  /**
    * Synthesize a transparent summary when the agent hits the step limit
    * without producing a final answer. Walks the conversation to count
    * tool usage and surface the last non-empty assistant message and the
@@ -820,9 +856,15 @@ export class Agent {
       };
     }
 
-    const warning = loop.type === 'repeat'
-      ? `[LOOP DETECTED: You've just called ${loop.name} ${loop.count} times with the same arguments and the same outcome. The current approach is NOT working. Try something fundamentally different: a different selector, a different tool, scroll to find a different element, or take a screenshot to see what's actually on screen. DO NOT repeat this exact call again — try a creative alternative.]`
-      : `[LOOP DETECTED: You're oscillating between ${loop.a} and ${loop.b} without making progress. Stop. Take a screenshot to see what's actually happening, then try a completely different approach.]`;
+    let warning;
+    if (loop.type === 'repeat') {
+      const shortcut = this._detectApiShortcut(tabId, loop, buf);
+      warning = shortcut
+        ? `[LOOP DETECTED + API SHORTCUT FOUND: You've called ${loop.name} ${loop.count} times. Each click triggered the same background request: ${shortcut.method} ${shortcut.url}. Instead of clicking again, call fetch_url({url: "${shortcut.url}", method: "${shortcut.method}"}) directly to get the next page's data.]`
+        : `[LOOP DETECTED: You've just called ${loop.name} ${loop.count} times with the same arguments and the same outcome. The current approach is NOT working. Try something fundamentally different: a different selector, a different tool, scroll to find a different element, or take a screenshot to see what's actually on screen. DO NOT repeat this exact call again — try a creative alternative.]`;
+    } else {
+      warning = `[LOOP DETECTED: You're oscillating between ${loop.a} and ${loop.b} without making progress. Stop. Take a screenshot to see what's actually happening, then try a completely different approach.]`;
+    }
     return { kind: 'nudge', warning };
   }
 

--- a/src/chrome/src/background.js
+++ b/src/chrome/src/background.js
@@ -562,6 +562,29 @@ chrome.webNavigation?.onCompleted?.addListener((details) => {
 
 chrome.tabs.onRemoved.addListener((tabId) => lastNavByTab.delete(tabId));
 
+// Background API call observer (issue #189). Watches XHR/fetch requests the
+// page itself fires — e.g. clicking "Next Page" — so the agent can later spot
+// a repeated UI action and shortcut to calling the underlying API directly.
+// Strict matching only: same tab, exact method/url captured as-is — no
+// param-pattern fuzzing yet.
+const API_REQUESTS_PER_TAB_LIMIT = 40;
+const apiRequestsByTab = new Map(); // tabId -> [{ url, method, ts }]
+globalThis.__webbrainApiRequests = apiRequestsByTab;
+
+chrome.webRequest.onBeforeRequest.addListener(
+  (details) => {
+    const { tabId, url, method } = details;
+    if (tabId == null || tabId < 0) return;
+    const list = apiRequestsByTab.get(tabId) || [];
+    list.push({ url, method, ts: Date.now() });
+    if (list.length > API_REQUESTS_PER_TAB_LIMIT) list.shift();
+    apiRequestsByTab.set(tabId, list);
+  },
+  { urls: ['<all_urls>'], types: ['xmlhttprequest'] }
+);
+
+chrome.tabs.onRemoved.addListener((tabId) => apiRequestsByTab.delete(tabId));
+
 /**
  * Central message handler.
  */

--- a/src/firefox/manifest.json
+++ b/src/firefox/manifest.json
@@ -7,6 +7,7 @@
     "activeTab",
     "menus",
     "webNavigation",
+    "webRequest",
     "storage",
     "unlimitedStorage",
     "tabs",

--- a/src/firefox/src/agent/agent.js
+++ b/src/firefox/src/agent/agent.js
@@ -485,6 +485,42 @@ export class Agent {
   }
 
   /**
+   * Issue #189 — mutation API observer shortcutter. When _checkLoop flags a
+   * repeated click (e.g. "Next Page" clicked 3x), check whether each click
+   * fired the same background XHR/fetch (captured by the webRequest
+   * listener in background.js). If so, surface the URL/method so the model
+   * can call fetch_url directly instead of clicking again.
+   *
+   * Strict matching only: same tab, exact url+method repeated, request must
+   * land within WINDOW_MS after the click that triggered it. No fuzzy
+   * param-pattern matching.
+   */
+  _detectApiShortcut(tabId, loop, buf) {
+    if (loop.type !== 'repeat') return null;
+    if (!['click', 'click_ax'].includes(loop.name)) return null;
+    const apiRequests = globalThis.__webbrainApiRequests?.get(tabId);
+    if (!apiRequests || apiRequests.length === 0) return null;
+
+    const clickTimes = buf.filter(e => e.key === loop.key).map(e => e.ts);
+    if (clickTimes.length < 2) return null;
+
+    const WINDOW_MS = 3000;
+    let candidate = null;
+    let matches = 0;
+    for (const clickTs of clickTimes) {
+      const hit = apiRequests.find(r =>
+        r.ts >= clickTs && r.ts <= clickTs + WINDOW_MS &&
+        (!candidate || (r.url === candidate.url && r.method === candidate.method))
+      );
+      if (!hit) continue;
+      if (!candidate) candidate = { url: hit.url, method: hit.method };
+      matches++;
+    }
+    if (!candidate || matches < 2) return null;
+    return { url: candidate.url, method: candidate.method, occurrences: matches };
+  }
+
+  /**
    * Synthesize a transparent summary when the agent hits the step limit
    * without producing a final answer. See chrome's copy for the rationale.
    */
@@ -570,9 +606,15 @@ export class Agent {
         message: `Stopped: I detected I was looping on ${desc} without making progress after multiple warnings. Please tell me what's blocking, give me a different instruction, or take a look at the page yourself.`,
       };
     }
-    const warning = loop.type === 'repeat'
-      ? `[LOOP DETECTED: You've just called ${loop.name} ${loop.count} times with the same arguments and the same outcome. The current approach is NOT working. Try something fundamentally different: a different selector, a different tool, scroll to find a different element, or take a screenshot to see what's actually on screen. DO NOT repeat this exact call again — try a creative alternative.]`
-      : `[LOOP DETECTED: You're oscillating between ${loop.a} and ${loop.b} without making progress. Stop. Take a screenshot to see what's actually happening, then try a completely different approach.]`;
+    let warning;
+    if (loop.type === 'repeat') {
+      const shortcut = this._detectApiShortcut(tabId, loop, buf);
+      warning = shortcut
+        ? `[LOOP DETECTED + API SHORTCUT FOUND: You've called ${loop.name} ${loop.count} times. Each click triggered the same background request: ${shortcut.method} ${shortcut.url}. Instead of clicking again, call fetch_url({url: "${shortcut.url}", method: "${shortcut.method}"}) directly to get the next page's data.]`
+        : `[LOOP DETECTED: You've just called ${loop.name} ${loop.count} times with the same arguments and the same outcome. The current approach is NOT working. Try something fundamentally different: a different selector, a different tool, scroll to find a different element, or take a screenshot to see what's actually on screen. DO NOT repeat this exact call again — try a creative alternative.]`;
+    } else {
+      warning = `[LOOP DETECTED: You're oscillating between ${loop.a} and ${loop.b} without making progress. Stop. Take a screenshot to see what's actually happening, then try a completely different approach.]`;
+    }
     return { kind: 'nudge', warning };
   }
 

--- a/src/firefox/src/background.js
+++ b/src/firefox/src/background.js
@@ -378,6 +378,29 @@ browser.webNavigation?.onReferenceFragmentUpdated?.addListener?.((details) => {
   if (details.frameId === 0) invalidateContextMenuForTab(details.tabId);
 });
 
+// Background API call observer (issue #189). Watches XHR/fetch requests the
+// page itself fires — e.g. clicking "Next Page" — so the agent can later spot
+// a repeated UI action and shortcut to calling the underlying API directly.
+// Strict matching only: same tab, exact method/url captured as-is — no
+// param-pattern fuzzing yet.
+const API_REQUESTS_PER_TAB_LIMIT = 40;
+const apiRequestsByTab = new Map(); // tabId -> [{ url, method, ts }]
+globalThis.__webbrainApiRequests = apiRequestsByTab;
+
+browser.webRequest.onBeforeRequest.addListener(
+  (details) => {
+    const { tabId, url, method } = details;
+    if (tabId == null || tabId < 0) return;
+    const list = apiRequestsByTab.get(tabId) || [];
+    list.push({ url, method, ts: Date.now() });
+    if (list.length > API_REQUESTS_PER_TAB_LIMIT) list.shift();
+    apiRequestsByTab.set(tabId, list);
+  },
+  { urls: ['<all_urls>'], types: ['xmlhttprequest'] }
+);
+
+browser.tabs.onRemoved.addListener((tabId) => apiRequestsByTab.delete(tabId));
+
 // Action click: toggle sidebar (existing UX) AND ensure source tab is
 // in the WebBrain group so the colored label appears immediately.
 browser.browserAction.onClicked.addListener((tab) => {


### PR DESCRIPTION
Implements issue #189.

When the agent detects it's clicking the same UI element repeatedly (like "Next Page"), it now checks background API calls that happened during those clicks. If it finds a matching pattern, it tells the agent the exact fetch_url call to make instead skipping the UI clicks entirely and going straight to the API.
Changes:

Added webRequest permission to Chrome and Firefox manifests
Added per-tab XHR/fetch request buffer in background.js (both builds)
Added _detectApiShortcut in agent.js wired into existing loop detection (both builds)

Closes #189