### PR TITLE
feat(providers): add Together AI cloud provider

### DIFF
--- a/src/chrome/src/providers/manager.js
+++ b/src/chrome/src/providers/manager.js
@@ -424,6 +424,18 @@ export class ProviderManager {
         apiKeyUrl: 'https://dashscope.console.aliyun.com/apiKey',
         enabled: false,
       },
+      together: {
+        type: 'openai',
+        category: 'cloud',
+        label: 'Together AI',
+        providerName: 'together',
+        baseUrl: 'https://api.together.xyz/v1',
+        model: 'meta-llama/Llama-3.3-70B-Instruct-Turbo',
+        supportsStreamUsageOptions: true,
+        apiKey: '',
+        apiKeyUrl: 'https://api.together.ai/settings/api-keys',
+        enabled: false,
+      },
       openrouter: {
         type: 'openai',
         category: 'router',

--- a/src/chrome/src/ui/settings.js
+++ b/src/chrome/src/ui/settings.js
@@ -1849,6 +1849,20 @@ function renderProviders() {
         ...COST_ESTIMATE_FIELDS,
       ],
     },
+    together: {
+      fields: [
+        { key: 'apiKey', labelKey: 'st.provider.field.api_key', type: 'password', placeholder: 'tgp_...' },
+        { key: 'model', labelKey: 'st.provider.field.model', type: 'text', placeholder: 'meta-llama/Llama-3.3-70B-Instruct-Turbo',
+          suggestions: [
+            'meta-llama/Llama-3.3-70B-Instruct-Turbo',
+            'meta-llama/Meta-Llama-3.1-70B-Instruct-Turbo',
+            'Qwen/Qwen2.5-72B-Instruct-Turbo',
+            'deepseek-ai/DeepSeek-V3',
+          ] },
+        { key: 'baseUrl', labelKey: 'st.provider.field.api_base_url', type: 'text', placeholder: 'https://api.together.xyz/v1' },
+        ...COST_ESTIMATE_FIELDS,
+      ],
+    },
     groq: {
       fields: [
         { key: 'apiKey', labelKey: 'st.provider.field.api_key', type: 'password', placeholder: 'gsk_...' },

--- a/src/firefox/src/providers/manager.js
+++ b/src/firefox/src/providers/manager.js
@@ -402,6 +402,18 @@ export class ProviderManager {
         apiKeyUrl: 'https://dashscope.console.aliyun.com/apiKey',
         enabled: false,
       },
+      together: {
+        type: 'openai',
+        category: 'cloud',
+        label: 'Together AI',
+        providerName: 'together',
+        baseUrl: 'https://api.together.xyz/v1',
+        model: 'meta-llama/Llama-3.3-70B-Instruct-Turbo',
+        supportsStreamUsageOptions: true,
+        apiKey: '',
+        apiKeyUrl: 'https://api.together.ai/settings/api-keys',
+        enabled: false,
+      },
       openrouter: {
         type: 'openai',
         category: 'router',

--- a/src/firefox/src/ui/settings.js
+++ b/src/firefox/src/ui/settings.js
@@ -1805,6 +1805,20 @@ function renderProviders() {
         ...COST_ESTIMATE_FIELDS,
       ],
     },
+    together: {
+      fields: [
+        { key: 'apiKey', labelKey: 'st.provider.field.api_key', type: 'password', placeholder: 'tgp_...' },
+        { key: 'model', labelKey: 'st.provider.field.model', type: 'text', placeholder: 'meta-llama/Llama-3.3-70B-Instruct-Turbo',
+          suggestions: [
+            'meta-llama/Llama-3.3-70B-Instruct-Turbo',
+            'meta-llama/Meta-Llama-3.1-70B-Instruct-Turbo',
+            'Qwen/Qwen2.5-72B-Instruct-Turbo',
+            'deepseek-ai/DeepSeek-V3',
+          ] },
+        { key: 'baseUrl', labelKey: 'st.provider.field.api_base_url', type: 'text', placeholder: 'https://api.together.xyz/v1' },
+        ...COST_ESTIMATE_FIELDS,
+      ],
+    },
     groq: {
       fields: [
         { key: 'apiKey', labelKey: 'st.provider.field.api_key', type: 'password', placeholder: 'gsk_...' },

--- a/test/run.js
+++ b/test/run.js
@@ -13094,6 +13094,7 @@ test('categoryFor: cloud family (openai / anthropic / gemini / mistral / deepsee
     assert.equal(PM.categoryFor('mistral', { type: 'openai' }), 'cloud');
     assert.equal(PM.categoryFor('deepseek', { type: 'openai' }), 'cloud');
     assert.equal(PM.categoryFor('xai', { type: 'openai' }), 'cloud');
+    assert.equal(PM.categoryFor('together', { type: 'openai' }), 'cloud');
     assert.equal(PM.categoryFor('claude_subscription', { type: 'anthropic_oauth' }), 'cloud');
   }
 });
@@ -14460,13 +14461,17 @@ test('_defaultConfigs: new cloud providers present and disabled by default', () 
   for (const PM of [ProviderManagerCh, ProviderManagerFx]) {
     const mgr = new PM();
     const defaults = mgr._defaultConfigs();
-    for (const id of ['gemini', 'mistral', 'deepseek', 'xai']) {
+    for (const id of ['gemini', 'mistral', 'deepseek', 'xai', 'together']) {
       assert.ok(defaults[id], `${PM.name}: missing default config for ${id}`);
       assert.equal(defaults[id].category, 'cloud', `${PM.name}: ${id} should be cloud`);
       assert.equal(defaults[id].enabled, false, `${PM.name}: ${id} should default to disabled`);
       assert.ok(defaults[id].baseUrl, `${PM.name}: ${id} missing baseUrl`);
       assert.ok(defaults[id].model, `${PM.name}: ${id} missing default model`);
     }
+    assert.equal(defaults.together.type, 'openai', `${PM.name}: together should use OpenAI-compatible provider`);
+    assert.equal(defaults.together.baseUrl, 'https://api.together.xyz/v1');
+    assert.equal(defaults.together.model, 'meta-llama/Llama-3.3-70B-Instruct-Turbo');
+    assert.equal(defaults.together.supportsStreamUsageOptions, true);
   }
 });
 


### PR DESCRIPTION
## Summary

Adds **Together AI** as a built-in cloud provider (OpenAI-compatible), disabled by default until an API key is set.

- Base URL: `https://api.together.xyz/v1`
- Default model: `meta-llama/Llama-3.3-70B-Instruct-Turbo`
- Mirrored in Chrome and Firefox (`manager.js` + Settings fields)
- Does **not** touch [#319](https://github.com/webbrain-one/webbrain/issues/319) (Muse Spark)

## Test plan

- [x] `node test/run.js`: **807 passed, 1 failed** (existing changelog test on `main`)
- [x] Settings → Providers → Cloud: Together AI card appears
- [x] With API key + Test connection: succeeds against Together
- [x] Select and run a short Act/Ask message