### PR TITLE
agent: add adapter for sahibinden.com

### DIFF
--- a/src/chrome/src/agent/adapters.js
+++ b/src/chrome/src/agent/adapters.js
@@ -553,6 +553,23 @@ const ADAPTERS = [
 - Pre-orders / "Made to order" listings have a longer ship date — surface that to the user before buying.`,
   },
 
+  // ─── Regional — Türkiye (TR) ──────────────────────────────────────────
+  // Regional adapters are the project's #1 wanted contribution (CONTRIBUTIONS.md);
+  // Türkiye is top of the priority list. Add more TR sites (trendyol,
+  // hepsiburada, n11, getir, yemeksepeti) below as separate, focused entries.
+  {
+    name: 'sahibinden',
+    category: 'general',
+    match: (url) => /^https?:\/\/(www\.)?sahibinden\.com\//.test(url),
+    notes: `
+- sahibinden is Türkiye's largest CLASSIFIEDS site (vehicles/"Vasıta", real estate/"Emlak", and general goods), NOT a checkout store. Most listings are "contact the seller", so do NOT hunt for a "Sepete Ekle"/Add-to-cart button on a typical car or property listing — the task is to read the listing and surface the seller's contact. "Mesaj Gönder" sends a message; the phone/"Cep" number is often revealed only after login.
+- ANTI-BOT TRAP: sahibinden runs aggressive bot protection (DataDome). You may hit a security/verification wall — a page saying "Güvenlik kontrolü", "İşleminize devam edebilmek için...", a slider/CAPTCHA, or "Erişiminiz engellendi". If you see one, STOP and tell the user a security check is blocking automated access. Do NOT loop retrying navigations/fetches — repeated automated requests escalate the block.
+- Do NOT re-fetch the same search/results URL repeatedly. The results list is already on the page; extract items from it (extract_data / get_accessibility_tree) before paginating. Re-running research_url/fetch_url on the same sorted URL (e.g. a "?...&sorting=..." or "?sd=..." variant) returns the same page and wastes steps.
+- Filtering: filters live in the LEFT rail (price range, "İl"/"İlçe" = province/district location, date, and category-specific facets). Set the location filter for local results. Sort via the "Sıralama" dropdown (e.g. price ascending) rather than guessing URL params.
+- Labels are Turkish: "Giriş Yap" = log in, "Üye Ol" = sign up, "İlan Ver"/"Ücretsiz İlan Ver" = post a listing, "Filtrele" = apply filters, "Sıralama" = sort.
+- Posting an "İlan" requires login and a multi-step form; after submitting it appears under "İlanlarım" with a status such as "Onay Bekliyor" (pending approval) — it is NOT live immediately. Do not report it as published until the status shows it is active ("Yayında").`,
+  },
+
   {
     name: 'apple',
     category: 'general',

--- a/src/firefox/src/agent/adapters.js
+++ b/src/firefox/src/agent/adapters.js
@@ -552,6 +552,23 @@ const ADAPTERS = [
 - Pre-orders / "Made to order" listings have a longer ship date — surface that to the user before buying.`,
   },
 
+  // ─── Regional — Türkiye (TR) ──────────────────────────────────────────
+  // Regional adapters are the project's #1 wanted contribution (CONTRIBUTIONS.md);
+  // Türkiye is top of the priority list. Add more TR sites (trendyol,
+  // hepsiburada, n11, getir, yemeksepeti) below as separate, focused entries.
+  {
+    name: 'sahibinden',
+    category: 'general',
+    match: (url) => /^https?:\/\/(www\.)?sahibinden\.com\//.test(url),
+    notes: `
+- sahibinden is Türkiye's largest CLASSIFIEDS site (vehicles/"Vasıta", real estate/"Emlak", and general goods), NOT a checkout store. Most listings are "contact the seller", so do NOT hunt for a "Sepete Ekle"/Add-to-cart button on a typical car or property listing — the task is to read the listing and surface the seller's contact. "Mesaj Gönder" sends a message; the phone/"Cep" number is often revealed only after login.
+- ANTI-BOT TRAP: sahibinden runs aggressive bot protection (DataDome). You may hit a security/verification wall — a page saying "Güvenlik kontrolü", "İşleminize devam edebilmek için...", a slider/CAPTCHA, or "Erişiminiz engellendi". If you see one, STOP and tell the user a security check is blocking automated access. Do NOT loop retrying navigations/fetches — repeated automated requests escalate the block.
+- Do NOT re-fetch the same search/results URL repeatedly. The results list is already on the page; extract items from it (extract_data / get_accessibility_tree) before paginating. Re-running research_url/fetch_url on the same sorted URL (e.g. a "?...&sorting=..." or "?sd=..." variant) returns the same page and wastes steps.
+- Filtering: filters live in the LEFT rail (price range, "İl"/"İlçe" = province/district location, date, and category-specific facets). Set the location filter for local results. Sort via the "Sıralama" dropdown (e.g. price ascending) rather than guessing URL params.
+- Labels are Turkish: "Giriş Yap" = log in, "Üye Ol" = sign up, "İlan Ver"/"Ücretsiz İlan Ver" = post a listing, "Filtrele" = apply filters, "Sıralama" = sort.
+- Posting an "İlan" requires login and a multi-step form; after submitting it appears under "İlanlarım" with a status such as "Onay Bekliyor" (pending approval) — it is NOT live immediately. Do not report it as published until the status shows it is active ("Yayında").`,
+  },
+
   {
     name: 'apple',
     category: 'general',

--- a/test/run.js
+++ b/test/run.js
@@ -539,6 +539,16 @@ test('matches apple store pages', () => {
   assert.equal(getActiveAdapter('https://secure.store.apple.com/shop/checkout')?.name, 'apple');
 });
 
+test('matches sahibinden.com and includes anti-bot guidance', () => {
+  assert.equal(getActiveAdapter('https://www.sahibinden.com/')?.name, 'sahibinden');
+  assert.equal(getActiveAdapter('https://sahibinden.com/kategori/vasita')?.name, 'sahibinden');
+  // lookalike / suffix domains must NOT match
+  assert.notEqual(getActiveAdapter('https://sahibinden.com.phishing.example/')?.name, 'sahibinden');
+  const a = getActiveAdapter('https://www.sahibinden.com/ilan/12345');
+  assert.match(a?.notes || '', /DataDome/);
+  assert.match(a?.notes || '', /classifieds/i);
+});
+
 test('matches stripe dashboard', () => {
   const a = getActiveAdapter('https://dashboard.stripe.com/payments');
   assert.equal(a?.name, 'stripe');


### PR DESCRIPTION
Adds a site adapter for **sahibinden.com**, Türkiye's largest classifieds site. CONTRIBUTIONS.md lists Turkish regional adapters as the #1 wanted contribution.

**Real failure modes it prevents**
- Hunting for an "Add to cart" on contact-the-seller listings — sahibinden is classifieds, not a checkout store.
- Looping into sahibinden's DataDome anti-bot wall instead of stopping and surfacing it to the user.
- Re-fetching the same sorted results URL repeatedly (the exact pattern documented in TODOs.md §4) instead of extracting from the page already loaded.

It also names the Turkish UI labels (Giriş Yap, İlan Ver, Sıralama, İl/İlçe) and the "Onay Bekliyor" pending-approval state so the agent doesn't report a listing as published prematurely.

- Mirrored to both `src/chrome/` and `src/firefox/` adapters.js.
- Adds a `getActiveAdapter` match + content test; `npm test` → 509/509 passing.