### PR TITLE
feat: add LocalAI as built-in local provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Open-source AI browser agent for Chrome and Firefox. Chat with any web page, aut
 - **Continue from Limit** — When the agent hits the step limit, click Continue to keep going
 - **Multi-Provider LLM** — Supports local and cloud models:
   - **WebBrain Cloud 1.0** (cloud, default) — Built-in managed cloud option; no local setup required
-  - **llama.cpp** (local) — No API key needed. Also **Ollama**, **LM Studio**, **Jan**, **vLLM**, and **SGLang**
+  - **llama.cpp** (local) — No API key needed. Also **Ollama**, **LM Studio**, **Jan**, **vLLM**, **SGLang**, and **LocalAI**
   - **OpenAI** (GPT-5.5, etc.)
   - **Anthropic Claude** (native API)
   - **Google Gemini**, **Mistral AI**, **DeepSeek**, **xAI Grok**, **Groq**
@@ -138,6 +138,7 @@ Click the gear icon or go to the extension's Options page to configure:
 | Jan | `http://localhost:1337/v1` | Not needed | (your loaded model) |
 | vLLM | `http://localhost:8000/v1` | Optional | (your served model) |
 | SGLang | `http://localhost:30000/v1` | Optional | (your served model) |
+| LocalAI | `http://localhost:8080/v1` | Optional | (your loaded model) |
 | OpenAI | `https://api.openai.com/v1` | Required | gpt-5.5 |
 | Anthropic Claude | `https://api.anthropic.com` | Required | claude-sonnet-4-6 |
 | Google Gemini | `https://generativelanguage.googleapis.com/v1beta/openai` | Required | gemini-3.1-flash |

--- a/docs/THREAT-MODEL.md
+++ b/docs/THREAT-MODEL.md
@@ -13,7 +13,7 @@ So the question this document answers is: **what is the agent equivalent of the 
 ## 2. System overview & trust boundaries
 
 - **Extension (Manifest V3).** The agent loop, prompt assembly, and tool dispatch run in the extension's standard MV3 sandbox.
-- **Local model process.** llama.cpp, Ollama, LM Studio, Jan, vLLM, or SGLang runs as a *separate* process and is reached over `localhost` HTTP. No custom binaries, no elevated privileges; the model itself has only the extension's permissions, indirectly.
+- **Local model process.** llama.cpp, Ollama, LM Studio, Jan, vLLM, SGLang, or LocalAI runs as a *separate* process and is reached over `localhost` HTTP. No custom binaries, no elevated privileges; the model itself has only the extension's permissions, indirectly.
 - **Automation surface.** Page reads and actions are performed through the extension APIs and, for richer control, CDP/debugger automation.
 - **Cloud option.** The same agent can target a cloud model instead of the local one.
 

--- a/docs/providers-and-models.md
+++ b/docs/providers-and-models.md
@@ -41,6 +41,7 @@ class BaseLLMProvider {
 | `jan` | `openai` | local | (loaded model) | Yes (default on) |
 | `vllm` | `openai` | local | (loaded model) | Yes (default on) |
 | `sglang` | `openai` | local | (loaded model) | Yes (default on) |
+| `localai` | `openai` | local | (loaded model) | Yes (default on) |
 | `openai` | `openai` | cloud | `gpt-5.5` | Model-name regex |
 | `anthropic` | `anthropic` | cloud | `claude-sonnet-4-6` | Model-name regex |
 | `claude_subscription` | `anthropic_oauth` | cloud | `claude-sonnet-4-6` | Yes |
@@ -56,7 +57,7 @@ class BaseLLMProvider {
 
 ### Local Providers
 
-Six local providers are enabled by default with no API key needed unless the
+Seven local providers are enabled by default with no API key needed unless the
 local server was started with auth:
 
 - **llama.cpp**: `http://localhost:8080` — runs `llama-server -m model.gguf`
@@ -65,8 +66,9 @@ local server was started with auth:
 - **Jan**: `http://localhost:1337/v1` — Jan's local OpenAI-compatible API server
 - **vLLM**: `http://localhost:8000/v1` — vLLM's OpenAI-compatible server
 - **SGLang**: `http://localhost:30000/v1` — SGLang's OpenAI-compatible server
+- **LocalAI**: `http://localhost:8080/v1` — LocalAI's OpenAI-compatible server
 
-All six default `supportsVision: true` since most models loaded locally in 2026 are multimodal.
+All seven default `supportsVision: true` since most models loaded locally in 2026 are multimodal.
 
 **Context window.** Load local models with **at least a 16k-token context window** for reliable agent runs — that's the usable minimum. 8k can work with the Compact tier selected; 4k is too small to hold the system prompt + tool schemas. The agent reads the window from `provider.contextWindow` (`providers/base.js`) to drive auto-compaction; when a provider config doesn't set `contextWindow`, local providers default to a conservative **16k** (cloud/router default to 128k). Set `config.contextWindow` explicitly to match a larger local window, and make sure the model server is actually started with that much context (e.g. `llama-server -c 16384`).
 
@@ -94,7 +96,7 @@ Ask mode ignores provider tier and stays read-only. Act mode uses the selected t
 | OpenAI-compatible | Regex against model name (`gpt-4o`, `gpt-5`, `claude-3`, `claude-sonnet-4`, `gemini-2.0-flash`, etc.) |
 | Anthropic | `claude-(3\|sonnet-4\|opus-4)` patterns |
 | llama.cpp | Explicit `supportsVision` config toggle |
-| Ollama / LM Studio / Jan / vLLM / SGLang | Explicit `supportsVision` config toggle (via OpenAI provider) |
+| Ollama / LM Studio / Jan / vLLM / SGLang / LocalAI | Explicit `supportsVision` config toggle (via OpenAI provider) |
 
 ### Anthropic Conversion
 

--- a/src/chrome/README.md
+++ b/src/chrome/README.md
@@ -72,10 +72,11 @@ ollama serve
 # Then set base URL to http://localhost:11434/v1 in settings
 # Or run: ollama launch webbrain --model <model>
 
-# Or using Jan, vLLM, or SGLang (OpenAI-compatible)
+# Or using Jan, vLLM, SGLang, or LocalAI (OpenAI-compatible)
 # Jan: http://localhost:1337/v1
 # vLLM: http://localhost:8000/v1
 # SGLang: http://localhost:30000/v1
+# LocalAI: http://localhost:8080/v1
 ```
 
 ### Use it
@@ -106,6 +107,7 @@ Click the gear icon or go to the extension's Options page to configure:
 | Jan | `http://localhost:1337/v1` | Not needed |
 | vLLM | `http://localhost:8000/v1` | Optional |
 | SGLang | `http://localhost:30000/v1` | Optional |
+| LocalAI | `http://localhost:8080/v1` | Optional |
 | OpenAI | `https://api.openai.com/v1` | Required |
 | OpenRouter | `https://openrouter.ai/api/v1` | Required |
 | Anthropic | `https://api.anthropic.com` | Required |

--- a/src/chrome/src/providers/manager.js
+++ b/src/chrome/src/providers/manager.js
@@ -187,6 +187,18 @@ export class ProviderManager {
         supportsVision: true,
         enabled: true,
       },
+      localai: {
+        type: 'openai',
+        category: 'local',
+        label: 'LocalAI (Local)',
+        providerName: 'localai',
+        baseUrl: 'http://localhost:8080/v1',
+        model: '',
+        contextWindow: 16384,
+        apiKey: '',
+        supportsVision: true,
+        enabled: true,
+      },
       openai: {
         type: 'openai',
         category: 'cloud',
@@ -412,7 +424,7 @@ export class ProviderManager {
 
   /**
    * Provider category for filter UI. Returns one of:
-   *   'local'  — runs on the user's machine (llama.cpp, ollama, lmstudio, jan, vllm, sglang)
+   *   'local'  — runs on the user's machine (llama.cpp, ollama, lmstudio, jan, vllm, sglang, localai)
    *   'cloud'  — first-party API endpoint (openai, anthropic, gemini, etc.)
    *   'router' — multi-model gateways that fan out to many backends (openrouter, cloudflare, nvidia, groq)
    * Reads `config.category` first; falls back to a per-id table so configs
@@ -421,7 +433,7 @@ export class ProviderManager {
   static categoryFor(id, config) {
     if (config && config.category) return config.category;
     if (config?.type === 'llamacpp') return 'local';
-    if (['llamacpp', 'ollama', 'lmstudio', 'jan', 'vllm', 'sglang'].includes(id)) return 'local';
+    if (['llamacpp', 'ollama', 'lmstudio', 'jan', 'vllm', 'sglang', 'localai'].includes(id)) return 'local';
     if (ROUTER_PROVIDER_IDS.includes(id)) return 'router';
     return 'cloud';
   }
@@ -615,13 +627,13 @@ export class ProviderManager {
 
   /**
    * Fetch selectable models for local providers. Ollama uses its native
-   * /api/tags endpoint; llama.cpp, LM Studio, Jan, vLLM, and SGLang use
+   * /api/tags endpoint; llama.cpp, LM Studio, Jan, vLLM, SGLang, and LocalAI use
    * OpenAI-compatible /v1/models.
    */
   async listProviderModels(id) {
     const provider = this.providers.get(id);
     if (!provider) return { ok: false, error: 'Provider not found' };
-    if (!['llamacpp', 'ollama', 'lmstudio', 'jan', 'vllm', 'sglang'].includes(id)) {
+    if (!['llamacpp', 'ollama', 'lmstudio', 'jan', 'vllm', 'sglang', 'localai'].includes(id)) {
       return { ok: false, error: 'Model loading is only supported for local providers' };
     }
 

--- a/src/chrome/src/ui/locales/en.js
+++ b/src/chrome/src/ui/locales/en.js
@@ -410,7 +410,7 @@ export default {
   'st.display.traces_link.desc': 'Inspect recorded runs side-by-side. Only available when tracing is on.',
   'st.display.traces_link.open': 'Open Traces →',
 
-  'st.providers.info.html': '<strong>Getting started with local models:</strong><br>Run <code>llama-server -m your-model.gguf --port 8080</code>, start Jan / LM Studio / Ollama, or launch vLLM / SGLang with an OpenAI-compatible server.<br>No API key needed unless your local server was started with auth.',
+  'st.providers.info.html': '<strong>Getting started with local models:</strong><br>Run <code>llama-server -m your-model.gguf --port 8080</code>, start Jan / LM Studio / Ollama / LocalAI, or launch vLLM / SGLang with an OpenAI-compatible server.<br>No API key needed unless your local server was started with auth.',
   'st.providers.filter.all': 'All',
   'st.providers.filter.local': 'Local',
   'st.providers.filter.cloud': 'Cloud',

--- a/src/chrome/src/ui/settings.js
+++ b/src/chrome/src/ui/settings.js
@@ -1229,6 +1229,16 @@ function renderProviders() {
         PROMPT_TIER_FIELD,
       ],
     },
+    localai: {
+      fields: [
+        { key: 'baseUrl', labelKey: 'st.provider.field.server_url', type: 'text', placeholder: 'http://localhost:8080/v1' },
+        { key: 'apiKey', labelKey: 'st.provider.field.api_key', type: 'password', placeholder: 'optional' },
+        { key: 'model', labelKey: 'st.provider.field.model', type: 'text', placeholder: 'gpt-4' },
+        CONTEXT_WINDOW_FIELD,
+        { key: 'supportsVision', labelKey: 'st.provider.field.supports_vision', type: 'checkbox' },
+        PROMPT_TIER_FIELD,
+      ],
+    },
     openai: {
       fields: [
         { key: 'apiKey', labelKey: 'st.provider.field.api_key', type: 'password', placeholder: 'sk-...' },
@@ -1422,7 +1432,7 @@ function renderProviders() {
           </div>
         `;
       } else {
-        const localModelProviders = ['llamacpp', 'ollama', 'lmstudio', 'jan', 'vllm', 'sglang'];
+        const localModelProviders = ['llamacpp', 'ollama', 'lmstudio', 'jan', 'vllm', 'sglang', 'localai'];
         const canLoadModels = localModelProviders.includes(id) && field.key === 'model';
         const listAttr = canLoadModels ? `list="models-${id}"` : '';
         const datalistHTML = canLoadModels ? `<datalist id="models-${id}"></datalist>` : '';

--- a/src/chrome/src/ui/sidepanel.js
+++ b/src/chrome/src/ui/sidepanel.js
@@ -65,7 +65,7 @@ if (globalThis.chrome?.storage?.onChanged) {
   const localModels = document.getElementById('ob-local-models');
   const localModelSelect = document.getElementById('ob-local-model-select');
   const totalSteps = steps.length;
-  const LOCAL_PROVIDER_ORDER = ['jan', 'lmstudio', 'ollama', 'llamacpp', 'vllm', 'sglang'];
+  const LOCAL_PROVIDER_ORDER = ['jan', 'lmstudio', 'ollama', 'llamacpp', 'vllm', 'sglang', 'localai'];
   let current = 0;
   let localScanStarted = false;
   let localModelChoices = [];

--- a/src/firefox/README.md
+++ b/src/firefox/README.md
@@ -58,10 +58,11 @@ ollama serve
 # Then set base URL to http://localhost:11434/v1 in settings
 # Or run: ollama launch webbrain --model <model>
 
-# Or using Jan, vLLM, or SGLang (OpenAI-compatible)
+# Or using Jan, vLLM, SGLang, or LocalAI (OpenAI-compatible)
 # Jan: http://localhost:1337/v1
 # vLLM: http://localhost:8000/v1
 # SGLang: http://localhost:30000/v1
+# LocalAI: http://localhost:8080/v1
 ```
 
 ### Use it
@@ -92,6 +93,7 @@ Click the gear icon or go to the extension's Options page to configure:
 | Jan | `http://localhost:1337/v1` | Not needed |
 | vLLM | `http://localhost:8000/v1` | Optional |
 | SGLang | `http://localhost:30000/v1` | Optional |
+| LocalAI | `http://localhost:8080/v1` | Optional |
 | OpenAI | `https://api.openai.com/v1` | Required |
 | OpenRouter | `https://openrouter.ai/api/v1` | Required |
 | Anthropic | `https://api.anthropic.com` | Required |

--- a/src/firefox/src/providers/manager.js
+++ b/src/firefox/src/providers/manager.js
@@ -174,6 +174,18 @@ export class ProviderManager {
         supportsVision: true,
         enabled: true,
       },
+      localai: {
+        type: 'openai',
+        category: 'local',
+        label: 'LocalAI (Local)',
+        providerName: 'localai',
+        baseUrl: 'http://localhost:8080/v1',
+        model: '',
+        contextWindow: 16384,
+        apiKey: '',
+        supportsVision: true,
+        enabled: true,
+      },
       openai: {
         type: 'openai',
         category: 'cloud',
@@ -400,7 +412,7 @@ export class ProviderManager {
   static categoryFor(id, config) {
     if (config && config.category) return config.category;
     if (config?.type === 'llamacpp') return 'local';
-    if (['llamacpp', 'ollama', 'lmstudio', 'jan', 'vllm', 'sglang'].includes(id)) return 'local';
+    if (['llamacpp', 'ollama', 'lmstudio', 'jan', 'vllm', 'sglang', 'localai'].includes(id)) return 'local';
     if (ROUTER_PROVIDER_IDS.includes(id)) return 'router';
     return 'cloud';
   }
@@ -602,7 +614,7 @@ export class ProviderManager {
   async listProviderModels(id) {
     const provider = this.providers.get(id);
     if (!provider) return { ok: false, error: 'Provider not found' };
-    if (!['llamacpp', 'ollama', 'lmstudio', 'jan', 'vllm', 'sglang'].includes(id)) {
+    if (!['llamacpp', 'ollama', 'lmstudio', 'jan', 'vllm', 'sglang', 'localai'].includes(id)) {
       return { ok: false, error: 'Model loading is only supported for local providers' };
     }
 

--- a/src/firefox/src/ui/locales/en.js
+++ b/src/firefox/src/ui/locales/en.js
@@ -397,7 +397,7 @@ export default {
   'st.display.traces_link.desc': 'Inspect recorded runs side-by-side. Only available when tracing is on.',
   'st.display.traces_link.open': 'Open Traces →',
 
-  'st.providers.info.html': '<strong>Getting started with local models:</strong><br>Run <code>llama-server -m your-model.gguf --port 8080</code>, start Jan / LM Studio / Ollama, or launch vLLM / SGLang with an OpenAI-compatible server.<br>No API key needed unless your local server was started with auth.',
+  'st.providers.info.html': '<strong>Getting started with local models:</strong><br>Run <code>llama-server -m your-model.gguf --port 8080</code>, start Jan / LM Studio / Ollama / LocalAI, or launch vLLM / SGLang with an OpenAI-compatible server.<br>No API key needed unless your local server was started with auth.',
   'st.providers.filter.all': 'All',
   'st.providers.filter.local': 'Local',
   'st.providers.filter.cloud': 'Cloud',

--- a/src/firefox/src/ui/settings.js
+++ b/src/firefox/src/ui/settings.js
@@ -1197,6 +1197,16 @@ function renderProviders() {
         PROMPT_TIER_FIELD,
       ],
     },
+    localai: {
+      fields: [
+        { key: 'baseUrl', labelKey: 'st.provider.field.server_url', type: 'text', placeholder: 'http://localhost:8080/v1' },
+        { key: 'apiKey', labelKey: 'st.provider.field.api_key', type: 'password', placeholder: 'optional' },
+        { key: 'model', labelKey: 'st.provider.field.model', type: 'text', placeholder: 'gpt-4' },
+        CONTEXT_WINDOW_FIELD,
+        { key: 'supportsVision', labelKey: 'st.provider.field.supports_vision', type: 'checkbox' },
+        PROMPT_TIER_FIELD,
+      ],
+    },
     openai: {
       fields: [
         { key: 'apiKey', labelKey: 'st.provider.field.api_key', type: 'password', placeholder: 'sk-...' },
@@ -1382,7 +1392,7 @@ function renderProviders() {
           </div>
         `;
       } else {
-        const localModelProviders = ['llamacpp', 'ollama', 'lmstudio', 'jan', 'vllm', 'sglang'];
+        const localModelProviders = ['llamacpp', 'ollama', 'lmstudio', 'jan', 'vllm', 'sglang', 'localai'];
         const canLoadModels = localModelProviders.includes(id) && field.key === 'model';
         const listAttr = canLoadModels ? `list="models-${id}"` : '';
         const datalistHTML = canLoadModels ? `<datalist id="models-${id}"></datalist>` : '';

--- a/src/firefox/src/ui/sidepanel.js
+++ b/src/firefox/src/ui/sidepanel.js
@@ -64,7 +64,7 @@ if (globalThis.browser?.storage?.onChanged) {
   const localModels = document.getElementById('ob-local-models');
   const localModelSelect = document.getElementById('ob-local-model-select');
   const totalSteps = steps.length;
-  const LOCAL_PROVIDER_ORDER = ['jan', 'lmstudio', 'ollama', 'llamacpp', 'vllm', 'sglang'];
+  const LOCAL_PROVIDER_ORDER = ['jan', 'lmstudio', 'ollama', 'llamacpp', 'vllm', 'sglang', 'localai'];
   let current = 0;
   let localScanStarted = false;
   let localModelChoices = [];

--- a/test/run.js
+++ b/test/run.js
@@ -9680,7 +9680,7 @@ console.log('\nprovider categorization');
 
 test('categoryFor: local family', () => {
   for (const PM of [ProviderManagerCh, ProviderManagerFx]) {
-    for (const id of ['llamacpp', 'ollama', 'lmstudio', 'jan', 'vllm', 'sglang']) {
+    for (const id of ['llamacpp', 'ollama', 'lmstudio', 'jan', 'vllm', 'sglang', 'localai']) {
       assert.equal(PM.categoryFor(id, { type: id === 'llamacpp' ? 'llamacpp' : 'openai' }), 'local');
     }
     assert.equal(PM.categoryFor('custom_llama_cpp', { type: 'llamacpp' }), 'local');
@@ -9739,7 +9739,7 @@ test('llama.cpp provider defaults to mid prompt tier for saved configs without c
 
 test('inferContextWindow: model-aware cloud/router defaults and local 16k fallback', () => {
   for (const infer of [inferContextWindowCh, inferContextWindowFx]) {
-    for (const providerName of ['lmstudio', 'jan', 'vllm', 'sglang']) {
+    for (const providerName of ['lmstudio', 'jan', 'vllm', 'sglang', 'localai']) {
       assert.equal(infer({ category: 'local', providerName, model: 'qwen3.7-plus' }), 16384);
     }
     assert.equal(infer({ category: 'cloud', providerName: 'openai', model: 'gpt-5.5-pro' }), 1050000);
@@ -9873,7 +9873,7 @@ test('listProviderModels sends saved API keys for auth-enabled OpenAI-compatible
 
   try {
     for (const PM of [ProviderManagerCh, ProviderManagerFx]) {
-      for (const id of ['jan', 'vllm', 'sglang']) {
+      for (const id of ['jan', 'vllm', 'sglang', 'localai']) {
         const mgr = new PM();
         const config = {
           ...mgr._defaultConfigs()[id],
@@ -10483,7 +10483,7 @@ test('_defaultConfigs: new offline providers present and enabled by default', ()
   for (const PM of [ProviderManagerCh, ProviderManagerFx]) {
     const mgr = new PM();
     const defaults = mgr._defaultConfigs();
-    for (const id of ['jan', 'vllm', 'sglang']) {
+    for (const id of ['jan', 'vllm', 'sglang', 'localai']) {
       assert.ok(defaults[id], `${PM.name}: missing default config for ${id}`);
       assert.equal(defaults[id].type, 'openai', `${PM.name}: ${id} should use OpenAI-compatible provider`);
       assert.equal(defaults[id].category, 'local', `${PM.name}: ${id} should be local`);
@@ -10493,11 +10493,11 @@ test('_defaultConfigs: new offline providers present and enabled by default', ()
   }
 });
 
-test('_defaultConfigs: OpenRouter defaults to MiniMax M3 and migrates old default', () => {
+test('_defaultConfigs: OpenRouter defaults to openrouter/free and migrates legacy default', () => {
   for (const PM of [ProviderManagerCh, ProviderManagerFx]) {
     const mgr = new PM();
     const defaults = mgr._defaultConfigs();
-    assert.equal(defaults.openrouter.model, 'minimax/minimax-m3');
+    assert.equal(defaults.openrouter.model, 'openrouter/free');
 
     const migrated = mgr._migrateStoredProviderConfigs({
       openrouter: {
@@ -10505,7 +10505,7 @@ test('_defaultConfigs: OpenRouter defaults to MiniMax M3 and migrates old defaul
         apiKey: 'kept',
       },
     });
-    assert.equal(migrated.openrouter.model, 'minimax/minimax-m3');
+    assert.equal(migrated.openrouter.model, 'openrouter/free');
     assert.equal(migrated.openrouter.apiKey, 'kept');
 
     const custom = mgr._migrateStoredProviderConfigs({
@@ -10614,6 +10614,7 @@ test('OpenAI-compatible local streams do not request usage metadata', () => {
       { category: 'local', providerName: 'jan' },
       { category: 'local', providerName: 'vllm' },
       { category: 'local', providerName: 'sglang' },
+      { category: 'local', providerName: 'localai' },
       { category: 'local', providerName: 'openai' },
     ]) {
       const provider = new Provider(config);
@@ -10626,7 +10627,7 @@ test('OpenAI-compatible local streams do not request usage metadata', () => {
 
 test('OpenAI-compatible local providers always use legacy request token fields', () => {
   for (const Provider of [OpenAIProviderCh, OpenAIProviderFx]) {
-    for (const providerName of ['ollama', 'lmstudio', 'jan', 'vllm', 'sglang']) {
+    for (const providerName of ['ollama', 'lmstudio', 'jan', 'vllm', 'sglang', 'localai']) {
       const provider = new Provider({
         category: 'local',
         providerName,


### PR DESCRIPTION
## Summary
- Add **LocalAI (Local)** as a seventh built-in local provider (`http://localhost:8080/v1`), matching the existing OpenAI-compatible local backend pattern (Jan / vLLM / SGLang).
- Wire LocalAI through Chrome + Firefox: provider defaults, settings card, Load models, onboarding local scan, and docs.
- Extend regression tests for categorization, model listing, and default config presence.
- Fix stale OpenRouter default-config test (`openrouter/free` is the current default on main).

## Test plan
- [x] `npm test` — 661 passed, 0 failed
- [x] Settings → Providers → Local → **LocalAI (Local)** appears with default URL `http://localhost:8080/v1`
- [x] **Load models** lists models when LocalAI is running with OpenAI API enabled
- [x] **Test connection** succeeds against a running LocalAI instance
- [x] Onboarding local scan detects LocalAI when server is reachable

## Notes
LocalAI shares port 8080 with llama.cpp’s default host, but uses the `/v1` OpenAI-compatible path. Users running both should change one server’s port.