### PR TITLE
fable5 bugfixes

### DIFF
--- a/src/chrome/src/agent/agent.js
+++ b/src/chrome/src/agent/agent.js
@@ -1980,6 +1980,14 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
           // are page-derived and get persisted as history for the next turn.
           content: this._wrapUntrusted(fnName, this._limitToolResult(toolResult)),
         });
+        // If `done` wasn't the last call in the batch, the remaining tool_calls
+        // in this assistant message still need matching tool results — otherwise
+        // the persisted conversation has orphaned tool_calls and the provider
+        // rejects the next turn with a 400. Mirror the abort / bulk-replay paths.
+        this._appendSyntheticToolResults(
+          tabId, toolCalls, toolIndex + 1, messages, onUpdate, step,
+          () => ({ success: false, skipped: true, error: 'skipped: run ended via done' })
+        );
         this._persist(tabId);
         return { action: 'return', value: finalResponse };
       }
@@ -7062,7 +7070,12 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
               format: 'png', quality: 100, fromSurface: true,
             })
           );
-          result.image = `data:image/png;base64,${shot.data}`;
+          // Route the screenshot through `_attachImage` (like the `screenshot`
+          // tool) so the batch loop strips it and re-attaches it as an
+          // image_url block. Left inline as `result.image`, the base64 blob
+          // blows past the tool-result char cap and gets truncated to garbage
+          // that the vision model can never read.
+          result._attachImage = `data:image/png;base64,${shot.data}`;
         } catch {
           result.screenshotFailed = true;
         }

--- a/src/chrome/src/agent/pdf-tools.js
+++ b/src/chrome/src/agent/pdf-tools.js
@@ -159,6 +159,11 @@ export async function extractPdfText(url, opts = {}) {
   const pages = [];
   let charCount = 0;
   let truncated = false;
+  // Last page actually read, so the truncation notice's "read more with
+  // fromPage" advice resolves to a page that was really covered. Reporting
+  // `endPage` after an early `break` would make a caller resume past the
+  // unread pages and silently lose them.
+  let lastRead = startPage - 1;
 
   for (let i = startPage; i <= endPage; i++) {
     const page = await pdf.getPage(i);
@@ -176,12 +181,14 @@ export async function extractPdfText(url, opts = {}) {
     if (charCount + pageText.length > maxChars) {
       const remaining = Math.max(0, maxChars - charCount);
       pages.push(pageText.slice(0, remaining) + '… [page truncated, use read_pdf with fromPage to read more]');
+      lastRead = i;
       truncated = true;
       break;
     }
 
     pages.push(pageText);
     charCount += pageText.length;
+    lastRead = i;
 
     // Free per-page resources — pdfjs caches aggressively otherwise.
     page.cleanup?.();
@@ -196,7 +203,7 @@ export async function extractPdfText(url, opts = {}) {
     title,
     totalPages,
     fromPage: startPage,
-    toPage: endPage,
+    toPage: lastRead,
     pageCount: pages.length,
     pages,
     hasExtractableText,

--- a/src/chrome/src/content/content.js
+++ b/src/chrome/src/content/content.js
@@ -2213,6 +2213,26 @@
                 };
               }
             }
+            if (el.tagName === 'SELECT') {
+              // Native <select>: match the requested text against options by
+              // value, then by visible text (exact, then substring). A select's
+              // value can't be set through the INPUT prototype setter used below
+              // (Web IDL brand-check throws "Illegal invocation"), so handle it
+              // here with the HTMLSelectElement setter — mirrors _typeTextInner.
+              const needle = (text || '').trim();
+              const byValue = Array.from(el.options).find((o) => o.value === needle);
+              const byText = Array.from(el.options).find((o) => o.text.trim() === needle)
+                || Array.from(el.options).find((o) => o.text.trim().toLowerCase().includes(needle.toLowerCase()));
+              const match = byValue || byText;
+              if (!match) {
+                return { success: false, error: `No <option> matching "${text}" in select ref_id ${ref_id}.` };
+              }
+              const selSetter = Object.getOwnPropertyDescriptor(window.HTMLSelectElement.prototype, 'value')?.set;
+              if (selSetter) selSetter.call(el, match.value); else el.value = match.value;
+              el.dispatchEvent(new Event('input', { bubbles: true }));
+              el.dispatchEvent(new Event('change', { bubbles: true }));
+              return { success: true, method: 'type_ax_select', ref_id, value: el.value, rect: typeRect };
+            }
             if (clear) el.value = '';
             // Use the native setter so React's synthetic event system picks it up.
             const proto = el.tagName === 'TEXTAREA'

--- a/src/chrome/src/providers/anthropic.js
+++ b/src/chrome/src/providers/anthropic.js
@@ -90,15 +90,25 @@ export class AnthropicProvider extends BaseLLMProvider {
       }
 
       if (msg.role === 'tool') {
-        // Convert tool result messages
-        converted.push({
-          role: 'user',
-          content: [{
-            type: 'tool_result',
-            tool_use_id: msg.tool_call_id,
-            content: msg.content,
-          }],
-        });
+        // Convert tool result messages. Anthropic requires ALL tool_result
+        // blocks answering one assistant turn's parallel tool_use calls to live
+        // in a SINGLE user message — emitting one user message per tool result
+        // produces consecutive same-role messages that the API rejects with 400.
+        const block = {
+          type: 'tool_result',
+          tool_use_id: msg.tool_call_id,
+          content: msg.content,
+        };
+        const prev = converted[converted.length - 1];
+        if (
+          prev && prev.role === 'user' && Array.isArray(prev.content) &&
+          prev.content.length > 0 &&
+          prev.content.every((b) => b && b.type === 'tool_result')
+        ) {
+          prev.content.push(block);
+        } else {
+          converted.push({ role: 'user', content: [block] });
+        }
         continue;
       }
 

--- a/src/chrome/src/ui/recommended-actions.js
+++ b/src/chrome/src/ui/recommended-actions.js
@@ -66,7 +66,11 @@ function hasCartOrPriceSignal(pageInfo = {}) {
     ...(pageInfo.links || []).slice(0, 40).flatMap((link) => [link?.text, link?.href]),
     ...(pageInfo.forms || []).flatMap((form) => (form?.inputs || []).flatMap((input) => [input?.name, input?.id, input?.placeholder])),
   ].filter(Boolean).join(' ');
-  return /\b(add to cart|buy now|checkout|basket|cart|price|discount|sale|shipping|₺|\$|€|£)\b/i.test(haystack);
+  // Currency symbols are non-word characters, so `\b…\b` around them can never
+  // match — keep the word-boundary anchors for the keywords and test the
+  // symbols separately so a symbol-only price (e.g. "Total $50") still registers.
+  return /\b(add to cart|buy now|checkout|basket|cart|price|discount|sale|shipping)\b/i.test(haystack)
+    || /[₺$€£]/.test(haystack);
 }
 
 function communicationSignal(pageInfo = {}, { includeUrl = true } = {}) {

--- a/src/firefox/src/agent/agent.js
+++ b/src/firefox/src/agent/agent.js
@@ -1623,6 +1623,14 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
           // are page-derived and get persisted as history for the next turn.
           content: this._wrapUntrusted(fnName, this._limitToolResult(toolResult)),
         });
+        // If `done` wasn't the last call in the batch, the remaining tool_calls
+        // in this assistant message still need matching tool results — otherwise
+        // the persisted conversation has orphaned tool_calls and the provider
+        // rejects the next turn with a 400. Mirror the abort / bulk-replay paths.
+        this._appendSyntheticToolResults(
+          tabId, toolCalls, toolIndex + 1, messages, onUpdate, step,
+          () => ({ success: false, skipped: true, error: 'skipped: run ended via done' })
+        );
         this._persist(tabId);
         return { action: 'return', value: finalResponse };
       }
@@ -6149,7 +6157,11 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
         try {
           const tab = await browser.tabs.get(tabId);
           if (tab?.active) {
-            result.image = await this._withIndicatorsHidden(tabId, () =>
+            // Route through `_attachImage` (like the `screenshot` tool) so the
+            // batch loop strips it and re-attaches it as an image_url block.
+            // Left inline as `result.image`, the base64 data URL blows past the
+            // tool-result char cap and gets truncated to unreadable garbage.
+            result._attachImage = await this._withIndicatorsHidden(tabId, () =>
               browser.tabs.captureVisibleTab(tab.windowId, { format: 'png', quality: 80 })
             );
           } else {

--- a/src/firefox/src/agent/pdf-tools.js
+++ b/src/firefox/src/agent/pdf-tools.js
@@ -159,6 +159,11 @@ export async function extractPdfText(url, opts = {}) {
   const pages = [];
   let charCount = 0;
   let truncated = false;
+  // Last page actually read, so the truncation notice's "read more with
+  // fromPage" advice resolves to a page that was really covered. Reporting
+  // `endPage` after an early `break` would make a caller resume past the
+  // unread pages and silently lose them.
+  let lastRead = startPage - 1;
 
   for (let i = startPage; i <= endPage; i++) {
     const page = await pdf.getPage(i);
@@ -176,12 +181,14 @@ export async function extractPdfText(url, opts = {}) {
     if (charCount + pageText.length > maxChars) {
       const remaining = Math.max(0, maxChars - charCount);
       pages.push(pageText.slice(0, remaining) + '… [page truncated, use read_pdf with fromPage to read more]');
+      lastRead = i;
       truncated = true;
       break;
     }
 
     pages.push(pageText);
     charCount += pageText.length;
+    lastRead = i;
 
     // Free per-page resources — pdfjs caches aggressively otherwise.
     page.cleanup?.();
@@ -196,7 +203,7 @@ export async function extractPdfText(url, opts = {}) {
     title,
     totalPages,
     fromPage: startPage,
-    toPage: endPage,
+    toPage: lastRead,
     pageCount: pages.length,
     pages,
     hasExtractableText,

--- a/src/firefox/src/content/content.js
+++ b/src/firefox/src/content/content.js
@@ -2435,6 +2435,26 @@
                 return { success: false, error: `ref_id ${ref_id} is an <input type="${inputType}"> which is not text-typeable. Use click_ax to toggle/activate it instead.` };
               }
             }
+            if (el.tagName === 'SELECT') {
+              // Native <select>: match the requested text against options by
+              // value, then by visible text (exact, then substring). A select's
+              // value can't be set through the INPUT prototype setter used below
+              // (Web IDL brand-check throws "Illegal invocation"), so handle it
+              // here with the HTMLSelectElement setter.
+              const needle = (text || '').trim();
+              const byValue = Array.from(el.options).find((o) => o.value === needle);
+              const byText = Array.from(el.options).find((o) => o.text.trim() === needle)
+                || Array.from(el.options).find((o) => o.text.trim().toLowerCase().includes(needle.toLowerCase()));
+              const match = byValue || byText;
+              if (!match) {
+                return { success: false, error: `No <option> matching "${text}" in select ref_id ${ref_id}.` };
+              }
+              const selSetter = Object.getOwnPropertyDescriptor(window.HTMLSelectElement.prototype, 'value')?.set;
+              if (selSetter) selSetter.call(el, match.value); else el.value = match.value;
+              el.dispatchEvent(new Event('input', { bubbles: true }));
+              el.dispatchEvent(new Event('change', { bubbles: true }));
+              return { success: true, method: 'type_ax_select', ref_id, value: el.value, rect: typeRect };
+            }
             if (clear) el.value = '';
             const proto = el.tagName === 'TEXTAREA'
               ? window.HTMLTextAreaElement.prototype

--- a/src/firefox/src/providers/anthropic.js
+++ b/src/firefox/src/providers/anthropic.js
@@ -89,15 +89,25 @@ export class AnthropicProvider extends BaseLLMProvider {
       }
 
       if (msg.role === 'tool') {
-        // Convert tool result messages
-        converted.push({
-          role: 'user',
-          content: [{
-            type: 'tool_result',
-            tool_use_id: msg.tool_call_id,
-            content: msg.content,
-          }],
-        });
+        // Convert tool result messages. Anthropic requires ALL tool_result
+        // blocks answering one assistant turn's parallel tool_use calls to live
+        // in a SINGLE user message — emitting one user message per tool result
+        // produces consecutive same-role messages that the API rejects with 400.
+        const block = {
+          type: 'tool_result',
+          tool_use_id: msg.tool_call_id,
+          content: msg.content,
+        };
+        const prev = converted[converted.length - 1];
+        if (
+          prev && prev.role === 'user' && Array.isArray(prev.content) &&
+          prev.content.length > 0 &&
+          prev.content.every((b) => b && b.type === 'tool_result')
+        ) {
+          prev.content.push(block);
+        } else {
+          converted.push({ role: 'user', content: [block] });
+        }
         continue;
       }
 

--- a/src/firefox/src/ui/recommended-actions.js
+++ b/src/firefox/src/ui/recommended-actions.js
@@ -65,7 +65,11 @@ function hasCartOrPriceSignal(pageInfo = {}) {
     ...(pageInfo.links || []).slice(0, 40).flatMap((link) => [link?.text, link?.href]),
     ...(pageInfo.forms || []).flatMap((form) => (form?.inputs || []).flatMap((input) => [input?.name, input?.id, input?.placeholder])),
   ].filter(Boolean).join(' ');
-  return /\b(add to cart|buy now|checkout|basket|cart|price|discount|sale|shipping|₺|\$|€|£)\b/i.test(haystack);
+  // Currency symbols are non-word characters, so `\b…\b` around them can never
+  // match — keep the word-boundary anchors for the keywords and test the
+  // symbols separately so a symbol-only price (e.g. "Total $50") still registers.
+  return /\b(add to cart|buy now|checkout|basket|cart|price|discount|sale|shipping)\b/i.test(haystack)
+    || /[₺$€£]/.test(haystack);
 }
 
 function communicationSignal(pageInfo = {}, { includeUrl = true } = {}) {

--- a/test/run.js
+++ b/test/run.js
@@ -89,6 +89,15 @@ const { sanitizeLink, sanitizeMarkdownLinks } = await import(
   'file://' + path.join(ROOT, 'src/chrome/src/ui/markdown-link.js').replace(/\\/g, '/')
 );
 
+// anthropic.js imports cleanly under Node (its chrome.* touches are lazy); we
+// only exercise the pure _convertMessages transform here.
+const { AnthropicProvider: AnthropicProviderCh } = await import(
+  'file://' + path.join(ROOT, 'src/chrome/src/providers/anthropic.js').replace(/\\/g, '/')
+);
+const { AnthropicProvider: AnthropicProviderFx } = await import(
+  'file://' + path.join(ROOT, 'src/firefox/src/providers/anthropic.js').replace(/\\/g, '/')
+);
+
 const {
   PLANNER_SYSTEM_PROMPT,
   PLANNER_API_REPLAY_RULE,
@@ -14951,5 +14960,54 @@ test('planner input: recent conversation digest is included for follow-up acts',
   const plainUser = noHistory.find((m) => m.role === 'user');
   assert.ok(!/Recent conversation/.test(plainUser.content), 'no history section when there is no prior context');
 });
+
+// ── Anthropic parallel tool_result merge (regression) ──────────────────────
+// One assistant turn emitting parallel tool_use calls must have ALL its
+// tool_result blocks combined into a SINGLE user message — otherwise the
+// Messages API rejects the consecutive user roles with a 400.
+for (const [label, Provider] of [['chrome', AnthropicProviderCh], ['firefox', AnthropicProviderFx]]) {
+  test(`anthropic (${label}): parallel tool results merge into one user message`, () => {
+    const provider = new Provider({});
+    const { messages } = provider._convertMessages([
+      { role: 'system', content: 'sys' },
+      { role: 'user', content: 'hi' },
+      { role: 'assistant', content: '', tool_calls: [
+        { id: 't1', function: { name: 'a', arguments: '{}' } },
+        { id: 't2', function: { name: 'b', arguments: '{}' } },
+      ] },
+      { role: 'tool', tool_call_id: 't1', content: 'r1' },
+      { role: 'tool', tool_call_id: 't2', content: 'r2' },
+    ]);
+    // No two adjacent messages share the same role.
+    for (let i = 1; i < messages.length; i++) {
+      assert.notEqual(messages[i].role, messages[i - 1].role, `messages ${i - 1}/${i} must alternate roles`);
+    }
+    const toolMsg = messages.find(
+      (m) => m.role === 'user' && Array.isArray(m.content) && m.content[0]?.type === 'tool_result',
+    );
+    assert.ok(toolMsg, 'a merged tool_result user message exists');
+    assert.equal(toolMsg.content.length, 2, 'both tool_result blocks live in one user message');
+    assert.deepEqual(toolMsg.content.map((b) => b.tool_use_id), ['t1', 't2'], 'both tool_use_ids preserved in order');
+  });
+}
+
+// ── Recommended actions: symbol-only price triggers compare-price (regression) ─
+// A product page whose only price cue is a currency symbol must still surface
+// the compare-price action — the old `\b…\b` around the symbols could never match.
+for (const [label, build] of [['chrome', buildRecommendedActionsCh], ['firefox', buildRecommendedActionsFx]]) {
+  test(`recommended-actions (${label}): symbol-only price surfaces compare-price`, () => {
+    const pageInfo = {
+      url: 'https://www.amazon.com/dp/B0EXAMPLE',
+      title: 'Wireless Headphones',
+      description: 'Great sound. Total $50 today only.',
+    };
+    const actions = build(pageInfo);
+    assert.ok(actions.some((a) => a.id === 'compare-price'), 'compare-price offered for a $-only price');
+
+    // Non-shopping page with no price cue must NOT get the action.
+    const noPrice = build({ url: 'https://example.com/about', title: 'About us' });
+    assert.ok(!noPrice.some((a) => a.id === 'compare-price'), 'no compare-price without a shopping/price signal');
+  });
+}
 
 await run();


### PR DESCRIPTION
I ran a parallel bug-hunt across the core logic (four independent reviewers over agent.js, tools.js, content.js, network-tools.js, background.js, the providers, scheduler, and the UI), verified every reported finding against the real code, and discarded the non-bugs (unreachable variable refs, harmless no-ops, comment-vs-code mismatches). Five genuine bugs survived verification and are now fixed in both the Chrome and Firefox trees, with regression tests where the module was unit-testable.

Bugs fixed

1. verify_form screenshot corrupted, never seen by the model — agent.js
It stored the screenshot inline as result.image, but only _attachImage is stripped before stringifying. The inline base64 blew past the tool-result char cap and got truncated to garbage. Now routes through _attachImage like every other screenshot path.
2. done mid-batch produced a malformed conversation → provider 400 — agent.js
When done wasn't the last call in a tool batch, the early return left the remaining tool_calls with no matching results (orphaned tool calls the API rejects next turn). Now appends synthetic skip-results for the trailing calls, matching the abort/bulk-replay paths.
3. PDF pagination silently dropped pages — pdf-tools.js
On char-budget truncation it breaks but still returned toPage: endPage, so a caller resuming at toPage+1 skipped every unread page. Now returns the last page actually read.
4. Anthropic parallel tool calls rejected with 400 — anthropic.js
Each tool message became its own user message; parallel tool results produced consecutive same-role messages the Messages API rejects. Now merges all tool_result blocks for one turn into a single user message. (regression test added, chrome + firefox)
5. type_ax on a <select> always threw "Illegal invocation" — content.js
It used HTMLInputElement's value setter on a select receiver. Added a dedicated <select> branch that matches options by value/text and uses the HTMLSelectElement setter, mirroring _typeTextInner.

Plus a low-severity one the UI reviewer caught: currency-symbol price detection never fired in recommended-actions.js (\b around non-word symbols like $/€ can never match), so symbol-only prices missed the "compare price" action. Fixed and regression-tested in both trees.

Findings that were investigated and deliberately not changed (verified non-bugs): the captcha-solver timeout-variable ref (unreachable), the sendBtn event-spread no-op, protocol-relative markdown hrefs (fail safe under the extension origin), and several comment-vs-code mismatches with no behavioral impact.