### PR TITLE
agent: add adapter for hepsiburada.com

### DIFF
--- a/src/chrome/src/agent/adapters.js
+++ b/src/chrome/src/agent/adapters.js
@@ -16124,6 +16124,18 @@ const ADAPTERS = [
 - Sort with the "Sıralama" dropdown ("En düşük fiyat" = price low→high, "En yüksek fiyat", "En yeniler", "Çok satanlar"); set filters in the left rail ("Marka" brand, "Fiyat" price, "Beden", rating) instead of guessing URL params.
 - Add-to-cart opens a drawer ("Sepete Git" vs keep shopping); the cart lives at /sepetim and checkout requires login. "Trendyol Go" (food/grocery quick-commerce) is a separate flow from the marketplace catalog.`,
   },
+  {
+    name: 'hepsiburada',
+    category: 'general',
+    match: (url) => /^https?:\/\/(www\.)?hepsiburada\.com\//.test(url),
+    notes: `
+- Hepsiburada is a major Turkish e-commerce MARKETPLACE (electronics-heavy, but sells everything) with third-party sellers per product. Turkish labels: "Sepete Ekle" = add to cart, "Sepetim" = cart, "Favorilerime Ekle" = wishlist (needs login), "Giriş Yap" = log in, "Sıralama" = sort, "Filtreler" = filters, "Değerlendirmeler" = reviews.
+- Variant trap: pick color/size/capacity (e.g. "Renk", "Beden", storage) BEFORE "Sepete Ekle" — until a required variant is chosen the button won't add the item.
+- Multiple-seller trap: the buy box is for ONE seller; open "Diğer Satıcılar" / "Tüm Satıcıları Gör" to compare price and cargo speed before quoting "the price". The default seller isn't always the cheapest.
+- Price trap: the listed price is not the final total. Hepsiburada shows "Sepette %X indirim" (extra discount applied only in the cart) plus extra "HepsiPay ile ödemede" (pay-with-HepsiPay) discounts — quote the cart/payment total, not the card price.
+- Sort with the "Sıralama" dropdown ("En düşük fiyat" = price low→high, "En yüksek fiyat", "En yeniler", "En çok değerlendirilen"); set filters in the left rail ("Marka" brand, "Fiyat" price, "Satıcı" seller, "Kargo" shipping) rather than editing URL params.
+- "Hepsiexpress" (quick grocery/market delivery) and "Hepsiburada Seyahat" (travel) are separate flows from the main product catalog — don't expect the standard product/cart layout there.`,
+  },
 
   {
     name: 'apple',

--- a/src/firefox/src/agent/adapters.js
+++ b/src/firefox/src/agent/adapters.js
@@ -16123,6 +16123,18 @@ const ADAPTERS = [
 - Sort with the "Sıralama" dropdown ("En düşük fiyat" = price low→high, "En yüksek fiyat", "En yeniler", "Çok satanlar"); set filters in the left rail ("Marka" brand, "Fiyat" price, "Beden", rating) instead of guessing URL params.
 - Add-to-cart opens a drawer ("Sepete Git" vs keep shopping); the cart lives at /sepetim and checkout requires login. "Trendyol Go" (food/grocery quick-commerce) is a separate flow from the marketplace catalog.`,
   },
+  {
+    name: 'hepsiburada',
+    category: 'general',
+    match: (url) => /^https?:\/\/(www\.)?hepsiburada\.com\//.test(url),
+    notes: `
+- Hepsiburada is a major Turkish e-commerce MARKETPLACE (electronics-heavy, but sells everything) with third-party sellers per product. Turkish labels: "Sepete Ekle" = add to cart, "Sepetim" = cart, "Favorilerime Ekle" = wishlist (needs login), "Giriş Yap" = log in, "Sıralama" = sort, "Filtreler" = filters, "Değerlendirmeler" = reviews.
+- Variant trap: pick color/size/capacity (e.g. "Renk", "Beden", storage) BEFORE "Sepete Ekle" — until a required variant is chosen the button won't add the item.
+- Multiple-seller trap: the buy box is for ONE seller; open "Diğer Satıcılar" / "Tüm Satıcıları Gör" to compare price and cargo speed before quoting "the price". The default seller isn't always the cheapest.
+- Price trap: the listed price is not the final total. Hepsiburada shows "Sepette %X indirim" (extra discount applied only in the cart) plus extra "HepsiPay ile ödemede" (pay-with-HepsiPay) discounts — quote the cart/payment total, not the card price.
+- Sort with the "Sıralama" dropdown ("En düşük fiyat" = price low→high, "En yüksek fiyat", "En yeniler", "En çok değerlendirilen"); set filters in the left rail ("Marka" brand, "Fiyat" price, "Satıcı" seller, "Kargo" shipping) rather than editing URL params.
+- "Hepsiexpress" (quick grocery/market delivery) and "Hepsiburada Seyahat" (travel) are separate flows from the main product catalog — don't expect the standard product/cart layout there.`,
+  },
 
   {
     name: 'apple',

--- a/test/run.js
+++ b/test/run.js
@@ -697,6 +697,16 @@ test('matches trendyol.com and includes marketplace guidance', () => {
   assert.match(a?.notes || '', /Sepete Ekle/);
 });
 
+test('matches hepsiburada.com and includes marketplace guidance', () => {
+  assert.equal(getActiveAdapter('https://www.hepsiburada.com/')?.name, 'hepsiburada');
+  assert.equal(getActiveAdapter('https://hepsiburada.com/ara?q=telefon')?.name, 'hepsiburada');
+  // lookalike / suffix domains must NOT match
+  assert.notEqual(getActiveAdapter('https://hepsiburada.com.phishing.example/')?.name, 'hepsiburada');
+  const a = getActiveAdapter('https://www.hepsiburada.com/telefonlar-c-371965');
+  assert.match(a?.notes || '', /marketplace/i);
+  assert.match(a?.notes || '', /Diğer Satıcılar/);
+});
+
 test('matches stripe dashboard', () => {
   const a = getActiveAdapter('https://dashboard.stripe.com/payments');
   assert.equal(a?.name, 'stripe');


### PR DESCRIPTION
Adds a site adapter for **hepsiburada.com**, Türkiye's other major e-commerce marketplace. Follow-up to #234 (sahibinden) and #265 (trendyol) — continuing the TR regional adapters @esokullu asked for.

**Real failure modes it prevents**
- **Variant-before-cart:** "Sepete Ekle" won't add the item until a required color/size/capacity variant is chosen.
- **Marketplace sellers:** the buy box is one seller's offer; cheaper/faster ones sit under "Diğer Satıcılar" / "Tüm Satıcıları Gör".
- **Non-final prices:** "Sepette %X indirim" and HepsiPay payment discounts only land at the basket, so the card price isn't the total.
- **Sort/filter via UI:** use the "Sıralama" dropdown and left-rail "Filtreler" instead of guessing URL params.

It also flags that "Hepsiexpress" (quick grocery) and "Hepsiburada Seyahat" (travel) are separate flows from the product catalog.

- Mirrored to both `src/chrome/` and `src/firefox/` adapters.js.
- Adds a `getActiveAdapter` match + content test; `npm test` → 628/628 passing.
