### PR TITLE
agent: support ArrowUp/ArrowDown/ArrowLeft/ArrowRight in press_keys

### DIFF
--- a/src/chrome/src/agent/agent.js
+++ b/src/chrome/src/agent/agent.js
@@ -9675,16 +9675,25 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
       const key = args.key;
       const repeatRaw = Number(args.repeat ?? 1);
       const repeat = Math.max(1, Math.min(3, Number.isFinite(repeatRaw) ? Math.floor(repeatRaw) : 1));
-      if (!['Escape', 'Tab', 'Enter'].includes(key)) {
-        return { success: false, error: `Unsupported key "${key}". V1 supports Escape, Tab, and Enter.` };
+      const SUPPORTED_KEYS = ['Escape', 'Tab', 'Enter', 'ArrowUp', 'ArrowDown', 'ArrowLeft', 'ArrowRight'];
+      if (!SUPPORTED_KEYS.includes(key)) {
+        return { success: false, error: `Unsupported key "${key}". Supported keys: ${SUPPORTED_KEYS.join(', ')}.` };
       }
 
       try {
         await cdpClient.attach(tabId);
+        // windowsVirtualKeyCode values below match the same ArrowUp/ArrowDown
+        // dispatch already used by the <select> fast-path above — trusted
+        // CDP key events are what let native controls (range sliders, native
+        // <select>) respond exactly as they would to a real key press.
         const keyMeta = {
           Escape: { code: 'Escape', windowsVirtualKeyCode: 27 },
           Tab: { code: 'Tab', windowsVirtualKeyCode: 9 },
           Enter: { code: 'Enter', windowsVirtualKeyCode: 13 },
+          ArrowLeft: { code: 'ArrowLeft', windowsVirtualKeyCode: 37 },
+          ArrowUp: { code: 'ArrowUp', windowsVirtualKeyCode: 38 },
+          ArrowRight: { code: 'ArrowRight', windowsVirtualKeyCode: 39 },
+          ArrowDown: { code: 'ArrowDown', windowsVirtualKeyCode: 40 },
         }[key];
 
         for (let i = 0; i < repeat; i++) {

--- a/src/chrome/src/agent/tools.js
+++ b/src/chrome/src/agent/tools.js
@@ -252,11 +252,11 @@ export const AGENT_TOOLS = [
     type: 'function',
     function: {
       name: 'press_keys',
-      description: 'Press keyboard keys. V1 supports Escape, Tab, and Enter. Useful for dismissing modals/dropdowns (Escape), moving focus (Tab), and confirming dialogs/forms (Enter).',
+      description: 'Press keyboard keys. Supports Escape, Tab, Enter, ArrowUp, ArrowDown, ArrowLeft, and ArrowRight. Useful for dismissing modals/dropdowns (Escape), moving focus (Tab), confirming dialogs/forms (Enter), and nudging range sliders or custom widgets that respond to arrow keys (ArrowUp/ArrowDown/ArrowLeft/ArrowRight).',
       parameters: {
         type: 'object',
         properties: {
-          key: { type: 'string', enum: ['Escape', 'Tab', 'Enter'], description: 'Key to press.' },
+          key: { type: 'string', enum: ['Escape', 'Tab', 'Enter', 'ArrowUp', 'ArrowDown', 'ArrowLeft', 'ArrowRight'], description: 'Key to press.' },
           repeat: { type: 'number', description: 'How many times to press the key (default: 1, max: 3).' },
         },
         required: ['key'],

--- a/src/chrome/src/agent/tools.js
+++ b/src/chrome/src/agent/tools.js
@@ -1375,7 +1375,7 @@ TOOLS — use ONLY these:
 - set_field({ref_id, text}): Focus + clear + type in one call. PREFERRED for forms.
 - click({text}): Click by visible text. Fallback when no ref_id.
 - type_text({text}): Type into the focused element. Click the field first.
-- press_keys({key}): Press Escape, Tab, or Enter.
+- press_keys({key}): Press Escape, Tab, Enter, ArrowUp, ArrowDown, ArrowLeft, or ArrowRight.
 - navigate({url}): Go to a URL.
 - new_tab({url}): Open a URL in a new tab.
 - wait_for_element({selector}): Wait for an element to appear.

--- a/src/chrome/src/content/content.js
+++ b/src/chrome/src/content/content.js
@@ -1078,14 +1078,25 @@
     const key = params?.key;
     const repeatRaw = Number(params?.repeat ?? 1);
     const repeat = Math.max(1, Math.min(3, Number.isFinite(repeatRaw) ? Math.floor(repeatRaw) : 1));
-    if (!['Escape', 'Tab', 'Enter'].includes(key)) {
-      return { success: false, error: `Unsupported key "${key}". V1 supports Escape, Tab, and Enter.` };
+    const SUPPORTED_KEYS = ['Escape', 'Tab', 'Enter', 'ArrowUp', 'ArrowDown', 'ArrowLeft', 'ArrowRight'];
+    if (!SUPPORTED_KEYS.includes(key)) {
+      return { success: false, error: `Unsupported key "${key}". Supported keys: ${SUPPORTED_KEYS.join(', ')}.` };
     }
 
+    // NOTE: this path dispatches untrusted (isTrusted: false) KeyboardEvents,
+    // used only when CDP is unavailable (agent.js prefers the trusted CDP
+    // dispatch — see agent.js's press_keys handler). Native browser default
+    // actions (e.g. a range input actually moving) are only guaranteed for
+    // trusted events, so arrow keys here reliably reach JS keydown listeners
+    // but may not step native controls the way the CDP path does.
     const keyMeta = {
       Escape: { code: 'Escape', keyCode: 27 },
       Tab: { code: 'Tab', keyCode: 9 },
       Enter: { code: 'Enter', keyCode: 13 },
+      ArrowLeft: { code: 'ArrowLeft', keyCode: 37 },
+      ArrowUp: { code: 'ArrowUp', keyCode: 38 },
+      ArrowRight: { code: 'ArrowRight', keyCode: 39 },
+      ArrowDown: { code: 'ArrowDown', keyCode: 40 },
     }[key];
     const target = (document.activeElement && document.activeElement !== document.body)
       ? document.activeElement

--- a/src/firefox/src/agent/tools.js
+++ b/src/firefox/src/agent/tools.js
@@ -252,11 +252,11 @@ export const AGENT_TOOLS = [
     type: 'function',
     function: {
       name: 'press_keys',
-      description: 'Press keyboard keys. V1 supports Escape, Tab, and Enter. Useful for dismissing modals/dropdowns (Escape), moving focus (Tab), and confirming dialogs/forms (Enter).',
+      description: 'Press keyboard keys. Supports Escape, Tab, Enter, ArrowUp, ArrowDown, ArrowLeft, and ArrowRight. Useful for dismissing modals/dropdowns (Escape), moving focus (Tab), confirming dialogs/forms (Enter), and nudging range sliders or custom widgets that respond to arrow keys (ArrowUp/ArrowDown/ArrowLeft/ArrowRight). Note: Firefox has no CDP, so these are untrusted synthetic events — they reach JS keydown listeners reliably but may not step native controls on every site (see ARCHITECTURE.md).',
       parameters: {
         type: 'object',
         properties: {
-          key: { type: 'string', enum: ['Escape', 'Tab', 'Enter'], description: 'Key to press.' },
+          key: { type: 'string', enum: ['Escape', 'Tab', 'Enter', 'ArrowUp', 'ArrowDown', 'ArrowLeft', 'ArrowRight'], description: 'Key to press.' },
           repeat: { type: 'number', description: 'How many times to press the key (default: 1, max: 3).' },
         },
         required: ['key'],

--- a/src/firefox/src/agent/tools.js
+++ b/src/firefox/src/agent/tools.js
@@ -1017,7 +1017,7 @@ TOOLS - use only these:
 - set_field({ref_id, text}): Focus + clear + type in one call. Preferred for forms.
 - click({text}): Click by visible text. Fallback when no ref_id works.
 - type_text({text}): Type into the focused element. Click the field first.
-- press_keys({key}): Press Escape, Tab, or Enter.
+- press_keys({key}): Press Escape, Tab, Enter, ArrowUp, ArrowDown, ArrowLeft, or ArrowRight.
 - navigate({url}): Go to a URL.
 - new_tab({url}): Open a URL in a new tab.
 - wait_for_element({selector}): Wait for an element to appear.

--- a/src/firefox/src/content/content.js
+++ b/src/firefox/src/content/content.js
@@ -1475,14 +1475,26 @@
     const key = params?.key;
     const repeatRaw = Number(params?.repeat ?? 1);
     const repeat = Math.max(1, Math.min(3, Number.isFinite(repeatRaw) ? Math.floor(repeatRaw) : 1));
-    if (!['Escape', 'Tab', 'Enter'].includes(key)) {
-      return { success: false, error: `Unsupported key "${key}". V1 supports Escape, Tab, and Enter.` };
+    const SUPPORTED_KEYS = ['Escape', 'Tab', 'Enter', 'ArrowUp', 'ArrowDown', 'ArrowLeft', 'ArrowRight'];
+    if (!SUPPORTED_KEYS.includes(key)) {
+      return { success: false, error: `Unsupported key "${key}". Supported keys: ${SUPPORTED_KEYS.join(', ')}.` };
     }
 
+    // NOTE: Firefox has no `debugger`/CDP permission (see ARCHITECTURE.md's
+    // "No trusted keyboard events" row), so this is the only press_keys
+    // implementation on this platform and it always dispatches untrusted
+    // (isTrusted: false) KeyboardEvents. That's sufficient for JS keydown
+    // listeners (most custom widgets) but arrow keys may not step native
+    // controls (e.g. <input type="range">) on sites that only respond to
+    // trusted input, same caveat that already applies to Escape/Tab/Enter.
     const keyMeta = {
       Escape: { code: 'Escape', keyCode: 27 },
       Tab: { code: 'Tab', keyCode: 9 },
       Enter: { code: 'Enter', keyCode: 13 },
+      ArrowLeft: { code: 'ArrowLeft', keyCode: 37 },
+      ArrowUp: { code: 'ArrowUp', keyCode: 38 },
+      ArrowRight: { code: 'ArrowRight', keyCode: 39 },
+      ArrowDown: { code: 'ArrowDown', keyCode: 40 },
     }[key];
     const target = (document.activeElement && document.activeElement !== document.body)
       ? document.activeElement


### PR DESCRIPTION
agent: support ArrowUp/ArrowDown/ArrowLeft/ArrowRight in press_keys

press_keys was hard-limited to Escape/Tab/Enter, which meant the agent
had no way to nudge native range sliders, custom listboxes, or other
arrow-key-driven widgets once clicking/dragging didn't move them.

Chrome (primary path, agent.js): reuses the same CDP
Input.dispatchKeyEvent + windowsVirtualKeyCode dispatch already proven
for the <select> fast-path a few lines up, so arrow presses are
trusted synthetic events just like Escape/Tab/Enter already are.

Chrome (content.js) and Firefox (content.js, its only implementation
since Firefox has no CDP/debugger permission) get the same key list
via untrusted KeyboardEvent dispatch, with a comment noting the
existing trusted-vs-untrusted caveat also documented in
src/firefox/ARCHITECTURE.md's known-issues table.

Updated tool schema/description in both browsers' tools.js to match.

node test/run.js: 627/627 passed
node test/security/injection-corpus.mjs: 60/60 passed
