### PR TITLE
agent: add adapter for yemeksepeti.com

### DIFF
--- a/src/chrome/src/agent/adapters.js
+++ b/src/chrome/src/agent/adapters.js
@@ -16124,6 +16124,18 @@ const ADAPTERS = [
 - Sort with the "Sıralama" dropdown ("En düşük fiyat" = price low→high, "En yüksek fiyat", "En yeniler", "Çok satanlar"); set filters in the left rail ("Marka" brand, "Fiyat" price, "Beden", rating) instead of guessing URL params.
 - Add-to-cart opens a drawer ("Sepete Git" vs keep shopping); the cart lives at /sepetim and checkout requires login. "Trendyol Go" (food/grocery quick-commerce) is a separate flow from the marketplace catalog.`,
   },
+  {
+    name: 'hepsiburada',
+    category: 'general',
+    match: (url) => /^https?:\/\/(www\.)?hepsiburada\.com\//.test(url),
+    notes: `
+- Hepsiburada is a major Turkish e-commerce MARKETPLACE (electronics-heavy, but sells everything) with third-party sellers per product. Turkish labels: "Sepete Ekle" = add to cart, "Sepetim" = cart, "Favorilerime Ekle" = wishlist (needs login), "Giriş Yap" = log in, "Sıralama" = sort, "Filtreler" = filters, "Değerlendirmeler" = reviews.
+- Variant trap: pick color/size/capacity (e.g. "Renk", "Beden", storage) BEFORE "Sepete Ekle" — until a required variant is chosen the button won't add the item.
+- Multiple-seller trap: the buy box is for ONE seller; open "Diğer Satıcılar" / "Tüm Satıcıları Gör" to compare price and cargo speed before quoting "the price". The default seller isn't always the cheapest.
+- Price trap: the listed price is not the final total. Hepsiburada shows "Sepette %X indirim" (extra discount applied only in the cart) plus extra "HepsiPay ile ödemede" (pay-with-HepsiPay) discounts — quote the cart/payment total, not the card price.
+- Sort with the "Sıralama" dropdown ("En düşük fiyat" = price low→high, "En yüksek fiyat", "En yeniler", "En çok değerlendirilen"); set filters in the left rail ("Marka" brand, "Fiyat" price, "Satıcı" seller, "Kargo" shipping) rather than editing URL params.
+- "Hepsiexpress" (quick grocery/market delivery) and "Hepsiburada Seyahat" (travel) are separate flows from the main product catalog — don't expect the standard product/cart layout there.`,
+  },
 
   {
     name: 'apple',

--- a/src/chrome/src/agent/adapters.js
+++ b/src/chrome/src/agent/adapters.js
@@ -16136,6 +16136,17 @@ const ADAPTERS = [
 - Sort with the "Sıralama" dropdown ("En düşük fiyat" = price low→high, "En yüksek fiyat", "En yeniler", "En çok değerlendirilen"); set filters in the left rail ("Marka" brand, "Fiyat" price, "Satıcı" seller, "Kargo" shipping) rather than editing URL params.
 - "Hepsiexpress" (quick grocery/market delivery) and "Hepsiburada Seyahat" (travel) are separate flows from the main product catalog — don't expect the standard product/cart layout there.`,
   },
+  {
+    name: 'n11',
+    category: 'general',
+    match: (url) => /^https?:\/\/(www\.)?n11\.com\//.test(url),
+    notes: `
+- n11 is a Turkish e-commerce MARKETPLACE where products are sold by third-party stores ("mağaza"). Turkish labels: "Sepete Ekle" = add to cart, "Sepetim" = cart, "Giriş Yap" = log in, "Favorilerim" = wishlist (needs login), "Sıralama" = sort, "Filtrele"/"Filtreler" = filters.
+- Seller/store trap: each listing is fulfilled by a specific "mağaza" with its own "Mağaza Puanı" (store rating), price, and shipping. The same product may be cheaper from another store — check before quoting a price, and surface a very low store rating to the user.
+- Variant trap: for fashion/multi-option products, pick "Renk"/"Beden" (color/size) BEFORE "Sepete Ekle" — the add won't register until a required option is selected.
+- Price trap: coupons and "n11 Cüzdan" (wallet) balance can change the final total at checkout, so the listed price isn't always what the user pays — confirm the cart total.
+- Sort with the "Sıralama" dropdown ("En düşük fiyat" = price low→high, "En yüksek fiyat", "En yeniler"); set filters in the left rail ("Marka" brand, "Fiyat" price, store) rather than guessing URL params.`,
+  },
 
   {
     name: 'apple',

--- a/src/chrome/src/agent/adapters.js
+++ b/src/chrome/src/agent/adapters.js
@@ -16147,6 +16147,17 @@ const ADAPTERS = [
 - Price trap: coupons and "n11 Cüzdan" (wallet) balance can change the final total at checkout, so the listed price isn't always what the user pays — confirm the cart total.
 - Sort with the "Sıralama" dropdown ("En düşük fiyat" = price low→high, "En yüksek fiyat", "En yeniler"); set filters in the left rail ("Marka" brand, "Fiyat" price, store) rather than guessing URL params.`,
   },
+  {
+    name: 'getir',
+    category: 'general',
+    match: (url) => /^https?:\/\/(www\.)?getir\.com\//.test(url),
+    notes: `
+- Getir is Turkish QUICK-COMMERCE (fast grocery delivery), app-first — the website may push you to the app and full ordering usually needs login (phone number). Turkish labels: "Sepete Ekle"/"+" = add, "Sepetim" = cart, "Adres" = delivery address, "Giriş Yap" = log in.
+- LOCATION-FIRST trap: set a delivery "Adres" (address/neighborhood) BEFORE the catalog is meaningful — products, prices, and availability come from the local warehouse, so without an address you'll see an empty or generic page. Set the address first, then browse.
+- Multiple verticals with different catalogs/carts: Getir (grocery), "GetirYemek" (restaurant food), "GetirBüyük" (bulk/weekly grocery), "GetirSu" (water), "GetirÇarşı" (local shops). Pick the one that matches the task — the grocery catalog does not cover restaurant food.
+- Checkout gates: there is a "minimum sepet tutarı" (minimum basket total) before you can order, and a "teslimat ücreti" (delivery fee) may apply — surface both before promising a total.
+- Stock is real-time and thin (fast delivery from a small local stock), so an item can go out of stock between adding and checkout — re-check the cart before finalizing.`,
+  },
 
   {
     name: 'apple',

--- a/src/chrome/src/agent/adapters.js
+++ b/src/chrome/src/agent/adapters.js
@@ -16158,6 +16158,17 @@ const ADAPTERS = [
 - Checkout gates: there is a "minimum sepet tutarı" (minimum basket total) before you can order, and a "teslimat ücreti" (delivery fee) may apply — surface both before promising a total.
 - Stock is real-time and thin (fast delivery from a small local stock), so an item can go out of stock between adding and checkout — re-check the cart before finalizing.`,
   },
+  {
+    name: 'yemeksepeti',
+    category: 'general',
+    match: (url) => /^https?:\/\/(www\.)?yemeksepeti\.com\//.test(url),
+    notes: `
+- Yemeksepeti is Türkiye's largest FOOD-DELIVERY platform (order from restaurants); login-first for ordering. Turkish labels: "Adres" = delivery address, "Restoranlar" = restaurants, "Sepete Ekle" = add to cart, "Sepetim" = cart, "Giriş Yap" = log in.
+- LOCATION-FIRST trap: set a delivery "Adres" BEFORE anything — which restaurants appear, their menus, and whether they deliver all depend on the address; without one you can't see real options.
+- Restaurant-scoped cart: you order from ONE restaurant at a time. Pick a "Restoran", then add menu items — you cannot combine items from two restaurants in a single order.
+- Availability gates: a restaurant may be "Kapalı" (closed — can't order now) and each has a "minimum sepet tutarı" (minimum order total) plus a delivery fee. Check the open status and the minimum before promising delivery.
+- "Yemeksepeti Mahalle" (grocery/market quick delivery) is a separate flow from restaurant food ordering — don't expect restaurant menus there.`,
+  },
 
   {
     name: 'apple',

--- a/src/firefox/src/agent/adapters.js
+++ b/src/firefox/src/agent/adapters.js
@@ -16123,6 +16123,18 @@ const ADAPTERS = [
 - Sort with the "Sıralama" dropdown ("En düşük fiyat" = price low→high, "En yüksek fiyat", "En yeniler", "Çok satanlar"); set filters in the left rail ("Marka" brand, "Fiyat" price, "Beden", rating) instead of guessing URL params.
 - Add-to-cart opens a drawer ("Sepete Git" vs keep shopping); the cart lives at /sepetim and checkout requires login. "Trendyol Go" (food/grocery quick-commerce) is a separate flow from the marketplace catalog.`,
   },
+  {
+    name: 'hepsiburada',
+    category: 'general',
+    match: (url) => /^https?:\/\/(www\.)?hepsiburada\.com\//.test(url),
+    notes: `
+- Hepsiburada is a major Turkish e-commerce MARKETPLACE (electronics-heavy, but sells everything) with third-party sellers per product. Turkish labels: "Sepete Ekle" = add to cart, "Sepetim" = cart, "Favorilerime Ekle" = wishlist (needs login), "Giriş Yap" = log in, "Sıralama" = sort, "Filtreler" = filters, "Değerlendirmeler" = reviews.
+- Variant trap: pick color/size/capacity (e.g. "Renk", "Beden", storage) BEFORE "Sepete Ekle" — until a required variant is chosen the button won't add the item.
+- Multiple-seller trap: the buy box is for ONE seller; open "Diğer Satıcılar" / "Tüm Satıcıları Gör" to compare price and cargo speed before quoting "the price". The default seller isn't always the cheapest.
+- Price trap: the listed price is not the final total. Hepsiburada shows "Sepette %X indirim" (extra discount applied only in the cart) plus extra "HepsiPay ile ödemede" (pay-with-HepsiPay) discounts — quote the cart/payment total, not the card price.
+- Sort with the "Sıralama" dropdown ("En düşük fiyat" = price low→high, "En yüksek fiyat", "En yeniler", "En çok değerlendirilen"); set filters in the left rail ("Marka" brand, "Fiyat" price, "Satıcı" seller, "Kargo" shipping) rather than editing URL params.
+- "Hepsiexpress" (quick grocery/market delivery) and "Hepsiburada Seyahat" (travel) are separate flows from the main product catalog — don't expect the standard product/cart layout there.`,
+  },
 
   {
     name: 'apple',

--- a/src/firefox/src/agent/adapters.js
+++ b/src/firefox/src/agent/adapters.js
@@ -16146,6 +16146,17 @@ const ADAPTERS = [
 - Price trap: coupons and "n11 Cüzdan" (wallet) balance can change the final total at checkout, so the listed price isn't always what the user pays — confirm the cart total.
 - Sort with the "Sıralama" dropdown ("En düşük fiyat" = price low→high, "En yüksek fiyat", "En yeniler"); set filters in the left rail ("Marka" brand, "Fiyat" price, store) rather than guessing URL params.`,
   },
+  {
+    name: 'getir',
+    category: 'general',
+    match: (url) => /^https?:\/\/(www\.)?getir\.com\//.test(url),
+    notes: `
+- Getir is Turkish QUICK-COMMERCE (fast grocery delivery), app-first — the website may push you to the app and full ordering usually needs login (phone number). Turkish labels: "Sepete Ekle"/"+" = add, "Sepetim" = cart, "Adres" = delivery address, "Giriş Yap" = log in.
+- LOCATION-FIRST trap: set a delivery "Adres" (address/neighborhood) BEFORE the catalog is meaningful — products, prices, and availability come from the local warehouse, so without an address you'll see an empty or generic page. Set the address first, then browse.
+- Multiple verticals with different catalogs/carts: Getir (grocery), "GetirYemek" (restaurant food), "GetirBüyük" (bulk/weekly grocery), "GetirSu" (water), "GetirÇarşı" (local shops). Pick the one that matches the task — the grocery catalog does not cover restaurant food.
+- Checkout gates: there is a "minimum sepet tutarı" (minimum basket total) before you can order, and a "teslimat ücreti" (delivery fee) may apply — surface both before promising a total.
+- Stock is real-time and thin (fast delivery from a small local stock), so an item can go out of stock between adding and checkout — re-check the cart before finalizing.`,
+  },
 
   {
     name: 'apple',

--- a/src/firefox/src/agent/adapters.js
+++ b/src/firefox/src/agent/adapters.js
@@ -16135,6 +16135,17 @@ const ADAPTERS = [
 - Sort with the "Sıralama" dropdown ("En düşük fiyat" = price low→high, "En yüksek fiyat", "En yeniler", "En çok değerlendirilen"); set filters in the left rail ("Marka" brand, "Fiyat" price, "Satıcı" seller, "Kargo" shipping) rather than editing URL params.
 - "Hepsiexpress" (quick grocery/market delivery) and "Hepsiburada Seyahat" (travel) are separate flows from the main product catalog — don't expect the standard product/cart layout there.`,
   },
+  {
+    name: 'n11',
+    category: 'general',
+    match: (url) => /^https?:\/\/(www\.)?n11\.com\//.test(url),
+    notes: `
+- n11 is a Turkish e-commerce MARKETPLACE where products are sold by third-party stores ("mağaza"). Turkish labels: "Sepete Ekle" = add to cart, "Sepetim" = cart, "Giriş Yap" = log in, "Favorilerim" = wishlist (needs login), "Sıralama" = sort, "Filtrele"/"Filtreler" = filters.
+- Seller/store trap: each listing is fulfilled by a specific "mağaza" with its own "Mağaza Puanı" (store rating), price, and shipping. The same product may be cheaper from another store — check before quoting a price, and surface a very low store rating to the user.
+- Variant trap: for fashion/multi-option products, pick "Renk"/"Beden" (color/size) BEFORE "Sepete Ekle" — the add won't register until a required option is selected.
+- Price trap: coupons and "n11 Cüzdan" (wallet) balance can change the final total at checkout, so the listed price isn't always what the user pays — confirm the cart total.
+- Sort with the "Sıralama" dropdown ("En düşük fiyat" = price low→high, "En yüksek fiyat", "En yeniler"); set filters in the left rail ("Marka" brand, "Fiyat" price, store) rather than guessing URL params.`,
+  },
 
   {
     name: 'apple',

--- a/src/firefox/src/agent/adapters.js
+++ b/src/firefox/src/agent/adapters.js
@@ -16157,6 +16157,17 @@ const ADAPTERS = [
 - Checkout gates: there is a "minimum sepet tutarı" (minimum basket total) before you can order, and a "teslimat ücreti" (delivery fee) may apply — surface both before promising a total.
 - Stock is real-time and thin (fast delivery from a small local stock), so an item can go out of stock between adding and checkout — re-check the cart before finalizing.`,
   },
+  {
+    name: 'yemeksepeti',
+    category: 'general',
+    match: (url) => /^https?:\/\/(www\.)?yemeksepeti\.com\//.test(url),
+    notes: `
+- Yemeksepeti is Türkiye's largest FOOD-DELIVERY platform (order from restaurants); login-first for ordering. Turkish labels: "Adres" = delivery address, "Restoranlar" = restaurants, "Sepete Ekle" = add to cart, "Sepetim" = cart, "Giriş Yap" = log in.
+- LOCATION-FIRST trap: set a delivery "Adres" BEFORE anything — which restaurants appear, their menus, and whether they deliver all depend on the address; without one you can't see real options.
+- Restaurant-scoped cart: you order from ONE restaurant at a time. Pick a "Restoran", then add menu items — you cannot combine items from two restaurants in a single order.
+- Availability gates: a restaurant may be "Kapalı" (closed — can't order now) and each has a "minimum sepet tutarı" (minimum order total) plus a delivery fee. Check the open status and the minimum before promising delivery.
+- "Yemeksepeti Mahalle" (grocery/market quick delivery) is a separate flow from restaurant food ordering — don't expect restaurant menus there.`,
+  },
 
   {
     name: 'apple',

--- a/test/run.js
+++ b/test/run.js
@@ -707,6 +707,16 @@ test('matches hepsiburada.com and includes marketplace guidance', () => {
   assert.match(a?.notes || '', /Diğer Satıcılar/);
 });
 
+test('matches n11.com and includes marketplace guidance', () => {
+  assert.equal(getActiveAdapter('https://www.n11.com/')?.name, 'n11');
+  assert.equal(getActiveAdapter('https://n11.com/telefon')?.name, 'n11');
+  // lookalike / suffix domains must NOT match
+  assert.notEqual(getActiveAdapter('https://n11.com.phishing.example/')?.name, 'n11');
+  const a = getActiveAdapter('https://www.n11.com/arama?q=telefon');
+  assert.match(a?.notes || '', /marketplace/i);
+  assert.match(a?.notes || '', /mağaza/i);
+});
+
 test('matches stripe dashboard', () => {
   const a = getActiveAdapter('https://dashboard.stripe.com/payments');
   assert.equal(a?.name, 'stripe');

--- a/test/run.js
+++ b/test/run.js
@@ -697,6 +697,16 @@ test('matches trendyol.com and includes marketplace guidance', () => {
   assert.match(a?.notes || '', /Sepete Ekle/);
 });
 
+test('matches hepsiburada.com and includes marketplace guidance', () => {
+  assert.equal(getActiveAdapter('https://www.hepsiburada.com/')?.name, 'hepsiburada');
+  assert.equal(getActiveAdapter('https://hepsiburada.com/ara?q=telefon')?.name, 'hepsiburada');
+  // lookalike / suffix domains must NOT match
+  assert.notEqual(getActiveAdapter('https://hepsiburada.com.phishing.example/')?.name, 'hepsiburada');
+  const a = getActiveAdapter('https://www.hepsiburada.com/telefonlar-c-371965');
+  assert.match(a?.notes || '', /marketplace/i);
+  assert.match(a?.notes || '', /Diğer Satıcılar/);
+});
+
 test('matches stripe dashboard', () => {
   const a = getActiveAdapter('https://dashboard.stripe.com/payments');
   assert.equal(a?.name, 'stripe');

--- a/test/run.js
+++ b/test/run.js
@@ -717,6 +717,16 @@ test('matches n11.com and includes marketplace guidance', () => {
   assert.match(a?.notes || '', /mağaza/i);
 });
 
+test('matches getir.com and includes quick-commerce guidance', () => {
+  assert.equal(getActiveAdapter('https://www.getir.com/')?.name, 'getir');
+  assert.equal(getActiveAdapter('https://getir.com/kategori/icecek')?.name, 'getir');
+  // lookalike / suffix domains must NOT match
+  assert.notEqual(getActiveAdapter('https://getir.com.phishing.example/')?.name, 'getir');
+  const a = getActiveAdapter('https://getir.com/');
+  assert.match(a?.notes || '', /quick-commerce/i);
+  assert.match(a?.notes || '', /Adres/);
+});
+
 test('matches stripe dashboard', () => {
   const a = getActiveAdapter('https://dashboard.stripe.com/payments');
   assert.equal(a?.name, 'stripe');

--- a/test/run.js
+++ b/test/run.js
@@ -727,6 +727,16 @@ test('matches getir.com and includes quick-commerce guidance', () => {
   assert.match(a?.notes || '', /Adres/);
 });
 
+test('matches yemeksepeti.com and includes food-delivery guidance', () => {
+  assert.equal(getActiveAdapter('https://www.yemeksepeti.com/')?.name, 'yemeksepeti');
+  assert.equal(getActiveAdapter('https://yemeksepeti.com/istanbul')?.name, 'yemeksepeti');
+  // lookalike / suffix domains must NOT match
+  assert.notEqual(getActiveAdapter('https://yemeksepeti.com.phishing.example/')?.name, 'yemeksepeti');
+  const a = getActiveAdapter('https://www.yemeksepeti.com/');
+  assert.match(a?.notes || '', /food-delivery/i);
+  assert.match(a?.notes || '', /Restoran/);
+});
+
 test('matches stripe dashboard', () => {
   const a = getActiveAdapter('https://dashboard.stripe.com/payments');
   assert.equal(a?.name, 'stripe');


### PR DESCRIPTION
Adds a site adapter for **yemeksepeti.com**, Türkiye's largest food-delivery platform — completes the TR regional set (#234 sahibinden, #265 trendyol, #277 hepsiburada, #278 n11, #279 getir).

> ⚠️ **Stacked on #279 → #278 → #277.** Until those merge, this PR's diff also shows the hepsiburada + n11 + getir adapters; it reduces to just yemeksepeti once they land. Merging the chain in order keeps each PR clean. Happy to rebase onto `main` if you'd prefer independent PRs.

**What it encodes**
- **Location-first:** restaurants, menus and availability only appear after a delivery "Adres" is set.
- **Restaurant-scoped cart:** you order from one restaurant at a time; items from two restaurants can't share a cart.
- **Availability gates:** a restaurant may be "Kapalı" (closed), and each has a "minimum sepet tutarı" plus a delivery fee.
- **Separate vertical:** "Yemeksepeti Mahalle" (grocery quick-delivery) is not the restaurant flow.

- Mirrored to both `src/chrome/` and `src/firefox/` adapters.js.
- Adds a `getActiveAdapter` match + content test; `npm test` → 631/631 passing.
