### PR TITLE
Support GPT-5.6 provider compatibility

### DIFF
--- a/src/chrome/src/providers/azure-openai.js
+++ b/src/chrome/src/providers/azure-openai.js
@@ -63,7 +63,7 @@ export class AzureOpenAIProvider extends BaseLLMProvider {
 
   _addMaxTokens(body, options) {
     // Azure OpenAI follows the legacy OpenAI contract here.
-    body.max_tokens = options.maxTokens ?? 4096;
+    this._addConfiguredMaxTokens(body, options, 'max_tokens');
   }
 
   _addTemperature(body, options) {
@@ -89,17 +89,21 @@ export class AzureOpenAIProvider extends BaseLLMProvider {
     body.stream_options = { ...streamOptions, include_usage: true };
   }
 
-  async chat(messages, options = {}) {
-    const body = { messages, stream: false };
+  _buildRequestBody(messages, options = {}, stream = false) {
+    let body = { messages: this._mapMessages(messages), stream };
     this._addTemperature(body, options);
     this._addMaxTokens(body, options);
     if (this._shouldSendTools(messages, options)) {
       body.tools = options.tools;
       body.tool_choice = options.toolChoice || 'auto';
     }
-    if (options.extraBody && typeof options.extraBody === 'object') {
-      Object.assign(body, options.extraBody);
-    }
+    body = this._mergeConfiguredRequestBody(body, options);
+    if (stream) this._addStreamUsageOptions(body);
+    return body;
+  }
+
+  async chat(messages, options = {}) {
+    const body = this._buildRequestBody(messages, options, false);
 
     const url = this._chatUrl();
     let res;
@@ -129,17 +133,7 @@ export class AzureOpenAIProvider extends BaseLLMProvider {
   }
 
   async *chatStream(messages, options = {}) {
-    const body = { messages, stream: true };
-    this._addTemperature(body, options);
-    this._addMaxTokens(body, options);
-    if (this._shouldSendTools(messages, options)) {
-      body.tools = options.tools;
-      body.tool_choice = options.toolChoice || 'auto';
-    }
-    if (options.extraBody && typeof options.extraBody === 'object') {
-      Object.assign(body, options.extraBody);
-    }
-    this._addStreamUsageOptions(body);
+    const body = this._buildRequestBody(messages, options, true);
 
     const url = this._chatUrl();
     let res;
@@ -185,4 +179,3 @@ export class AzureOpenAIProvider extends BaseLLMProvider {
     yield { type: 'done', content: '' };
   }
 }
-

--- a/src/chrome/src/providers/base.js
+++ b/src/chrome/src/providers/base.js
@@ -1,4 +1,9 @@
 import { inferContextWindow } from './context-windows.js';
+import {
+  addConfiguredMaxTokens,
+  mapProviderMessages,
+  mergeProviderRequestBody,
+} from './provider-compatibility.js';
 
 /**
  * Base LLM Provider — all providers implement this interface.
@@ -81,6 +86,18 @@ export class BaseLLMProvider {
    */
   get useCompactPrompt() {
     return !!this.config.useCompactPrompt;
+  }
+
+  _mapMessages(messages) {
+    return mapProviderMessages(messages, this.config);
+  }
+
+  _addConfiguredMaxTokens(body, options, fallback = 'max_tokens') {
+    return addConfiguredMaxTokens(body, options.maxTokens ?? 4096, this.config, fallback);
+  }
+
+  _mergeConfiguredRequestBody(body, options = {}) {
+    return mergeProviderRequestBody(body, this.config, options.extraBody);
   }
 
   /**

--- a/src/chrome/src/providers/context-windows.js
+++ b/src/chrome/src/providers/context-windows.js
@@ -243,6 +243,7 @@ export function inferContextWindow(config = {}) {
   if (!model) return DEFAULT_CLOUD_CONTEXT_WINDOW;
 
   // OpenAI
+  if (/^gpt-5\.6(?:-|$)/.test(model)) return 1050000;
   if (model.includes('gpt-5.5-pro')) return 1050000;
   if (/^gpt-5(?:[.\-]|$)/.test(model) || model.includes('/gpt-5')) return 400000;
 

--- a/src/chrome/src/providers/llamacpp.js
+++ b/src/chrome/src/providers/llamacpp.js
@@ -38,22 +38,23 @@ export class LlamaCppProvider extends BaseLLMProvider {
     return !!this.config.useCompactPrompt;
   }
 
-  async chat(messages, options = {}) {
+  _buildRequestBody(messages, options = {}, stream = false) {
     const body = {
-      messages,
+      messages: this._mapMessages(messages),
       temperature: options.temperature ?? 0.7,
-      max_tokens: options.maxTokens ?? 4096,
-      stream: false,
+      stream,
     };
-
-    if (this.model) {
-      body.model = this.model;
-    }
-
+    this._addConfiguredMaxTokens(body, options, 'max_tokens');
+    if (this.model) body.model = this.model;
     if (options.tools && options.tools.length > 0) {
       body.tools = options.tools;
       body.tool_choice = options.toolChoice || 'auto';
     }
+    return this._mergeConfiguredRequestBody(body, options);
+  }
+
+  async chat(messages, options = {}) {
+    const body = this._buildRequestBody(messages, options, false);
 
     const url = `${this.baseUrl}/v1/chat/completions`;
     let res;
@@ -90,21 +91,7 @@ export class LlamaCppProvider extends BaseLLMProvider {
   }
 
   async *chatStream(messages, options = {}) {
-    const body = {
-      messages,
-      temperature: options.temperature ?? 0.7,
-      max_tokens: options.maxTokens ?? 4096,
-      stream: true,
-    };
-
-    if (this.model) {
-      body.model = this.model;
-    }
-
-    if (options.tools && options.tools.length > 0) {
-      body.tools = options.tools;
-      body.tool_choice = options.toolChoice || 'auto';
-    }
+    const body = this._buildRequestBody(messages, options, true);
 
     const streamUrl = `${this.baseUrl}/v1/chat/completions`;
     let res;

--- a/src/chrome/src/providers/manager.js
+++ b/src/chrome/src/providers/manager.js
@@ -287,7 +287,7 @@ export class ProviderManager {
         label: 'OpenAI',
         providerName: 'openai',
         baseUrl: 'https://api.openai.com/v1',
-        model: 'gpt-5.5',
+        model: 'gpt-5.6-terra',
         inputCostPerMillionUsd: 5,
         outputCostPerMillionUsd: 22.5,
         supportsStreamUsageOptions: true,

--- a/src/chrome/src/providers/openai.js
+++ b/src/chrome/src/providers/openai.js
@@ -1,5 +1,6 @@
 import { BaseLLMProvider } from './base.js';
 import { fetchWithFallback } from './fetch-with-fallback.js';
+import { shouldUseOpenAIResponsesApi } from './provider-compatibility.js';
 
 /**
  * Provider for OpenAI-compatible APIs (ChatGPT, OpenRouter, any OpenAI-compatible endpoint).
@@ -79,12 +80,8 @@ export class OpenAICompatibleProvider extends BaseLLMProvider {
   }
 
   _addMaxTokens(body, options) {
-    const max = options.maxTokens ?? 4096;
-    if (this._isNewOpenAIContract()) {
-      body.max_completion_tokens = max;
-    } else {
-      body.max_tokens = max;
-    }
+    const fallback = this._isNewOpenAIContract() ? 'max_completion_tokens' : 'max_tokens';
+    this._addConfiguredMaxTokens(body, options, fallback);
   }
 
   _addTemperature(body, options) {
@@ -175,26 +172,160 @@ export class OpenAICompatibleProvider extends BaseLLMProvider {
     }
   }
 
-  async chat(messages, options = {}) {
-    const body = {
+  _usesResponsesApi() {
+    return shouldUseOpenAIResponsesApi(this.config);
+  }
+
+  _buildChatCompletionsBody(messages, options = {}, stream = false) {
+    let body = {
       model: this.model,
-      messages,
-      stream: false,
+      messages: this._mapMessages(messages),
+      stream,
     };
     this._addTemperature(body, options);
     this._addMaxTokens(body, options);
-
     if (this._shouldSendTools(messages, options)) {
       body.tools = options.tools;
       body.tool_choice = options.toolChoice || 'auto';
     }
-
-    if (options.extraBody && typeof options.extraBody === 'object') {
-      Object.assign(body, options.extraBody);
-    }
+    body = this._mergeConfiguredRequestBody(body, options);
     this._addWebBrainCloudContext(body, options);
+    if (stream) this._addStreamUsageOptions(body);
+    return body;
+  }
 
-    const url = `${this.baseUrl}/chat/completions`;
+  _responsesContent(content, role) {
+    if (!Array.isArray(content)) return content;
+    return content.map((block) => {
+      if (!block || typeof block !== 'object') return block;
+      if (block.type === 'text') {
+        return { type: role === 'assistant' ? 'output_text' : 'input_text', text: block.text || '' };
+      }
+      if (block.type === 'image_url' || block.type === 'image') {
+        const imageUrl = typeof block.image_url === 'string' ? block.image_url : block.image_url?.url;
+        return {
+          type: 'input_image',
+          image_url: imageUrl || block.source?.data || '',
+          ...(block.image_url?.detail ? { detail: block.image_url.detail } : {}),
+        };
+      }
+      return block;
+    });
+  }
+
+  _responsesInput(messages) {
+    const input = [];
+    for (const message of this._mapMessages(messages)) {
+      if (!message || typeof message !== 'object') continue;
+      if (message.role === 'tool') {
+        const output = typeof message.content === 'string'
+          ? message.content
+          : JSON.stringify(message.content ?? '');
+        input.push({ type: 'function_call_output', call_id: message.tool_call_id, output });
+        continue;
+      }
+      if (message.role === 'assistant' && Array.isArray(message.tool_calls)) {
+        if (message.content) {
+          input.push({ role: 'assistant', content: this._responsesContent(message.content, 'assistant') });
+        }
+        for (const toolCall of message.tool_calls) {
+          input.push({
+            type: 'function_call',
+            call_id: toolCall.id,
+            name: toolCall.function?.name || '',
+            arguments: toolCall.function?.arguments || '{}',
+          });
+        }
+        continue;
+      }
+      input.push({
+        role: message.role,
+        content: this._responsesContent(message.content, message.role),
+      });
+    }
+    return input;
+  }
+
+  _responsesTools(tools) {
+    return (tools || []).map((tool) => {
+      if (tool?.type !== 'function') return tool;
+      const fn = tool.function || {};
+      return {
+        type: 'function',
+        name: fn.name || '',
+        description: fn.description || '',
+        parameters: fn.parameters || { type: 'object', properties: {} },
+        strict: fn.strict === true,
+      };
+    });
+  }
+
+  _buildResponsesBody(messages, options = {}, stream = false) {
+    let body = {
+      model: this.model,
+      input: this._responsesInput(messages),
+      stream,
+      store: false,
+      max_output_tokens: options.maxTokens ?? 4096,
+    };
+    if (this._shouldSendTools(messages, options)) {
+      body.tools = this._responsesTools(options.tools);
+      body.tool_choice = options.toolChoice || 'auto';
+    }
+    body = this._mergeConfiguredRequestBody(body, options);
+    if (typeof body.reasoning_effort === 'string') {
+      body.reasoning = { ...(body.reasoning || {}), effort: body.reasoning_effort };
+      delete body.reasoning_effort;
+    }
+    return body;
+  }
+
+  _normalizeResponsesUsage(usage) {
+    if (!usage || typeof usage !== 'object') return null;
+    return {
+      ...usage,
+      prompt_tokens: usage.prompt_tokens ?? usage.input_tokens ?? 0,
+      completion_tokens: usage.completion_tokens ?? usage.output_tokens ?? 0,
+      total_tokens: usage.total_tokens ?? ((usage.input_tokens || 0) + (usage.output_tokens || 0)),
+    };
+  }
+
+  _parseResponsesData(data) {
+    const output = Array.isArray(data?.output) ? data.output : [];
+    const text = [];
+    const reasoning = [];
+    const toolCalls = [];
+    for (const item of output) {
+      if (item?.type === 'message' && Array.isArray(item.content)) {
+        for (const block of item.content) {
+          if (block?.type === 'output_text' && block.text) text.push(block.text);
+          if (block?.type === 'refusal' && block.refusal) text.push(block.refusal);
+        }
+      } else if (item?.type === 'function_call') {
+        toolCalls.push({
+          id: item.call_id || item.id || '',
+          type: 'function',
+          function: { name: item.name || '', arguments: item.arguments || '{}' },
+        });
+      } else if (item?.type === 'reasoning' && Array.isArray(item.summary)) {
+        for (const part of item.summary) if (part?.text) reasoning.push(part.text);
+      }
+    }
+    return {
+      content: text.join(''),
+      reasoningContent: reasoning.join('\n'),
+      toolCalls: toolCalls.length ? toolCalls : null,
+      usage: this._normalizeResponsesUsage(data?.usage),
+      raw: data,
+    };
+  }
+
+  async chat(messages, options = {}) {
+    const useResponses = this._usesResponsesApi();
+    const body = useResponses
+      ? this._buildResponsesBody(messages, options, false)
+      : this._buildChatCompletionsBody(messages, options, false);
+    const url = `${this.baseUrl}/${useResponses ? 'responses' : 'chat/completions'}`;
     let res;
     try {
       res = await fetchWithFallback(url, {
@@ -216,6 +347,7 @@ export class OpenAICompatibleProvider extends BaseLLMProvider {
     try { data = await res.json(); } catch {
       throw new Error(`${this.name} returned invalid JSON in chat response.`);
     }
+    if (useResponses) return this._parseResponsesData(data);
     const choice = data.choices?.[0];
     const message = choice?.message;
 
@@ -229,26 +361,11 @@ export class OpenAICompatibleProvider extends BaseLLMProvider {
   }
 
   async *chatStream(messages, options = {}) {
-    const body = {
-      model: this.model,
-      messages,
-      stream: true,
-    };
-    this._addTemperature(body, options);
-    this._addMaxTokens(body, options);
-
-    if (this._shouldSendTools(messages, options)) {
-      body.tools = options.tools;
-      body.tool_choice = options.toolChoice || 'auto';
-    }
-
-    if (options.extraBody && typeof options.extraBody === 'object') {
-      Object.assign(body, options.extraBody);
-    }
-    this._addWebBrainCloudContext(body, options);
-    this._addStreamUsageOptions(body);
-
-    const streamUrl = `${this.baseUrl}/chat/completions`;
+    const useResponses = this._usesResponsesApi();
+    const body = useResponses
+      ? this._buildResponsesBody(messages, options, true)
+      : this._buildChatCompletionsBody(messages, options, true);
+    const streamUrl = `${this.baseUrl}/${useResponses ? 'responses' : 'chat/completions'}`;
     let res;
     try {
       res = await fetchWithFallback(streamUrl, {
@@ -287,17 +404,44 @@ export class OpenAICompatibleProvider extends BaseLLMProvider {
         }
         try {
           const json = JSON.parse(payload);
-          if (json.usage) {
-            yield { type: 'usage', usage: json.usage };
-          }
-          const delta = json.choices?.[0]?.delta;
-          if (delta?.content) {
-            yield { type: 'text', content: delta.content };
-          }
-          if (delta?.tool_calls) {
-            yield { type: 'tool_call', content: delta.tool_calls };
+          if (useResponses) {
+            if (json.type === 'response.output_text.delta' && json.delta) {
+              yield { type: 'text', content: json.delta };
+            } else if (json.type === 'response.output_item.added' && json.item?.type === 'function_call') {
+              yield {
+                type: 'tool_call',
+                content: [{
+                  index: json.output_index ?? 0,
+                  id: json.item.call_id || json.item.id || '',
+                  function: { name: json.item.name || '', arguments: json.item.arguments || '' },
+                }],
+              };
+            } else if (json.type === 'response.function_call_arguments.delta' && json.delta) {
+              yield {
+                type: 'tool_call',
+                content: [{
+                  index: json.output_index ?? 0,
+                  function: { arguments: json.delta },
+                }],
+              };
+            } else if (json.type === 'response.completed') {
+              const usage = this._normalizeResponsesUsage(json.response?.usage);
+              if (usage) yield { type: 'usage', usage };
+              yield { type: 'done', content: '' };
+              return;
+            } else if (json.type === 'response.failed' || json.type === 'error') {
+              const streamError = new Error(json.response?.error?.message || json.error?.message || json.message || 'Responses API stream failed.');
+              streamError.name = 'ResponsesStreamError';
+              throw streamError;
+            }
+          } else {
+            if (json.usage) yield { type: 'usage', usage: json.usage };
+            const delta = json.choices?.[0]?.delta;
+            if (delta?.content) yield { type: 'text', content: delta.content };
+            if (delta?.tool_calls) yield { type: 'tool_call', content: delta.tool_calls };
           }
         } catch (e) {
+          if (e?.name === 'ResponsesStreamError') throw e;
           console.warn(`[${this.name}] malformed SSE chunk skipped:`, payload?.slice(0, 120), e?.message);
         }
       }

--- a/src/chrome/src/providers/provider-compatibility.js
+++ b/src/chrome/src/providers/provider-compatibility.js
@@ -1,0 +1,212 @@
+const COMPATIBILITY_PRESETS = new Set(['auto', 'openai', 'qwen', 'deepseek', 'openrouter', 'custom']);
+const REASONING_EFFORTS = new Set(['auto', 'off', 'minimal', 'low', 'medium', 'high', 'xhigh', 'max']);
+const SYSTEM_PROMPT_ROLES = new Set(['auto', 'system', 'developer']);
+const MAX_TOKEN_FIELDS = new Set(['auto', 'max_tokens', 'max_completion_tokens']);
+
+export const RESERVED_EXTRA_BODY_KEYS = new Set([
+  'model',
+  'messages',
+  'input',
+  'instructions',
+  'tools',
+  'tool_choice',
+  'stream',
+  'max_tokens',
+  'max_completion_tokens',
+  'max_output_tokens',
+]);
+
+const UNSAFE_OBJECT_KEYS = new Set(['__proto__', 'prototype', 'constructor']);
+
+function clean(value) {
+  return String(value || '').trim().toLowerCase();
+}
+
+export function isPlainObject(value) {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return false;
+  const prototype = Object.getPrototypeOf(value);
+  return prototype === Object.prototype || prototype === null;
+}
+
+function allowedValue(value, allowed, fallback = 'auto') {
+  const normalized = clean(value);
+  return allowed.has(normalized) ? normalized : fallback;
+}
+
+export function normalizeProviderCompatibility(config = {}) {
+  const compat = isPlainObject(config.compat) ? config.compat : {};
+  return {
+    preset: allowedValue(compat.preset ?? config.compatibilityPreset, COMPATIBILITY_PRESETS),
+    reasoningEffort: allowedValue(compat.reasoningEffort ?? config.reasoningEffort, REASONING_EFFORTS),
+    systemPromptRole: allowedValue(compat.systemPromptRole ?? config.systemPromptRole, SYSTEM_PROMPT_ROLES),
+    maxTokensField: allowedValue(compat.maxTokensField ?? config.maxTokensField, MAX_TOKEN_FIELDS),
+  };
+}
+
+export function isOfficialOpenAIConfig(config = {}) {
+  const providerName = clean(config.providerName);
+  if (providerName && providerName !== 'openai') return false;
+  try {
+    const url = new URL(config.baseUrl || 'https://api.openai.com/v1');
+    return url.protocol === 'https:' && url.hostname.toLowerCase() === 'api.openai.com';
+  } catch {
+    return false;
+  }
+}
+
+export function shouldUseOpenAIResponsesApi(config = {}) {
+  return isOfficialOpenAIConfig(config) && /^gpt-5\.6(?:-|$)/i.test(String(config.model || '').trim());
+}
+
+export function detectedCompatibilityPreset(config = {}) {
+  const providerName = clean(config.providerName);
+  const model = clean(config.model);
+  if (providerName === 'openrouter') return 'openrouter';
+  if (providerName === 'deepseek' || model.includes('deepseek')) return 'deepseek';
+  if (model.includes('qwen')) return 'qwen';
+  if (isOfficialOpenAIConfig(config)) return 'openai';
+  return 'standard';
+}
+
+export function effectiveCompatibilityPreset(config = {}) {
+  const compat = normalizeProviderCompatibility(config);
+  return compat.preset === 'auto' ? detectedCompatibilityPreset(config) : compat.preset;
+}
+
+export function mapProviderMessages(messages, config = {}) {
+  if (!Array.isArray(messages)) return [];
+  const { systemPromptRole } = normalizeProviderCompatibility(config);
+  if (systemPromptRole !== 'developer') return messages;
+  return messages.map((message) => {
+    if (!message || message.role !== 'system') return message;
+    return { ...message, role: 'developer' };
+  });
+}
+
+export function configuredMaxTokensField(config = {}, fallback = 'max_tokens') {
+  const { maxTokensField } = normalizeProviderCompatibility(config);
+  return maxTokensField === 'auto' ? fallback : maxTokensField;
+}
+
+export function addConfiguredMaxTokens(body, value, config = {}, fallback = 'max_tokens') {
+  body[configuredMaxTokensField(config, fallback)] = value;
+  return body;
+}
+
+function safeClone(value) {
+  if (Array.isArray(value)) return value.map((item) => safeClone(item));
+  if (!isPlainObject(value)) return value;
+  const clone = {};
+  for (const [key, child] of Object.entries(value)) {
+    if (UNSAFE_OBJECT_KEYS.has(key)) continue;
+    clone[key] = safeClone(child);
+  }
+  return clone;
+}
+
+function deepMerge(target, source) {
+  const merged = isPlainObject(target) ? safeClone(target) : {};
+  if (!isPlainObject(source)) return merged;
+  for (const [key, value] of Object.entries(source)) {
+    if (UNSAFE_OBJECT_KEYS.has(key)) continue;
+    if (isPlainObject(value)) {
+      merged[key] = deepMerge(merged[key], value);
+    } else {
+      merged[key] = safeClone(value);
+    }
+  }
+  return merged;
+}
+
+function safeExtraBody(source) {
+  if (!isPlainObject(source)) return {};
+  const filtered = {};
+  for (const [key, value] of Object.entries(source)) {
+    if (RESERVED_EXTRA_BODY_KEYS.has(key) || UNSAFE_OBJECT_KEYS.has(key)) continue;
+    filtered[key] = safeClone(value);
+  }
+  return filtered;
+}
+
+function mappedReasoningEffort(effort, preset) {
+  if (effort === 'off') return 'none';
+  if (preset === 'openrouter') {
+    if (effort === 'minimal') return 'low';
+    if (effort === 'xhigh' || effort === 'max') return 'high';
+  }
+  if (effort === 'max') return 'xhigh';
+  return effort;
+}
+
+export function compatibilityRequestBody(config = {}) {
+  const compat = normalizeProviderCompatibility(config);
+  if (compat.reasoningEffort === 'auto') return {};
+
+  const preset = effectiveCompatibilityPreset(config);
+  const enabled = compat.reasoningEffort !== 'off';
+  if (preset === 'qwen') {
+    return {
+      chat_template_kwargs: enabled
+        ? { enable_thinking: true, preserve_thinking: true }
+        : { enable_thinking: false },
+    };
+  }
+  if (preset === 'deepseek') {
+    return { chat_template_kwargs: { thinking: enabled } };
+  }
+  if (preset === 'openrouter') {
+    return enabled
+      ? { reasoning: { effort: mappedReasoningEffort(compat.reasoningEffort, preset) } }
+      : { reasoning: { enabled: false } };
+  }
+  if (preset === 'openai') {
+    const effort = mappedReasoningEffort(compat.reasoningEffort, preset);
+    return shouldUseOpenAIResponsesApi(config)
+      ? { reasoning: { effort } }
+      : { reasoning_effort: effort };
+  }
+  return {};
+}
+
+export function mergeProviderRequestBody(body, config = {}, perRequestExtraBody = undefined) {
+  let extras = compatibilityRequestBody(config);
+  extras = deepMerge(extras, safeExtraBody(config.extraBody));
+  extras = deepMerge(extras, safeExtraBody(perRequestExtraBody));
+  if (extras.chat_template_kwargs?.enable_thinking === false) {
+    delete extras.chat_template_kwargs.preserve_thinking;
+  }
+  return { ...body, ...extras };
+}
+
+export function validateProviderExtraBody(value) {
+  if (!isPlainObject(value)) {
+    return { ok: false, error: 'Custom request body must be a JSON object.' };
+  }
+  const reserved = Object.keys(value).filter((key) => RESERVED_EXTRA_BODY_KEYS.has(key));
+  const unsafe = Object.keys(value).filter((key) => UNSAFE_OBJECT_KEYS.has(key));
+  if (reserved.length) {
+    return {
+      ok: false,
+      error: `Use the dedicated settings for reserved fields: ${reserved.join(', ')}.`,
+      reserved,
+    };
+  }
+  if (unsafe.length) {
+    return { ok: false, error: `Unsafe object keys are not allowed: ${unsafe.join(', ')}.` };
+  }
+  return { ok: true, value };
+}
+
+export function parseProviderExtraBodyJson(raw) {
+  const text = String(raw || '').trim();
+  if (!text) return {};
+  let parsed;
+  try {
+    parsed = JSON.parse(text);
+  } catch (error) {
+    throw new Error(`Custom request body is not valid JSON: ${error.message}`);
+  }
+  const validation = validateProviderExtraBody(parsed);
+  if (!validation.ok) throw new Error(validation.error);
+  return parsed;
+}

--- a/src/chrome/src/ui/settings.html
+++ b/src/chrome/src/ui/settings.html
@@ -385,6 +385,103 @@
       border-radius: var(--radius);
     }
 
+    .provider-compatibility {
+      margin-top: 14px;
+      border-top: 1px solid var(--border);
+      border-bottom: 1px solid var(--border);
+    }
+    .provider-compatibility summary {
+      display: grid;
+      grid-template-columns: minmax(180px, auto) minmax(0, 1fr);
+      align-items: center;
+      gap: 12px;
+      padding: 11px 28px 11px 0;
+      color: var(--text2);
+      cursor: pointer;
+      list-style: none;
+      position: relative;
+      user-select: none;
+    }
+    .provider-compatibility summary::-webkit-details-marker { display: none; }
+    .provider-compatibility summary::after {
+      content: '+';
+      position: absolute;
+      right: 4px;
+      color: var(--text2);
+      font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+      font-size: 15px;
+    }
+    .provider-compatibility[open] summary::after { content: '−'; }
+    .provider-compatibility summary:hover,
+    .provider-compatibility[open] summary { color: var(--text); }
+    .provider-compatibility-title {
+      font-size: 11px;
+      font-weight: 700;
+      letter-spacing: 0.45px;
+      text-transform: uppercase;
+    }
+    .provider-compatibility-summary {
+      min-width: 0;
+      overflow: hidden;
+      color: var(--text2);
+      font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+      font-size: 10px;
+      text-align: right;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+    .provider-compatibility-body {
+      padding: 14px;
+      margin-bottom: 12px;
+      background: rgba(108,99,255,0.055);
+      border: 1px solid rgba(108,99,255,0.16);
+      border-radius: 8px;
+    }
+    .provider-compatibility-body > p {
+      margin: 0 0 12px;
+      color: var(--text2);
+      font-size: 12px;
+      line-height: 1.5;
+    }
+    .provider-compatibility-grid {
+      display: grid;
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+      gap: 0 12px;
+    }
+    .provider-compatibility-json textarea {
+      min-height: 116px;
+      font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+      font-size: 12px;
+      tab-size: 2;
+    }
+    .provider-compatibility-json textarea[aria-invalid="true"] {
+      border-color: var(--danger, #e66);
+      box-shadow: 0 0 0 1px rgba(238,102,102,0.18);
+    }
+    .provider-compatibility-help {
+      margin-top: 5px;
+      color: var(--text2);
+      font-size: 10px;
+      line-height: 1.45;
+    }
+    .provider-compatibility-footer {
+      display: flex;
+      align-items: center;
+      gap: 10px;
+      min-height: 32px;
+    }
+    .provider-compatibility-validation {
+      color: var(--danger, #e66);
+      font-size: 11px;
+      line-height: 1.35;
+    }
+    @media (max-width: 600px) {
+      .provider-compatibility summary { grid-template-columns: 1fr; gap: 3px; }
+      .provider-compatibility-summary { text-align: left; }
+      .provider-compatibility-grid { grid-template-columns: 1fr; }
+      .provider-compatibility-footer { align-items: flex-start; flex-direction: column; }
+    }
+
     .field { margin-bottom: 10px; }
     .field label {
       display: block;

--- a/src/chrome/src/ui/settings.js
+++ b/src/chrome/src/ui/settings.js
@@ -26,6 +26,12 @@ import {
   USER_MEMORY_MAX_PROMPT_CHARS_KEY,
   normalizeUserMemoryMaxPromptChars,
 } from '../agent/user-memory.js';
+import {
+  detectedCompatibilityPreset,
+  normalizeProviderCompatibility,
+  parseProviderExtraBodyJson,
+  shouldUseOpenAIResponsesApi,
+} from '../providers/provider-compatibility.js';
 
 // Version shown in the subtitle. Kept here so it only needs one update per
 // release; the subtitle string itself is translated.
@@ -1653,6 +1659,164 @@ function providerInputValue(input) {
   return input.value;
 }
 
+function setProviderConfigValue(config, path, value) {
+  const keys = String(path || '').split('.').filter(Boolean);
+  if (!keys.length) return;
+  let target = config;
+  for (const key of keys.slice(0, -1)) {
+    if (!target[key] || typeof target[key] !== 'object' || Array.isArray(target[key])) target[key] = {};
+    target = target[key];
+  }
+  target[keys.at(-1)] = value;
+}
+
+function supportsProviderCompatibilitySettings(id, config = {}) {
+  return id !== 'webbrain_cloud' && ['openai', 'llamacpp', 'azure_openai'].includes(config.type);
+}
+
+function providerExtraBodyText(value) {
+  if (typeof value === 'string') return value;
+  if (!value || typeof value !== 'object' || Array.isArray(value) || Object.keys(value).length === 0) return '';
+  try { return JSON.stringify(value, null, 2); } catch { return ''; }
+}
+
+function prettyCompatibilityValue(value) {
+  const labels = {
+    auto: 'Auto',
+    qwen: 'Qwen',
+    deepseek: 'DeepSeek',
+    openrouter: 'OpenRouter',
+    openai: 'OpenAI',
+    standard: 'standard',
+    custom: 'Custom',
+    off: 'Off',
+    minimal: 'Minimal',
+    low: 'Low',
+    medium: 'Medium',
+    high: 'High',
+    xhigh: 'XHigh',
+    max: 'Max',
+    system: 'System',
+    developer: 'Developer',
+  };
+  return labels[value] || value;
+}
+
+function automaticTokenField(config) {
+  if (shouldUseOpenAIResponsesApi(config)) return 'max_output_tokens';
+  const model = String(config.model || '').toLowerCase();
+  const isNewOfficialContract = config.type === 'openai'
+    && config.category !== 'local'
+    && config.providerName !== 'lmstudio'
+    && /^(gpt-5|gpt-4\.1|o1|o3|o4)/.test(model);
+  return isNewOfficialContract ? 'max_completion_tokens' : 'max_tokens';
+}
+
+function compatibilitySummary(config) {
+  const compat = normalizeProviderCompatibility(config);
+  const detected = detectedCompatibilityPreset(config);
+  const preset = compat.preset === 'auto'
+    ? `Auto → ${prettyCompatibilityValue(detected)}`
+    : prettyCompatibilityValue(compat.preset);
+  const reasoning = compat.reasoningEffort === 'auto'
+    ? 'provider default'
+    : prettyCompatibilityValue(compat.reasoningEffort);
+  const role = compat.systemPromptRole === 'auto' ? 'System' : prettyCompatibilityValue(compat.systemPromptRole);
+  const tokens = compat.maxTokensField === 'auto' ? automaticTokenField(config) : compat.maxTokensField;
+  const extraBody = config.extraBody && typeof config.extraBody === 'object' && !Array.isArray(config.extraBody)
+    ? Object.keys(config.extraBody).length
+    : 0;
+  return `${preset} · reasoning ${reasoning} · ${role} role · ${tokens}${extraBody ? ` · ${extraBody} custom field${extraBody === 1 ? '' : 's'}` : ''}`;
+}
+
+function currentProviderCompatibilityConfig(id) {
+  const source = providersData[id] || {};
+  const config = { ...source, compat: { ...(source.compat || {}) } };
+  document.querySelectorAll(`.provider-compatibility [data-provider="${id}"]`).forEach((input) => {
+    if (input.dataset.type === 'json') {
+      try { config.extraBody = parseProviderExtraBodyJson(input.value); } catch { config.extraBody = {}; }
+      return;
+    }
+    setProviderConfigValue(config, input.dataset.key, providerInputValue(input));
+  });
+  const modelInput = document.querySelector(`input[data-provider="${id}"][data-key="model"]`);
+  const baseUrlInput = document.querySelector(`input[data-provider="${id}"][data-key="baseUrl"]`);
+  if (modelInput) config.model = modelInput.value;
+  if (baseUrlInput) config.baseUrl = baseUrlInput.value;
+  return config;
+}
+
+function refreshProviderCompatibilitySummary(id) {
+  const details = document.querySelector(`.provider-compatibility[data-provider-id="${id}"]`);
+  if (!details) return;
+  const textarea = details.querySelector('textarea[data-type="json"]');
+  const validation = details.querySelector('.provider-compatibility-validation');
+  let error = '';
+  if (textarea) {
+    try { parseProviderExtraBodyJson(textarea.value); } catch (e) { error = e.message; }
+    textarea.setAttribute('aria-invalid', error ? 'true' : 'false');
+  }
+  if (validation) validation.textContent = error;
+  const summary = details.querySelector('.provider-compatibility-summary');
+  if (summary) summary.textContent = compatibilitySummary(currentProviderCompatibilityConfig(id));
+}
+
+function renderProviderCompatibilitySettings(id, config) {
+  if (!supportsProviderCompatibilitySettings(id, config)) return '';
+  const compat = normalizeProviderCompatibility(config);
+  const extraBody = providerExtraBodyText(config.extraBody);
+  const options = (items, current) => items.map(([value, label]) => (
+    `<option value="${value}"${value === current ? ' selected' : ''}>${label}</option>`
+  )).join('');
+  return `
+    <details class="provider-compatibility" data-provider-id="${id}">
+      <summary>
+        <span class="provider-compatibility-title">Advanced model compatibility</span>
+        <span class="provider-compatibility-summary">${escapeHtml(compatibilitySummary(config))}</span>
+      </summary>
+      <div class="provider-compatibility-body">
+        <p>Keep these on Auto unless the model or endpoint documents a different request contract.</p>
+        <div class="provider-compatibility-grid">
+          <div class="field">
+            <label>Compatibility preset</label>
+            <select data-provider="${id}" data-key="compat.preset" data-type="select">
+              ${options([['auto', 'Auto'], ['openai', 'OpenAI'], ['qwen', 'Qwen'], ['deepseek', 'DeepSeek'], ['openrouter', 'OpenRouter'], ['custom', 'Custom']], compat.preset)}
+            </select>
+          </div>
+          <div class="field">
+            <label>Reasoning</label>
+            <select data-provider="${id}" data-key="compat.reasoningEffort" data-type="select">
+              ${options([['auto', 'Auto'], ['off', 'Off'], ['minimal', 'Minimal'], ['low', 'Low'], ['medium', 'Medium'], ['high', 'High'], ['xhigh', 'XHigh'], ['max', 'Max']], compat.reasoningEffort)}
+            </select>
+          </div>
+          <div class="field">
+            <label>System prompt role</label>
+            <select data-provider="${id}" data-key="compat.systemPromptRole" data-type="select">
+              ${options([['auto', 'Auto'], ['system', 'System'], ['developer', 'Developer']], compat.systemPromptRole)}
+            </select>
+          </div>
+          <div class="field">
+            <label>Token limit field</label>
+            <select data-provider="${id}" data-key="compat.maxTokensField" data-type="select">
+              ${options([['auto', 'Auto'], ['max_tokens', 'max_tokens'], ['max_completion_tokens', 'max_completion_tokens']], compat.maxTokensField)}
+            </select>
+          </div>
+        </div>
+        <div class="field provider-compatibility-json">
+          <label>Custom request body (JSON)</label>
+          <textarea data-provider="${id}" data-key="extraBody" data-type="json" spellcheck="false"
+                    aria-invalid="false" placeholder='{"chat_template_kwargs":{"enable_thinking":true}}'>${escapeHtml(extraBody)}</textarea>
+          <div class="provider-compatibility-help">Merged after the preset. Per-call WebBrain overrides still win. Model, messages, tools, stream, and token-limit fields are protected.</div>
+        </div>
+        <div class="provider-compatibility-footer">
+          <button type="button" class="btn-secondary btn-reset-compatibility" data-provider="${id}">Reset to automatic</button>
+          <span class="provider-compatibility-validation" role="status"></span>
+        </div>
+      </div>
+    </details>
+  `;
+}
+
 // Effective tier for the dropdown's initial value — same precedence as the
 // provider getter: cloud is forced full; an explicit promptTier wins; the
 // legacy useCompactPrompt boolean maps to compact; otherwise local → mid.
@@ -1683,6 +1847,9 @@ function providerSearchTextForEntry(id, config, fieldDefs) {
     config.model,
     config.baseUrl,
     fieldText,
+    supportsProviderCompatibilitySettings(id, config)
+      ? 'advanced model compatibility reasoning thinking system developer max tokens custom request body json'
+      : '',
   ].filter(Boolean).join(' '));
 }
 
@@ -1787,8 +1954,8 @@ function renderProviders() {
     openai: {
       fields: [
         { key: 'apiKey', labelKey: 'st.provider.field.api_key', type: 'password', placeholder: 'sk-...' },
-        { key: 'model', labelKey: 'st.provider.field.model', type: 'text', placeholder: 'gpt-5.5',
-          suggestions: ['gpt-5.5', 'gpt-5.4', 'gpt-5.2', 'gpt-5.3-codex'] },
+        { key: 'model', labelKey: 'st.provider.field.model', type: 'text', placeholder: 'gpt-5.6-terra',
+          suggestions: ['gpt-5.6-terra', 'gpt-5.6-sol', 'gpt-5.6-luna', 'gpt-5.6', 'gpt-5.5', 'gpt-5.4', 'gpt-5.2', 'gpt-5.3-codex'] },
         { key: 'baseUrl', labelKey: 'st.provider.field.api_base_url', type: 'text', placeholder: 'https://api.openai.com/v1' },
         ...COST_ESTIMATE_FIELDS,
       ],
@@ -2066,10 +2233,12 @@ function renderProviders() {
            ${t('st.providers.webbrain_data_use.body', { privacyLink, subscribeLink, accountLink })}
          </div>`;
     }
+    const compatibilitySettings = renderProviderCompatibilitySettings(id, config);
 
     const body = `
       ${fieldsHTML}
       ${providerNote}
+      ${compatibilitySettings}
       <div class="btn-row">
         <button class="btn-primary btn-save" data-provider="${id}">${escapeHtml(t('st.providers.save'))}</button>
         <button class="btn-secondary btn-test" data-provider="${id}">${escapeHtml(t('st.providers.test'))}</button>
@@ -2126,6 +2295,24 @@ function renderProviders() {
         input.style.display = 'none';
         input.value = sel.value;
       }
+      refreshProviderCompatibilitySummary(providerId);
+    });
+  });
+  document.querySelectorAll('.provider-compatibility select[data-provider], .provider-compatibility textarea[data-provider]').forEach((input) => {
+    const eventName = input.tagName === 'TEXTAREA' ? 'input' : 'change';
+    input.addEventListener(eventName, () => refreshProviderCompatibilitySummary(input.dataset.provider));
+  });
+  document.querySelectorAll('input[data-key="model"], input[data-key="baseUrl"]').forEach((input) => {
+    input.addEventListener('input', () => refreshProviderCompatibilitySummary(input.dataset.provider));
+  });
+  document.querySelectorAll('.btn-reset-compatibility').forEach((button) => {
+    button.addEventListener('click', () => {
+      const id = button.dataset.provider;
+      const details = button.closest('.provider-compatibility');
+      details?.querySelectorAll('select[data-provider]').forEach((select) => { select.value = 'auto'; });
+      const textarea = details?.querySelector('textarea[data-type="json"]');
+      if (textarea) textarea.value = '';
+      refreshProviderCompatibilitySummary(id);
     });
   });
   document.querySelectorAll('.loaded-model-dialog').forEach(dialog => {
@@ -2402,13 +2589,16 @@ function setProviderTestResult(id, className, message, color) {
 }
 
 async function saveProvider(id, { showFlash = true, markConfigured = true } = {}) {
-  const inputs = document.querySelectorAll(`input[data-provider="${id}"], select[data-provider="${id}"]`);
+  const inputs = document.querySelectorAll(`input[data-provider="${id}"], select[data-provider="${id}"], textarea[data-provider="${id}"]`);
   const config = {};
-  inputs.forEach(input => {
-    config[input.dataset.key] = providerInputValue(input);
-  });
 
   try {
+    inputs.forEach(input => {
+      const value = input.dataset.type === 'json'
+        ? parseProviderExtraBodyJson(input.value)
+        : providerInputValue(input);
+      setProviderConfigValue(config, input.dataset.key, value);
+    });
     await sendToBackground('update_provider', { providerId: id, config, markConfigured });
   } catch (e) {
     if (showFlash) setProviderTestResult(id, 'fail', t('st.providers.failed', { error: e.message }));
@@ -2474,11 +2664,11 @@ async function testProvider(id) {
  * silently throws away whatever the user has typed but not yet saved.
  */
 function syncInputsIntoProvidersData() {
-  document.querySelectorAll('input[data-provider], select[data-provider]').forEach((input) => {
+  document.querySelectorAll('input[data-provider], select[data-provider], textarea[data-provider]').forEach((input) => {
     const id = input.dataset.provider;
     const key = input.dataset.key;
     if (!id || !key || !providersData[id]) return;
-    providersData[id][key] = providerInputValue(input);
+    setProviderConfigValue(providersData[id], key, providerInputValue(input));
   });
 }
 

--- a/src/firefox/src/providers/azure-openai.js
+++ b/src/firefox/src/providers/azure-openai.js
@@ -60,7 +60,7 @@ export class AzureOpenAIProvider extends BaseLLMProvider {
   }
 
   _addMaxTokens(body, options) {
-    body.max_tokens = options.maxTokens ?? 4096;
+    this._addConfiguredMaxTokens(body, options, 'max_tokens');
   }
 
   _addTemperature(body, options) {
@@ -86,17 +86,21 @@ export class AzureOpenAIProvider extends BaseLLMProvider {
     body.stream_options = { ...streamOptions, include_usage: true };
   }
 
-  async chat(messages, options = {}) {
-    const body = { messages, stream: false };
+  _buildRequestBody(messages, options = {}, stream = false) {
+    let body = { messages: this._mapMessages(messages), stream };
     this._addTemperature(body, options);
     this._addMaxTokens(body, options);
     if (this._shouldSendTools(messages, options)) {
       body.tools = options.tools;
       body.tool_choice = options.toolChoice || 'auto';
     }
-    if (options.extraBody && typeof options.extraBody === 'object') {
-      Object.assign(body, options.extraBody);
-    }
+    body = this._mergeConfiguredRequestBody(body, options);
+    if (stream) this._addStreamUsageOptions(body);
+    return body;
+  }
+
+  async chat(messages, options = {}) {
+    const body = this._buildRequestBody(messages, options, false);
 
     const url = this._chatUrl();
     let res;
@@ -126,17 +130,7 @@ export class AzureOpenAIProvider extends BaseLLMProvider {
   }
 
   async *chatStream(messages, options = {}) {
-    const body = { messages, stream: true };
-    this._addTemperature(body, options);
-    this._addMaxTokens(body, options);
-    if (this._shouldSendTools(messages, options)) {
-      body.tools = options.tools;
-      body.tool_choice = options.toolChoice || 'auto';
-    }
-    if (options.extraBody && typeof options.extraBody === 'object') {
-      Object.assign(body, options.extraBody);
-    }
-    this._addStreamUsageOptions(body);
+    const body = this._buildRequestBody(messages, options, true);
 
     const url = this._chatUrl();
     let res;
@@ -182,4 +176,3 @@ export class AzureOpenAIProvider extends BaseLLMProvider {
     yield { type: 'done', content: '' };
   }
 }
-

--- a/src/firefox/src/providers/base.js
+++ b/src/firefox/src/providers/base.js
@@ -1,4 +1,9 @@
 import { inferContextWindow } from './context-windows.js';
+import {
+  addConfiguredMaxTokens,
+  mapProviderMessages,
+  mergeProviderRequestBody,
+} from './provider-compatibility.js';
 
 /**
  * Base LLM Provider — all providers implement this interface.
@@ -81,6 +86,18 @@ export class BaseLLMProvider {
    */
   get useCompactPrompt() {
     return !!this.config.useCompactPrompt;
+  }
+
+  _mapMessages(messages) {
+    return mapProviderMessages(messages, this.config);
+  }
+
+  _addConfiguredMaxTokens(body, options, fallback = 'max_tokens') {
+    return addConfiguredMaxTokens(body, options.maxTokens ?? 4096, this.config, fallback);
+  }
+
+  _mergeConfiguredRequestBody(body, options = {}) {
+    return mergeProviderRequestBody(body, this.config, options.extraBody);
   }
 
   /**

--- a/src/firefox/src/providers/context-windows.js
+++ b/src/firefox/src/providers/context-windows.js
@@ -243,6 +243,7 @@ export function inferContextWindow(config = {}) {
   if (!model) return DEFAULT_CLOUD_CONTEXT_WINDOW;
 
   // OpenAI
+  if (/^gpt-5\.6(?:-|$)/.test(model)) return 1050000;
   if (model.includes('gpt-5.5-pro')) return 1050000;
   if (/^gpt-5(?:[.\-]|$)/.test(model) || model.includes('/gpt-5')) return 400000;
 

--- a/src/firefox/src/providers/llamacpp.js
+++ b/src/firefox/src/providers/llamacpp.js
@@ -36,22 +36,23 @@ export class LlamaCppProvider extends BaseLLMProvider {
     return !!this.config.useCompactPrompt;
   }
 
-  async chat(messages, options = {}) {
+  _buildRequestBody(messages, options = {}, stream = false) {
     const body = {
-      messages,
+      messages: this._mapMessages(messages),
       temperature: options.temperature ?? 0.7,
-      max_tokens: options.maxTokens ?? 4096,
-      stream: false,
+      stream,
     };
-
-    if (this.model) {
-      body.model = this.model;
-    }
-
+    this._addConfiguredMaxTokens(body, options, 'max_tokens');
+    if (this.model) body.model = this.model;
     if (options.tools && options.tools.length > 0) {
       body.tools = options.tools;
       body.tool_choice = options.toolChoice || 'auto';
     }
+    return this._mergeConfiguredRequestBody(body, options);
+  }
+
+  async chat(messages, options = {}) {
+    const body = this._buildRequestBody(messages, options, false);
 
     const url = `${this.baseUrl}/v1/chat/completions`;
     let res;
@@ -88,21 +89,7 @@ export class LlamaCppProvider extends BaseLLMProvider {
   }
 
   async *chatStream(messages, options = {}) {
-    const body = {
-      messages,
-      temperature: options.temperature ?? 0.7,
-      max_tokens: options.maxTokens ?? 4096,
-      stream: true,
-    };
-
-    if (this.model) {
-      body.model = this.model;
-    }
-
-    if (options.tools && options.tools.length > 0) {
-      body.tools = options.tools;
-      body.tool_choice = options.toolChoice || 'auto';
-    }
+    const body = this._buildRequestBody(messages, options, true);
 
     const streamUrl = `${this.baseUrl}/v1/chat/completions`;
     let res;

--- a/src/firefox/src/providers/manager.js
+++ b/src/firefox/src/providers/manager.js
@@ -269,7 +269,7 @@ export class ProviderManager {
         label: 'OpenAI',
         providerName: 'openai',
         baseUrl: 'https://api.openai.com/v1',
-        model: 'gpt-5.5',
+        model: 'gpt-5.6-terra',
         inputCostPerMillionUsd: 5,
         outputCostPerMillionUsd: 22.5,
         supportsStreamUsageOptions: true,

--- a/src/firefox/src/providers/openai.js
+++ b/src/firefox/src/providers/openai.js
@@ -1,5 +1,6 @@
 import { BaseLLMProvider } from './base.js';
 import { fetchWithTimeout } from './fetch-timeout.js';
+import { shouldUseOpenAIResponsesApi } from './provider-compatibility.js';
 
 /**
  * Provider for OpenAI-compatible APIs (ChatGPT, OpenRouter, any OpenAI-compatible endpoint).
@@ -73,12 +74,8 @@ export class OpenAICompatibleProvider extends BaseLLMProvider {
   }
 
   _addMaxTokens(body, options) {
-    const max = options.maxTokens ?? 4096;
-    if (this._isNewOpenAIContract()) {
-      body.max_completion_tokens = max;
-    } else {
-      body.max_tokens = max;
-    }
+    const fallback = this._isNewOpenAIContract() ? 'max_completion_tokens' : 'max_tokens';
+    this._addConfiguredMaxTokens(body, options, fallback);
   }
 
   _addTemperature(body, options) {
@@ -166,26 +163,160 @@ export class OpenAICompatibleProvider extends BaseLLMProvider {
     }
   }
 
-  async chat(messages, options = {}) {
-    const body = {
+  _usesResponsesApi() {
+    return shouldUseOpenAIResponsesApi(this.config);
+  }
+
+  _buildChatCompletionsBody(messages, options = {}, stream = false) {
+    let body = {
       model: this.model,
-      messages,
-      stream: false,
+      messages: this._mapMessages(messages),
+      stream,
     };
     this._addTemperature(body, options);
     this._addMaxTokens(body, options);
-
     if (this._shouldSendTools(messages, options)) {
       body.tools = options.tools;
       body.tool_choice = options.toolChoice || 'auto';
     }
-
-    if (options.extraBody && typeof options.extraBody === 'object') {
-      Object.assign(body, options.extraBody);
-    }
+    body = this._mergeConfiguredRequestBody(body, options);
     this._addWebBrainCloudContext(body, options);
+    if (stream) this._addStreamUsageOptions(body);
+    return body;
+  }
 
-    const url = `${this.baseUrl}/chat/completions`;
+  _responsesContent(content, role) {
+    if (!Array.isArray(content)) return content;
+    return content.map((block) => {
+      if (!block || typeof block !== 'object') return block;
+      if (block.type === 'text') {
+        return { type: role === 'assistant' ? 'output_text' : 'input_text', text: block.text || '' };
+      }
+      if (block.type === 'image_url' || block.type === 'image') {
+        const imageUrl = typeof block.image_url === 'string' ? block.image_url : block.image_url?.url;
+        return {
+          type: 'input_image',
+          image_url: imageUrl || block.source?.data || '',
+          ...(block.image_url?.detail ? { detail: block.image_url.detail } : {}),
+        };
+      }
+      return block;
+    });
+  }
+
+  _responsesInput(messages) {
+    const input = [];
+    for (const message of this._mapMessages(messages)) {
+      if (!message || typeof message !== 'object') continue;
+      if (message.role === 'tool') {
+        const output = typeof message.content === 'string'
+          ? message.content
+          : JSON.stringify(message.content ?? '');
+        input.push({ type: 'function_call_output', call_id: message.tool_call_id, output });
+        continue;
+      }
+      if (message.role === 'assistant' && Array.isArray(message.tool_calls)) {
+        if (message.content) {
+          input.push({ role: 'assistant', content: this._responsesContent(message.content, 'assistant') });
+        }
+        for (const toolCall of message.tool_calls) {
+          input.push({
+            type: 'function_call',
+            call_id: toolCall.id,
+            name: toolCall.function?.name || '',
+            arguments: toolCall.function?.arguments || '{}',
+          });
+        }
+        continue;
+      }
+      input.push({
+        role: message.role,
+        content: this._responsesContent(message.content, message.role),
+      });
+    }
+    return input;
+  }
+
+  _responsesTools(tools) {
+    return (tools || []).map((tool) => {
+      if (tool?.type !== 'function') return tool;
+      const fn = tool.function || {};
+      return {
+        type: 'function',
+        name: fn.name || '',
+        description: fn.description || '',
+        parameters: fn.parameters || { type: 'object', properties: {} },
+        strict: fn.strict === true,
+      };
+    });
+  }
+
+  _buildResponsesBody(messages, options = {}, stream = false) {
+    let body = {
+      model: this.model,
+      input: this._responsesInput(messages),
+      stream,
+      store: false,
+      max_output_tokens: options.maxTokens ?? 4096,
+    };
+    if (this._shouldSendTools(messages, options)) {
+      body.tools = this._responsesTools(options.tools);
+      body.tool_choice = options.toolChoice || 'auto';
+    }
+    body = this._mergeConfiguredRequestBody(body, options);
+    if (typeof body.reasoning_effort === 'string') {
+      body.reasoning = { ...(body.reasoning || {}), effort: body.reasoning_effort };
+      delete body.reasoning_effort;
+    }
+    return body;
+  }
+
+  _normalizeResponsesUsage(usage) {
+    if (!usage || typeof usage !== 'object') return null;
+    return {
+      ...usage,
+      prompt_tokens: usage.prompt_tokens ?? usage.input_tokens ?? 0,
+      completion_tokens: usage.completion_tokens ?? usage.output_tokens ?? 0,
+      total_tokens: usage.total_tokens ?? ((usage.input_tokens || 0) + (usage.output_tokens || 0)),
+    };
+  }
+
+  _parseResponsesData(data) {
+    const output = Array.isArray(data?.output) ? data.output : [];
+    const text = [];
+    const reasoning = [];
+    const toolCalls = [];
+    for (const item of output) {
+      if (item?.type === 'message' && Array.isArray(item.content)) {
+        for (const block of item.content) {
+          if (block?.type === 'output_text' && block.text) text.push(block.text);
+          if (block?.type === 'refusal' && block.refusal) text.push(block.refusal);
+        }
+      } else if (item?.type === 'function_call') {
+        toolCalls.push({
+          id: item.call_id || item.id || '',
+          type: 'function',
+          function: { name: item.name || '', arguments: item.arguments || '{}' },
+        });
+      } else if (item?.type === 'reasoning' && Array.isArray(item.summary)) {
+        for (const part of item.summary) if (part?.text) reasoning.push(part.text);
+      }
+    }
+    return {
+      content: text.join(''),
+      reasoningContent: reasoning.join('\n'),
+      toolCalls: toolCalls.length ? toolCalls : null,
+      usage: this._normalizeResponsesUsage(data?.usage),
+      raw: data,
+    };
+  }
+
+  async chat(messages, options = {}) {
+    const useResponses = this._usesResponsesApi();
+    const body = useResponses
+      ? this._buildResponsesBody(messages, options, false)
+      : this._buildChatCompletionsBody(messages, options, false);
+    const url = `${this.baseUrl}/${useResponses ? 'responses' : 'chat/completions'}`;
     let res;
     try {
       res = await fetchWithTimeout(url, {
@@ -207,6 +338,7 @@ export class OpenAICompatibleProvider extends BaseLLMProvider {
     try { data = await res.json(); } catch {
       throw new Error(`${this.name} returned invalid JSON in chat response.`);
     }
+    if (useResponses) return this._parseResponsesData(data);
     const choice = data.choices?.[0];
     const message = choice?.message;
 
@@ -220,26 +352,11 @@ export class OpenAICompatibleProvider extends BaseLLMProvider {
   }
 
   async *chatStream(messages, options = {}) {
-    const body = {
-      model: this.model,
-      messages,
-      stream: true,
-    };
-    this._addTemperature(body, options);
-    this._addMaxTokens(body, options);
-
-    if (this._shouldSendTools(messages, options)) {
-      body.tools = options.tools;
-      body.tool_choice = options.toolChoice || 'auto';
-    }
-
-    if (options.extraBody && typeof options.extraBody === 'object') {
-      Object.assign(body, options.extraBody);
-    }
-    this._addWebBrainCloudContext(body, options);
-    this._addStreamUsageOptions(body);
-
-    const streamUrl = `${this.baseUrl}/chat/completions`;
+    const useResponses = this._usesResponsesApi();
+    const body = useResponses
+      ? this._buildResponsesBody(messages, options, true)
+      : this._buildChatCompletionsBody(messages, options, true);
+    const streamUrl = `${this.baseUrl}/${useResponses ? 'responses' : 'chat/completions'}`;
     let res;
     try {
       res = await fetchWithTimeout(streamUrl, {
@@ -278,17 +395,44 @@ export class OpenAICompatibleProvider extends BaseLLMProvider {
         }
         try {
           const json = JSON.parse(payload);
-          if (json.usage) {
-            yield { type: 'usage', usage: json.usage };
-          }
-          const delta = json.choices?.[0]?.delta;
-          if (delta?.content) {
-            yield { type: 'text', content: delta.content };
-          }
-          if (delta?.tool_calls) {
-            yield { type: 'tool_call', content: delta.tool_calls };
+          if (useResponses) {
+            if (json.type === 'response.output_text.delta' && json.delta) {
+              yield { type: 'text', content: json.delta };
+            } else if (json.type === 'response.output_item.added' && json.item?.type === 'function_call') {
+              yield {
+                type: 'tool_call',
+                content: [{
+                  index: json.output_index ?? 0,
+                  id: json.item.call_id || json.item.id || '',
+                  function: { name: json.item.name || '', arguments: json.item.arguments || '' },
+                }],
+              };
+            } else if (json.type === 'response.function_call_arguments.delta' && json.delta) {
+              yield {
+                type: 'tool_call',
+                content: [{
+                  index: json.output_index ?? 0,
+                  function: { arguments: json.delta },
+                }],
+              };
+            } else if (json.type === 'response.completed') {
+              const usage = this._normalizeResponsesUsage(json.response?.usage);
+              if (usage) yield { type: 'usage', usage };
+              yield { type: 'done', content: '' };
+              return;
+            } else if (json.type === 'response.failed' || json.type === 'error') {
+              const streamError = new Error(json.response?.error?.message || json.error?.message || json.message || 'Responses API stream failed.');
+              streamError.name = 'ResponsesStreamError';
+              throw streamError;
+            }
+          } else {
+            if (json.usage) yield { type: 'usage', usage: json.usage };
+            const delta = json.choices?.[0]?.delta;
+            if (delta?.content) yield { type: 'text', content: delta.content };
+            if (delta?.tool_calls) yield { type: 'tool_call', content: delta.tool_calls };
           }
         } catch (e) {
+          if (e?.name === 'ResponsesStreamError') throw e;
           console.warn(`[${this.name}] malformed SSE chunk skipped:`, payload?.slice(0, 120), e?.message);
         }
       }

--- a/src/firefox/src/providers/provider-compatibility.js
+++ b/src/firefox/src/providers/provider-compatibility.js
@@ -1,0 +1,212 @@
+const COMPATIBILITY_PRESETS = new Set(['auto', 'openai', 'qwen', 'deepseek', 'openrouter', 'custom']);
+const REASONING_EFFORTS = new Set(['auto', 'off', 'minimal', 'low', 'medium', 'high', 'xhigh', 'max']);
+const SYSTEM_PROMPT_ROLES = new Set(['auto', 'system', 'developer']);
+const MAX_TOKEN_FIELDS = new Set(['auto', 'max_tokens', 'max_completion_tokens']);
+
+export const RESERVED_EXTRA_BODY_KEYS = new Set([
+  'model',
+  'messages',
+  'input',
+  'instructions',
+  'tools',
+  'tool_choice',
+  'stream',
+  'max_tokens',
+  'max_completion_tokens',
+  'max_output_tokens',
+]);
+
+const UNSAFE_OBJECT_KEYS = new Set(['__proto__', 'prototype', 'constructor']);
+
+function clean(value) {
+  return String(value || '').trim().toLowerCase();
+}
+
+export function isPlainObject(value) {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return false;
+  const prototype = Object.getPrototypeOf(value);
+  return prototype === Object.prototype || prototype === null;
+}
+
+function allowedValue(value, allowed, fallback = 'auto') {
+  const normalized = clean(value);
+  return allowed.has(normalized) ? normalized : fallback;
+}
+
+export function normalizeProviderCompatibility(config = {}) {
+  const compat = isPlainObject(config.compat) ? config.compat : {};
+  return {
+    preset: allowedValue(compat.preset ?? config.compatibilityPreset, COMPATIBILITY_PRESETS),
+    reasoningEffort: allowedValue(compat.reasoningEffort ?? config.reasoningEffort, REASONING_EFFORTS),
+    systemPromptRole: allowedValue(compat.systemPromptRole ?? config.systemPromptRole, SYSTEM_PROMPT_ROLES),
+    maxTokensField: allowedValue(compat.maxTokensField ?? config.maxTokensField, MAX_TOKEN_FIELDS),
+  };
+}
+
+export function isOfficialOpenAIConfig(config = {}) {
+  const providerName = clean(config.providerName);
+  if (providerName && providerName !== 'openai') return false;
+  try {
+    const url = new URL(config.baseUrl || 'https://api.openai.com/v1');
+    return url.protocol === 'https:' && url.hostname.toLowerCase() === 'api.openai.com';
+  } catch {
+    return false;
+  }
+}
+
+export function shouldUseOpenAIResponsesApi(config = {}) {
+  return isOfficialOpenAIConfig(config) && /^gpt-5\.6(?:-|$)/i.test(String(config.model || '').trim());
+}
+
+export function detectedCompatibilityPreset(config = {}) {
+  const providerName = clean(config.providerName);
+  const model = clean(config.model);
+  if (providerName === 'openrouter') return 'openrouter';
+  if (providerName === 'deepseek' || model.includes('deepseek')) return 'deepseek';
+  if (model.includes('qwen')) return 'qwen';
+  if (isOfficialOpenAIConfig(config)) return 'openai';
+  return 'standard';
+}
+
+export function effectiveCompatibilityPreset(config = {}) {
+  const compat = normalizeProviderCompatibility(config);
+  return compat.preset === 'auto' ? detectedCompatibilityPreset(config) : compat.preset;
+}
+
+export function mapProviderMessages(messages, config = {}) {
+  if (!Array.isArray(messages)) return [];
+  const { systemPromptRole } = normalizeProviderCompatibility(config);
+  if (systemPromptRole !== 'developer') return messages;
+  return messages.map((message) => {
+    if (!message || message.role !== 'system') return message;
+    return { ...message, role: 'developer' };
+  });
+}
+
+export function configuredMaxTokensField(config = {}, fallback = 'max_tokens') {
+  const { maxTokensField } = normalizeProviderCompatibility(config);
+  return maxTokensField === 'auto' ? fallback : maxTokensField;
+}
+
+export function addConfiguredMaxTokens(body, value, config = {}, fallback = 'max_tokens') {
+  body[configuredMaxTokensField(config, fallback)] = value;
+  return body;
+}
+
+function safeClone(value) {
+  if (Array.isArray(value)) return value.map((item) => safeClone(item));
+  if (!isPlainObject(value)) return value;
+  const clone = {};
+  for (const [key, child] of Object.entries(value)) {
+    if (UNSAFE_OBJECT_KEYS.has(key)) continue;
+    clone[key] = safeClone(child);
+  }
+  return clone;
+}
+
+function deepMerge(target, source) {
+  const merged = isPlainObject(target) ? safeClone(target) : {};
+  if (!isPlainObject(source)) return merged;
+  for (const [key, value] of Object.entries(source)) {
+    if (UNSAFE_OBJECT_KEYS.has(key)) continue;
+    if (isPlainObject(value)) {
+      merged[key] = deepMerge(merged[key], value);
+    } else {
+      merged[key] = safeClone(value);
+    }
+  }
+  return merged;
+}
+
+function safeExtraBody(source) {
+  if (!isPlainObject(source)) return {};
+  const filtered = {};
+  for (const [key, value] of Object.entries(source)) {
+    if (RESERVED_EXTRA_BODY_KEYS.has(key) || UNSAFE_OBJECT_KEYS.has(key)) continue;
+    filtered[key] = safeClone(value);
+  }
+  return filtered;
+}
+
+function mappedReasoningEffort(effort, preset) {
+  if (effort === 'off') return 'none';
+  if (preset === 'openrouter') {
+    if (effort === 'minimal') return 'low';
+    if (effort === 'xhigh' || effort === 'max') return 'high';
+  }
+  if (effort === 'max') return 'xhigh';
+  return effort;
+}
+
+export function compatibilityRequestBody(config = {}) {
+  const compat = normalizeProviderCompatibility(config);
+  if (compat.reasoningEffort === 'auto') return {};
+
+  const preset = effectiveCompatibilityPreset(config);
+  const enabled = compat.reasoningEffort !== 'off';
+  if (preset === 'qwen') {
+    return {
+      chat_template_kwargs: enabled
+        ? { enable_thinking: true, preserve_thinking: true }
+        : { enable_thinking: false },
+    };
+  }
+  if (preset === 'deepseek') {
+    return { chat_template_kwargs: { thinking: enabled } };
+  }
+  if (preset === 'openrouter') {
+    return enabled
+      ? { reasoning: { effort: mappedReasoningEffort(compat.reasoningEffort, preset) } }
+      : { reasoning: { enabled: false } };
+  }
+  if (preset === 'openai') {
+    const effort = mappedReasoningEffort(compat.reasoningEffort, preset);
+    return shouldUseOpenAIResponsesApi(config)
+      ? { reasoning: { effort } }
+      : { reasoning_effort: effort };
+  }
+  return {};
+}
+
+export function mergeProviderRequestBody(body, config = {}, perRequestExtraBody = undefined) {
+  let extras = compatibilityRequestBody(config);
+  extras = deepMerge(extras, safeExtraBody(config.extraBody));
+  extras = deepMerge(extras, safeExtraBody(perRequestExtraBody));
+  if (extras.chat_template_kwargs?.enable_thinking === false) {
+    delete extras.chat_template_kwargs.preserve_thinking;
+  }
+  return { ...body, ...extras };
+}
+
+export function validateProviderExtraBody(value) {
+  if (!isPlainObject(value)) {
+    return { ok: false, error: 'Custom request body must be a JSON object.' };
+  }
+  const reserved = Object.keys(value).filter((key) => RESERVED_EXTRA_BODY_KEYS.has(key));
+  const unsafe = Object.keys(value).filter((key) => UNSAFE_OBJECT_KEYS.has(key));
+  if (reserved.length) {
+    return {
+      ok: false,
+      error: `Use the dedicated settings for reserved fields: ${reserved.join(', ')}.`,
+      reserved,
+    };
+  }
+  if (unsafe.length) {
+    return { ok: false, error: `Unsafe object keys are not allowed: ${unsafe.join(', ')}.` };
+  }
+  return { ok: true, value };
+}
+
+export function parseProviderExtraBodyJson(raw) {
+  const text = String(raw || '').trim();
+  if (!text) return {};
+  let parsed;
+  try {
+    parsed = JSON.parse(text);
+  } catch (error) {
+    throw new Error(`Custom request body is not valid JSON: ${error.message}`);
+  }
+  const validation = validateProviderExtraBody(parsed);
+  if (!validation.ok) throw new Error(validation.error);
+  return parsed;
+}

--- a/src/firefox/src/ui/settings.html
+++ b/src/firefox/src/ui/settings.html
@@ -379,6 +379,103 @@
       border-radius: var(--radius);
     }
 
+    .provider-compatibility {
+      margin-top: 14px;
+      border-top: 1px solid var(--border);
+      border-bottom: 1px solid var(--border);
+    }
+    .provider-compatibility summary {
+      display: grid;
+      grid-template-columns: minmax(180px, auto) minmax(0, 1fr);
+      align-items: center;
+      gap: 12px;
+      padding: 11px 28px 11px 0;
+      color: var(--text2);
+      cursor: pointer;
+      list-style: none;
+      position: relative;
+      user-select: none;
+    }
+    .provider-compatibility summary::-webkit-details-marker { display: none; }
+    .provider-compatibility summary::after {
+      content: '+';
+      position: absolute;
+      right: 4px;
+      color: var(--text2);
+      font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+      font-size: 15px;
+    }
+    .provider-compatibility[open] summary::after { content: '−'; }
+    .provider-compatibility summary:hover,
+    .provider-compatibility[open] summary { color: var(--text); }
+    .provider-compatibility-title {
+      font-size: 11px;
+      font-weight: 700;
+      letter-spacing: 0.45px;
+      text-transform: uppercase;
+    }
+    .provider-compatibility-summary {
+      min-width: 0;
+      overflow: hidden;
+      color: var(--text2);
+      font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+      font-size: 10px;
+      text-align: right;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+    .provider-compatibility-body {
+      padding: 14px;
+      margin-bottom: 12px;
+      background: rgba(108,99,255,0.055);
+      border: 1px solid rgba(108,99,255,0.16);
+      border-radius: 8px;
+    }
+    .provider-compatibility-body > p {
+      margin: 0 0 12px;
+      color: var(--text2);
+      font-size: 12px;
+      line-height: 1.5;
+    }
+    .provider-compatibility-grid {
+      display: grid;
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+      gap: 0 12px;
+    }
+    .provider-compatibility-json textarea {
+      min-height: 116px;
+      font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+      font-size: 12px;
+      tab-size: 2;
+    }
+    .provider-compatibility-json textarea[aria-invalid="true"] {
+      border-color: var(--danger, #e66);
+      box-shadow: 0 0 0 1px rgba(238,102,102,0.18);
+    }
+    .provider-compatibility-help {
+      margin-top: 5px;
+      color: var(--text2);
+      font-size: 10px;
+      line-height: 1.45;
+    }
+    .provider-compatibility-footer {
+      display: flex;
+      align-items: center;
+      gap: 10px;
+      min-height: 32px;
+    }
+    .provider-compatibility-validation {
+      color: var(--danger, #e66);
+      font-size: 11px;
+      line-height: 1.35;
+    }
+    @media (max-width: 600px) {
+      .provider-compatibility summary { grid-template-columns: 1fr; gap: 3px; }
+      .provider-compatibility-summary { text-align: left; }
+      .provider-compatibility-grid { grid-template-columns: 1fr; }
+      .provider-compatibility-footer { align-items: flex-start; flex-direction: column; }
+    }
+
     .field { margin-bottom: 10px; }
     .field label {
       display: block;

--- a/src/firefox/src/ui/settings.js
+++ b/src/firefox/src/ui/settings.js
@@ -26,6 +26,12 @@ import {
   USER_MEMORY_MAX_PROMPT_CHARS_KEY,
   normalizeUserMemoryMaxPromptChars,
 } from '../agent/user-memory.js';
+import {
+  detectedCompatibilityPreset,
+  normalizeProviderCompatibility,
+  parseProviderExtraBodyJson,
+  shouldUseOpenAIResponsesApi,
+} from '../providers/provider-compatibility.js';
 
 // Version shown in the subtitle. Kept here so it only needs one update per
 // release; the subtitle string itself is translated.
@@ -1609,6 +1615,164 @@ function providerInputValue(input) {
   return input.value;
 }
 
+function setProviderConfigValue(config, path, value) {
+  const keys = String(path || '').split('.').filter(Boolean);
+  if (!keys.length) return;
+  let target = config;
+  for (const key of keys.slice(0, -1)) {
+    if (!target[key] || typeof target[key] !== 'object' || Array.isArray(target[key])) target[key] = {};
+    target = target[key];
+  }
+  target[keys.at(-1)] = value;
+}
+
+function supportsProviderCompatibilitySettings(id, config = {}) {
+  return id !== 'webbrain_cloud' && ['openai', 'llamacpp', 'azure_openai'].includes(config.type);
+}
+
+function providerExtraBodyText(value) {
+  if (typeof value === 'string') return value;
+  if (!value || typeof value !== 'object' || Array.isArray(value) || Object.keys(value).length === 0) return '';
+  try { return JSON.stringify(value, null, 2); } catch { return ''; }
+}
+
+function prettyCompatibilityValue(value) {
+  const labels = {
+    auto: 'Auto',
+    qwen: 'Qwen',
+    deepseek: 'DeepSeek',
+    openrouter: 'OpenRouter',
+    openai: 'OpenAI',
+    standard: 'standard',
+    custom: 'Custom',
+    off: 'Off',
+    minimal: 'Minimal',
+    low: 'Low',
+    medium: 'Medium',
+    high: 'High',
+    xhigh: 'XHigh',
+    max: 'Max',
+    system: 'System',
+    developer: 'Developer',
+  };
+  return labels[value] || value;
+}
+
+function automaticTokenField(config) {
+  if (shouldUseOpenAIResponsesApi(config)) return 'max_output_tokens';
+  const model = String(config.model || '').toLowerCase();
+  const isNewOfficialContract = config.type === 'openai'
+    && config.category !== 'local'
+    && config.providerName !== 'lmstudio'
+    && /^(gpt-5|gpt-4\.1|o1|o3|o4)/.test(model);
+  return isNewOfficialContract ? 'max_completion_tokens' : 'max_tokens';
+}
+
+function compatibilitySummary(config) {
+  const compat = normalizeProviderCompatibility(config);
+  const detected = detectedCompatibilityPreset(config);
+  const preset = compat.preset === 'auto'
+    ? `Auto → ${prettyCompatibilityValue(detected)}`
+    : prettyCompatibilityValue(compat.preset);
+  const reasoning = compat.reasoningEffort === 'auto'
+    ? 'provider default'
+    : prettyCompatibilityValue(compat.reasoningEffort);
+  const role = compat.systemPromptRole === 'auto' ? 'System' : prettyCompatibilityValue(compat.systemPromptRole);
+  const tokens = compat.maxTokensField === 'auto' ? automaticTokenField(config) : compat.maxTokensField;
+  const extraBody = config.extraBody && typeof config.extraBody === 'object' && !Array.isArray(config.extraBody)
+    ? Object.keys(config.extraBody).length
+    : 0;
+  return `${preset} · reasoning ${reasoning} · ${role} role · ${tokens}${extraBody ? ` · ${extraBody} custom field${extraBody === 1 ? '' : 's'}` : ''}`;
+}
+
+function currentProviderCompatibilityConfig(id) {
+  const source = providersData[id] || {};
+  const config = { ...source, compat: { ...(source.compat || {}) } };
+  document.querySelectorAll(`.provider-compatibility [data-provider="${id}"]`).forEach((input) => {
+    if (input.dataset.type === 'json') {
+      try { config.extraBody = parseProviderExtraBodyJson(input.value); } catch { config.extraBody = {}; }
+      return;
+    }
+    setProviderConfigValue(config, input.dataset.key, providerInputValue(input));
+  });
+  const modelInput = document.querySelector(`input[data-provider="${id}"][data-key="model"]`);
+  const baseUrlInput = document.querySelector(`input[data-provider="${id}"][data-key="baseUrl"]`);
+  if (modelInput) config.model = modelInput.value;
+  if (baseUrlInput) config.baseUrl = baseUrlInput.value;
+  return config;
+}
+
+function refreshProviderCompatibilitySummary(id) {
+  const details = document.querySelector(`.provider-compatibility[data-provider-id="${id}"]`);
+  if (!details) return;
+  const textarea = details.querySelector('textarea[data-type="json"]');
+  const validation = details.querySelector('.provider-compatibility-validation');
+  let error = '';
+  if (textarea) {
+    try { parseProviderExtraBodyJson(textarea.value); } catch (e) { error = e.message; }
+    textarea.setAttribute('aria-invalid', error ? 'true' : 'false');
+  }
+  if (validation) validation.textContent = error;
+  const summary = details.querySelector('.provider-compatibility-summary');
+  if (summary) summary.textContent = compatibilitySummary(currentProviderCompatibilityConfig(id));
+}
+
+function renderProviderCompatibilitySettings(id, config) {
+  if (!supportsProviderCompatibilitySettings(id, config)) return '';
+  const compat = normalizeProviderCompatibility(config);
+  const extraBody = providerExtraBodyText(config.extraBody);
+  const options = (items, current) => items.map(([value, label]) => (
+    `<option value="${value}"${value === current ? ' selected' : ''}>${label}</option>`
+  )).join('');
+  return `
+    <details class="provider-compatibility" data-provider-id="${id}">
+      <summary>
+        <span class="provider-compatibility-title">Advanced model compatibility</span>
+        <span class="provider-compatibility-summary">${escapeHtml(compatibilitySummary(config))}</span>
+      </summary>
+      <div class="provider-compatibility-body">
+        <p>Keep these on Auto unless the model or endpoint documents a different request contract.</p>
+        <div class="provider-compatibility-grid">
+          <div class="field">
+            <label>Compatibility preset</label>
+            <select data-provider="${id}" data-key="compat.preset" data-type="select">
+              ${options([['auto', 'Auto'], ['openai', 'OpenAI'], ['qwen', 'Qwen'], ['deepseek', 'DeepSeek'], ['openrouter', 'OpenRouter'], ['custom', 'Custom']], compat.preset)}
+            </select>
+          </div>
+          <div class="field">
+            <label>Reasoning</label>
+            <select data-provider="${id}" data-key="compat.reasoningEffort" data-type="select">
+              ${options([['auto', 'Auto'], ['off', 'Off'], ['minimal', 'Minimal'], ['low', 'Low'], ['medium', 'Medium'], ['high', 'High'], ['xhigh', 'XHigh'], ['max', 'Max']], compat.reasoningEffort)}
+            </select>
+          </div>
+          <div class="field">
+            <label>System prompt role</label>
+            <select data-provider="${id}" data-key="compat.systemPromptRole" data-type="select">
+              ${options([['auto', 'Auto'], ['system', 'System'], ['developer', 'Developer']], compat.systemPromptRole)}
+            </select>
+          </div>
+          <div class="field">
+            <label>Token limit field</label>
+            <select data-provider="${id}" data-key="compat.maxTokensField" data-type="select">
+              ${options([['auto', 'Auto'], ['max_tokens', 'max_tokens'], ['max_completion_tokens', 'max_completion_tokens']], compat.maxTokensField)}
+            </select>
+          </div>
+        </div>
+        <div class="field provider-compatibility-json">
+          <label>Custom request body (JSON)</label>
+          <textarea data-provider="${id}" data-key="extraBody" data-type="json" spellcheck="false"
+                    aria-invalid="false" placeholder='{"chat_template_kwargs":{"enable_thinking":true}}'>${escapeHtml(extraBody)}</textarea>
+          <div class="provider-compatibility-help">Merged after the preset. Per-call WebBrain overrides still win. Model, messages, tools, stream, and token-limit fields are protected.</div>
+        </div>
+        <div class="provider-compatibility-footer">
+          <button type="button" class="btn-secondary btn-reset-compatibility" data-provider="${id}">Reset to automatic</button>
+          <span class="provider-compatibility-validation" role="status"></span>
+        </div>
+      </div>
+    </details>
+  `;
+}
+
 // Effective tier for the dropdown's initial value — same precedence as the
 // provider getter: cloud is forced full; an explicit promptTier wins; the
 // legacy useCompactPrompt boolean maps to compact; otherwise local → mid.
@@ -1639,6 +1803,9 @@ function providerSearchTextForEntry(id, config, fieldDefs) {
     config.model,
     config.baseUrl,
     fieldText,
+    supportsProviderCompatibilitySettings(id, config)
+      ? 'advanced model compatibility reasoning thinking system developer max tokens custom request body json'
+      : '',
   ].filter(Boolean).join(' '));
 }
 
@@ -1743,8 +1910,8 @@ function renderProviders() {
     openai: {
       fields: [
         { key: 'apiKey', labelKey: 'st.provider.field.api_key', type: 'password', placeholder: 'sk-...' },
-        { key: 'model', labelKey: 'st.provider.field.model', type: 'text', placeholder: 'gpt-5.5',
-          suggestions: ['gpt-5.5', 'gpt-5.4', 'gpt-5.2', 'gpt-5.3-codex'] },
+        { key: 'model', labelKey: 'st.provider.field.model', type: 'text', placeholder: 'gpt-5.6-terra',
+          suggestions: ['gpt-5.6-terra', 'gpt-5.6-sol', 'gpt-5.6-luna', 'gpt-5.6', 'gpt-5.5', 'gpt-5.4', 'gpt-5.2', 'gpt-5.3-codex'] },
         { key: 'baseUrl', labelKey: 'st.provider.field.api_base_url', type: 'text', placeholder: 'https://api.openai.com/v1' },
         ...COST_ESTIMATE_FIELDS,
       ],
@@ -2018,10 +2185,12 @@ function renderProviders() {
            ${t('st.providers.webbrain_data_use.body', { privacyLink, subscribeLink, accountLink })}
          </div>`;
     }
+    const compatibilitySettings = renderProviderCompatibilitySettings(id, config);
 
     const body = `
       ${fieldsHTML}
       ${providerNote}
+      ${compatibilitySettings}
       <div class="btn-row">
         <button class="btn-primary btn-save" data-provider="${id}">${escapeHtml(t('st.providers.save'))}</button>
         <button class="btn-secondary btn-test" data-provider="${id}">${escapeHtml(t('st.providers.test'))}</button>
@@ -2075,6 +2244,24 @@ function renderProviders() {
         input.style.display = 'none';
         input.value = sel.value;
       }
+      refreshProviderCompatibilitySummary(providerId);
+    });
+  });
+  document.querySelectorAll('.provider-compatibility select[data-provider], .provider-compatibility textarea[data-provider]').forEach((input) => {
+    const eventName = input.tagName === 'TEXTAREA' ? 'input' : 'change';
+    input.addEventListener(eventName, () => refreshProviderCompatibilitySummary(input.dataset.provider));
+  });
+  document.querySelectorAll('input[data-key="model"], input[data-key="baseUrl"]').forEach((input) => {
+    input.addEventListener('input', () => refreshProviderCompatibilitySummary(input.dataset.provider));
+  });
+  document.querySelectorAll('.btn-reset-compatibility').forEach((button) => {
+    button.addEventListener('click', () => {
+      const id = button.dataset.provider;
+      const details = button.closest('.provider-compatibility');
+      details?.querySelectorAll('select[data-provider]').forEach((select) => { select.value = 'auto'; });
+      const textarea = details?.querySelector('textarea[data-type="json"]');
+      if (textarea) textarea.value = '';
+      refreshProviderCompatibilitySummary(id);
     });
   });
   document.querySelectorAll('.loaded-model-dialog').forEach(dialog => {
@@ -2342,13 +2529,16 @@ function setProviderTestResult(id, className, message, color) {
 }
 
 async function saveProvider(id, { showFlash = true, markConfigured = true } = {}) {
-  const inputs = document.querySelectorAll(`input[data-provider="${id}"], select[data-provider="${id}"]`);
+  const inputs = document.querySelectorAll(`input[data-provider="${id}"], select[data-provider="${id}"], textarea[data-provider="${id}"]`);
   const config = {};
-  inputs.forEach(input => {
-    config[input.dataset.key] = providerInputValue(input);
-  });
 
   try {
+    inputs.forEach(input => {
+      const value = input.dataset.type === 'json'
+        ? parseProviderExtraBodyJson(input.value)
+        : providerInputValue(input);
+      setProviderConfigValue(config, input.dataset.key, value);
+    });
     await sendToBackground('update_provider', { providerId: id, config, markConfigured });
   } catch (e) {
     if (showFlash) setProviderTestResult(id, 'fail', t('st.providers.failed', { error: e.message }));
@@ -2408,11 +2598,11 @@ async function testProvider(id) {
 }
 
 function syncInputsIntoProvidersData() {
-  document.querySelectorAll('input[data-provider], select[data-provider]').forEach((input) => {
+  document.querySelectorAll('input[data-provider], select[data-provider], textarea[data-provider]').forEach((input) => {
     const id = input.dataset.provider;
     const key = input.dataset.key;
     if (!id || !key || !providersData[id]) return;
-    providersData[id][key] = providerInputValue(input);
+    setProviderConfigValue(providersData[id], key, providerInputValue(input));
   });
 }
 

--- a/test/run.js
+++ b/test/run.js
@@ -479,6 +479,12 @@ const { AzureOpenAIProvider: AzureOpenAIProviderCh } = await import(
 const { AzureOpenAIProvider: AzureOpenAIProviderFx } = await import(
   'file://' + path.join(ROOT, 'src/firefox/src/providers/azure-openai.js').replace(/\\/g, '/')
 );
+const ProviderCompatibilityCh = await import(
+  'file://' + path.join(ROOT, 'src/chrome/src/providers/provider-compatibility.js').replace(/\\/g, '/')
+);
+const ProviderCompatibilityFx = await import(
+  'file://' + path.join(ROOT, 'src/firefox/src/providers/provider-compatibility.js').replace(/\\/g, '/')
+);
 const { AwsBedrockProvider: AwsBedrockProviderCh } = await import(
   'file://' + path.join(ROOT, 'src/chrome/src/providers/aws-bedrock.js').replace(/\\/g, '/')
 );
@@ -10366,6 +10372,44 @@ test('settings exposes a Cloudflare account ID field before the base URL templat
   }
 });
 
+test('settings exposes collapsed compatibility controls only for compatible provider types', () => {
+  for (const [label, settingsRel, htmlRel, PM] of [
+    ['chrome', 'src/chrome/src/ui/settings.js', 'src/chrome/src/ui/settings.html', ProviderManagerCh],
+    ['firefox', 'src/firefox/src/ui/settings.js', 'src/firefox/src/ui/settings.html', ProviderManagerFx],
+  ]) {
+    const settings = fs.readFileSync(path.join(ROOT, settingsRel), 'utf8');
+    const html = fs.readFileSync(path.join(ROOT, htmlRel), 'utf8');
+    assert.match(
+      settings,
+      /id !== 'webbrain_cloud' && \['openai', 'llamacpp', 'azure_openai'\]\.includes\(config\.type\)/,
+      `${label}: compatibility controls should exclude Cloud, Anthropic, and Bedrock`,
+    );
+    for (const text of [
+      'Advanced model compatibility',
+      'Compatibility preset',
+      'Reasoning',
+      'System prompt role',
+      'Token limit field',
+      'Custom request body (JSON)',
+      'Reset to automatic',
+    ]) {
+      assert.match(settings, new RegExp(text.replace(/[()]/g, '\\$&')), `${label}: missing ${text}`);
+    }
+    assert.match(settings, /data-key="compat\.reasoningEffort"/, `${label}: reasoning setting should persist under compat`);
+    assert.match(settings, /data-key="extraBody" data-type="json"/, `${label}: custom body textarea should be typed as JSON`);
+    assert.match(settings, /parseProviderExtraBodyJson\(input\.value\)/, `${label}: Save and Test should reject invalid JSON before updating the provider`);
+    assert.match(settings, /textarea\[data-provider/, `${label}: provider save should include the JSON textarea`);
+    assert.match(html, /\.provider-compatibility \{/, `${label}: compatibility disclosure styling missing`);
+    assert.match(html, /textarea\[aria-invalid="true"\]/, `${label}: invalid JSON needs a visible error state`);
+
+    const defaults = new PM()._defaultConfigs();
+    assert.equal(defaults.openai.model, 'gpt-5.6-terra', `${label}: Terra should be the new-install OpenAI default`);
+    for (const model of ['gpt-5.6-terra', 'gpt-5.6-sol', 'gpt-5.6-luna', 'gpt-5.6']) {
+      assert.match(settings, new RegExp(`['"]${model.replace('.', '\\.')}['"]`), `${label}: model picker missing ${model}`);
+    }
+  }
+});
+
 test('settings scopes WebBrain Cloud billing button to provider card only', () => {
   for (const [label, settingsRel, htmlRel] of [
     ['chrome', 'src/chrome/src/ui/settings.js', 'src/chrome/src/ui/settings.html'],
@@ -14411,6 +14455,7 @@ test('inferContextWindow: model-aware cloud/router defaults and local 16k fallba
     for (const providerName of ['lmstudio', 'jan', 'vllm', 'sglang', 'localai']) {
       assert.equal(infer({ category: 'local', providerName, model: 'qwen3.7-plus' }), 16384);
     }
+    assert.equal(infer({ category: 'cloud', providerName: 'openai', model: 'gpt-5.6-terra' }), 1050000);
     assert.equal(infer({ category: 'cloud', providerName: 'openai', model: 'gpt-5.5-pro' }), 1050000);
     assert.equal(infer({ category: 'cloud', providerName: 'openai', model: 'gpt-5.5' }), 400000);
     assert.equal(infer({ category: 'cloud', providerName: 'anthropic', model: 'claude-opus-4-8' }), 1000000);
@@ -16106,6 +16151,228 @@ test('OpenAI-compatible local providers always use legacy request token fields',
       assert.equal(body.max_tokens, 123, `${providerName} should use max_tokens`);
       assert.equal(body.max_completion_tokens, undefined, `${providerName} should not use max_completion_tokens`);
     }
+  }
+});
+
+test('provider compatibility defaults preserve legacy chat request bodies', () => {
+  const messages = [{ role: 'system', content: 'rules' }, { role: 'user', content: 'hello' }];
+  for (const Provider of [OpenAIProviderCh, OpenAIProviderFx]) {
+    const provider = new Provider({
+      category: 'cloud',
+      providerName: 'custom',
+      baseUrl: 'https://example.test/v1',
+      model: 'gpt-4o',
+    });
+    assert.deepEqual(provider._buildChatCompletionsBody(messages, { temperature: 0.2, maxTokens: 123 }, false), {
+      model: 'gpt-4o',
+      messages,
+      stream: false,
+      temperature: 0.2,
+      max_tokens: 123,
+    });
+    assert.deepEqual(provider._buildChatCompletionsBody(messages, { temperature: 0.2, maxTokens: 123 }, true), {
+      model: 'gpt-4o',
+      messages,
+      stream: true,
+      temperature: 0.2,
+      max_tokens: 123,
+    });
+  }
+  for (const Provider of [LlamaCppProviderCh, LlamaCppProviderFx]) {
+    const provider = new Provider({ baseUrl: 'http://localhost:8080' });
+    assert.deepEqual(provider._buildRequestBody(messages, { temperature: 0.2, maxTokens: 123 }, false), {
+      messages,
+      temperature: 0.2,
+      stream: false,
+      max_tokens: 123,
+    });
+  }
+  for (const Provider of [AzureOpenAIProviderCh, AzureOpenAIProviderFx]) {
+    const provider = new Provider({
+      baseUrl: 'https://x.openai.azure.com',
+      model: 'deployment',
+      apiVersion: '2024-10-21',
+      supportsStreamUsageOptions: false,
+    });
+    assert.deepEqual(provider._buildRequestBody(messages, { temperature: 0.2, maxTokens: 123 }, false), {
+      messages,
+      stream: false,
+      temperature: 0.2,
+      max_tokens: 123,
+    });
+  }
+});
+
+test('provider compatibility maps reasoning, roles, token fields, and per-call overrides safely', () => {
+  const originalMessages = [{ role: 'system', content: 'rules' }, { role: 'user', content: 'hello' }];
+  for (const compat of [ProviderCompatibilityCh, ProviderCompatibilityFx]) {
+    const qwenConfig = {
+      providerName: 'vllm',
+      model: 'Qwen/Qwen3.6-27B',
+      compat: { reasoningEffort: 'high', systemPromptRole: 'developer', maxTokensField: 'max_completion_tokens' },
+      extraBody: { chat_template_kwargs: { custom_flag: true }, repetition_penalty: 1.05 },
+    };
+    const mapped = compat.mapProviderMessages(originalMessages, qwenConfig);
+    assert.equal(mapped[0].role, 'developer');
+    assert.equal(originalMessages[0].role, 'system', 'role mapping must not mutate stored history');
+
+    const body = { messages: mapped };
+    compat.addConfiguredMaxTokens(body, 99, qwenConfig, 'max_tokens');
+    const merged = compat.mergeProviderRequestBody(body, qwenConfig, {
+      chat_template_kwargs: { enable_thinking: false },
+    });
+    assert.equal(merged.max_completion_tokens, 99);
+    assert.equal(merged.max_tokens, undefined);
+    assert.deepEqual(merged.chat_template_kwargs, { custom_flag: true, enable_thinking: false });
+    assert.equal(merged.repetition_penalty, 1.05);
+    assert.equal(qwenConfig.extraBody.chat_template_kwargs.custom_flag, true, 'request merging must not mutate saved config');
+
+    assert.deepEqual(compat.compatibilityRequestBody({
+      providerName: 'deepseek',
+      model: 'deepseek-v4',
+      compat: { reasoningEffort: 'off' },
+    }), { chat_template_kwargs: { thinking: false } });
+    assert.deepEqual(compat.compatibilityRequestBody({
+      providerName: 'openrouter',
+      compat: { reasoningEffort: 'medium' },
+    }), { reasoning: { effort: 'medium' } });
+    assert.deepEqual(compat.compatibilityRequestBody({
+      providerName: 'custom',
+      baseUrl: 'https://proxy.example/v1',
+      model: 'gpt-5.6-terra',
+      compat: { preset: 'openai', reasoningEffort: 'off' },
+    }), { reasoning_effort: 'none' });
+
+    assert.throws(
+      () => compat.parseProviderExtraBodyJson('{"model":"blocked"}'),
+      /reserved fields: model/,
+    );
+    assert.throws(() => compat.parseProviderExtraBodyJson('[]'), /must be a JSON object/);
+    assert.throws(() => compat.parseProviderExtraBodyJson('{bad'), /not valid JSON/);
+    assert.deepEqual(
+      compat.mergeProviderRequestBody({ model: 'safe', stream: false }, {
+        extraBody: { model: 'override', stream: true, temperature: 0.4 },
+      }),
+      { model: 'safe', stream: false, temperature: 0.4 },
+    );
+  }
+});
+
+test('official GPT-5.6 uses Responses while older and custom OpenAI-compatible endpoints stay on Chat Completions', () => {
+  const tools = [{
+    type: 'function',
+    function: {
+      name: 'click',
+      description: 'Click something',
+      parameters: { type: 'object', properties: { ref: { type: 'string' } }, required: ['ref'] },
+    },
+  }];
+  const messages = [
+    { role: 'system', content: 'rules' },
+    { role: 'user', content: 'go' },
+    { role: 'assistant', content: null, tool_calls: [{ id: 'call_1', type: 'function', function: { name: 'click', arguments: '{"ref":"r1"}' } }] },
+    { role: 'tool', tool_call_id: 'call_1', content: '{"ok":true}' },
+  ];
+  for (const Provider of [OpenAIProviderCh, OpenAIProviderFx]) {
+    const provider = new Provider({
+      category: 'cloud',
+      providerName: 'openai',
+      baseUrl: 'https://api.openai.com/v1',
+      model: 'gpt-5.6-terra',
+      compat: { reasoningEffort: 'high', systemPromptRole: 'developer' },
+    });
+    assert.equal(provider._usesResponsesApi(), true);
+    const body = provider._buildResponsesBody(messages, { tools, maxTokens: 321 }, false);
+    assert.equal(body.max_output_tokens, 321);
+    assert.equal(body.max_completion_tokens, undefined);
+    assert.equal(body.messages, undefined);
+    assert.deepEqual(body.reasoning, { effort: 'high' });
+    assert.equal(body.input[0].role, 'developer');
+    assert.deepEqual(body.input[2], {
+      type: 'function_call',
+      call_id: 'call_1',
+      name: 'click',
+      arguments: '{"ref":"r1"}',
+    });
+    assert.deepEqual(body.input[3], {
+      type: 'function_call_output',
+      call_id: 'call_1',
+      output: '{"ok":true}',
+    });
+    assert.deepEqual(body.tools[0], {
+      type: 'function',
+      name: 'click',
+      description: 'Click something',
+      parameters: tools[0].function.parameters,
+      strict: false,
+    });
+
+    const parsed = provider._parseResponsesData({
+      output: [
+        { type: 'reasoning', summary: [{ type: 'summary_text', text: 'Checked the page.' }] },
+        { type: 'message', content: [{ type: 'output_text', text: 'Done' }] },
+        { type: 'function_call', call_id: 'call_2', name: 'click', arguments: '{"ref":"r2"}' },
+      ],
+      usage: { input_tokens: 10, output_tokens: 4, total_tokens: 14 },
+    });
+    assert.equal(parsed.content, 'Done');
+    assert.equal(parsed.reasoningContent, 'Checked the page.');
+    assert.equal(parsed.toolCalls[0].id, 'call_2');
+    assert.equal(parsed.usage.prompt_tokens, 10);
+    assert.equal(parsed.usage.completion_tokens, 4);
+
+    assert.equal(new Provider({
+      providerName: 'openai',
+      baseUrl: 'https://api.openai.com/v1',
+      model: 'gpt-5.5',
+    })._usesResponsesApi(), false);
+    assert.equal(new Provider({
+      providerName: 'openai',
+      baseUrl: 'https://proxy.example/v1',
+      model: 'gpt-5.6-terra',
+    })._usesResponsesApi(), false);
+  }
+});
+
+test('official GPT-5.6 streaming uses Responses events for text, tools, and usage', async () => {
+  const originalFetch = globalThis.fetch;
+  try {
+    for (const Provider of [OpenAIProviderCh, OpenAIProviderFx]) {
+      let capturedUrl = '';
+      let capturedBody = null;
+      globalThis.fetch = async (url, options = {}) => {
+        capturedUrl = String(url);
+        capturedBody = JSON.parse(options.body);
+        const events = [
+          { type: 'response.output_text.delta', delta: 'Hello' },
+          { type: 'response.output_item.added', output_index: 1, item: { type: 'function_call', call_id: 'call_1', name: 'click', arguments: '' } },
+          { type: 'response.function_call_arguments.delta', output_index: 1, delta: '{"ref":"r1"}' },
+          { type: 'response.completed', response: { usage: { input_tokens: 8, output_tokens: 3, total_tokens: 11 } } },
+        ].map((event) => `data: ${JSON.stringify(event)}\n\n`).join('');
+        return new Response(events, { status: 200, headers: { 'Content-Type': 'text/event-stream' } });
+      };
+      const provider = new Provider({
+        category: 'cloud',
+        providerName: 'openai',
+        baseUrl: 'https://api.openai.com/v1',
+        model: 'gpt-5.6-terra',
+        compat: { reasoningEffort: 'low' },
+      });
+      const chunks = [];
+      for await (const chunk of provider.chatStream([{ role: 'user', content: 'hello' }], { maxTokens: 10 })) {
+        chunks.push(chunk);
+      }
+      assert.equal(capturedUrl, 'https://api.openai.com/v1/responses');
+      assert.equal(capturedBody.stream, true);
+      assert.deepEqual(capturedBody.reasoning, { effort: 'low' });
+      assert.equal(chunks[0].content, 'Hello');
+      assert.equal(chunks[1].content[0].id, 'call_1');
+      assert.equal(chunks[2].content[0].function.arguments, '{"ref":"r1"}');
+      assert.equal(chunks[3].usage.prompt_tokens, 8);
+      assert.equal(chunks.at(-1).type, 'done');
+    }
+  } finally {
+    globalThis.fetch = originalFetch;
   }
 });
 


### PR DESCRIPTION
## Summary

- route official OpenAI GPT-5.6 requests through the Responses API so function tools and reasoning can be used together
- keep older models and custom OpenAI-compatible endpoints on Chat Completions by default
- add shared OpenAI, Qwen, DeepSeek, and OpenRouter compatibility mappings for reasoning, system roles, token-limit fields, and custom request JSON
- add GPT-5.6 Terra, Sol, Luna, and alias model choices, with Terra as the new-install default
- add a collapsed Advanced model compatibility drawer to provider settings in both Chrome and Firefox

## Root cause

GPT-5.6 rejects function tools combined with `reasoning_effort` on `/v1/chat/completions`. Setting the effort to `none` avoids the error but disables reasoning. Official GPT-5.6 requests now use `/v1/responses`, while endpoint detection remains deliberately narrow so existing providers and older APIs retain their current request shape.

This also addresses the configurable provider request mappings described in #236 and the GPT-5.6 failure reported in #382.

## User impact

- GPT-5.6 can retain reasoning while using WebBrain tools.
- Existing saved provider selections remain unchanged.
- Automatic compatibility settings preserve legacy bodies for OpenAI-compatible, llama.cpp, and Azure endpoints.
- Invalid custom JSON is rejected before Save or Test connection.

## Validation

- `node test/run.js`: 844 passed, 1 failed (845 total)
- the sole failure is the pre-existing repository mismatch between `package.json` 23.3.7 and the newest `CHANGELOG.md` entry 23.3.6; the same failure was present before this change
- `git diff --check`
- JavaScript syntax checks for changed provider, settings, and test files
- Chrome/Firefox compatibility module parity check
- visual interaction check for collapsed/expanded settings, invalid JSON feedback, and reset behavior
