### PR TITLE
agent: add adapter for n11.com

### DIFF
--- a/src/chrome/src/agent/adapters.js
+++ b/src/chrome/src/agent/adapters.js
@@ -16124,6 +16124,18 @@ const ADAPTERS = [
 - Sort with the "Sıralama" dropdown ("En düşük fiyat" = price low→high, "En yüksek fiyat", "En yeniler", "Çok satanlar"); set filters in the left rail ("Marka" brand, "Fiyat" price, "Beden", rating) instead of guessing URL params.
 - Add-to-cart opens a drawer ("Sepete Git" vs keep shopping); the cart lives at /sepetim and checkout requires login. "Trendyol Go" (food/grocery quick-commerce) is a separate flow from the marketplace catalog.`,
   },
+  {
+    name: 'hepsiburada',
+    category: 'general',
+    match: (url) => /^https?:\/\/(www\.)?hepsiburada\.com\//.test(url),
+    notes: `
+- Hepsiburada is a major Turkish e-commerce MARKETPLACE (electronics-heavy, but sells everything) with third-party sellers per product. Turkish labels: "Sepete Ekle" = add to cart, "Sepetim" = cart, "Favorilerime Ekle" = wishlist (needs login), "Giriş Yap" = log in, "Sıralama" = sort, "Filtreler" = filters, "Değerlendirmeler" = reviews.
+- Variant trap: pick color/size/capacity (e.g. "Renk", "Beden", storage) BEFORE "Sepete Ekle" — until a required variant is chosen the button won't add the item.
+- Multiple-seller trap: the buy box is for ONE seller; open "Diğer Satıcılar" / "Tüm Satıcıları Gör" to compare price and cargo speed before quoting "the price". The default seller isn't always the cheapest.
+- Price trap: the listed price is not the final total. Hepsiburada shows "Sepette %X indirim" (extra discount applied only in the cart) plus extra "HepsiPay ile ödemede" (pay-with-HepsiPay) discounts — quote the cart/payment total, not the card price.
+- Sort with the "Sıralama" dropdown ("En düşük fiyat" = price low→high, "En yüksek fiyat", "En yeniler", "En çok değerlendirilen"); set filters in the left rail ("Marka" brand, "Fiyat" price, "Satıcı" seller, "Kargo" shipping) rather than editing URL params.
+- "Hepsiexpress" (quick grocery/market delivery) and "Hepsiburada Seyahat" (travel) are separate flows from the main product catalog — don't expect the standard product/cart layout there.`,
+  },
 
   {
     name: 'apple',

--- a/src/chrome/src/agent/adapters.js
+++ b/src/chrome/src/agent/adapters.js
@@ -16136,6 +16136,17 @@ const ADAPTERS = [
 - Sort with the "Sıralama" dropdown ("En düşük fiyat" = price low→high, "En yüksek fiyat", "En yeniler", "En çok değerlendirilen"); set filters in the left rail ("Marka" brand, "Fiyat" price, "Satıcı" seller, "Kargo" shipping) rather than editing URL params.
 - "Hepsiexpress" (quick grocery/market delivery) and "Hepsiburada Seyahat" (travel) are separate flows from the main product catalog — don't expect the standard product/cart layout there.`,
   },
+  {
+    name: 'n11',
+    category: 'general',
+    match: (url) => /^https?:\/\/(www\.)?n11\.com\//.test(url),
+    notes: `
+- n11 is a Turkish e-commerce MARKETPLACE where products are sold by third-party stores ("mağaza"). Turkish labels: "Sepete Ekle" = add to cart, "Sepetim" = cart, "Giriş Yap" = log in, "Favorilerim" = wishlist (needs login), "Sıralama" = sort, "Filtrele"/"Filtreler" = filters.
+- Seller/store trap: each listing is fulfilled by a specific "mağaza" with its own "Mağaza Puanı" (store rating), price, and shipping. The same product may be cheaper from another store — check before quoting a price, and surface a very low store rating to the user.
+- Variant trap: for fashion/multi-option products, pick "Renk"/"Beden" (color/size) BEFORE "Sepete Ekle" — the add won't register until a required option is selected.
+- Price trap: coupons and "n11 Cüzdan" (wallet) balance can change the final total at checkout, so the listed price isn't always what the user pays — confirm the cart total.
+- Sort with the "Sıralama" dropdown ("En düşük fiyat" = price low→high, "En yüksek fiyat", "En yeniler"); set filters in the left rail ("Marka" brand, "Fiyat" price, store) rather than guessing URL params.`,
+  },
 
   {
     name: 'apple',

--- a/src/firefox/src/agent/adapters.js
+++ b/src/firefox/src/agent/adapters.js
@@ -16123,6 +16123,18 @@ const ADAPTERS = [
 - Sort with the "Sıralama" dropdown ("En düşük fiyat" = price low→high, "En yüksek fiyat", "En yeniler", "Çok satanlar"); set filters in the left rail ("Marka" brand, "Fiyat" price, "Beden", rating) instead of guessing URL params.
 - Add-to-cart opens a drawer ("Sepete Git" vs keep shopping); the cart lives at /sepetim and checkout requires login. "Trendyol Go" (food/grocery quick-commerce) is a separate flow from the marketplace catalog.`,
   },
+  {
+    name: 'hepsiburada',
+    category: 'general',
+    match: (url) => /^https?:\/\/(www\.)?hepsiburada\.com\//.test(url),
+    notes: `
+- Hepsiburada is a major Turkish e-commerce MARKETPLACE (electronics-heavy, but sells everything) with third-party sellers per product. Turkish labels: "Sepete Ekle" = add to cart, "Sepetim" = cart, "Favorilerime Ekle" = wishlist (needs login), "Giriş Yap" = log in, "Sıralama" = sort, "Filtreler" = filters, "Değerlendirmeler" = reviews.
+- Variant trap: pick color/size/capacity (e.g. "Renk", "Beden", storage) BEFORE "Sepete Ekle" — until a required variant is chosen the button won't add the item.
+- Multiple-seller trap: the buy box is for ONE seller; open "Diğer Satıcılar" / "Tüm Satıcıları Gör" to compare price and cargo speed before quoting "the price". The default seller isn't always the cheapest.
+- Price trap: the listed price is not the final total. Hepsiburada shows "Sepette %X indirim" (extra discount applied only in the cart) plus extra "HepsiPay ile ödemede" (pay-with-HepsiPay) discounts — quote the cart/payment total, not the card price.
+- Sort with the "Sıralama" dropdown ("En düşük fiyat" = price low→high, "En yüksek fiyat", "En yeniler", "En çok değerlendirilen"); set filters in the left rail ("Marka" brand, "Fiyat" price, "Satıcı" seller, "Kargo" shipping) rather than editing URL params.
+- "Hepsiexpress" (quick grocery/market delivery) and "Hepsiburada Seyahat" (travel) are separate flows from the main product catalog — don't expect the standard product/cart layout there.`,
+  },
 
   {
     name: 'apple',

--- a/src/firefox/src/agent/adapters.js
+++ b/src/firefox/src/agent/adapters.js
@@ -16135,6 +16135,17 @@ const ADAPTERS = [
 - Sort with the "Sıralama" dropdown ("En düşük fiyat" = price low→high, "En yüksek fiyat", "En yeniler", "En çok değerlendirilen"); set filters in the left rail ("Marka" brand, "Fiyat" price, "Satıcı" seller, "Kargo" shipping) rather than editing URL params.
 - "Hepsiexpress" (quick grocery/market delivery) and "Hepsiburada Seyahat" (travel) are separate flows from the main product catalog — don't expect the standard product/cart layout there.`,
   },
+  {
+    name: 'n11',
+    category: 'general',
+    match: (url) => /^https?:\/\/(www\.)?n11\.com\//.test(url),
+    notes: `
+- n11 is a Turkish e-commerce MARKETPLACE where products are sold by third-party stores ("mağaza"). Turkish labels: "Sepete Ekle" = add to cart, "Sepetim" = cart, "Giriş Yap" = log in, "Favorilerim" = wishlist (needs login), "Sıralama" = sort, "Filtrele"/"Filtreler" = filters.
+- Seller/store trap: each listing is fulfilled by a specific "mağaza" with its own "Mağaza Puanı" (store rating), price, and shipping. The same product may be cheaper from another store — check before quoting a price, and surface a very low store rating to the user.
+- Variant trap: for fashion/multi-option products, pick "Renk"/"Beden" (color/size) BEFORE "Sepete Ekle" — the add won't register until a required option is selected.
+- Price trap: coupons and "n11 Cüzdan" (wallet) balance can change the final total at checkout, so the listed price isn't always what the user pays — confirm the cart total.
+- Sort with the "Sıralama" dropdown ("En düşük fiyat" = price low→high, "En yüksek fiyat", "En yeniler"); set filters in the left rail ("Marka" brand, "Fiyat" price, store) rather than guessing URL params.`,
+  },
 
   {
     name: 'apple',

--- a/test/run.js
+++ b/test/run.js
@@ -707,6 +707,16 @@ test('matches hepsiburada.com and includes marketplace guidance', () => {
   assert.match(a?.notes || '', /Diğer Satıcılar/);
 });
 
+test('matches n11.com and includes marketplace guidance', () => {
+  assert.equal(getActiveAdapter('https://www.n11.com/')?.name, 'n11');
+  assert.equal(getActiveAdapter('https://n11.com/telefon')?.name, 'n11');
+  // lookalike / suffix domains must NOT match
+  assert.notEqual(getActiveAdapter('https://n11.com.phishing.example/')?.name, 'n11');
+  const a = getActiveAdapter('https://www.n11.com/arama?q=telefon');
+  assert.match(a?.notes || '', /marketplace/i);
+  assert.match(a?.notes || '', /mağaza/i);
+});
+
 test('matches stripe dashboard', () => {
   const a = getActiveAdapter('https://dashboard.stripe.com/payments');
   assert.equal(a?.name, 'stripe');

--- a/test/run.js
+++ b/test/run.js
@@ -697,6 +697,16 @@ test('matches trendyol.com and includes marketplace guidance', () => {
   assert.match(a?.notes || '', /Sepete Ekle/);
 });
 
+test('matches hepsiburada.com and includes marketplace guidance', () => {
+  assert.equal(getActiveAdapter('https://www.hepsiburada.com/')?.name, 'hepsiburada');
+  assert.equal(getActiveAdapter('https://hepsiburada.com/ara?q=telefon')?.name, 'hepsiburada');
+  // lookalike / suffix domains must NOT match
+  assert.notEqual(getActiveAdapter('https://hepsiburada.com.phishing.example/')?.name, 'hepsiburada');
+  const a = getActiveAdapter('https://www.hepsiburada.com/telefonlar-c-371965');
+  assert.match(a?.notes || '', /marketplace/i);
+  assert.match(a?.notes || '', /Diğer Satıcılar/);
+});
+
 test('matches stripe dashboard', () => {
   const a = getActiveAdapter('https://dashboard.stripe.com/payments');
   assert.equal(a?.name, 'stripe');


### PR DESCRIPTION
Adds a site adapter for **n11.com**, a Turkish e-commerce marketplace. Continues the TR regional adapters (#234 sahibinden, #265 trendyol, #277 hepsiburada).

> ⚠️ **Stacked on #277 (hepsiburada).** Until that merges, this PR's diff also shows the hepsiburada adapter; once #277 lands it reduces to just the n11 change. Happy to rebase onto `main` instead if you'd prefer independent PRs.

**What it encodes**
- **Store marketplace:** each listing is fulfilled by a specific "mağaza" with its own "Mağaza Puanı" (rating), price and shipping — a cheaper store may exist, and a very low rating is worth surfacing.
- **Variant-before-cart:** pick "Renk"/"Beden" before "Sepete Ekle".
- **Non-final price:** coupons and "n11 Cüzdan" (wallet) shift the checkout total off the listed price.
- **Sort/filter via UI:** the "Sıralama" dropdown and left-rail filters, not URL params.

- Mirrored to both `src/chrome/` and `src/firefox/` adapters.js.
- Adds a `getActiveAdapter` match + content test; `npm test` → 629/629 passing.
