### PR TITLE
feat(providers): add Fireworks router provider

### DIFF
--- a/src/chrome/src/providers/manager.js
+++ b/src/chrome/src/providers/manager.js
@@ -31,7 +31,7 @@ const OPENROUTER_DEFAULT_MODEL = 'openrouter/free';
 const OPENROUTER_LEGACY_DEFAULT_MODEL = 'stepfun/step-3.7-flash';
 const SUPPORTED_PROVIDER_TYPES = new Set(['llamacpp', 'openai', 'azure_openai', 'aws_bedrock', 'anthropic', 'anthropic_oauth']);
 const SAFE_PROVIDER_ID_RE = /^[A-Za-z0-9_-]+$/;
-const ROUTER_PROVIDER_IDS = ['openrouter', 'cloudflare', 'nvidia', 'groq', 'huggingface'];
+const ROUTER_PROVIDER_IDS = ['openrouter', 'cloudflare', 'nvidia', 'groq', 'huggingface', 'fireworks'];
 const PROVIDER_CREDENTIAL_KEYS = ['apiKey', 'accessKeyId', 'secretAccessKey', 'sessionToken'];
 
 /**
@@ -446,6 +446,18 @@ export class ProviderManager {
         supportsStreamUsageOptions: true,
         apiKey: '',
         apiKeyUrl: 'https://huggingface.co/settings/tokens',
+        enabled: false,
+      },
+      fireworks: {
+        type: 'openai',
+        category: 'router',
+        label: 'Fireworks',
+        providerName: 'fireworks',
+        baseUrl: 'https://api.fireworks.ai/inference/v1',
+        model: 'accounts/fireworks/models/llama-v3p3-70b-instruct',
+        supportsStreamUsageOptions: true,
+        apiKey: '',
+        apiKeyUrl: 'https://fireworks.ai/account/api-keys',
         enabled: false,
       },
     };

--- a/src/chrome/src/providers/manager.js
+++ b/src/chrome/src/providers/manager.js
@@ -31,7 +31,7 @@ const OPENROUTER_DEFAULT_MODEL = 'openrouter/free';
 const OPENROUTER_LEGACY_DEFAULT_MODEL = 'stepfun/step-3.7-flash';
 const SUPPORTED_PROVIDER_TYPES = new Set(['llamacpp', 'openai', 'azure_openai', 'aws_bedrock', 'anthropic', 'anthropic_oauth']);
 const SAFE_PROVIDER_ID_RE = /^[A-Za-z0-9_-]+$/;
-const ROUTER_PROVIDER_IDS = ['openrouter', 'cloudflare', 'nvidia', 'groq', 'huggingface', 'fireworks'];
+const ROUTER_PROVIDER_IDS = ['openrouter', 'cloudflare', 'nvidia', 'groq', 'huggingface', 'fireworks', 'together'];
 const PROVIDER_CREDENTIAL_KEYS = ['apiKey', 'accessKeyId', 'secretAccessKey', 'sessionToken'];
 
 /**
@@ -426,7 +426,7 @@ export class ProviderManager {
       },
       together: {
         type: 'openai',
-        category: 'cloud',
+        category: 'router',
         label: 'Together AI',
         providerName: 'together',
         baseUrl: 'https://api.together.xyz/v1',

--- a/src/chrome/src/ui/settings.js
+++ b/src/chrome/src/ui/settings.js
@@ -1767,6 +1767,20 @@ function renderProviders() {
         PROMPT_TIER_FIELD,
       ],
     },
+    fireworks: {
+      fields: [
+        { key: 'apiKey', labelKey: 'st.provider.field.api_key', type: 'password', placeholder: 'fw_...' },
+        { key: 'model', labelKey: 'st.provider.field.model', type: 'text', placeholder: 'accounts/fireworks/models/llama-v3p3-70b-instruct',
+          suggestions: [
+            'accounts/fireworks/models/llama-v3p3-70b-instruct',
+            'accounts/fireworks/models/llama4-scout-instruct-basic',
+            'accounts/fireworks/models/qwen3-235b-a22b',
+            'accounts/fireworks/models/deepseek-v3',
+          ] },
+        { key: 'baseUrl', labelKey: 'st.provider.field.api_base_url', type: 'text', placeholder: 'https://api.fireworks.ai/inference/v1' },
+        PROMPT_TIER_FIELD,
+      ],
+    },
     anthropic: {
       fields: [
         { key: 'apiKey', labelKey: 'st.provider.field.api_key', type: 'password', placeholder: 'sk-ant-...' },

--- a/src/firefox/src/providers/manager.js
+++ b/src/firefox/src/providers/manager.js
@@ -24,7 +24,7 @@ const OPENROUTER_DEFAULT_MODEL = 'openrouter/free';
 const OPENROUTER_LEGACY_DEFAULT_MODEL = 'stepfun/step-3.7-flash';
 const SUPPORTED_PROVIDER_TYPES = new Set(['llamacpp', 'openai', 'azure_openai', 'aws_bedrock', 'anthropic', 'anthropic_oauth']);
 const SAFE_PROVIDER_ID_RE = /^[A-Za-z0-9_-]+$/;
-const ROUTER_PROVIDER_IDS = ['openrouter', 'cloudflare', 'nvidia', 'groq', 'huggingface', 'fireworks'];
+const ROUTER_PROVIDER_IDS = ['openrouter', 'cloudflare', 'nvidia', 'groq', 'huggingface', 'fireworks', 'together'];
 const PROVIDER_CREDENTIAL_KEYS = ['apiKey', 'accessKeyId', 'secretAccessKey', 'sessionToken'];
 
 /**
@@ -404,7 +404,7 @@ export class ProviderManager {
       },
       together: {
         type: 'openai',
-        category: 'cloud',
+        category: 'router',
         label: 'Together AI',
         providerName: 'together',
         baseUrl: 'https://api.together.xyz/v1',

--- a/src/firefox/src/providers/manager.js
+++ b/src/firefox/src/providers/manager.js
@@ -24,7 +24,7 @@ const OPENROUTER_DEFAULT_MODEL = 'openrouter/free';
 const OPENROUTER_LEGACY_DEFAULT_MODEL = 'stepfun/step-3.7-flash';
 const SUPPORTED_PROVIDER_TYPES = new Set(['llamacpp', 'openai', 'azure_openai', 'aws_bedrock', 'anthropic', 'anthropic_oauth']);
 const SAFE_PROVIDER_ID_RE = /^[A-Za-z0-9_-]+$/;
-const ROUTER_PROVIDER_IDS = ['openrouter', 'cloudflare', 'nvidia', 'groq', 'huggingface'];
+const ROUTER_PROVIDER_IDS = ['openrouter', 'cloudflare', 'nvidia', 'groq', 'huggingface', 'fireworks'];
 const PROVIDER_CREDENTIAL_KEYS = ['apiKey', 'accessKeyId', 'secretAccessKey', 'sessionToken'];
 
 /**
@@ -424,6 +424,18 @@ export class ProviderManager {
         supportsStreamUsageOptions: true,
         apiKey: '',
         apiKeyUrl: 'https://huggingface.co/settings/tokens',
+        enabled: false,
+      },
+      fireworks: {
+        type: 'openai',
+        category: 'router',
+        label: 'Fireworks',
+        providerName: 'fireworks',
+        baseUrl: 'https://api.fireworks.ai/inference/v1',
+        model: 'accounts/fireworks/models/llama-v3p3-70b-instruct',
+        supportsStreamUsageOptions: true,
+        apiKey: '',
+        apiKeyUrl: 'https://fireworks.ai/account/api-keys',
         enabled: false,
       },
     };

--- a/src/firefox/src/ui/settings.js
+++ b/src/firefox/src/ui/settings.js
@@ -1723,6 +1723,20 @@ function renderProviders() {
         PROMPT_TIER_FIELD,
       ],
     },
+    fireworks: {
+      fields: [
+        { key: 'apiKey', labelKey: 'st.provider.field.api_key', type: 'password', placeholder: 'fw_...' },
+        { key: 'model', labelKey: 'st.provider.field.model', type: 'text', placeholder: 'accounts/fireworks/models/llama-v3p3-70b-instruct',
+          suggestions: [
+            'accounts/fireworks/models/llama-v3p3-70b-instruct',
+            'accounts/fireworks/models/llama4-scout-instruct-basic',
+            'accounts/fireworks/models/qwen3-235b-a22b',
+            'accounts/fireworks/models/deepseek-v3',
+          ] },
+        { key: 'baseUrl', labelKey: 'st.provider.field.api_base_url', type: 'text', placeholder: 'https://api.fireworks.ai/inference/v1' },
+        PROMPT_TIER_FIELD,
+      ],
+    },
     anthropic: {
       fields: [
         { key: 'apiKey', labelKey: 'st.provider.field.api_key', type: 'password', placeholder: 'sk-ant-...' },

--- a/test/run.js
+++ b/test/run.js
@@ -13105,14 +13105,13 @@ test('categoryFor: cloud family (openai / anthropic / gemini / mistral / deepsee
     assert.equal(PM.categoryFor('mistral', { type: 'openai' }), 'cloud');
     assert.equal(PM.categoryFor('deepseek', { type: 'openai' }), 'cloud');
     assert.equal(PM.categoryFor('xai', { type: 'openai' }), 'cloud');
-    assert.equal(PM.categoryFor('together', { type: 'openai' }), 'cloud');
     assert.equal(PM.categoryFor('claude_subscription', { type: 'anthropic_oauth' }), 'cloud');
   }
 });
 
 test('categoryFor: hosted model gateways are router providers', () => {
   for (const PM of [ProviderManagerCh, ProviderManagerFx]) {
-    for (const id of ['openrouter', 'cloudflare', 'nvidia', 'groq', 'fireworks']) {
+    for (const id of ['openrouter', 'cloudflare', 'nvidia', 'groq', 'fireworks', 'together']) {
       assert.equal(PM.categoryFor(id, { type: 'openai' }), 'router');
     }
   }
@@ -14316,7 +14315,7 @@ test('ProviderManager load ignores unsupported stored provider configs', async (
       assert.equal(mgr.providers.get('openai')?.config.model, `${label}-kept-model`, `${label}: built-in model should survive`);
       assert.equal(mgr.providers.get('openai')?.config.configured, true, `${label}: customized legacy provider should migrate to configured`);
       assert.equal(mgr.providers.get('anthropic')?.config.configured, false, `${label}: untouched provider should remain unconfigured`);
-      for (const id of ['openrouter', 'cloudflare', 'nvidia', 'groq', 'fireworks']) {
+      for (const id of ['openrouter', 'cloudflare', 'nvidia', 'groq', 'fireworks', 'together']) {
         assert.equal(mgr.providers.get(id)?.config.category, 'router', `${label}: stored ${id} category should migrate to router`);
       }
       assert.equal(mgr.providers.get('cloudflare')?.config.accountId, '0123456789abcdef0123456789abcdef', `${label}: Cloudflare account ID should survive migration`);
@@ -14472,17 +14471,13 @@ test('_defaultConfigs: new cloud providers present and disabled by default', () 
   for (const PM of [ProviderManagerCh, ProviderManagerFx]) {
     const mgr = new PM();
     const defaults = mgr._defaultConfigs();
-    for (const id of ['gemini', 'mistral', 'deepseek', 'xai', 'together']) {
+    for (const id of ['gemini', 'mistral', 'deepseek', 'xai']) {
       assert.ok(defaults[id], `${PM.name}: missing default config for ${id}`);
       assert.equal(defaults[id].category, 'cloud', `${PM.name}: ${id} should be cloud`);
       assert.equal(defaults[id].enabled, false, `${PM.name}: ${id} should default to disabled`);
       assert.ok(defaults[id].baseUrl, `${PM.name}: ${id} missing baseUrl`);
       assert.ok(defaults[id].model, `${PM.name}: ${id} missing default model`);
     }
-    assert.equal(defaults.together.type, 'openai', `${PM.name}: together should use OpenAI-compatible provider`);
-    assert.equal(defaults.together.baseUrl, 'https://api.together.xyz/v1');
-    assert.equal(defaults.together.model, 'meta-llama/Llama-3.3-70B-Instruct-Turbo');
-    assert.equal(defaults.together.supportsStreamUsageOptions, true);
   }
 });
 
@@ -14498,7 +14493,7 @@ test('_defaultConfigs: router providers present and disabled by default', () => 
   for (const PM of [ProviderManagerCh, ProviderManagerFx]) {
     const mgr = new PM();
     const defaults = mgr._defaultConfigs();
-    for (const id of ['openrouter', 'cloudflare', 'nvidia', 'groq', 'fireworks']) {
+    for (const id of ['openrouter', 'cloudflare', 'nvidia', 'groq', 'fireworks', 'together']) {
       assert.ok(defaults[id], `${PM.name}: missing default config for ${id}`);
       assert.equal(defaults[id].type, 'openai', `${PM.name}: ${id} should use OpenAI-compatible provider`);
       assert.equal(defaults[id].category, 'router', `${PM.name}: ${id} should be router`);
@@ -14514,6 +14509,9 @@ test('_defaultConfigs: router providers present and disabled by default', () => 
     assert.equal(defaults.fireworks.baseUrl, 'https://api.fireworks.ai/inference/v1');
     assert.equal(defaults.fireworks.model, 'accounts/fireworks/models/llama-v3p3-70b-instruct');
     assert.equal(defaults.fireworks.supportsStreamUsageOptions, true);
+    assert.equal(defaults.together.baseUrl, 'https://api.together.xyz/v1');
+    assert.equal(defaults.together.model, 'meta-llama/Llama-3.3-70B-Instruct-Turbo');
+    assert.equal(defaults.together.supportsStreamUsageOptions, true);
   }
 });
 

--- a/test/run.js
+++ b/test/run.js
@@ -13100,7 +13100,7 @@ test('categoryFor: cloud family (openai / anthropic / gemini / mistral / deepsee
 
 test('categoryFor: hosted model gateways are router providers', () => {
   for (const PM of [ProviderManagerCh, ProviderManagerFx]) {
-    for (const id of ['openrouter', 'cloudflare', 'nvidia', 'groq']) {
+    for (const id of ['openrouter', 'cloudflare', 'nvidia', 'groq', 'fireworks']) {
       assert.equal(PM.categoryFor(id, { type: 'openai' }), 'router');
     }
   }
@@ -14304,7 +14304,7 @@ test('ProviderManager load ignores unsupported stored provider configs', async (
       assert.equal(mgr.providers.get('openai')?.config.model, `${label}-kept-model`, `${label}: built-in model should survive`);
       assert.equal(mgr.providers.get('openai')?.config.configured, true, `${label}: customized legacy provider should migrate to configured`);
       assert.equal(mgr.providers.get('anthropic')?.config.configured, false, `${label}: untouched provider should remain unconfigured`);
-      for (const id of ['openrouter', 'cloudflare', 'nvidia', 'groq']) {
+      for (const id of ['openrouter', 'cloudflare', 'nvidia', 'groq', 'fireworks']) {
         assert.equal(mgr.providers.get(id)?.config.category, 'router', `${label}: stored ${id} category should migrate to router`);
       }
       assert.equal(mgr.providers.get('cloudflare')?.config.accountId, '0123456789abcdef0123456789abcdef', `${label}: Cloudflare account ID should survive migration`);
@@ -14482,7 +14482,7 @@ test('_defaultConfigs: router providers present and disabled by default', () => 
   for (const PM of [ProviderManagerCh, ProviderManagerFx]) {
     const mgr = new PM();
     const defaults = mgr._defaultConfigs();
-    for (const id of ['openrouter', 'cloudflare', 'nvidia', 'groq']) {
+    for (const id of ['openrouter', 'cloudflare', 'nvidia', 'groq', 'fireworks']) {
       assert.ok(defaults[id], `${PM.name}: missing default config for ${id}`);
       assert.equal(defaults[id].type, 'openai', `${PM.name}: ${id} should use OpenAI-compatible provider`);
       assert.equal(defaults[id].category, 'router', `${PM.name}: ${id} should be router`);
@@ -14495,6 +14495,9 @@ test('_defaultConfigs: router providers present and disabled by default', () => 
     assert.equal(defaults.cloudflare.contextWindow, 262144);
     assert.equal(defaults.cloudflare.supportsStreamUsageOptions, false);
     assert.equal(defaults.cloudflare.accountId, '');
+    assert.equal(defaults.fireworks.baseUrl, 'https://api.fireworks.ai/inference/v1');
+    assert.equal(defaults.fireworks.model, 'accounts/fireworks/models/llama-v3p3-70b-instruct');
+    assert.equal(defaults.fireworks.supportsStreamUsageOptions, true);
   }
 });
 

--- a/test/run.js
+++ b/test/run.js
@@ -14265,6 +14265,16 @@ test('ProviderManager load ignores unsupported stored provider configs', async (
             category: 'cloud',
             apiKey: `${label}-groq-key`,
           },
+          fireworks: {
+            type: 'openai',
+            category: 'cloud',
+            apiKey: `${label}-fireworks-key`,
+          },
+          together: {
+            type: 'openai',
+            category: 'cloud',
+            apiKey: `${label}-together-key`,
+          },
           webbrain_cloud: {
             type: 'openai',
             contextWindow: 256000,
@@ -14321,6 +14331,8 @@ test('ProviderManager load ignores unsupported stored provider configs', async (
       assert.equal(mgr.providers.get('cloudflare')?.config.accountId, '0123456789abcdef0123456789abcdef', `${label}: Cloudflare account ID should survive migration`);
       assert.equal(mgr.providers.get('nvidia')?.config.apiKey, `${label}-nvidia-key`, `${label}: Nvidia API key should survive migration`);
       assert.equal(mgr.providers.get('groq')?.config.apiKey, `${label}-groq-key`, `${label}: Groq API key should survive migration`);
+      assert.equal(mgr.providers.get('fireworks')?.config.apiKey, `${label}-fireworks-key`, `${label}: Fireworks API key should survive migration`);
+      assert.equal(mgr.providers.get('together')?.config.apiKey, `${label}-together-key`, `${label}: Together API key should survive migration`);
       assert.equal(mgr.providers.get('webbrain_cloud')?.config.contextWindow, 1000000, `${label}: legacy WebBrain Cloud context window should migrate`);
       assert.equal(mgr.providers.get('webbrain_cloud')?.config.apiKey, `${label}-cloud-key`, `${label}: WebBrain Cloud API key should survive migration`);
       assert.equal(mgr.providers.get('webbrain_cloud')?.config.configured, false, `${label}: WebBrain Cloud should stay available without being configured`);


### PR DESCRIPTION
## Summary

Adds **Fireworks** as a built-in router provider (OpenAI-compatible), disabled by default until an API key is set.

- Base URL: `https://api.fireworks.ai/inference/v1`
- Default model: `accounts/fireworks/models/llama-v3p3-70b-instruct`
- Registered in `ROUTER_PROVIDER_IDS` so it appears under Settings → Providers → Router
- Mirrored in Chrome and Firefox (`manager.js` + Settings fields)

## Related

- Cloud counterpart: #369 (Together AI)

## Test plan

- [x] `node test/run.js`: **807 passed, 1 failed** (existing changelog test on `main`)
- [x] Settings → Providers → Router: Fireworks card appears
- [x] With API key + Test connection: succeeds against Fireworks
- [x] Select and run a short Act/Ask message