### PR TITLE
agent: add adapter for google search (udm=14 clean results)

### DIFF
--- a/src/chrome/src/agent/adapters.js
+++ b/src/chrome/src/agent/adapters.js
@@ -15659,6 +15659,17 @@ const ADAPTERS = [
 - View switching: 1=day, 2=week, 3=month, 4=year, 5=schedule, 6=4-day.`,
   },
   {
+    name: 'google-search',
+    category: 'general',
+    match: (url) => /^https?:\/\/(www\.)?google\.[a-z.]{2,}\/search\b/.test(url),
+    notes: `
+- For clean, parseable results append \`&udm=14\` to the search URL (e.g. \`google.com/search?q=...&udm=14\`). This is the "Web" filter — it drops the AI Overview, knowledge panel, "People also ask", and most widgets, leaving a plain list of result links that is far easier to extract than the default page. (\`udm=2\` is the Images tab if you need images instead.)
+- On the DEFAULT results page the organic results sit under the main results container (\`#rso\` inside \`#search\`); each is a heading link + snippet. Skip the AI Overview / ads block at the very top — don't quote it as "the top result".
+- Put constraints in the query instead of post-filtering: \`site:\`, \`filetype:\`, \`intitle:\`, \`"exact phrase"\`, \`-exclude\`, and \`before:\`/\`after:\` for dates.
+- Do NOT rely on \`&num=100\` to load more results per page — Google removed that in 2025; paginate via the "Next" link / \`&start=10\` (20, 30…).
+- Results are personalized and localized (location, sign-in, history); you can't fully neutralize that from the URL, so flag it when the user needs unbiased results.`,
+  },
+  {
     name: 'slack',
     category: 'general',
     match: (url) => /^https?:\/\/app\.slack\.com\//.test(url) || /\.slack\.com\//.test(url),

--- a/src/firefox/src/agent/adapters.js
+++ b/src/firefox/src/agent/adapters.js
@@ -15659,6 +15659,17 @@ const ADAPTERS = [
 - View switching: 1=day, 2=week, 3=month, 4=year, 5=schedule, 6=4-day.`,
   },
   {
+    name: 'google-search',
+    category: 'general',
+    match: (url) => /^https?:\/\/(www\.)?google\.[a-z.]{2,}\/search\b/.test(url),
+    notes: `
+- For clean, parseable results append \`&udm=14\` to the search URL (e.g. \`google.com/search?q=...&udm=14\`). This is the "Web" filter — it drops the AI Overview, knowledge panel, "People also ask", and most widgets, leaving a plain list of result links that is far easier to extract than the default page. (\`udm=2\` is the Images tab if you need images instead.)
+- On the DEFAULT results page the organic results sit under the main results container (\`#rso\` inside \`#search\`); each is a heading link + snippet. Skip the AI Overview / ads block at the very top — don't quote it as "the top result".
+- Put constraints in the query instead of post-filtering: \`site:\`, \`filetype:\`, \`intitle:\`, \`"exact phrase"\`, \`-exclude\`, and \`before:\`/\`after:\` for dates.
+- Do NOT rely on \`&num=100\` to load more results per page — Google removed that in 2025; paginate via the "Next" link / \`&start=10\` (20, 30…).
+- Results are personalized and localized (location, sign-in, history); you can't fully neutralize that from the URL, so flag it when the user needs unbiased results.`,
+  },
+  {
     name: 'slack',
     category: 'general',
     match: (url) => /^https?:\/\/app\.slack\.com\//.test(url) || /\.slack\.com\//.test(url),

--- a/test/run.js
+++ b/test/run.js
@@ -675,6 +675,18 @@ test('matches gmail.com under mail.google.com', () => {
   assert.equal(a?.name, 'gmail');
 });
 
+test('matches google search across TLDs and includes udm=14, without hijacking other google apps', () => {
+  assert.equal(getActiveAdapter('https://www.google.com/search?q=test')?.name, 'google-search');
+  assert.equal(getActiveAdapter('https://google.co.uk/search?q=test')?.name, 'google-search');
+  assert.equal(getActiveAdapter('https://www.google.com.tr/search?q=x')?.name, 'google-search');
+  // must NOT hijack other google properties
+  assert.equal(getActiveAdapter('https://mail.google.com/mail/u/0/#inbox')?.name, 'gmail');
+  assert.notEqual(getActiveAdapter('https://docs.google.com/document/d/abc/edit')?.name, 'google-search');
+  assert.notEqual(getActiveAdapter('https://www.google.com/maps/place/x')?.name, 'google-search');
+  const a = getActiveAdapter('https://www.google.com/search?q=webbrain');
+  assert.match(a?.notes || '', /udm=14/);
+});
+
 test('matches twitter.com and x.com', () => {
   assert.equal(getActiveAdapter('https://twitter.com/elonmusk')?.name, 'twitter');
   assert.equal(getActiveAdapter('https://x.com/elonmusk')?.name, 'twitter');


### PR DESCRIPTION
Adds a **google-search** adapter — first of the "top global sites, high-value guidance" direction from #281 (the reddit→old.reddit / wordpress→classic-editor pattern @esokullu pointed at).

**The core tip:** append **`&udm=14`** to the search URL — Google's "Web" filter that strips the AI Overview, knowledge panel, "People also ask" and widgets, leaving a plain list of result links that's far easier to extract than the default page.

Also covers:
- the `#rso`/`#search` organic-results container on the default page (skip the AI/ads block up top),
- search operators (`site:`, `filetype:`, `"exact"`, `before:`/`after:`…),
- the removed `&num=100` param (paginate with `&start=` instead),
- result personalization/localization.

The match is scoped to `google.<tld>/search` so it doesn't shadow gmail / docs / maps / flights — the test verifies `google.com/maps` still resolves to `google-maps` and `mail.google.com` still to `gmail`.

- Mirrored to both `src/chrome/` and `src/firefox/` adapters.js.
- Adds a `getActiveAdapter` match + content test; `npm test` → 637/637 passing.
