### PR TITLE
Move suggested actions into chat-body pills (#223)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to WebBrain are documented in this file.
 
 This changelog was generated from the repository Git history and release tags. Versions without a Git tag are inferred from version-bump commits and the current `package.json` / browser manifest versions.
 
+## [20.4.1] - 2026-07-04
+
+### Changed
+- Moved the sidepanel pills to the middle of the sidepanel.
+
 ## [20.4.0] - 2026-07-03
 
 ### Changed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "webbrain",
-  "version": "20.4.0",
+  "version": "20.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "webbrain",
-      "version": "20.4.0",
+      "version": "20.4.1",
       "license": "MIT",
       "devDependencies": {
         "playwright": "^1.48.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webbrain",
-  "version": "20.4.0",
+  "version": "20.4.1",
   "description": "Open-source AI browser agent — chat with pages, automate tasks, multi-provider LLM support.",
   "private": true,
   "type": "module",

--- a/src/chrome/ARCHITECTURE.md
+++ b/src/chrome/ARCHITECTURE.md
@@ -1,6 +1,6 @@
 # WebBrain Chrome/Edge Extension — Architecture
 
-> Version 20.4.0 · Manifest V3 · Service Worker background
+> Version 20.4.1 · Manifest V3 · Service Worker background
 
 ## High-Level Overview
 

--- a/src/chrome/manifest.json
+++ b/src/chrome/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "WebBrain",
-  "version": "20.4.0",
+  "version": "20.4.1",
   "description": "Open-source AI browser agent — chat with pages, automate tasks, multi-provider LLM support.",
   "permissions": [
     "sidePanel",

--- a/src/chrome/src/ui/recommended-actions.js
+++ b/src/chrome/src/ui/recommended-actions.js
@@ -271,3 +271,13 @@ export function buildRecommendedActions(pageInfo = {}, options = {}) {
 
   return actions.slice(0, Math.max(0, max));
 }
+
+/**
+ * Whether the suggested-action pill row should be visible. Pills live in the
+ * chat body and disappear once the user has sent a message or a run is active.
+ */
+export function shouldShowRecommendedActions({ tabId, isProcessing, hasUserMessages }) {
+  if (tabId == null || isProcessing) return false;
+  if (hasUserMessages) return false;
+  return true;
+}

--- a/src/chrome/src/ui/settings.js
+++ b/src/chrome/src/ui/settings.js
@@ -19,7 +19,7 @@ import {
 
 // Version shown in the subtitle. Kept here so it only needs one update per
 // release; the subtitle string itself is translated.
-const EXT_VERSION = '20.4.0';
+const EXT_VERSION = '20.4.1';
 
 const providersContainer = document.getElementById('providers');
 const displaySettings = document.getElementById('display-settings');

--- a/src/chrome/src/ui/sidepanel.html
+++ b/src/chrome/src/ui/sidepanel.html
@@ -158,6 +158,25 @@
           </div>
         </div>
       </div>
+      <div id="recommended-actions" class="recommended-actions hidden" aria-live="polite">
+        <div class="recommended-actions-header">
+          <div class="recommended-actions-title" data-i18n="sp.recommended.title">Suggested actions</div>
+          <button
+            id="recommended-actions-toggle"
+            class="recommended-actions-toggle"
+            type="button"
+            aria-controls="recommended-actions-list"
+            aria-expanded="true"
+            data-i18n-title="sp.recommended.collapse"
+            data-i18n-aria-label="sp.recommended.collapse"
+          >
+            <svg viewBox="0 0 24 24" aria-hidden="true">
+              <path d="M6 9l6 6 6-6"/>
+            </svg>
+          </button>
+        </div>
+        <div id="recommended-actions-list" class="recommended-actions-list"></div>
+      </div>
     </div>
 
     <!-- Agent Activity Indicator -->
@@ -182,25 +201,6 @@
 
     <!-- Input Area -->
     <div id="input-area">
-      <div id="recommended-actions" class="recommended-actions hidden" aria-live="polite">
-        <div class="recommended-actions-header">
-          <div class="recommended-actions-title" data-i18n="sp.recommended.title">Suggested actions</div>
-          <button
-            id="recommended-actions-toggle"
-            class="recommended-actions-toggle"
-            type="button"
-            aria-controls="recommended-actions-list"
-            aria-expanded="true"
-            data-i18n-title="sp.recommended.collapse"
-            data-i18n-aria-label="sp.recommended.collapse"
-          >
-            <svg viewBox="0 0 24 24" aria-hidden="true">
-              <path d="M6 9l6 6 6-6"/>
-            </svg>
-          </button>
-        </div>
-        <div id="recommended-actions-list" class="recommended-actions-list"></div>
-      </div>
       <div id="mode-toggle">
         <button id="btn-mode-ask" class="mode-btn active" data-i18n="sp.mode.ask" data-i18n-title="sp.mode.ask.title"></button>
         <button id="btn-mode-act" class="mode-btn" data-i18n="sp.mode.act" data-i18n-title="sp.mode.act.title"></button>

--- a/src/chrome/src/ui/sidepanel.js
+++ b/src/chrome/src/ui/sidepanel.js
@@ -6,7 +6,7 @@
 import { t, getLocale, setLocale, LANGUAGES, applyDOMTranslations } from './i18n.js';
 import { sanitizeMarkdownLinks } from './markdown-link.js';
 import { applyMode, loadMode, watch } from './theme.js';
-import { buildRecommendedActions } from './recommended-actions.js';
+import { buildRecommendedActions, shouldShowRecommendedActions } from './recommended-actions.js';
 import { createContextMenuPromptHandler } from './context-menu-prompts.js';
 
 // Hydrate the theme from chrome.storage.local (the inline <head> bootstrap
@@ -1812,6 +1812,10 @@ async function switchToTab(newTabId) {
   consumePendingContextMenuPrompt().then(() => drainQueuedContextMenuPrompts()).catch(() => {});
 }
 
+function conversationHasUserMessages() {
+  return messagesEl.querySelector('.message.user') != null;
+}
+
 function hideRecommendedActions() {
   if (!recommendedActionsEl || !recommendedActionsListEl) return;
   recommendedActionsListEl.replaceChildren();
@@ -1863,7 +1867,11 @@ document.addEventListener('wb-locale-changed', updateRecommendedActionsCollapsed
 
 async function refreshRecommendedActions() {
   const requestId = ++recommendationsRequestId;
-  if (!recommendedActionsEl || !recommendedActionsListEl || currentTabId == null || isProcessing) {
+  if (!recommendedActionsEl || !recommendedActionsListEl || !shouldShowRecommendedActions({
+    tabId: currentTabId,
+    isProcessing,
+    hasUserMessages: conversationHasUserMessages(),
+  })) {
     hideRecommendedActions();
     return;
   }

--- a/src/chrome/styles/sidepanel.css
+++ b/src/chrome/styles/sidepanel.css
@@ -514,6 +514,7 @@ body {
   overflow-y: auto;
   padding: 12px;
   scroll-behavior: smooth;
+  position: relative;
 }
 
 #messages {
@@ -1039,17 +1040,26 @@ body {
 
 
 
-/* Context-aware recommendations */
+/* Context-aware recommendations — centered pill row in the chat body */
 .recommended-actions {
-  margin-bottom: 6px;
-  padding: 5px 6px;
-  border: 1px solid var(--border);
-  border-radius: var(--radius-sm);
-  background: var(--tint-soft-2);
+  position: absolute;
+  inset: 0;
+  z-index: 2;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  margin: 0;
+  padding: 16px 12px;
+  border: none;
+  border-radius: 0;
+  background: transparent;
+  pointer-events: none;
 }
 
 .recommended-actions.collapsed {
-  padding: 4px 6px;
+  padding: 16px 12px;
 }
 
 .recommended-actions.hidden {
@@ -1059,9 +1069,10 @@ body {
 .recommended-actions-header {
   display: flex;
   align-items: center;
-  justify-content: space-between;
+  justify-content: center;
   gap: 6px;
-  margin-bottom: 4px;
+  margin-bottom: 0;
+  pointer-events: auto;
 }
 
 .recommended-actions.collapsed .recommended-actions-header {
@@ -1072,7 +1083,7 @@ body {
   color: var(--text-muted);
   font-size: 10px;
   font-weight: 700;
-  letter-spacing: 0.02em;
+  letter-spacing: 0.04em;
   line-height: 1;
   text-transform: uppercase;
 }
@@ -1117,7 +1128,10 @@ body {
 .recommended-actions-list {
   display: flex;
   flex-wrap: wrap;
-  gap: 4px;
+  gap: 6px;
+  justify-content: center;
+  max-width: min(100%, 340px);
+  pointer-events: auto;
 }
 
 .recommended-actions.collapsed .recommended-actions-list {
@@ -1127,14 +1141,16 @@ body {
 .recommended-action-chip {
   border: 1px solid var(--border);
   border-radius: 999px;
-  background: var(--bg-input);
+  background: color-mix(in srgb, var(--bg-secondary) 82%, transparent);
+  backdrop-filter: blur(6px);
   color: var(--text-secondary);
   cursor: pointer;
   font: inherit;
   font-size: 11px;
   line-height: 1.2;
-  padding: 4px 7px;
+  padding: 6px 10px;
   transition: border-color 0.15s, color 0.15s, background 0.15s, transform 0.1s;
+  box-shadow: 0 1px 2px color-mix(in srgb, var(--border) 40%, transparent);
 }
 
 .recommended-action-chip:hover {

--- a/src/firefox/ARCHITECTURE.md
+++ b/src/firefox/ARCHITECTURE.md
@@ -1,6 +1,6 @@
 # WebBrain Firefox Extension — Architecture
 
-> Version 20.4.0 · Manifest V2 · Background Page
+> Version 20.4.1 · Manifest V2 · Background Page
 
 ## How Firefox Differs from Chrome
 

--- a/src/firefox/manifest.json
+++ b/src/firefox/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "WebBrain",
-  "version": "20.4.0",
+  "version": "20.4.1",
   "description": "Open-source AI browser agent — chat with pages, automate tasks, multi-provider LLM support.",
   "permissions": [
     "activeTab",

--- a/src/firefox/src/ui/recommended-actions.js
+++ b/src/firefox/src/ui/recommended-actions.js
@@ -261,3 +261,13 @@ export function buildRecommendedActions(pageInfo = {}, options = {}) {
 
   return actions.slice(0, Math.max(0, max));
 }
+
+/**
+ * Whether the suggested-action pill row should be visible. Pills live in the
+ * chat body and disappear once the user has sent a message or a run is active.
+ */
+export function shouldShowRecommendedActions({ tabId, isProcessing, hasUserMessages }) {
+  if (tabId == null || isProcessing) return false;
+  if (hasUserMessages) return false;
+  return true;
+}

--- a/src/firefox/src/ui/settings.js
+++ b/src/firefox/src/ui/settings.js
@@ -19,7 +19,7 @@ import {
 
 // Version shown in the subtitle. Kept here so it only needs one update per
 // release; the subtitle string itself is translated.
-const EXT_VERSION = '20.4.0';
+const EXT_VERSION = '20.4.1';
 
 const providersContainer = document.getElementById('providers');
 const displaySettings = document.getElementById('display-settings');

--- a/src/firefox/src/ui/sidepanel.html
+++ b/src/firefox/src/ui/sidepanel.html
@@ -147,6 +147,25 @@
           </div>
         </div>
       </div>
+      <div id="recommended-actions" class="recommended-actions hidden" aria-live="polite">
+        <div class="recommended-actions-header">
+          <div class="recommended-actions-title" data-i18n="sp.recommended.title">Suggested actions</div>
+          <button
+            id="recommended-actions-toggle"
+            class="recommended-actions-toggle"
+            type="button"
+            aria-controls="recommended-actions-list"
+            aria-expanded="true"
+            data-i18n-title="sp.recommended.collapse"
+            data-i18n-aria-label="sp.recommended.collapse"
+          >
+            <svg viewBox="0 0 24 24" aria-hidden="true">
+              <path d="M6 9l6 6 6-6"/>
+            </svg>
+          </button>
+        </div>
+        <div id="recommended-actions-list" class="recommended-actions-list"></div>
+      </div>
     </div>
 
     <!-- Agent Activity Indicator -->
@@ -171,25 +190,6 @@
 
     <!-- Input Area -->
     <div id="input-area">
-      <div id="recommended-actions" class="recommended-actions hidden" aria-live="polite">
-        <div class="recommended-actions-header">
-          <div class="recommended-actions-title" data-i18n="sp.recommended.title">Suggested actions</div>
-          <button
-            id="recommended-actions-toggle"
-            class="recommended-actions-toggle"
-            type="button"
-            aria-controls="recommended-actions-list"
-            aria-expanded="true"
-            data-i18n-title="sp.recommended.collapse"
-            data-i18n-aria-label="sp.recommended.collapse"
-          >
-            <svg viewBox="0 0 24 24" aria-hidden="true">
-              <path d="M6 9l6 6 6-6"/>
-            </svg>
-          </button>
-        </div>
-        <div id="recommended-actions-list" class="recommended-actions-list"></div>
-      </div>
       <div id="mode-toggle">
         <button id="btn-mode-ask" class="mode-btn active" data-i18n="sp.mode.ask" data-i18n-title="sp.mode.ask.title"></button>
         <button id="btn-mode-act" class="mode-btn" data-i18n="sp.mode.act" data-i18n-title="sp.mode.act.title"></button>

--- a/src/firefox/src/ui/sidepanel.js
+++ b/src/firefox/src/ui/sidepanel.js
@@ -6,7 +6,7 @@
 import { t, getLocale, setLocale, LANGUAGES, applyDOMTranslations } from './i18n.js';
 import { sanitizeMarkdownLinks } from './markdown-link.js';
 import { applyMode, loadMode, watch } from './theme.js';
-import { buildRecommendedActions } from './recommended-actions.js';
+import { buildRecommendedActions, shouldShowRecommendedActions } from './recommended-actions.js';
 import { createContextMenuPromptHandler } from './context-menu-prompts.js';
 
 // Hydrate the theme from browser.storage.local (the inline <head> bootstrap
@@ -1776,6 +1776,10 @@ async function switchToTab(newTabId) {
   consumePendingContextMenuPrompt().then(() => drainQueuedContextMenuPrompts()).catch(() => {});
 }
 
+function conversationHasUserMessages() {
+  return messagesEl.querySelector('.message.user') != null;
+}
+
 function hideRecommendedActions() {
   if (!recommendedActionsEl || !recommendedActionsListEl) return;
   recommendedActionsListEl.replaceChildren();
@@ -1827,7 +1831,11 @@ document.addEventListener('wb-locale-changed', updateRecommendedActionsCollapsed
 
 async function refreshRecommendedActions() {
   const requestId = ++recommendationsRequestId;
-  if (!recommendedActionsEl || !recommendedActionsListEl || currentTabId == null || isProcessing) {
+  if (!recommendedActionsEl || !recommendedActionsListEl || !shouldShowRecommendedActions({
+    tabId: currentTabId,
+    isProcessing,
+    hasUserMessages: conversationHasUserMessages(),
+  })) {
     hideRecommendedActions();
     return;
   }

--- a/src/firefox/styles/sidepanel.css
+++ b/src/firefox/styles/sidepanel.css
@@ -513,6 +513,7 @@ body {
   overflow-y: auto;
   padding: 12px;
   scroll-behavior: smooth;
+  position: relative;
 }
 
 #messages {
@@ -1038,17 +1039,26 @@ body {
 
 
 
-/* Context-aware recommendations */
+/* Context-aware recommendations — centered pill row in the chat body */
 .recommended-actions {
-  margin-bottom: 6px;
-  padding: 5px 6px;
-  border: 1px solid var(--border);
-  border-radius: var(--radius-sm);
-  background: var(--tint-soft-2);
+  position: absolute;
+  inset: 0;
+  z-index: 2;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  margin: 0;
+  padding: 16px 12px;
+  border: none;
+  border-radius: 0;
+  background: transparent;
+  pointer-events: none;
 }
 
 .recommended-actions.collapsed {
-  padding: 4px 6px;
+  padding: 16px 12px;
 }
 
 .recommended-actions.hidden {
@@ -1058,9 +1068,10 @@ body {
 .recommended-actions-header {
   display: flex;
   align-items: center;
-  justify-content: space-between;
+  justify-content: center;
   gap: 6px;
-  margin-bottom: 4px;
+  margin-bottom: 0;
+  pointer-events: auto;
 }
 
 .recommended-actions.collapsed .recommended-actions-header {
@@ -1071,7 +1082,7 @@ body {
   color: var(--text-muted);
   font-size: 10px;
   font-weight: 700;
-  letter-spacing: 0.02em;
+  letter-spacing: 0.04em;
   line-height: 1;
   text-transform: uppercase;
 }
@@ -1116,7 +1127,10 @@ body {
 .recommended-actions-list {
   display: flex;
   flex-wrap: wrap;
-  gap: 4px;
+  gap: 6px;
+  justify-content: center;
+  max-width: min(100%, 340px);
+  pointer-events: auto;
 }
 
 .recommended-actions.collapsed .recommended-actions-list {
@@ -1126,14 +1140,16 @@ body {
 .recommended-action-chip {
   border: 1px solid var(--border);
   border-radius: 999px;
-  background: var(--bg-input);
+  background: color-mix(in srgb, var(--bg-secondary) 82%, transparent);
+  backdrop-filter: blur(6px);
   color: var(--text-secondary);
   cursor: pointer;
   font: inherit;
   font-size: 11px;
   line-height: 1.2;
-  padding: 4px 7px;
+  padding: 6px 10px;
   transition: border-color 0.15s, color 0.15s, background 0.15s, transform 0.1s;
+  box-shadow: 0 1px 2px color-mix(in srgb, var(--border) 40%, transparent);
 }
 
 .recommended-action-chip:hover {

--- a/test/run.js
+++ b/test/run.js
@@ -267,10 +267,10 @@ const { LlamaCppProvider: LlamaCppProviderCh } = await import(
 const { LlamaCppProvider: LlamaCppProviderFx } = await import(
   'file://' + path.join(ROOT, 'src/firefox/src/providers/llamacpp.js').replace(/\\/g, '/')
 );
-const { buildRecommendedActions: buildRecommendedActionsCh } = await import(
+const { buildRecommendedActions: buildRecommendedActionsCh, shouldShowRecommendedActions: shouldShowRecommendedActionsCh } = await import(
   'file://' + path.join(ROOT, 'src/chrome/src/ui/recommended-actions.js').replace(/\\/g, '/')
 );
-const { buildRecommendedActions: buildRecommendedActionsFx } = await import(
+const { buildRecommendedActions: buildRecommendedActionsFx, shouldShowRecommendedActions: shouldShowRecommendedActionsFx } = await import(
   'file://' + path.join(ROOT, 'src/firefox/src/ui/recommended-actions.js').replace(/\\/g, '/')
 );
 const { Agent: AgentCh } = await import(
@@ -2769,6 +2769,31 @@ test('firefox recommended actions omit Chrome-only recording', () => {
   const meetingPage = { url: 'https://meet.google.com/abc-defg-hij', title: 'Team meeting' };
   assert.equal(buildRecommendedActionsCh(meetingPage).some((a) => a.id === 'record-meeting'), true);
   assert.equal(buildRecommendedActionsFx(meetingPage).some((a) => a.id === 'record-meeting'), false);
+});
+
+test('suggested pills hide when conversation has user messages', () => {
+  for (const shouldShow of [shouldShowRecommendedActionsCh, shouldShowRecommendedActionsFx]) {
+    assert.equal(shouldShow({ tabId: 1, isProcessing: false, hasUserMessages: false }), true);
+    assert.equal(shouldShow({ tabId: 1, isProcessing: false, hasUserMessages: true }), false);
+    assert.equal(shouldShow({ tabId: null, isProcessing: false, hasUserMessages: false }), false);
+    assert.equal(shouldShow({ tabId: 1, isProcessing: true, hasUserMessages: false }), false);
+  }
+});
+
+test('suggested actions live in chat body not input area', () => {
+  for (const [label, htmlRel] of [
+    ['chrome', 'src/chrome/src/ui/sidepanel.html'],
+    ['firefox', 'src/firefox/src/ui/sidepanel.html'],
+  ]) {
+    const html = fs.readFileSync(path.join(ROOT, htmlRel), 'utf8');
+    const chatStart = html.indexOf('id="chat-container"');
+    const inputStart = html.indexOf('id="input-area"');
+    const actionsIdx = html.indexOf('id="recommended-actions"');
+    assert.notEqual(chatStart, -1, `${label}: chat container missing`);
+    assert.notEqual(inputStart, -1, `${label}: input area missing`);
+    assert.notEqual(actionsIdx, -1, `${label}: recommended actions missing`);
+    assert.equal(actionsIdx > chatStart && actionsIdx < inputStart, true, `${label}: suggested actions should live inside the chat container, not the input area`);
+  }
 });
 
 // ────────────────────────────────────────────────────────────────────────
@@ -5989,6 +6014,7 @@ test('sidepanel drops stale recommended-action refreshes after tab changes or ru
     const match = panel.match(/async function refreshRecommendedActions\(\) \{([\s\S]*?)\n\}/);
     assert.ok(match, `${label}: refreshRecommendedActions missing`);
     const body = match[1];
+    assert.match(body, /shouldShowRecommendedActions\(\{[\s\S]*?hasUserMessages: conversationHasUserMessages\(\)/, `${label}: recommended-action refresh should hide pills when the conversation has user messages`);
     const captureIdx = body.indexOf('const tabId = currentTabId;');
     const sendIdx = body.indexOf("sendToBackground('get_page_info', { tabId })");
     const guard = 'requestId !== recommendationsRequestId || currentTabId !== tabId || isProcessing';


### PR DESCRIPTION
## Summary
- Moves suggested actions from the input chrome into the **center of the chat body** as translucent pill buttons (matches maintainer mock in #223).
- Pills **disappear with the dialog**: hidden once the user sends a message, while a run is active, or when restored tab chat already contains user messages.
- Reuses existing `buildRecommendedActions()` heuristics and collapse preference; Chrome + Firefox parity.

Closes #223

## UX (per maintainer feedback)
| State | Pills |
|-------|-------|
| Fresh/empty chat + page loaded | Centered pills in chat viewport |
| User sends message | Hidden immediately |
| Run in progress | Hidden |
| Clear conversation (`+`) | Shown again when page context is valid |
| Tab switch to chat with history | Hidden (user messages present) |

## Test plan
- [x] `npm test` — all tests passing (includes new placement + visibility helpers)
- [ ] Chrome: open side panel on a normal page → pills centered in chat, not above input
- [ ] Click a pill → prompt sends, pills disappear
- [ ] Clear chat → pills return
- [ ] Firefox: same matrix