### PR TITLE
providers: add AWS Bedrock (Converse)

### DIFF
--- a/docs/providers-and-models.md
+++ b/docs/providers-and-models.md
@@ -42,6 +42,7 @@ class BaseLLMProvider {
 | `vllm` | `openai` | local | (loaded model) | Yes (default on) |
 | `sglang` | `openai` | local | (loaded model) | Yes (default on) |
 | `localai` | `openai` | local | (loaded model) | Yes (default on) |
+| `aws_bedrock` | `aws_bedrock` | cloud | (model id) | No |
 | `openai` | `openai` | cloud | `gpt-5.5` | Model-name regex |
 | `anthropic` | `anthropic` | cloud | `claude-sonnet-4-6` | Model-name regex |
 | `claude_subscription` | `anthropic_oauth` | cloud | `claude-sonnet-4-6` | Yes |

--- a/src/chrome/src/providers/aws-bedrock.js
+++ b/src/chrome/src/providers/aws-bedrock.js
@@ -28,6 +28,10 @@ export class AwsBedrockProvider extends BaseLLMProvider {
     return String(this.config.model || '').trim();
   }
 
+  get model() {
+    return this.modelId;
+  }
+
   get accessKeyId() {
     return String(this.config.accessKeyId || '').trim();
   }
@@ -227,6 +231,17 @@ export class AwsBedrockProvider extends BaseLLMProvider {
     });
   }
 
+  _normalizeUsage(usage) {
+    if (!usage) return null;
+    const input = usage.inputTokens ?? usage.prompt_tokens ?? 0;
+    const output = usage.outputTokens ?? usage.completion_tokens ?? 0;
+    return {
+      prompt_tokens: input,
+      completion_tokens: output,
+      total_tokens: usage.totalTokens ?? (input + output),
+    };
+  }
+
   _fromBedrockResponse(data) {
     const message = data?.output?.message;
     const contentBlocks = Array.isArray(message?.content) ? message.content : [];
@@ -240,9 +255,10 @@ export class AwsBedrockProvider extends BaseLLMProvider {
       .filter(Boolean);
 
     const toolCalls = toolUses.length
-      ? toolUses.map((u) => ({
+      ? toolUses.map((u, index) => ({
           id: u.toolUseId || crypto.randomUUID(),
           type: 'function',
+          index,
           function: {
             name: u.name,
             arguments: JSON.stringify(u.input ?? {}),
@@ -253,7 +269,7 @@ export class AwsBedrockProvider extends BaseLLMProvider {
     return {
       content: text || '',
       toolCalls,
-      usage: data?.usage || null,
+      usage: this._normalizeUsage(data?.usage),
       raw: data,
     };
   }
@@ -290,6 +306,7 @@ export class AwsBedrockProvider extends BaseLLMProvider {
     const res = await this.chat(messages, options);
     if (res.content) yield { type: 'text', content: res.content };
     if (res.toolCalls) yield { type: 'tool_call', content: res.toolCalls };
+    if (res.usage) yield { type: 'usage', usage: res.usage };
     yield { type: 'done', content: '' };
   }
 }

--- a/src/chrome/src/providers/aws-bedrock.js
+++ b/src/chrome/src/providers/aws-bedrock.js
@@ -1,0 +1,321 @@
+import { BaseLLMProvider } from './base.js';
+import { fetchWithFallback } from './fetch-with-fallback.js';
+
+/**
+ * AWS Bedrock provider (Converse API).
+ *
+ * Implements SigV4 signing in-browser. This is intentionally dependency-free.
+ * Credentials are provided by the user via extension settings.
+ */
+export class AwsBedrockProvider extends BaseLLMProvider {
+  get name() {
+    return this.config.providerName || 'aws-bedrock';
+  }
+
+  get supportsTools() {
+    return true;
+  }
+
+  get supportsVision() {
+    return false;
+  }
+
+  get region() {
+    return String(this.config.region || '').trim() || 'us-east-1';
+  }
+
+  get modelId() {
+    return String(this.config.model || '').trim();
+  }
+
+  get accessKeyId() {
+    return String(this.config.accessKeyId || '').trim();
+  }
+
+  get secretAccessKey() {
+    return String(this.config.secretAccessKey || '').trim();
+  }
+
+  get sessionToken() {
+    return String(this.config.sessionToken || '').trim();
+  }
+
+  _assertConfigured() {
+    if (!this.modelId) throw new Error('Bedrock model id is required (Model field).');
+    if (!this.accessKeyId || !this.secretAccessKey) {
+      throw new Error('AWS Access Key ID and Secret Access Key are required.');
+    }
+    if (!this.region) throw new Error('AWS region is required.');
+  }
+
+  _endpoint() {
+    const host = `bedrock-runtime.${this.region}.amazonaws.com`;
+    const path = `/model/${encodeURIComponent(this.modelId)}/converse`;
+    return { host, url: `https://${host}${path}`, path };
+  }
+
+  _messagesContainImage(messages) {
+    return messages.some((msg) => Array.isArray(msg?.content) && msg.content.some((block) => {
+      return block && (block.type === 'image_url' || block.type === 'image');
+    }));
+  }
+
+  _toBedrockPayload(openAiMessages, options = {}) {
+    if (this._messagesContainImage(openAiMessages)) {
+      throw new Error('Bedrock Converse provider does not support image inputs yet. Disable screenshots or use a vision-capable provider.');
+    }
+
+    const systemTexts = [];
+    const messages = [];
+
+    const pushMessage = (role, contentBlocks) => {
+      if (!contentBlocks.length) return;
+      messages.push({ role, content: contentBlocks });
+    };
+
+    const toTextBlocks = (content) => {
+      if (content == null) return [];
+      if (Array.isArray(content)) {
+        // OpenAI multimodal format: [{type:'text',text:'...'}]
+        return content
+          .filter((b) => b && b.type === 'text' && typeof b.text === 'string')
+          .map((b) => ({ text: b.text }));
+      }
+      const s = String(content);
+      return s ? [{ text: s }] : [];
+    };
+
+    for (const msg of openAiMessages || []) {
+      const role = msg?.role;
+      if (role === 'system') {
+        const text = Array.isArray(msg?.content)
+          ? msg.content.filter((b) => b?.type === 'text').map((b) => b.text).join('\n')
+          : String(msg?.content || '');
+        if (text.trim()) systemTexts.push(text.trim());
+        continue;
+      }
+
+      if (role === 'user') {
+        pushMessage('user', toTextBlocks(msg.content));
+        continue;
+      }
+
+      if (role === 'assistant') {
+        const blocks = [];
+        blocks.push(...toTextBlocks(msg.content));
+        const toolCalls = Array.isArray(msg.tool_calls) ? msg.tool_calls : null;
+        if (toolCalls) {
+          for (const call of toolCalls) {
+            const fn = call?.function;
+            const name = fn?.name;
+            if (!name) continue;
+            let input = {};
+            try { input = fn?.arguments ? JSON.parse(fn.arguments) : {}; } catch { input = {}; }
+            blocks.push({
+              toolUse: {
+                toolUseId: call.id || crypto.randomUUID(),
+                name,
+                input,
+              },
+            });
+          }
+        }
+        pushMessage('assistant', blocks);
+        continue;
+      }
+
+      if (role === 'tool') {
+        // OpenAI tool result: { role:'tool', tool_call_id, name, content }
+        const toolUseId = msg.tool_call_id || msg.toolCallId || '';
+        const name = msg.name || '';
+        const text = typeof msg.content === 'string' ? msg.content : JSON.stringify(msg.content ?? '');
+        pushMessage('user', [{
+          toolResult: {
+            toolUseId: toolUseId || name || crypto.randomUUID(),
+            content: [{ text }],
+          },
+        }]);
+      }
+    }
+
+    const toolConfig = (options.tools && options.tools.length)
+      ? {
+          tools: options.tools
+            .map((t) => t?.function)
+            .filter(Boolean)
+            .map((fn) => ({
+              toolSpec: {
+                name: fn.name,
+                description: fn.description || '',
+                inputSchema: { json: fn.parameters || { type: 'object', properties: {} } },
+              },
+            })),
+          toolChoice: { auto: {} },
+        }
+      : undefined;
+
+    const payload = {
+      messages,
+      ...(systemTexts.length ? { system: systemTexts.map((t) => ({ text: t })) } : {}),
+      inferenceConfig: {
+        maxTokens: options.maxTokens ?? 4096,
+        temperature: options.temperature ?? 0.7,
+      },
+      ...(toolConfig ? { toolConfig } : {}),
+    };
+    return payload;
+  }
+
+  async _signAndFetch({ url, host, path }, body) {
+    const method = 'POST';
+    const service = 'bedrock';
+
+    const now = new Date();
+    const amzDate = now.toISOString().replace(/[:-]|\.\d{3}/g, ''); // YYYYMMDDTHHMMSSZ
+    const dateStamp = amzDate.slice(0, 8); // YYYYMMDD
+
+    const payload = JSON.stringify(body);
+    const payloadHash = await sha256Hex(payload);
+
+    const headers = {
+      host,
+      'content-type': 'application/json',
+      accept: 'application/json',
+      'x-amz-date': amzDate,
+    };
+    if (this.sessionToken) headers['x-amz-security-token'] = this.sessionToken;
+
+    const signedHeaders = Object.keys(headers).map((h) => h.toLowerCase()).sort().join(';');
+    const canonicalHeaders = Object.keys(headers)
+      .map((h) => h.toLowerCase())
+      .sort()
+      .map((h) => `${h}:${String(headers[h]).trim()}\n`)
+      .join('');
+
+    const canonicalRequest = [
+      method,
+      path,
+      '',
+      canonicalHeaders,
+      signedHeaders,
+      payloadHash,
+    ].join('\n');
+
+    const algorithm = 'AWS4-HMAC-SHA256';
+    const credentialScope = `${dateStamp}/${this.region}/${service}/aws4_request`;
+    const stringToSign = [
+      algorithm,
+      amzDate,
+      credentialScope,
+      await sha256Hex(canonicalRequest),
+    ].join('\n');
+
+    const signingKey = await getSignatureKey(this.secretAccessKey, dateStamp, this.region, service);
+    const signature = await hmacHex(signingKey, stringToSign);
+
+    const authorization = `${algorithm} Credential=${this.accessKeyId}/${credentialScope}, SignedHeaders=${signedHeaders}, Signature=${signature}`;
+
+    const finalHeaders = {
+      ...headers,
+      authorization,
+    };
+
+    return await fetchWithFallback(url, {
+      method,
+      headers: finalHeaders,
+      body: payload,
+    });
+  }
+
+  _fromBedrockResponse(data) {
+    const message = data?.output?.message;
+    const contentBlocks = Array.isArray(message?.content) ? message.content : [];
+    const text = contentBlocks
+      .map((b) => b?.text)
+      .filter(Boolean)
+      .join('');
+
+    const toolUses = contentBlocks
+      .map((b) => b?.toolUse)
+      .filter(Boolean);
+
+    const toolCalls = toolUses.length
+      ? toolUses.map((u) => ({
+          id: u.toolUseId || crypto.randomUUID(),
+          type: 'function',
+          function: {
+            name: u.name,
+            arguments: JSON.stringify(u.input ?? {}),
+          },
+        }))
+      : null;
+
+    return {
+      content: text || '',
+      toolCalls,
+      usage: data?.usage || null,
+      raw: data,
+    };
+  }
+
+  async chat(messages, options = {}) {
+    this._assertConfigured();
+    const endpoint = this._endpoint();
+    const payload = this._toBedrockPayload(messages, options);
+
+    let res;
+    try {
+      res = await this._signAndFetch(endpoint, payload);
+    } catch (e) {
+      throw new Error(`${this.name} network error — could not reach ${endpoint.url} (${e.message}).`);
+    }
+
+    if (!res.ok) {
+      let err = '';
+      try { err = (await res.text()).slice(0, 1200); } catch {}
+      throw new Error(`${this.name} error ${res.status}: ${err || res.statusText}`);
+    }
+
+    let data;
+    try { data = await res.json(); } catch {
+      throw new Error(`${this.name} returned invalid JSON.`);
+    }
+
+    return this._fromBedrockResponse(data);
+  }
+
+  async *chatStream(messages, options = {}) {
+    // Bedrock streaming uses /converse-stream with event frames. Keep a
+    // non-stream fallback for now so the UI remains functional.
+    const res = await this.chat(messages, options);
+    if (res.content) yield { type: 'text', content: res.content };
+    if (res.toolCalls) yield { type: 'tool_call', content: res.toolCalls };
+    yield { type: 'done', content: '' };
+  }
+}
+
+async function sha256Hex(data) {
+  const bytes = typeof data === 'string' ? new TextEncoder().encode(data) : data;
+  const digest = await crypto.subtle.digest('SHA-256', bytes);
+  return Array.from(new Uint8Array(digest), (b) => b.toString(16).padStart(2, '0')).join('');
+}
+
+async function hmacRaw(keyBytes, data) {
+  const key = await crypto.subtle.importKey('raw', keyBytes, { name: 'HMAC', hash: 'SHA-256' }, false, ['sign']);
+  const sig = await crypto.subtle.sign('HMAC', key, new TextEncoder().encode(data));
+  return new Uint8Array(sig);
+}
+
+async function hmacHex(keyBytes, data) {
+  const sig = await hmacRaw(keyBytes, data);
+  return Array.from(sig, (b) => b.toString(16).padStart(2, '0')).join('');
+}
+
+async function getSignatureKey(secretAccessKey, dateStamp, regionName, serviceName) {
+  const kDate = await hmacRaw(new TextEncoder().encode('AWS4' + secretAccessKey), dateStamp);
+  const kRegion = await hmacRaw(kDate, regionName);
+  const kService = await hmacRaw(kRegion, serviceName);
+  const kSigning = await hmacRaw(kService, 'aws4_request');
+  return kSigning;
+}
+

--- a/src/chrome/src/providers/manager.js
+++ b/src/chrome/src/providers/manager.js
@@ -2,6 +2,7 @@ import { LlamaCppProvider } from './llamacpp.js';
 import { OpenAICompatibleProvider } from './openai.js';
 import { AnthropicProvider, AnthropicOAuthProvider } from './anthropic.js';
 import { signOutClaude } from './oauth-claude.js';
+import { AwsBedrockProvider } from './aws-bedrock.js';
 // Static, NOT dynamic: this module runs in the MV3 service worker, where
 // `await import()` throws "import() is disallowed on ServiceWorkerGlobalScope".
 // The provider modules above already import this statically, so it's in the SW
@@ -16,7 +17,7 @@ const WEBBRAIN_CLOUD_LEGACY_CONTEXT_WINDOW = 256000;
 const WEBBRAIN_DEVICE_GUID_KEY = 'webbrainDeviceGuid';
 const OPENROUTER_DEFAULT_MODEL = 'openrouter/free';
 const OPENROUTER_LEGACY_DEFAULT_MODEL = 'stepfun/step-3.7-flash';
-const SUPPORTED_PROVIDER_TYPES = new Set(['llamacpp', 'openai', 'anthropic', 'anthropic_oauth']);
+const SUPPORTED_PROVIDER_TYPES = new Set(['llamacpp', 'openai', 'aws_bedrock', 'anthropic', 'anthropic_oauth']);
 const SAFE_PROVIDER_ID_RE = /^[A-Za-z0-9_-]+$/;
 const ROUTER_PROVIDER_IDS = ['openrouter', 'cloudflare', 'nvidia', 'groq', 'huggingface'];
 
@@ -205,6 +206,22 @@ export class ProviderManager {
         apiKey: '',
         supportsVision: true,
         enabled: true,
+      },
+      aws_bedrock: {
+        type: 'aws_bedrock',
+        category: 'cloud',
+        label: 'AWS Bedrock (Converse)',
+        providerName: 'aws-bedrock',
+        // Bedrock endpoint is derived from region; baseUrl is unused but kept for UI consistency.
+        baseUrl: 'https://bedrock-runtime.{region}.amazonaws.com',
+        // "model" is the Bedrock model id, e.g. "anthropic.claude-3-sonnet-20240229-v1:0"
+        model: '',
+        region: 'us-east-1',
+        accessKeyId: '',
+        secretAccessKey: '',
+        sessionToken: '',
+        supportsVision: false,
+        enabled: false,
       },
       openai: {
         type: 'openai',
@@ -454,6 +471,8 @@ export class ProviderManager {
         return new LlamaCppProvider(normalizedConfig);
       case 'openai':
         return new OpenAICompatibleProvider(normalizedConfig);
+      case 'aws_bedrock':
+        return new AwsBedrockProvider(normalizedConfig);
       case 'anthropic':
         return new AnthropicProvider(normalizedConfig);
       case 'anthropic_oauth':

--- a/src/chrome/src/ui/locales/en.js
+++ b/src/chrome/src/ui/locales/en.js
@@ -482,6 +482,13 @@ export default {
   'st.provider.field.output_cost_per_million': 'Estimated output cost ($ / 1M tokens)',
   'st.provider.field.model_loaded_hint': 'leave blank to use loaded model',
   'st.provider.field.model_custom': 'Custom...',
+  'st.provider.field.deployment_name': 'Deployment name',
+  'st.provider.field.api_version': 'API version',
+  'st.provider.field.aws_region': 'AWS region',
+  'st.provider.field.aws_access_key_id': 'AWS Access Key ID',
+  'st.provider.field.aws_secret_access_key': 'AWS Secret Access Key',
+  'st.provider.field.aws_session_token': 'AWS Session Token',
+  'st.provider.field.bedrock_model_id': 'Bedrock model id',
 
   'st.vision.heading': 'Vision',
   'st.vision.desc': 'If set, screenshots are sent to this model for reading the page, while the active provider handles planning and tool calls. Leave blank to use the active provider for vision too. OpenAI-compatible endpoints only.',

--- a/src/chrome/src/ui/settings.js
+++ b/src/chrome/src/ui/settings.js
@@ -1241,11 +1241,11 @@ function renderProviders() {
     },
     aws_bedrock: {
       fields: [
-        { key: 'region', label: 'AWS region', type: 'text', placeholder: 'us-east-1' },
-        { key: 'accessKeyId', label: 'AWS Access Key ID', type: 'text', placeholder: 'AKIA...' },
-        { key: 'secretAccessKey', label: 'AWS Secret Access Key', type: 'password', placeholder: '********' },
-        { key: 'sessionToken', label: 'AWS Session Token', type: 'password', placeholder: 'optional (STS)' },
-        { key: 'model', label: 'Bedrock model id', type: 'text', placeholder: 'anthropic.claude-3-sonnet-20240229-v1:0' },
+        { key: 'region', labelKey: 'st.provider.field.aws_region', type: 'text', placeholder: 'us-east-1' },
+        { key: 'accessKeyId', labelKey: 'st.provider.field.aws_access_key_id', type: 'text', placeholder: 'AKIA...' },
+        { key: 'secretAccessKey', labelKey: 'st.provider.field.aws_secret_access_key', type: 'password', placeholder: '********' },
+        { key: 'sessionToken', labelKey: 'st.provider.field.aws_session_token', type: 'password', placeholder: 'optional (STS)' },
+        { key: 'model', labelKey: 'st.provider.field.bedrock_model_id', type: 'text', placeholder: 'anthropic.claude-3-sonnet-20240229-v1:0' },
         ...COST_ESTIMATE_FIELDS,
       ],
     },

--- a/src/chrome/src/ui/settings.js
+++ b/src/chrome/src/ui/settings.js
@@ -1239,6 +1239,16 @@ function renderProviders() {
         PROMPT_TIER_FIELD,
       ],
     },
+    aws_bedrock: {
+      fields: [
+        { key: 'region', label: 'AWS region', type: 'text', placeholder: 'us-east-1' },
+        { key: 'accessKeyId', label: 'AWS Access Key ID', type: 'text', placeholder: 'AKIA...' },
+        { key: 'secretAccessKey', label: 'AWS Secret Access Key', type: 'password', placeholder: '********' },
+        { key: 'sessionToken', label: 'AWS Session Token', type: 'password', placeholder: 'optional (STS)' },
+        { key: 'model', label: 'Bedrock model id', type: 'text', placeholder: 'anthropic.claude-3-sonnet-20240229-v1:0' },
+        ...COST_ESTIMATE_FIELDS,
+      ],
+    },
     openai: {
       fields: [
         { key: 'apiKey', labelKey: 'st.provider.field.api_key', type: 'password', placeholder: 'sk-...' },

--- a/src/firefox/src/providers/aws-bedrock.js
+++ b/src/firefox/src/providers/aws-bedrock.js
@@ -25,6 +25,10 @@ export class AwsBedrockProvider extends BaseLLMProvider {
     return String(this.config.model || '').trim();
   }
 
+  get model() {
+    return this.modelId;
+  }
+
   get accessKeyId() {
     return String(this.config.accessKeyId || '').trim();
   }
@@ -215,6 +219,17 @@ export class AwsBedrockProvider extends BaseLLMProvider {
     return await fetchWithTimeout(url, { method, headers: finalHeaders, body: payload });
   }
 
+  _normalizeUsage(usage) {
+    if (!usage) return null;
+    const input = usage.inputTokens ?? usage.prompt_tokens ?? 0;
+    const output = usage.outputTokens ?? usage.completion_tokens ?? 0;
+    return {
+      prompt_tokens: input,
+      completion_tokens: output,
+      total_tokens: usage.totalTokens ?? (input + output),
+    };
+  }
+
   _fromBedrockResponse(data) {
     const message = data?.output?.message;
     const contentBlocks = Array.isArray(message?.content) ? message.content : [];
@@ -222,9 +237,10 @@ export class AwsBedrockProvider extends BaseLLMProvider {
 
     const toolUses = contentBlocks.map((b) => b?.toolUse).filter(Boolean);
     const toolCalls = toolUses.length
-      ? toolUses.map((u) => ({
+      ? toolUses.map((u, index) => ({
           id: u.toolUseId || crypto.randomUUID(),
           type: 'function',
+          index,
           function: {
             name: u.name,
             arguments: JSON.stringify(u.input ?? {}),
@@ -235,7 +251,7 @@ export class AwsBedrockProvider extends BaseLLMProvider {
     return {
       content: text || '',
       toolCalls,
-      usage: data?.usage || null,
+      usage: this._normalizeUsage(data?.usage),
       raw: data,
     };
   }
@@ -270,6 +286,7 @@ export class AwsBedrockProvider extends BaseLLMProvider {
     const res = await this.chat(messages, options);
     if (res.content) yield { type: 'text', content: res.content };
     if (res.toolCalls) yield { type: 'tool_call', content: res.toolCalls };
+    if (res.usage) yield { type: 'usage', usage: res.usage };
     yield { type: 'done', content: '' };
   }
 }

--- a/src/firefox/src/providers/aws-bedrock.js
+++ b/src/firefox/src/providers/aws-bedrock.js
@@ -1,0 +1,301 @@
+import { BaseLLMProvider } from './base.js';
+import { fetchWithTimeout } from './fetch-timeout.js';
+
+/**
+ * AWS Bedrock provider (Converse API) with SigV4 signing.
+ */
+export class AwsBedrockProvider extends BaseLLMProvider {
+  get name() {
+    return this.config.providerName || 'aws-bedrock';
+  }
+
+  get supportsTools() {
+    return true;
+  }
+
+  get supportsVision() {
+    return false;
+  }
+
+  get region() {
+    return String(this.config.region || '').trim() || 'us-east-1';
+  }
+
+  get modelId() {
+    return String(this.config.model || '').trim();
+  }
+
+  get accessKeyId() {
+    return String(this.config.accessKeyId || '').trim();
+  }
+
+  get secretAccessKey() {
+    return String(this.config.secretAccessKey || '').trim();
+  }
+
+  get sessionToken() {
+    return String(this.config.sessionToken || '').trim();
+  }
+
+  _assertConfigured() {
+    if (!this.modelId) throw new Error('Bedrock model id is required (Model field).');
+    if (!this.accessKeyId || !this.secretAccessKey) {
+      throw new Error('AWS Access Key ID and Secret Access Key are required.');
+    }
+    if (!this.region) throw new Error('AWS region is required.');
+  }
+
+  _endpoint() {
+    const host = `bedrock-runtime.${this.region}.amazonaws.com`;
+    const path = `/model/${encodeURIComponent(this.modelId)}/converse`;
+    return { host, url: `https://${host}${path}`, path };
+  }
+
+  _messagesContainImage(messages) {
+    return messages.some((msg) => Array.isArray(msg?.content) && msg.content.some((block) => {
+      return block && (block.type === 'image_url' || block.type === 'image');
+    }));
+  }
+
+  _toBedrockPayload(openAiMessages, options = {}) {
+    if (this._messagesContainImage(openAiMessages)) {
+      throw new Error('Bedrock Converse provider does not support image inputs yet. Disable screenshots or use a vision-capable provider.');
+    }
+
+    const systemTexts = [];
+    const messages = [];
+
+    const pushMessage = (role, contentBlocks) => {
+      if (!contentBlocks.length) return;
+      messages.push({ role, content: contentBlocks });
+    };
+
+    const toTextBlocks = (content) => {
+      if (content == null) return [];
+      if (Array.isArray(content)) {
+        return content
+          .filter((b) => b && b.type === 'text' && typeof b.text === 'string')
+          .map((b) => ({ text: b.text }));
+      }
+      const s = String(content);
+      return s ? [{ text: s }] : [];
+    };
+
+    for (const msg of openAiMessages || []) {
+      const role = msg?.role;
+      if (role === 'system') {
+        const text = Array.isArray(msg?.content)
+          ? msg.content.filter((b) => b?.type === 'text').map((b) => b.text).join('\n')
+          : String(msg?.content || '');
+        if (text.trim()) systemTexts.push(text.trim());
+        continue;
+      }
+
+      if (role === 'user') {
+        pushMessage('user', toTextBlocks(msg.content));
+        continue;
+      }
+
+      if (role === 'assistant') {
+        const blocks = [];
+        blocks.push(...toTextBlocks(msg.content));
+        const toolCalls = Array.isArray(msg.tool_calls) ? msg.tool_calls : null;
+        if (toolCalls) {
+          for (const call of toolCalls) {
+            const fn = call?.function;
+            const name = fn?.name;
+            if (!name) continue;
+            let input = {};
+            try { input = fn?.arguments ? JSON.parse(fn.arguments) : {}; } catch { input = {}; }
+            blocks.push({
+              toolUse: {
+                toolUseId: call.id || crypto.randomUUID(),
+                name,
+                input,
+              },
+            });
+          }
+        }
+        pushMessage('assistant', blocks);
+        continue;
+      }
+
+      if (role === 'tool') {
+        const toolUseId = msg.tool_call_id || msg.toolCallId || '';
+        const name = msg.name || '';
+        const text = typeof msg.content === 'string' ? msg.content : JSON.stringify(msg.content ?? '');
+        pushMessage('user', [{
+          toolResult: {
+            toolUseId: toolUseId || name || crypto.randomUUID(),
+            content: [{ text }],
+          },
+        }]);
+      }
+    }
+
+    const toolConfig = (options.tools && options.tools.length)
+      ? {
+          tools: options.tools
+            .map((t) => t?.function)
+            .filter(Boolean)
+            .map((fn) => ({
+              toolSpec: {
+                name: fn.name,
+                description: fn.description || '',
+                inputSchema: { json: fn.parameters || { type: 'object', properties: {} } },
+              },
+            })),
+          toolChoice: { auto: {} },
+        }
+      : undefined;
+
+    const payload = {
+      messages,
+      ...(systemTexts.length ? { system: systemTexts.map((t) => ({ text: t })) } : {}),
+      inferenceConfig: {
+        maxTokens: options.maxTokens ?? 4096,
+        temperature: options.temperature ?? 0.7,
+      },
+      ...(toolConfig ? { toolConfig } : {}),
+    };
+    return payload;
+  }
+
+  async _signAndFetch({ url, host, path }, body) {
+    const method = 'POST';
+    const service = 'bedrock';
+
+    const now = new Date();
+    const amzDate = now.toISOString().replace(/[:-]|\.\d{3}/g, '');
+    const dateStamp = amzDate.slice(0, 8);
+
+    const payload = JSON.stringify(body);
+    const payloadHash = await sha256Hex(payload);
+
+    const headers = {
+      host,
+      'content-type': 'application/json',
+      accept: 'application/json',
+      'x-amz-date': amzDate,
+    };
+    if (this.sessionToken) headers['x-amz-security-token'] = this.sessionToken;
+
+    const signedHeaders = Object.keys(headers).map((h) => h.toLowerCase()).sort().join(';');
+    const canonicalHeaders = Object.keys(headers)
+      .map((h) => h.toLowerCase())
+      .sort()
+      .map((h) => `${h}:${String(headers[h]).trim()}\n`)
+      .join('');
+
+    const canonicalRequest = [
+      method,
+      path,
+      '',
+      canonicalHeaders,
+      signedHeaders,
+      payloadHash,
+    ].join('\n');
+
+    const algorithm = 'AWS4-HMAC-SHA256';
+    const credentialScope = `${dateStamp}/${this.region}/${service}/aws4_request`;
+    const stringToSign = [
+      algorithm,
+      amzDate,
+      credentialScope,
+      await sha256Hex(canonicalRequest),
+    ].join('\n');
+
+    const signingKey = await getSignatureKey(this.secretAccessKey, dateStamp, this.region, service);
+    const signature = await hmacHex(signingKey, stringToSign);
+
+    const authorization = `${algorithm} Credential=${this.accessKeyId}/${credentialScope}, SignedHeaders=${signedHeaders}, Signature=${signature}`;
+
+    const finalHeaders = { ...headers, authorization };
+
+    return await fetchWithTimeout(url, { method, headers: finalHeaders, body: payload });
+  }
+
+  _fromBedrockResponse(data) {
+    const message = data?.output?.message;
+    const contentBlocks = Array.isArray(message?.content) ? message.content : [];
+    const text = contentBlocks.map((b) => b?.text).filter(Boolean).join('');
+
+    const toolUses = contentBlocks.map((b) => b?.toolUse).filter(Boolean);
+    const toolCalls = toolUses.length
+      ? toolUses.map((u) => ({
+          id: u.toolUseId || crypto.randomUUID(),
+          type: 'function',
+          function: {
+            name: u.name,
+            arguments: JSON.stringify(u.input ?? {}),
+          },
+        }))
+      : null;
+
+    return {
+      content: text || '',
+      toolCalls,
+      usage: data?.usage || null,
+      raw: data,
+    };
+  }
+
+  async chat(messages, options = {}) {
+    this._assertConfigured();
+    const endpoint = this._endpoint();
+    const payload = this._toBedrockPayload(messages, options);
+
+    let res;
+    try {
+      res = await this._signAndFetch(endpoint, payload);
+    } catch (e) {
+      throw new Error(`${this.name} network error — could not reach ${endpoint.url} (${e.message}).`);
+    }
+
+    if (!res.ok) {
+      let err = '';
+      try { err = (await res.text()).slice(0, 1200); } catch {}
+      throw new Error(`${this.name} error ${res.status}: ${err || res.statusText}`);
+    }
+
+    let data;
+    try { data = await res.json(); } catch {
+      throw new Error(`${this.name} returned invalid JSON.`);
+    }
+
+    return this._fromBedrockResponse(data);
+  }
+
+  async *chatStream(messages, options = {}) {
+    const res = await this.chat(messages, options);
+    if (res.content) yield { type: 'text', content: res.content };
+    if (res.toolCalls) yield { type: 'tool_call', content: res.toolCalls };
+    yield { type: 'done', content: '' };
+  }
+}
+
+async function sha256Hex(data) {
+  const bytes = typeof data === 'string' ? new TextEncoder().encode(data) : data;
+  const digest = await crypto.subtle.digest('SHA-256', bytes);
+  return Array.from(new Uint8Array(digest), (b) => b.toString(16).padStart(2, '0')).join('');
+}
+
+async function hmacRaw(keyBytes, data) {
+  const key = await crypto.subtle.importKey('raw', keyBytes, { name: 'HMAC', hash: 'SHA-256' }, false, ['sign']);
+  const sig = await crypto.subtle.sign('HMAC', key, new TextEncoder().encode(data));
+  return new Uint8Array(sig);
+}
+
+async function hmacHex(keyBytes, data) {
+  const sig = await hmacRaw(keyBytes, data);
+  return Array.from(sig, (b) => b.toString(16).padStart(2, '0')).join('');
+}
+
+async function getSignatureKey(secretAccessKey, dateStamp, regionName, serviceName) {
+  const kDate = await hmacRaw(new TextEncoder().encode('AWS4' + secretAccessKey), dateStamp);
+  const kRegion = await hmacRaw(kDate, regionName);
+  const kService = await hmacRaw(kRegion, serviceName);
+  const kSigning = await hmacRaw(kService, 'aws4_request');
+  return kSigning;
+}
+

--- a/src/firefox/src/providers/manager.js
+++ b/src/firefox/src/providers/manager.js
@@ -2,6 +2,7 @@ import { LlamaCppProvider } from './llamacpp.js';
 import { OpenAICompatibleProvider } from './openai.js';
 import { AnthropicProvider, AnthropicOAuthProvider } from './anthropic.js';
 import { signOutClaude } from './oauth-claude.js';
+import { AwsBedrockProvider } from './aws-bedrock.js';
 
 const WEBBRAIN_CLOUD_PROVIDER_ID = 'webbrain_cloud';
 const WEBBRAIN_CLOUD_CONTEXT_WINDOW = 1000000;
@@ -9,7 +10,7 @@ const WEBBRAIN_CLOUD_LEGACY_CONTEXT_WINDOW = 256000;
 const WEBBRAIN_DEVICE_GUID_KEY = 'webbrainDeviceGuid';
 const OPENROUTER_DEFAULT_MODEL = 'openrouter/free';
 const OPENROUTER_LEGACY_DEFAULT_MODEL = 'stepfun/step-3.7-flash';
-const SUPPORTED_PROVIDER_TYPES = new Set(['llamacpp', 'openai', 'anthropic', 'anthropic_oauth']);
+const SUPPORTED_PROVIDER_TYPES = new Set(['llamacpp', 'openai', 'aws_bedrock', 'anthropic', 'anthropic_oauth']);
 const SAFE_PROVIDER_ID_RE = /^[A-Za-z0-9_-]+$/;
 const ROUTER_PROVIDER_IDS = ['openrouter', 'cloudflare', 'nvidia', 'groq', 'huggingface'];
 
@@ -192,6 +193,20 @@ export class ProviderManager {
         apiKey: '',
         supportsVision: true,
         enabled: true,
+      },
+      aws_bedrock: {
+        type: 'aws_bedrock',
+        category: 'cloud',
+        label: 'AWS Bedrock (Converse)',
+        providerName: 'aws-bedrock',
+        baseUrl: 'https://bedrock-runtime.{region}.amazonaws.com',
+        model: '',
+        region: 'us-east-1',
+        accessKeyId: '',
+        secretAccessKey: '',
+        sessionToken: '',
+        supportsVision: false,
+        enabled: false,
       },
       openai: {
         type: 'openai',
@@ -435,6 +450,8 @@ export class ProviderManager {
         return new LlamaCppProvider(normalizedConfig);
       case 'openai':
         return new OpenAICompatibleProvider(normalizedConfig);
+      case 'aws_bedrock':
+        return new AwsBedrockProvider(normalizedConfig);
       case 'anthropic':
         return new AnthropicProvider(normalizedConfig);
       case 'anthropic_oauth':

--- a/src/firefox/src/ui/locales/en.js
+++ b/src/firefox/src/ui/locales/en.js
@@ -469,6 +469,13 @@ export default {
   'st.provider.field.output_cost_per_million': 'Estimated output cost ($ / 1M tokens)',
   'st.provider.field.model_loaded_hint': 'leave blank to use loaded model',
   'st.provider.field.model_custom': 'Custom...',
+  'st.provider.field.deployment_name': 'Deployment name',
+  'st.provider.field.api_version': 'API version',
+  'st.provider.field.aws_region': 'AWS region',
+  'st.provider.field.aws_access_key_id': 'AWS Access Key ID',
+  'st.provider.field.aws_secret_access_key': 'AWS Secret Access Key',
+  'st.provider.field.aws_session_token': 'AWS Session Token',
+  'st.provider.field.bedrock_model_id': 'Bedrock model id',
 
   'st.vision.heading': 'Vision',
   'st.vision.desc': 'If set, screenshots are sent to this model for reading the page, while the active provider handles planning and tool calls. Leave blank to use the active provider for vision too. OpenAI-compatible endpoints only.',

--- a/src/firefox/src/ui/settings.js
+++ b/src/firefox/src/ui/settings.js
@@ -1209,11 +1209,11 @@ function renderProviders() {
     },
     aws_bedrock: {
       fields: [
-        { key: 'region', label: 'AWS region', type: 'text', placeholder: 'us-east-1' },
-        { key: 'accessKeyId', label: 'AWS Access Key ID', type: 'text', placeholder: 'AKIA...' },
-        { key: 'secretAccessKey', label: 'AWS Secret Access Key', type: 'password', placeholder: '********' },
-        { key: 'sessionToken', label: 'AWS Session Token', type: 'password', placeholder: 'optional (STS)' },
-        { key: 'model', label: 'Bedrock model id', type: 'text', placeholder: 'anthropic.claude-3-sonnet-20240229-v1:0' },
+        { key: 'region', labelKey: 'st.provider.field.aws_region', type: 'text', placeholder: 'us-east-1' },
+        { key: 'accessKeyId', labelKey: 'st.provider.field.aws_access_key_id', type: 'text', placeholder: 'AKIA...' },
+        { key: 'secretAccessKey', labelKey: 'st.provider.field.aws_secret_access_key', type: 'password', placeholder: '********' },
+        { key: 'sessionToken', labelKey: 'st.provider.field.aws_session_token', type: 'password', placeholder: 'optional (STS)' },
+        { key: 'model', labelKey: 'st.provider.field.bedrock_model_id', type: 'text', placeholder: 'anthropic.claude-3-sonnet-20240229-v1:0' },
         ...COST_ESTIMATE_FIELDS,
       ],
     },

--- a/src/firefox/src/ui/settings.js
+++ b/src/firefox/src/ui/settings.js
@@ -1207,6 +1207,16 @@ function renderProviders() {
         PROMPT_TIER_FIELD,
       ],
     },
+    aws_bedrock: {
+      fields: [
+        { key: 'region', label: 'AWS region', type: 'text', placeholder: 'us-east-1' },
+        { key: 'accessKeyId', label: 'AWS Access Key ID', type: 'text', placeholder: 'AKIA...' },
+        { key: 'secretAccessKey', label: 'AWS Secret Access Key', type: 'password', placeholder: '********' },
+        { key: 'sessionToken', label: 'AWS Session Token', type: 'password', placeholder: 'optional (STS)' },
+        { key: 'model', label: 'Bedrock model id', type: 'text', placeholder: 'anthropic.claude-3-sonnet-20240229-v1:0' },
+        ...COST_ESTIMATE_FIELDS,
+      ],
+    },
     openai: {
       fields: [
         { key: 'apiKey', labelKey: 'st.provider.field.api_key', type: 'password', placeholder: 'sk-...' },

--- a/test/run.js
+++ b/test/run.js
@@ -267,6 +267,12 @@ const { LlamaCppProvider: LlamaCppProviderCh } = await import(
 const { LlamaCppProvider: LlamaCppProviderFx } = await import(
   'file://' + path.join(ROOT, 'src/firefox/src/providers/llamacpp.js').replace(/\\/g, '/')
 );
+const { AwsBedrockProvider: AwsBedrockProviderCh } = await import(
+  'file://' + path.join(ROOT, 'src/chrome/src/providers/aws-bedrock.js').replace(/\\/g, '/')
+);
+const { AwsBedrockProvider: AwsBedrockProviderFx } = await import(
+  'file://' + path.join(ROOT, 'src/firefox/src/providers/aws-bedrock.js').replace(/\\/g, '/')
+);
 const { buildRecommendedActions: buildRecommendedActionsCh, shouldShowRecommendedActions: shouldShowRecommendedActionsCh } = await import(
   'file://' + path.join(ROOT, 'src/chrome/src/ui/recommended-actions.js').replace(/\\/g, '/')
 );
@@ -10767,6 +10773,39 @@ test('OpenAI-compatible streams request usage metadata only for supporting provi
       provider._addStreamUsageOptions(body);
       assert.equal(body.stream_options, undefined);
     }
+  }
+});
+
+test('AWS Bedrock provider normalizes usage and indexes parallel tool calls', () => {
+  for (const Provider of [AwsBedrockProviderCh, AwsBedrockProviderFx]) {
+    const provider = new Provider({
+      region: 'us-east-1',
+      accessKeyId: 'AKIA123',
+      secretAccessKey: 'secret',
+      model: 'anthropic.claude-3-sonnet-20240229-v1:0',
+    });
+    assert.equal(provider.model, 'anthropic.claude-3-sonnet-20240229-v1:0');
+
+    const parsed = provider._fromBedrockResponse({
+      output: {
+        message: {
+          content: [
+            { text: 'hello' },
+            { toolUse: { toolUseId: 'a', name: 'click', input: { x: 1 } } },
+            { toolUse: { toolUseId: 'b', name: 'type_text', input: { text: 'hi' } } },
+          ],
+        },
+      },
+      usage: { inputTokens: 10, outputTokens: 5, totalTokens: 15 },
+    });
+    assert.deepEqual(parsed.usage, {
+      prompt_tokens: 10,
+      completion_tokens: 5,
+      total_tokens: 15,
+    });
+    assert.equal(parsed.toolCalls.length, 2);
+    assert.equal(parsed.toolCalls[0].index, 0);
+    assert.equal(parsed.toolCalls[1].index, 1);
   }
 });
 


### PR DESCRIPTION
## Summary
- Add `aws_bedrock` provider implementing the Bedrock Runtime Converse API with SigV4 signing.
- Add Settings fields for region, credentials, and Bedrock model id.
- Mirror implementation and registration across Chrome + Firefox.

## Test plan
- Load unpacked extension.
- Configure AWS Bedrock provider with region + credentials + model id.
- Click **Test Connection**.
- Send a simple prompt in the side panel.