### PR TITLE
agent: add adapter for galaxus

### DIFF
--- a/src/chrome/src/agent/adapters.js
+++ b/src/chrome/src/agent/adapters.js
@@ -16181,6 +16181,18 @@ const ADAPTERS = [
 - "Yemeksepeti Mahalle" (grocery/market quick delivery) is a separate flow from restaurant food ordering — don't expect restaurant menus there.`,
   },
 
+  // ─── Regional — Digitec Galaxus (CH + EU: one in-house platform) ──────
+  // galaxus.* (CH/DE/AT/FR/IT/BE/NL) and digitec.ch share product IDs, slugs, and
+  // UI, so one adapter covers both. digitec.ch = the CH tech-only storefront.
+  {
+    name: 'galaxus',
+    category: 'general',
+    match: (url) => /^https?:\/\/(www\.)?(galaxus\.(ch|de|at|fr|it|be|nl)|digitec\.ch)\//.test(url),
+    notes: `
+- Background HTTP fetches are blocked here (Akamai bot protection). fetch_url and research_url will fail or return a challenge page on galaxus and digitec — do not call them on this site.
+- Read the page with the accessibility tree and DOM tools instead; they work reliably here. If a fetch does fail anyway, switch to the DOM immediately — do not retry it, and do not restart the task to recover.`,
+  },
+
   {
     name: 'apple',
     category: 'general',

--- a/src/firefox/src/agent/adapters.js
+++ b/src/firefox/src/agent/adapters.js
@@ -16180,6 +16180,18 @@ const ADAPTERS = [
 - "Yemeksepeti Mahalle" (grocery/market quick delivery) is a separate flow from restaurant food ordering — don't expect restaurant menus there.`,
   },
 
+  // ─── Regional — Digitec Galaxus (CH + EU: one in-house platform) ──────
+  // galaxus.* (CH/DE/AT/FR/IT/BE/NL) and digitec.ch share product IDs, slugs, and
+  // UI, so one adapter covers both. digitec.ch = the CH tech-only storefront.
+  {
+    name: 'galaxus',
+    category: 'general',
+    match: (url) => /^https?:\/\/(www\.)?(galaxus\.(ch|de|at|fr|it|be|nl)|digitec\.ch)\//.test(url),
+    notes: `
+- Background HTTP fetches are blocked here (Akamai bot protection). fetch_url and research_url will fail or return a challenge page on galaxus and digitec — do not call them on this site.
+- Read the page with the accessibility tree and DOM tools instead; they work reliably here. If a fetch does fail anyway, switch to the DOM immediately — do not retry it, and do not restart the task to recover.`,
+  },
+
   {
     name: 'apple',
     category: 'general',

--- a/test/run.js
+++ b/test/run.js
@@ -1074,6 +1074,24 @@ test('matches yemeksepeti.com and includes food-delivery guidance', () => {
   assert.match(a?.notes || '', /Restoran/);
 });
 
+test('matches galaxus + digitec and includes anti-bot fetch guidance', () => {
+  assert.equal(getActiveAdapter('https://www.galaxus.ch/de/s1/product/x-123')?.name, 'galaxus');
+  assert.equal(getActiveAdapter('https://www.digitec.ch/de/s1/product/x-123')?.name, 'galaxus');
+  for (const tld of ['de', 'at', 'fr', 'it', 'be', 'nl']) {                   // EU storefronts, same platform
+    assert.equal(getActiveAdapter(`https://www.galaxus.${tld}/`)?.name, 'galaxus');
+  }
+  assert.equal(getActiveAdapter('https://www.digitec.de/'), null);            // digitec is CH-only
+  // lookalike / suffix domains must NOT match
+  assert.notEqual(getActiveAdapter('https://galaxus.ch.phishing.example/')?.name, 'galaxus');
+  assert.notEqual(getActiveAdapter('https://digitec.ch.evil.example/')?.name, 'galaxus');
+  const a = getActiveAdapter('https://www.galaxus.ch/de/s1/product/sony-20761668');
+  assert.match(a?.notes || '', /Akamai/i);
+  assert.match(a?.notes || '', /fetch_url/);
+  assert.match(a?.notes || '', /research_url/);
+  assert.match(a?.notes || '', /accessibility tree/i);
+  assert.equal(getActiveAdapterFx('https://www.galaxus.ch/de/')?.name, 'galaxus');   // firefox parity
+});
+
 test('matches stripe dashboard', () => {
   const a = getActiveAdapter('https://dashboard.stripe.com/payments');
   assert.equal(a?.name, 'stripe');


### PR DESCRIPTION
## Summary

Adds a site adapter for **Galaxus / Digitec** (Digitec Galaxus AG). One adapter covers `galaxus.ch/.de/.at/.fr/.it/.be/.nl` and `digitec.ch` — they run the same in-house platform (identical product IDs, slugs, and UI).

It is deliberately **one trap, two bullets**: Galaxus/Digitec sit behind Akamai bot protection that blocks background fetches. `fetch_url` and `research_url` hit the wall and return challenge pages, so — without guidance — the agent retries them and derails. The adapter steers it to the DOM path (accessibility tree + `click_ax`), which works reliably on these sites.

```
- Background HTTP fetches are blocked here (Akamai bot protection). fetch_url and research_url will fail or return a challenge page on galaxus and digitec — do not call them on this site.
- Read the page with the accessibility tree and DOM tools instead; they work reliably here. If a fetch does fail anyway, switch to the DOM immediately — do not retry it, and do not restart the task to recover.
```

**Why only two bullets?** The adapter docs suggest 4–8, but this ships two on purpose. I baselined the other predicted traps against the live sites — localised labels, variant/price confusion, multi-seller offers, search behaviour — and only the Akamai fetch wall actually fired. Padding to a bullet count would mean shipping guidance for problems that don't exist here. What was tested and dropped is listed below.

## Why — before → after

Logged out, model **Haiku**, starting on the `galaxus.ch` homepage: *"Find the cheapest Sony WH-1000XM5 and tell me the price."*

| | without adapter | with adapter |
|---|---|---|
| `fetch_url` | ✗ failed (Akamai) | **never called** |
| `research_url` | 4+ calls, retry loop | **never called** |
| steps | 38 (stopped manually) | **~14, terminated on its own** |
| answer | only after the derail | direct — **CHF 203** (correct) |

With the adapter the tool chain is DOM-only: `get_accessibility_tree → set_field → wait_for_stable → get_accessibility_tree → scroll → read page → done`. The answer also improved — it names CHF 203 as the cheapest standard model (listing 204/219/221) and rejects the CHF 149 "WH-1000XM5**SA** mit Softcase" as a different product.

**Site-specific wall, not a broken tool.** Control: the identical `fetch_url` on `de.wikipedia.org/wiki/Sony` ("fetch this page and summarize it") returns green in **2 steps**. Only Galaxus/Digitec block it — the same Akamai wall that returns 403 to a direct fetch on all seven storefront TLDs.

## One adapter, not two

`digitec.ch` and `galaxus.ch` serve the **same product ID and slug** (e.g. `…-kopfhoerer-24938021` on both), with an identical colour picker, prices (221/204/203/219), labels, and cross-sell modal — only the accent colour differs. `digitec.ch` is the CH tech-only storefront.

## Fires on mid-run navigation, too

Adapter notes inject on the first turn (`agent.js` ~L1602) **and** on navigation mid-conversation: `_maybeReinjectAdapter` (`agent.js` L1675, called at L11465 / L11830) pushes a `[Site context changed → now on galaxus…]` message before the next LLM call. So the common path — the user starts on Google and the agent navigates to Galaxus — still gets the notes, before the agent's first action on the site. This is the shared mechanism every adapter relies on.

## What I deliberately did NOT ship (tested against the live sites and dropped, not overlooked)

- **No DE/FR/IT glossary.** Verified on galaxus.ch (German) and galaxus.ch/fr (French): with no glossary, the agent grounded the localised UI unaided and completed add-to-cart using only accessibility-tree and DOM tools. Unlike Turkish (where "Sepete Ekle" genuinely needs a hint), DE/FR ground trivially. Italian is untested — I expect it behaves the same, but I have not run it.
- **No variant-page bullet.** Galaxus models colours as separate product pages with separate prices; I expected the agent to add the wrong colour or misquote. It didn't — asked for Midnight Blue, it added Midnight Blue at the right price.
- **No search-behaviour bullet.** The agent used the search box correctly (never guessed a URL). The one observed search re-submit was a downstream symptom of the fetch failure, already absorbed by *"do not restart the task to recover."*

## Scope / honesty

Verified with the agent on **galaxus.ch and digitec.ch** only. The six other country storefronts (`galaxus.de/.at/.fr/.it/.be/.nl`) run the same in-house platform, so the guidance should hold — and the Akamai 403 reproduced on all seven TLDs to a direct fetch — but I have **not** run the agent against them. Happy to narrow the matcher to `.ch` (+ `digitec.ch`) if you'd rather ship only what's agent-tested.

## Test plan

- `npm test` → **713 passed, 0 failed** (712 baseline + 1 new adapter test) and the injection corpus **60/60**.
- `node --check` clean on both `adapters.js` and `test/run.js`.
- New test: matches on `galaxus.ch` / `digitec.ch` + all six EU TLDs; `digitec.de` → no match; lookalike / suffix domains rejected; notes contain the anti-bot guidance; Firefox parity via `getActiveAdapterFx`.

## Chrome / Firefox

Notes are identical in both builds (no Chrome-only capabilities referenced), so `src/chrome/src/agent/adapters.js` and `src/firefox/src/agent/adapters.js` get the byte-identical entry.

Site adapters are listed as the project's most-wanted contribution in `CONTRIBUTIONS.md`; there is no tracking issue for this one.
