### PR TITLE
agent: add adapter for trendyol.com

### DIFF
--- a/src/chrome/src/agent/adapters.js
+++ b/src/chrome/src/agent/adapters.js
@@ -16112,6 +16112,18 @@ const ADAPTERS = [
 - Labels are Turkish: "Giriş Yap" = log in, "Üye Ol" = sign up, "İlan Ver"/"Ücretsiz İlan Ver" = post a listing, "Filtrele" = apply filters, "Sıralama" = sort.
 - Posting an "İlan" requires login and a multi-step form; after submitting it appears under "İlanlarım" with a status such as "Onay Bekliyor" (pending approval) — it is NOT live immediately. Do not report it as published until the status shows it is active ("Yayında").`,
   },
+  {
+    name: 'trendyol',
+    category: 'general',
+    match: (url) => /^https?:\/\/(www\.)?trendyol\.com\//.test(url),
+    notes: `
+- Trendyol is Türkiye's largest e-commerce MARKETPLACE (many third-party sellers per product), fashion-first but sells everything. Turkish labels: "Sepete Ekle" = add to cart, "Sepetim" = cart, "Hemen Al" = buy now, "Favorilere Ekle" = wishlist (needs login), "Giriş Yap" = log in, "Sıralama" = sort, "Filtrele" = filter.
+- Variant trap: pick "Beden" (size) and/or "Renk" (color) BEFORE "Sepete Ekle". If none is selected the button is inert and the page prompts you to choose a size — select the variant first, then add.
+- Marketplace-seller trap: the same product has multiple sellers. "Sepete Ekle" buys from the CURRENTLY SELECTED seller; a cheaper or faster one is often listed under "Diğer Satıcılar" (other sellers). Check it before quoting "the price".
+- Basket-discount trap: the listed price is NOT always final. Trendyol applies "Sepette %X indirim" (extra discount in cart) and coupons only at the basket, so quote the CART total — not the card/detail price — when the user asks what they'll pay.
+- Sort with the "Sıralama" dropdown ("En düşük fiyat" = price low→high, "En yüksek fiyat", "En yeniler", "Çok satanlar"); set filters in the left rail ("Marka" brand, "Fiyat" price, "Beden", rating) instead of guessing URL params.
+- Add-to-cart opens a drawer ("Sepete Git" vs keep shopping); the cart lives at /sepetim and checkout requires login. "Trendyol Go" (food/grocery quick-commerce) is a separate flow from the marketplace catalog.`,
+  },
 
   {
     name: 'apple',

--- a/src/firefox/src/agent/adapters.js
+++ b/src/firefox/src/agent/adapters.js
@@ -16111,6 +16111,18 @@ const ADAPTERS = [
 - Labels are Turkish: "Giriş Yap" = log in, "Üye Ol" = sign up, "İlan Ver"/"Ücretsiz İlan Ver" = post a listing, "Filtrele" = apply filters, "Sıralama" = sort.
 - Posting an "İlan" requires login and a multi-step form; after submitting it appears under "İlanlarım" with a status such as "Onay Bekliyor" (pending approval) — it is NOT live immediately. Do not report it as published until the status shows it is active ("Yayında").`,
   },
+  {
+    name: 'trendyol',
+    category: 'general',
+    match: (url) => /^https?:\/\/(www\.)?trendyol\.com\//.test(url),
+    notes: `
+- Trendyol is Türkiye's largest e-commerce MARKETPLACE (many third-party sellers per product), fashion-first but sells everything. Turkish labels: "Sepete Ekle" = add to cart, "Sepetim" = cart, "Hemen Al" = buy now, "Favorilere Ekle" = wishlist (needs login), "Giriş Yap" = log in, "Sıralama" = sort, "Filtrele" = filter.
+- Variant trap: pick "Beden" (size) and/or "Renk" (color) BEFORE "Sepete Ekle". If none is selected the button is inert and the page prompts you to choose a size — select the variant first, then add.
+- Marketplace-seller trap: the same product has multiple sellers. "Sepete Ekle" buys from the CURRENTLY SELECTED seller; a cheaper or faster one is often listed under "Diğer Satıcılar" (other sellers). Check it before quoting "the price".
+- Basket-discount trap: the listed price is NOT always final. Trendyol applies "Sepette %X indirim" (extra discount in cart) and coupons only at the basket, so quote the CART total — not the card/detail price — when the user asks what they'll pay.
+- Sort with the "Sıralama" dropdown ("En düşük fiyat" = price low→high, "En yüksek fiyat", "En yeniler", "Çok satanlar"); set filters in the left rail ("Marka" brand, "Fiyat" price, "Beden", rating) instead of guessing URL params.
+- Add-to-cart opens a drawer ("Sepete Git" vs keep shopping); the cart lives at /sepetim and checkout requires login. "Trendyol Go" (food/grocery quick-commerce) is a separate flow from the marketplace catalog.`,
+  },
 
   {
     name: 'apple',

--- a/test/run.js
+++ b/test/run.js
@@ -672,6 +672,16 @@ test('matches sahibinden.com and includes anti-bot guidance', () => {
   assert.match(a?.notes || '', /classifieds/i);
 });
 
+test('matches trendyol.com and includes marketplace guidance', () => {
+  assert.equal(getActiveAdapter('https://www.trendyol.com/')?.name, 'trendyol');
+  assert.equal(getActiveAdapter('https://trendyol.com/cok-satanlar')?.name, 'trendyol');
+  // lookalike / suffix domains must NOT match
+  assert.notEqual(getActiveAdapter('https://trendyol.com.phishing.example/')?.name, 'trendyol');
+  const a = getActiveAdapter('https://www.trendyol.com/sr?q=ayakkabi');
+  assert.match(a?.notes || '', /marketplace/i);
+  assert.match(a?.notes || '', /Sepete Ekle/);
+});
+
 test('matches stripe dashboard', () => {
   const a = getActiveAdapter('https://dashboard.stripe.com/payments');
   assert.equal(a?.name, 'stripe');


### PR DESCRIPTION
Adds a site adapter for **trendyol.com**, Türkiye's largest e-commerce marketplace. Follow-up to #234 (sahibinden) — @esokullu asked for more TR regional adapters, one focused PR each.

**Real failure modes it prevents**
- **Variant-before-cart:** "Sepete Ekle" stays inert until a "Beden"/"Renk" (size/color) variant is picked — otherwise the agent clicks a dead button and loops.
- **Marketplace sellers:** each product has multiple sellers; the buy button uses the selected one, and a cheaper/faster offer often sits under "Diğer Satıcılar". Don't quote a single seller as "the price".
- **Basket-only discounts:** the listed price isn't final — "Sepette %X indirim" and coupons apply at the cart, so the real total is the basket total.
- **Sort/filter via UI:** use the "Sıralama" dropdown and the left-rail "Filtrele" instead of guessing URL params.

It also names the Turkish labels (Sepete Ekle, Sepetim, Favorilere Ekle, Sıralama…) and flags that Trendyol Go (food/grocery quick-commerce) is a separate flow from the marketplace catalog.

- Mirrored to both `src/chrome/` and `src/firefox/` adapters.js.
- Adds a `getActiveAdapter` match + content test; `npm test` → 591/591 passing.
