### PR TITLE
fix: accept JSON in file picker and use app locale for speech input

### DIFF
--- a/src/chrome/src/agent/agent.js
+++ b/src/chrome/src/agent/agent.js
@@ -9712,6 +9712,8 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
           source: { type: 'base64', media_type: 'application/pdf', data: String(att.dataUrl || '').split(',')[1] || '' },
           ...(att.name ? { title: att.name } : {}),
         });
+      } else if (att.kind === 'text') {
+        blocks.push({ type: 'text', text: `[Attached file: ${att.name || 'file.json'}]\n${att.textContent || ''}` });
       }
     }
     if (blocks.length) {

--- a/src/chrome/src/ui/sidepanel.html
+++ b/src/chrome/src/ui/sidepanel.html
@@ -211,7 +211,7 @@
       </div>
       <div id="slash-command-menu" class="slash-command-menu hidden" role="listbox" data-i18n-aria-label="sp.slash.commands_label"></div>
       <div id="attachment-preview-list" class="attachment-preview-list hidden"></div>
-      <input type="file" id="file-attach-input" accept="image/*,application/pdf" multiple hidden>
+      <input type="file" id="file-attach-input" accept="image/*,application/pdf,application/json" multiple hidden>
       <div id="input-wrapper">
         <button id="btn-attach" data-i18n-title="sp.btn.attach">
           <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round">

--- a/src/chrome/src/ui/sidepanel.js
+++ b/src/chrome/src/ui/sidepanel.js
@@ -4148,7 +4148,7 @@ function startListening() {
   if (!SpeechRecognitionImpl || !inputEl) return;
   const recognition = new SpeechRecognitionImpl();
   speechRecognition = recognition;
-  recognition.lang = navigator.language || 'en-US';
+  recognition.lang = getLocale() || navigator.language || 'en-US';
   recognition.continuous = true;
   recognition.interimResults = true;
   micInterimText = '';
@@ -4441,7 +4441,8 @@ async function handleAttachedFiles(fileList, tabId = renderedTabId ?? currentTab
       }
       const isImage = file.type.startsWith('image/');
       const isPdf = file.type === 'application/pdf';
-      if (!isImage && !isPdf) {
+      const isJson = file.type === 'application/json';
+      if (!isImage && !isPdf && !isJson) {
         if (normalizeAttachmentTabId() === numericTabId) {
           addMessage('system', systemHtml(tSystemHtml('sp.attach.unsupported_type', { name: file.name })));
         }

--- a/src/chrome/src/ui/sidepanel.js
+++ b/src/chrome/src/ui/sidepanel.js
@@ -4424,6 +4424,15 @@ function readFileAsDataUrl(file) {
   });
 }
 
+function readFileAsText(file) {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => resolve(reader.result);
+    reader.onerror = () => reject(reader.error);
+    reader.readAsText(file);
+  });
+}
+
 async function handleAttachedFiles(fileList, tabId = renderedTabId ?? currentTabId) {
   const numericTabId = normalizeAttachmentTabId(tabId);
   if (numericTabId == null) return;
@@ -4449,9 +4458,15 @@ async function handleAttachedFiles(fileList, tabId = renderedTabId ?? currentTab
         continue;
       }
       try {
-        const dataUrl = await readFileAsDataUrl(file);
-        if (generation !== getAttachmentGeneration(numericTabId)) continue;
-        getPendingAttachmentsForTab(numericTabId).push({ kind: isImage ? 'image' : 'document', name: file.name, dataUrl });
+        if (isJson) {
+          const textContent = await readFileAsText(file);
+          if (generation !== getAttachmentGeneration(numericTabId)) continue;
+          getPendingAttachmentsForTab(numericTabId).push({ kind: 'text', name: file.name, textContent });
+        } else {
+          const dataUrl = await readFileAsDataUrl(file);
+          if (generation !== getAttachmentGeneration(numericTabId)) continue;
+          getPendingAttachmentsForTab(numericTabId).push({ kind: isImage ? 'image' : 'document', name: file.name, dataUrl });
+        }
       } catch {
         if (generation === getAttachmentGeneration(numericTabId) && normalizeAttachmentTabId() === numericTabId) {
           addMessage('system', systemHtml(tSystemHtml('sp.attach.read_failed', { name: file.name })));

--- a/src/chrome/src/ui/sidepanel.js
+++ b/src/chrome/src/ui/sidepanel.js
@@ -411,7 +411,7 @@ let renderedTabId = null;
 let pendingTabSwitch = null; // tab the user switched to while isProcessing was true
 let tabSwitchTransitionId = null;
 let queuedTabSwitchMessages = [];
-const pendingAttachmentsByTab = new Map(); // tabId -> [{ kind: 'image'|'document', name, dataUrl }]
+const pendingAttachmentsByTab = new Map(); // tabId -> [{ kind: 'image'|'document'|'text', name, dataUrl?, textContent? }]
 const attachmentReadCountsByTab = new Map();
 const attachmentGenerationByTab = new Map();
 let isProcessing = false;
@@ -4148,7 +4148,7 @@ function startListening() {
   if (!SpeechRecognitionImpl || !inputEl) return;
   const recognition = new SpeechRecognitionImpl();
   speechRecognition = recognition;
-  recognition.lang = getLocale() || navigator.language || 'en-US';
+  recognition.lang = getLocale();
   recognition.continuous = true;
   recognition.interimResults = true;
   micInterimText = '';

--- a/src/firefox/src/agent/agent.js
+++ b/src/firefox/src/agent/agent.js
@@ -6700,6 +6700,8 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
           source: { type: 'base64', media_type: 'application/pdf', data: String(att.dataUrl || '').split(',')[1] || '' },
           ...(att.name ? { title: att.name } : {}),
         });
+      } else if (att.kind === 'text') {
+        blocks.push({ type: 'text', text: `[Attached file: ${att.name || 'file.json'}]\n${att.textContent || ''}` });
       }
     }
     if (blocks.length) {

--- a/src/firefox/src/ui/sidepanel.html
+++ b/src/firefox/src/ui/sidepanel.html
@@ -196,7 +196,7 @@
       </div>
       <div id="slash-command-menu" class="slash-command-menu hidden" role="listbox" data-i18n-aria-label="sp.slash.commands_label"></div>
       <div id="attachment-preview-list" class="attachment-preview-list hidden"></div>
-      <input type="file" id="file-attach-input" accept="image/*,application/pdf" multiple hidden>
+      <input type="file" id="file-attach-input" accept="image/*,application/pdf,application/json" multiple hidden>
       <div id="input-wrapper">
         <button id="btn-attach" data-i18n-title="sp.btn.attach">
           <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round">

--- a/src/firefox/src/ui/sidepanel.js
+++ b/src/firefox/src/ui/sidepanel.js
@@ -3764,7 +3764,7 @@ function startListening() {
   if (!SpeechRecognitionImpl || !inputEl) return;
   const recognition = new SpeechRecognitionImpl();
   speechRecognition = recognition;
-  recognition.lang = navigator.language || 'en-US';
+  recognition.lang = getLocale() || navigator.language || 'en-US';
   recognition.continuous = true;
   recognition.interimResults = true;
   micInterimText = '';
@@ -3964,7 +3964,8 @@ async function handleAttachedFiles(fileList, tabId = currentTabId) {
       }
       const isImage = file.type.startsWith('image/');
       const isPdf = file.type === 'application/pdf';
-      if (!isImage && !isPdf) {
+      const isJson = file.type === 'application/json';
+      if (!isImage && !isPdf && !isJson) {
         if (normalizeAttachmentTabId() === numericTabId) {
           addMessage('system', systemHtml(tSystemHtml('sp.attach.unsupported_type', { name: file.name })));
         }

--- a/src/firefox/src/ui/sidepanel.js
+++ b/src/firefox/src/ui/sidepanel.js
@@ -3947,6 +3947,15 @@ function readFileAsDataUrl(file) {
   });
 }
 
+function readFileAsText(file) {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => resolve(reader.result);
+    reader.onerror = () => reject(reader.error);
+    reader.readAsText(file);
+  });
+}
+
 async function handleAttachedFiles(fileList, tabId = currentTabId) {
   const numericTabId = normalizeAttachmentTabId(tabId);
   if (numericTabId == null) return;
@@ -3972,9 +3981,15 @@ async function handleAttachedFiles(fileList, tabId = currentTabId) {
         continue;
       }
       try {
-        const dataUrl = await readFileAsDataUrl(file);
-        if (generation !== getAttachmentGeneration(numericTabId)) continue;
-        getPendingAttachmentsForTab(numericTabId).push({ kind: isImage ? 'image' : 'document', name: file.name, dataUrl });
+        if (isJson) {
+          const textContent = await readFileAsText(file);
+          if (generation !== getAttachmentGeneration(numericTabId)) continue;
+          getPendingAttachmentsForTab(numericTabId).push({ kind: 'text', name: file.name, textContent });
+        } else {
+          const dataUrl = await readFileAsDataUrl(file);
+          if (generation !== getAttachmentGeneration(numericTabId)) continue;
+          getPendingAttachmentsForTab(numericTabId).push({ kind: isImage ? 'image' : 'document', name: file.name, dataUrl });
+        }
       } catch {
         if (generation === getAttachmentGeneration(numericTabId) && normalizeAttachmentTabId() === numericTabId) {
           addMessage('system', systemHtml(tSystemHtml('sp.attach.read_failed', { name: file.name })));

--- a/src/firefox/src/ui/sidepanel.js
+++ b/src/firefox/src/ui/sidepanel.js
@@ -378,7 +378,7 @@ const BUSY_SLASH_NOTICE_COOLDOWN_MS = 3000;
 let currentTabId = null;
 let renderedTabId = null;
 let pendingTabSwitch = null; // tab the user switched to while isProcessing was true
-const pendingAttachmentsByTab = new Map(); // tabId -> [{ kind: 'image'|'document', name, dataUrl }]
+const pendingAttachmentsByTab = new Map(); // tabId -> [{ kind: 'image'|'document'|'text', name, dataUrl?, textContent? }]
 const attachmentReadCountsByTab = new Map();
 const attachmentGenerationByTab = new Map();
 let tabSwitchTransitionId = null;
@@ -3764,7 +3764,7 @@ function startListening() {
   if (!SpeechRecognitionImpl || !inputEl) return;
   const recognition = new SpeechRecognitionImpl();
   speechRecognition = recognition;
-  recognition.lang = getLocale() || navigator.language || 'en-US';
+  recognition.lang = getLocale();
   recognition.continuous = true;
   recognition.interimResults = true;
   micInterimText = '';

--- a/test/run.js
+++ b/test/run.js
@@ -15180,6 +15180,25 @@ test('attachments: uploaded documents are pruned for non-document providers', ()
   }
 });
 
+test('attachments: uploaded text files are injected as plain text blocks', () => {
+  for (const [label, AgentClass] of [['chrome', AgentCh], ['firefox', AgentFx]]) {
+    const agent = new AgentClass({});
+    const provider = { name: 'text-test', supportsVision: false, supportsDocuments: false };
+    const enriched = { role: 'user', content: 'analyze this config' };
+
+    const result = agent._applyAttachments(enriched, [
+      { kind: 'text', name: 'config.json', textContent: '{"key": "value"}' },
+    ], provider);
+
+    assert.equal(result.ok, true, `${label} should accept text attachments`);
+    const textBlock = enriched.content.find(block => block?.text?.includes('[Attached file: config.json]'));
+    assert.ok(textBlock, `${label} should inject a text block prefixed with the filename`);
+    assert.match(textBlock.text, /"key": "value"/, `${label} text block should contain the file content`);
+    const noticeBlock = enriched.content.find(block => block?.text?.startsWith('[UNTRUSTED USER ATTACHMENTS'));
+    assert.ok(noticeBlock, `${label} should include the untrusted attachment notice`);
+  }
+});
+
 test('sidepanel: pending attachments are tab-scoped and send-gated while loading', () => {
   for (const [label, file] of [
     ['chrome', 'src/chrome/src/ui/sidepanel.js'],


### PR DESCRIPTION
1. **File picker now accepts JSON** — added `application/json` to the `<input>` accept attribute and the JS type filter in `handleAttachedFiles()`.

2. **Mic uses app locale instead of browser default** — `recognition.lang` now reads from `getLocale()` (the globe icon setting) instead of `navigator.language`, so speech recognition matches the language the user actually selected.

Both Chrome and Firefox builds updated.
