### PR TITLE
Add context detection for more local providers

### DIFF
--- a/src/chrome/src/providers/context-windows.js
+++ b/src/chrome/src/providers/context-windows.js
@@ -153,6 +153,65 @@ export function parseLmStudioModelsContextWindow(data, preferredModel = '') {
   return null;
 }
 
+function openAiModelCardContextWindow(model) {
+  if (!model || typeof model !== 'object') return null;
+  return normalizeDetectedContextWindow(
+    model.max_model_len ??
+    model.maxModelLen ??
+    model.max_context_length ??
+    model.maxContextLength ??
+    model.context_window ??
+    model.contextWindow
+  );
+}
+
+/**
+ * OpenAI-compatible `GET /v1/models` extensions used by vLLM and SGLang.
+ * Prefer an exact preferred model match; if none is selected, use the first
+ * model card that carries explicit context metadata.
+ */
+export function parseOpenAiModelListContextWindow(data, preferredModel = '') {
+  const source = Array.isArray(data?.data) ? data.data : [];
+  if (!source.length) return null;
+
+  const want = String(preferredModel || '').trim();
+  const cards = source.filter((m) => m && typeof m === 'object' && m.id);
+
+  if (want) {
+    const preferred = cards.find((m) => modelIdsMatch(m.id, want));
+    return preferred ? openAiModelCardContextWindow(preferred) : null;
+  }
+
+  for (const model of cards) {
+    const n = openAiModelCardContextWindow(model);
+    if (n != null) return n;
+  }
+  return null;
+}
+
+/**
+ * LocalAI `GET /api/models/config-json/:name` — use configured runtime
+ * `context_size` only. Do not infer from architecture/model maxima.
+ */
+export function parseLocalAiModelConfigContextWindow(data) {
+  if (!data || typeof data !== 'object') return null;
+  const candidates = [
+    data.context_size,
+    data.contextSize,
+    data.config?.context_size,
+    data.config?.contextSize,
+    data.model_config?.context_size,
+    data.model_config?.contextSize,
+    data.parameters?.context_size,
+    data.parameters?.contextSize,
+  ];
+  for (const value of candidates) {
+    const n = normalizeDetectedContextWindow(value);
+    if (n != null) return n;
+  }
+  return null;
+}
+
 /**
  * True when LM Studio detection came from a loaded model's
  * `loaded_context_length` (safe to shrink a manual override).

--- a/src/chrome/src/providers/manager.js
+++ b/src/chrome/src/providers/manager.js
@@ -14,9 +14,11 @@ import { fetchWithFallback } from './fetch-with-fallback.js';
 import {
   lmStudioContextWindowIsLive,
   parseLlamaCppPropsContextWindow,
+  parseLocalAiModelConfigContextWindow,
   parseLmStudioModelsContextWindow,
   parseOllamaPsContextWindow,
   parseOllamaShowContextWindow,
+  parseOpenAiModelListContextWindow,
   shouldApplyDetectedContextWindow,
 } from './context-windows.js';
 
@@ -754,12 +756,14 @@ export class ProviderManager {
         if (candidate.configBaseUrl !== observedBaseUrl) {
           if (await this._updateProviderBaseUrl(id, candidate.configBaseUrl, observedBaseUrl)) {
             result.baseUrl = candidate.configBaseUrl;
+          } else {
+            return result;
           }
         }
-        if (id !== 'llamacpp') return result;
         const active = this.providers.get(id) || provider;
         return this._attachDetectedContextWindow(id, active, result, {
           requestBaseUrl: candidate.requestBaseUrl,
+          modelListData: data,
         });
       } catch (e) {
         if (!firstFailure) firstFailure = { ok: false, error: e.message };
@@ -915,8 +919,9 @@ export class ProviderManager {
   }
 
   /**
-   * Best-effort local context detection. Only llama.cpp / Ollama / LM Studio
-   * report usable windows today; other local ids no-op. Returns
+   * Best-effort local context detection. Supported local servers expose usable
+   * runtime/configured windows through provider-specific metadata; others no-op.
+   * Returns
    * `{ contextWindow, shrinkOverride }` where shrinkOverride means the value
    * came from live/runtime allocation (safe to shrink a manual override).
    */
@@ -981,6 +986,31 @@ export class ProviderManager {
         const contextWindow = parseOllamaShowContextWindow(await res.json());
         if (contextWindow == null) return null;
         return { contextWindow, shrinkOverride: false };
+      }
+
+      if (id === 'vllm' || id === 'sglang') {
+        let data = options.modelListData || null;
+        if (!data) {
+          const openAiBase = /\/v1$/i.test(rawBaseUrl) ? rawBaseUrl : `${root}/v1`;
+          const res = await fetchWithFallback(`${openAiBase}/models`, { method: 'GET', headers });
+          if (!res.ok) return null;
+          data = await res.json();
+        }
+        const contextWindow = parseOpenAiModelListContextWindow(data, model);
+        if (contextWindow == null) return null;
+        return { contextWindow, shrinkOverride: true };
+      }
+
+      if (id === 'localai') {
+        if (!model) return null;
+        const res = await fetchWithFallback(`${root}/api/models/config-json/${encodeURIComponent(model)}`, {
+          method: 'GET',
+          headers,
+        });
+        if (!res.ok) return null;
+        const contextWindow = parseLocalAiModelConfigContextWindow(await res.json());
+        if (contextWindow == null) return null;
+        return { contextWindow, shrinkOverride: true };
       }
     } catch {
       return null;

--- a/src/chrome/src/providers/manager.js
+++ b/src/chrome/src/providers/manager.js
@@ -761,6 +761,12 @@ export class ProviderManager {
           }
         }
         const active = this.providers.get(id) || provider;
+        if (
+          active.config.baseUrl !== candidate.configBaseUrl ||
+          active.config.model !== provider.config.model
+        ) {
+          return result;
+        }
         return this._attachDetectedContextWindow(id, active, result, {
           requestBaseUrl: candidate.requestBaseUrl,
           modelListData: data,

--- a/src/firefox/src/providers/context-windows.js
+++ b/src/firefox/src/providers/context-windows.js
@@ -153,6 +153,65 @@ export function parseLmStudioModelsContextWindow(data, preferredModel = '') {
   return null;
 }
 
+function openAiModelCardContextWindow(model) {
+  if (!model || typeof model !== 'object') return null;
+  return normalizeDetectedContextWindow(
+    model.max_model_len ??
+    model.maxModelLen ??
+    model.max_context_length ??
+    model.maxContextLength ??
+    model.context_window ??
+    model.contextWindow
+  );
+}
+
+/**
+ * OpenAI-compatible `GET /v1/models` extensions used by vLLM and SGLang.
+ * Prefer an exact preferred model match; if none is selected, use the first
+ * model card that carries explicit context metadata.
+ */
+export function parseOpenAiModelListContextWindow(data, preferredModel = '') {
+  const source = Array.isArray(data?.data) ? data.data : [];
+  if (!source.length) return null;
+
+  const want = String(preferredModel || '').trim();
+  const cards = source.filter((m) => m && typeof m === 'object' && m.id);
+
+  if (want) {
+    const preferred = cards.find((m) => modelIdsMatch(m.id, want));
+    return preferred ? openAiModelCardContextWindow(preferred) : null;
+  }
+
+  for (const model of cards) {
+    const n = openAiModelCardContextWindow(model);
+    if (n != null) return n;
+  }
+  return null;
+}
+
+/**
+ * LocalAI `GET /api/models/config-json/:name` — use configured runtime
+ * `context_size` only. Do not infer from architecture/model maxima.
+ */
+export function parseLocalAiModelConfigContextWindow(data) {
+  if (!data || typeof data !== 'object') return null;
+  const candidates = [
+    data.context_size,
+    data.contextSize,
+    data.config?.context_size,
+    data.config?.contextSize,
+    data.model_config?.context_size,
+    data.model_config?.contextSize,
+    data.parameters?.context_size,
+    data.parameters?.contextSize,
+  ];
+  for (const value of candidates) {
+    const n = normalizeDetectedContextWindow(value);
+    if (n != null) return n;
+  }
+  return null;
+}
+
 /**
  * True when LM Studio detection came from a loaded model's
  * `loaded_context_length` (safe to shrink a manual override).

--- a/src/firefox/src/providers/manager.js
+++ b/src/firefox/src/providers/manager.js
@@ -7,9 +7,11 @@ import { AwsBedrockProvider } from './aws-bedrock.js';
 import {
   lmStudioContextWindowIsLive,
   parseLlamaCppPropsContextWindow,
+  parseLocalAiModelConfigContextWindow,
   parseLmStudioModelsContextWindow,
   parseOllamaPsContextWindow,
   parseOllamaShowContextWindow,
+  parseOpenAiModelListContextWindow,
   shouldApplyDetectedContextWindow,
 } from './context-windows.js';
 
@@ -732,12 +734,14 @@ export class ProviderManager {
         if (candidate.configBaseUrl !== observedBaseUrl) {
           if (await this._updateProviderBaseUrl(id, candidate.configBaseUrl, observedBaseUrl)) {
             result.baseUrl = candidate.configBaseUrl;
+          } else {
+            return result;
           }
         }
-        if (id !== 'llamacpp') return result;
         const active = this.providers.get(id) || provider;
         return this._attachDetectedContextWindow(id, active, result, {
           requestBaseUrl: candidate.requestBaseUrl,
+          modelListData: data,
         });
       } catch (e) {
         if (!firstFailure) firstFailure = { ok: false, error: e.message };
@@ -893,8 +897,9 @@ export class ProviderManager {
   }
 
   /**
-   * Best-effort local context detection. Only llama.cpp / Ollama / LM Studio
-   * report usable windows today; other local ids no-op. Returns
+   * Best-effort local context detection. Supported local servers expose usable
+   * runtime/configured windows through provider-specific metadata; others no-op.
+   * Returns
    * `{ contextWindow, shrinkOverride }` where shrinkOverride means the value
    * came from live/runtime allocation (safe to shrink a manual override).
    */
@@ -959,6 +964,31 @@ export class ProviderManager {
         const contextWindow = parseOllamaShowContextWindow(await res.json());
         if (contextWindow == null) return null;
         return { contextWindow, shrinkOverride: false };
+      }
+
+      if (id === 'vllm' || id === 'sglang') {
+        let data = options.modelListData || null;
+        if (!data) {
+          const openAiBase = /\/v1$/i.test(rawBaseUrl) ? rawBaseUrl : `${root}/v1`;
+          const res = await fetch(`${openAiBase}/models`, { method: 'GET', headers });
+          if (!res.ok) return null;
+          data = await res.json();
+        }
+        const contextWindow = parseOpenAiModelListContextWindow(data, model);
+        if (contextWindow == null) return null;
+        return { contextWindow, shrinkOverride: true };
+      }
+
+      if (id === 'localai') {
+        if (!model) return null;
+        const res = await fetch(`${root}/api/models/config-json/${encodeURIComponent(model)}`, {
+          method: 'GET',
+          headers,
+        });
+        if (!res.ok) return null;
+        const contextWindow = parseLocalAiModelConfigContextWindow(await res.json());
+        if (contextWindow == null) return null;
+        return { contextWindow, shrinkOverride: true };
       }
     } catch {
       return null;

--- a/src/firefox/src/providers/manager.js
+++ b/src/firefox/src/providers/manager.js
@@ -739,6 +739,12 @@ export class ProviderManager {
           }
         }
         const active = this.providers.get(id) || provider;
+        if (
+          active.config.baseUrl !== candidate.configBaseUrl ||
+          active.config.model !== provider.config.model
+        ) {
+          return result;
+        }
         return this._attachDetectedContextWindow(id, active, result, {
           requestBaseUrl: candidate.requestBaseUrl,
           modelListData: data,

--- a/test/run.js
+++ b/test/run.js
@@ -252,6 +252,8 @@ const {
   parseOllamaPsContextWindow: parseOllamaPsContextWindowCh,
   parseOllamaNumCtx: parseOllamaNumCtxCh,
   parseLmStudioModelsContextWindow: parseLmStudioModelsContextWindowCh,
+  parseOpenAiModelListContextWindow: parseOpenAiModelListContextWindowCh,
+  parseLocalAiModelConfigContextWindow: parseLocalAiModelConfigContextWindowCh,
   lmStudioContextWindowIsLive: lmStudioContextWindowIsLiveCh,
 } = await import(
   'file://' + path.join(ROOT, 'src/chrome/src/providers/context-windows.js').replace(/\\/g, '/')
@@ -265,6 +267,8 @@ const {
   parseOllamaPsContextWindow: parseOllamaPsContextWindowFx,
   parseOllamaNumCtx: parseOllamaNumCtxFx,
   parseLmStudioModelsContextWindow: parseLmStudioModelsContextWindowFx,
+  parseOpenAiModelListContextWindow: parseOpenAiModelListContextWindowFx,
+  parseLocalAiModelConfigContextWindow: parseLocalAiModelConfigContextWindowFx,
   lmStudioContextWindowIsLive: lmStudioContextWindowIsLiveFx,
 } = await import(
   'file://' + path.join(ROOT, 'src/firefox/src/providers/context-windows.js').replace(/\\/g, '/')
@@ -10500,7 +10504,7 @@ test('inferContextWindow: model-aware cloud/router defaults and local 16k fallba
   }
 });
 
-test('local context-window detection parsers: llama.cpp / Ollama / LM Studio', () => {
+test('local context-window detection parsers: local provider metadata', () => {
   const parsers = [
     {
       normalize: normalizeDetectedContextWindowCh,
@@ -10510,6 +10514,8 @@ test('local context-window detection parsers: llama.cpp / Ollama / LM Studio', (
       ollamaPs: parseOllamaPsContextWindowCh,
       ollamaNumCtx: parseOllamaNumCtxCh,
       lmstudio: parseLmStudioModelsContextWindowCh,
+      openAiList: parseOpenAiModelListContextWindowCh,
+      localAiConfig: parseLocalAiModelConfigContextWindowCh,
       lmLive: lmStudioContextWindowIsLiveCh,
     },
     {
@@ -10520,6 +10526,8 @@ test('local context-window detection parsers: llama.cpp / Ollama / LM Studio', (
       ollamaPs: parseOllamaPsContextWindowFx,
       ollamaNumCtx: parseOllamaNumCtxFx,
       lmstudio: parseLmStudioModelsContextWindowFx,
+      openAiList: parseOpenAiModelListContextWindowFx,
+      localAiConfig: parseLocalAiModelConfigContextWindowFx,
       lmLive: lmStudioContextWindowIsLiveFx,
     },
   ];
@@ -10628,6 +10636,33 @@ test('local context-window detection parsers: llama.cpp / Ollama / LM Studio', (
     assert.equal(p.lmLive({
       data: [{ id: 'chat-a', type: 'llm', state: 'not-loaded', max_context_length: 32768 }],
     }, 'chat-a'), false);
+
+    assert.equal(p.openAiList({
+      data: [
+        { id: 'other-model', max_model_len: 32768 },
+        { id: 'Qwen/Qwen3-4B', max_model_len: 65536 },
+      ],
+    }, 'Qwen/Qwen3-4B'), 65536);
+    assert.equal(p.openAiList({
+      data: [{ id: 'Qwen/Qwen3-4B', maxModelLen: '131072' }],
+    }, 'qwen/qwen3-4b'), 131072);
+    assert.equal(p.openAiList({
+      data: [{ id: 'Qwen/Qwen3-4B', max_model_len: 65536 }],
+    }, 'missing-model'), null);
+    assert.equal(p.openAiList({
+      data: [
+        { id: 'missing-window' },
+        { id: 'served-model', context_window: 12288 },
+      ],
+    }), 12288);
+    assert.equal(p.openAiList({ data: [{ id: 'served-model', context_length: 65536 }] }), null);
+
+    assert.equal(p.localAiConfig({ context_size: 8192 }), 8192);
+    assert.equal(p.localAiConfig({ contextSize: '24576' }), 24576);
+    assert.equal(p.localAiConfig({ config: { context_size: 12288 } }), 12288);
+    assert.equal(p.localAiConfig({ model_config: { contextSize: 32768 } }), 32768);
+    assert.equal(p.localAiConfig({ parameters: { context_size: 2048 } }), 4096);
+    assert.equal(p.localAiConfig({ model_max_context: 131072 }), null);
   }
 });
 
@@ -10926,6 +10961,98 @@ test('ProviderManager persists detected local context windows with safe apply po
             patch.providers?.lmstudio?.contextWindow === 8192
           ),
           `${label}: lmstudio selected-model persistence writes context window to storage`
+        );
+      }
+
+      // vLLM /v1/models includes max_model_len on model cards.
+      {
+        const writes = [];
+        globalThis[runtimeKey] = makeRuntime(writes);
+        globalThis.fetch = async (url) => {
+          const u = String(url);
+          if (u.endsWith('/models')) {
+            return jsonOk({
+              data: [
+                { id: 'other-model', max_model_len: 32768 },
+                { id: 'served-model', max_model_len: 65536 },
+              ],
+            });
+          }
+          return new Response('missing', { status: 404 });
+        };
+        const mgr = new PM();
+        const config = {
+          ...mgr._defaultConfigs().vllm,
+          model: 'served-model',
+          contextWindow: 16384,
+        };
+        mgr.providers.set('vllm', mgr._createProvider('vllm', config));
+        const result = await mgr.listProviderModels('vllm');
+        assert.equal(result.ok, true, `${label}: vllm list ok`);
+        assert.deepEqual(result.models, ['other-model', 'served-model']);
+        assert.equal(result.contextWindow, 65536, `${label}: vllm detects matching max_model_len`);
+        assert.equal(mgr.providers.get('vllm').config.contextWindow, 65536);
+        assert.ok(
+          writes.some((patch) => patch.providers?.vllm?.contextWindow === 65536),
+          `${label}: vllm persistence writes detected window to storage`
+        );
+      }
+
+      // SGLang model cards also expose max_model_len; treat it as runtime max.
+      {
+        const writes = [];
+        globalThis[runtimeKey] = makeRuntime(writes);
+        globalThis.fetch = async (url) => {
+          if (String(url).endsWith('/models')) {
+            return jsonOk({ data: [{ id: 'sglang-model', max_model_len: 8192 }] });
+          }
+          return new Response('missing', { status: 404 });
+        };
+        const mgr = new PM();
+        const config = {
+          ...mgr._defaultConfigs().sglang,
+          model: 'sglang-model',
+          contextWindow: 65536,
+        };
+        mgr.providers.set('sglang', mgr._createProvider('sglang', config));
+        const result = await mgr.detectProviderContextWindow('sglang', 'sglang-model');
+        assert.equal(result.ok, true, `${label}: sglang selected-model detection ok`);
+        assert.equal(result.contextWindow, 8192, `${label}: sglang shrinks stale manual override`);
+        assert.equal(mgr.providers.get('sglang').config.contextWindow, 8192);
+        assert.ok(
+          writes.some((patch) => patch.providers?.sglang?.contextWindow === 8192),
+          `${label}: sglang persistence writes detected window to storage`
+        );
+      }
+
+      // LocalAI exposes configured context_size through its model config API.
+      {
+        const writes = [];
+        const calls = [];
+        globalThis[runtimeKey] = makeRuntime(writes);
+        globalThis.fetch = async (url, init = {}) => {
+          calls.push({ url: String(url), headers: init.headers || {} });
+          if (String(url).endsWith('/api/models/config-json/owner%2Flocal-model')) {
+            return jsonOk({ context_size: 24576 });
+          }
+          return new Response('missing', { status: 404 });
+        };
+        const mgr = new PM();
+        const config = {
+          ...mgr._defaultConfigs().localai,
+          model: 'owner/local-model',
+          contextWindow: 16384,
+          apiKey: 'localai-secret',
+        };
+        mgr.providers.set('localai', mgr._createProvider('localai', config));
+        const result = await mgr.detectProviderContextWindow('localai', 'owner/local-model');
+        assert.equal(result.ok, true, `${label}: localai selected-model detection ok`);
+        assert.equal(result.contextWindow, 24576, `${label}: localai detects configured context_size`);
+        assert.equal(mgr.providers.get('localai').config.contextWindow, 24576);
+        assert.equal(calls[0].headers.Authorization, 'Bearer localai-secret');
+        assert.ok(
+          writes.some((patch) => patch.providers?.localai?.contextWindow === 24576),
+          `${label}: localai persistence writes detected window to storage`
         );
       }
 


### PR DESCRIPTION
## Summary

Adds conservative local context-window detection for more OpenAI-compatible local servers:

- vLLM and SGLang now read explicit context metadata from `/v1/models` model cards, including `max_model_len`-style fields.
- LocalAI now reads configured runtime `context_size` from `/api/models/config-json/:model` when a saved model is selected.
- The local model-loading path can attach detected context windows for supported local providers, while Jan remains a no-op because its model list does not expose a stable trusted context field.
- Chrome and Firefox provider managers and parser modules stay mirrored.

## Validation

- `git diff --check`
- `node test/run.js` — 703 passed
- `npm test` — 703 passed plus 60/60 injection corpus checks