### PR TITLE
agent: add adapters for Bilibili and Xiaohongshu

### DIFF
--- a/src/chrome/src/agent/adapters.js
+++ b/src/chrome/src/agent/adapters.js
@@ -131,6 +131,40 @@ function isFacebookInfiniteScrollUrl(url) {
   return /^\/(?:watch|groups|marketplace|search)(?:\/|$)/.test(path);
 }
 
+function isBilibiliUrl(url) {
+  const parts = adapterUrlParts(url);
+  if (!parts) return false;
+  const hostname = normalizedHostname(parts.parsed.hostname);
+  return hostname === 'bilibili.com' || hostname.endsWith('.bilibili.com');
+}
+
+function isBilibiliInfiniteScrollUrl(url) {
+  const parts = adapterUrlParts(url);
+  if (!parts || !isBilibiliUrl(url)) return false;
+  const hostname = normalizedHostname(parts.parsed.hostname);
+  if (hostname === 't.bilibili.com') return true;
+  if (hostname === 'bilibili.com' && parts.path === '/') return true;
+  return hostname === 'space.bilibili.com'
+    && /^\/\d+\/dynamic(?:\/|$)/.test(parts.path);
+}
+
+function isXiaohongshuUrl(url) {
+  const parts = adapterUrlParts(url);
+  if (!parts) return false;
+  const hostname = normalizedHostname(parts.parsed.hostname);
+  return hostname === 'xiaohongshu.com' || hostname.endsWith('.xiaohongshu.com');
+}
+
+function isXiaohongshuInfiniteScrollUrl(url) {
+  const parts = adapterUrlParts(url);
+  if (!parts || !isXiaohongshuUrl(url)) return false;
+  if (normalizedHostname(parts.parsed.hostname) !== 'xiaohongshu.com') return false;
+  return parts.path === '/'
+    || parts.path === '/explore'
+    || parts.path === '/search_result'
+    || /^\/user\/profile\/[^/]+(?:\/|$)/.test(parts.path);
+}
+
 function isMastodonInfiniteScrollUrl(url) {
   const { path } = adapterUrlParts(url) || {};
   if (!path) return false;
@@ -16366,6 +16400,34 @@ const ADAPTERS = [
   },
 
   // ─── Social (gaps) ────────────────────────────────────────────────────
+  {
+    name: 'bilibili',
+    category: 'general',
+    matches: isBilibiliUrl,
+    fullPageCapture: { infiniteScroll: isBilibiliInfiniteScrollUrl },
+    notes: `
+- Video pages (/video/BV...) may contain a multi-part playlist ("视频选集" / "分P"). Confirm the active part and the ?p= value before summarizing or seeking; the page title and description may describe the whole submission.
+- Player-only controls such as "字幕" (subtitles), "弹幕" (danmaku), speed, and episode selection may appear only after the player is focused or hovered. Use the visible tree or screenshot after revealing the controls; do not assume the description is a transcript.
+- Search runs on search.bilibili.com. Result tabs such as "综合", "视频", "番剧", "直播", and "用户" change the result type; re-read the page after switching tabs instead of reusing card indices.
+- Creator profiles live at space.bilibili.com/<uid>. "动态", "投稿", "合集和列表", and "收藏" are separate lazy-loaded views; collect exact video links before scrolling because card order can change.
+- Distinguish scrolling "弹幕" over the player from threaded "评论" below it. Comments and dynamic feeds load incrementally, and pinned comments can remain above newer replies.
+- "关注", "点赞", "投币", "收藏", "弹幕", "评论", and "一键三连" are state-changing. Do not activate them during read-only tasks; after an explicit request, verify the resulting state instead of trusting the click alone.
+- These interactions require sign-in and may open QR-code or SMS verification. Surface the QR/code step to the user rather than retrying or claiming the action succeeded.`,
+  },
+  {
+    name: 'xiaohongshu',
+    category: 'general',
+    matches: isXiaohongshuUrl,
+    fullPageCapture: { infiniteScroll: isXiaohongshuInfiniteScrollUrl },
+    notes: `
+- "发现" (/explore), search results, and profile note grids are infinite, reflowing masonry feeds. Extract each visible card's title, author, and exact link before scrolling; card positions and indices are not stable.
+- Note and profile links commonly carry xsec_token / xsec_source query parameters. Follow or preserve the page's actual href; do not synthesize a URL from the visible note ID or author name.
+- Opening a note from a feed may show it in a topmost modal over the still-mounted feed. Scope reads and actions to that dialog, and scroll the note/comment pane rather than the background page.
+- Note text, hashtags, and comments load incrementally. Expand visible "展开" controls and re-read after scrolling; do not mix neighboring feed-card text into the active note.
+- Profiles at /user/profile/<id> separate "笔记" and "收藏". A missing collection may be private ("收藏内容不可见"), not an empty or failed page.
+- "关注", "点赞", "收藏", "评论", and "发布" are state-changing and normally require sign-in. If a QR-code or phone verification prompt appears, ask the user to complete it.
+- "发布" opens the separate Creator Center on creator.xiaohongshu.com. Filling media, title, and body is not proof of publication; after an explicit publish request, verify the success state and final public note URL.`,
+  },
   {
     name: 'instagram',
     category: 'general',

--- a/src/chrome/src/cdp/cdp-client.js
+++ b/src/chrome/src/cdp/cdp-client.js
@@ -1187,13 +1187,42 @@ export class CDPClient {
     // on pages where the two paths race (shadow DOM, overlays, etc.).
     const result = await this.evaluate(tabId, `
       (() => {
+        const hostname = String(location.hostname || '').toLowerCase().replace(/\\.$/, '');
+        const onHost = (domain) => hostname === domain || hostname.endsWith('.' + domain);
+        const SITE_RULES = onHost('bilibili.com') ? [
+          ['.video-like', '点赞'], ['.video-coin', '投币'],
+          ['.video-fav', '收藏'], ['.video-share', '分享'],
+          ['.follow-btn', '关注'], ['.bpx-player-follow', '关注'],
+          ['.reply-box-send', '发布评论'],
+        ] : onHost('xiaohongshu.com') ? [
+          ['.like-wrapper', '点赞'], ['.collect-wrapper', '收藏'],
+          ['.chat-wrapper', '评论'], ['.share-wrapper', '分享'],
+          ['.follow-wrapper', '关注'], ['.follow-btn', '关注'],
+          ['.follow-button', '关注'], ['.send-btn', '发布评论'],
+          ['.publish-btn', '发布'], ['.publish-button', '发布'],
+        ] : [];
         const SELECTORS = [
           'a[href]', 'button', 'input:not([type="hidden"])', 'textarea', 'select',
           '[role="button"]', '[role="link"]', '[role="tab"]', '[role="menuitem"]',
           '[role="textbox"]', '[role="combobox"]', '[role="searchbox"]',
           '[contenteditable=""]', '[contenteditable="true"]', '[contenteditable="plaintext-only"]',
-          '[onclick]', '[data-action]', 'summary', 'label'
+          '[onclick]', '[data-action]', 'summary', 'label',
+          ...SITE_RULES.map(([selector]) => selector)
         ];
+
+        function interactiveText(el) {
+          for (const [selector, label] of SITE_RULES) {
+            try {
+              if (!el.matches(selector)) continue;
+            } catch (e) {
+              continue;
+            }
+            const explicit = String(el.getAttribute('aria-label') || el.getAttribute('title') || '').replace(/\\s+/g, ' ').trim();
+            const rendered = String(el.innerText || el.textContent || '').replace(/\\s+/g, ' ').trim().slice(0, 80);
+            return explicit || (rendered && rendered.includes(label) ? rendered : rendered ? label + ' ' + rendered : label);
+          }
+          return (el.innerText || el.value || el.placeholder || el.title || el.ariaLabel || '').trim();
+        }
 
         function isVisiblyInteractive(el) {
           if (!el || el.tagName === 'BODY' || el.tagName === 'HTML') return false;
@@ -1234,7 +1263,7 @@ export class CDPClient {
             tag: el.tagName.toLowerCase(),
             type: el.type || '',
             role: el.getAttribute('role') || '',
-            text: (el.innerText || el.value || el.placeholder || el.title || el.ariaLabel || '').trim().slice(0, 100),
+            text: interactiveText(el).slice(0, 100),
             id: el.id || '',
             name: el.name || '',
             href: el.href || '',

--- a/src/chrome/src/content/accessibility-tree.js
+++ b/src/chrome/src/content/accessibility-tree.js
@@ -113,7 +113,74 @@
     label: 'label',
   };
 
+  // Some high-traffic media sites render their primary actions as plain
+  // div/span wrappers with delegated Vue event handlers. They are genuinely
+  // clickable, but expose none of the native/ARIA signals used below. Keep
+  // this list intentionally narrow and hostname-scoped so generic page
+  // containers are not promoted to buttons elsewhere.
+  const SITE_INTERACTION_RULES = {
+    bilibili: [
+      ['.video-like', '点赞'],
+      ['.video-coin', '投币'],
+      ['.video-fav', '收藏'],
+      ['.video-share', '分享'],
+      ['.follow-btn', '关注'],
+      ['.bpx-player-follow', '关注'],
+      ['.reply-box-send', '发布评论'],
+    ],
+    xiaohongshu: [
+      ['.like-wrapper', '点赞'],
+      ['.collect-wrapper', '收藏'],
+      ['.chat-wrapper', '评论'],
+      ['.share-wrapper', '分享'],
+      ['.follow-wrapper', '关注'],
+      ['.follow-btn', '关注'],
+      ['.follow-button', '关注'],
+      ['.send-btn', '发布评论'],
+      ['.publish-btn', '发布'],
+      ['.publish-button', '发布'],
+    ],
+  };
+
+  function currentSiteInteractionConfig() {
+    const hostname = String(location.hostname || '').toLowerCase().replace(/\.$/, '');
+    const onHost = (domain) => hostname === domain || hostname.endsWith(`.${domain}`);
+    if (onHost('bilibili.com')) return { key: 'bilibili', rules: SITE_INTERACTION_RULES.bilibili };
+    if (onHost('xiaohongshu.com')) return { key: 'xiaohongshu', rules: SITE_INTERACTION_RULES.xiaohongshu };
+    return { key: '', rules: [] };
+  }
+
+  function getSiteInteractionDescriptor(el) {
+    if (!el || typeof el.matches !== 'function') return null;
+    for (const [selector, label] of currentSiteInteractionConfig().rules) {
+      try {
+        if (!el.matches(selector)) continue;
+      } catch {
+        continue;
+      }
+      const explicit = String(
+        el.getAttribute('aria-label') || el.getAttribute('title') || ''
+      ).replace(/\s+/g, ' ').trim();
+      const rendered = String(el.innerText || el.textContent || '')
+        .replace(/\s+/g, ' ').trim().slice(0, 80);
+      const name = explicit || (
+        rendered && rendered.includes(label) ? rendered
+          : rendered ? `${label} ${rendered}` : label
+      );
+      return { selector, label, name };
+    }
+    return null;
+  }
+
+  window.__wbSiteInteractions = Object.freeze({
+    selectors: () => currentSiteInteractionConfig().rules.map(([selector]) => selector),
+    describe: getSiteInteractionDescriptor,
+    isInteractive: (el) => !!getSiteInteractionDescriptor(el),
+    shouldPierceShadowRoots: () => currentSiteInteractionConfig().key === 'bilibili',
+  });
+
   function getRole(el) {
+    if (getSiteInteractionDescriptor(el)) return 'button';
     const explicit = el.getAttribute('role');
     if (explicit) return explicit;
     const tag = el.tagName.toLowerCase();
@@ -179,6 +246,9 @@
   // ── Accessible name (matches Claude's priority order) ───────────────────
   function getAccessibleName(el) {
     const tag = el.tagName.toLowerCase();
+
+    const siteInteraction = getSiteInteractionDescriptor(el);
+    if (siteInteraction) return siteInteraction.name;
 
     // <select> — prefer the currently selected option's label.
     if (tag === 'select') {
@@ -361,6 +431,7 @@
   function isInteractive(el) {
     const tag = el.tagName.toLowerCase();
     if (INTERACTIVE_TAGS.has(tag)) return true;
+    if (getSiteInteractionDescriptor(el)) return true;
     if (el.getAttribute('onclick') !== null) return true;
     if (el.getAttribute('tabindex') !== null) return true;
     const role = el.getAttribute('role');
@@ -538,6 +609,14 @@
       const nextDepth = included ? depth + 1 : depth;
       for (const child of el.children) {
         walk(child, nextDepth, opts, lines);
+      }
+      // Bilibili's current comment system is a hierarchy of open custom-
+      // element shadow roots. Traverse it here so the comment editor and
+      // Publish/Reply buttons receive the same stable ref_ids as light DOM.
+      if (window.__wbSiteInteractions.shouldPierceShadowRoots() && el.shadowRoot) {
+        for (const child of el.shadowRoot.children || []) {
+          walk(child, nextDepth, opts, lines);
+        }
       }
     }
   }

--- a/src/chrome/src/content/content.js
+++ b/src/chrome/src/content/content.js
@@ -214,6 +214,30 @@
     'label',
   ];
 
+  function _siteInteractiveSelectors() {
+    try {
+      return window.__wbSiteInteractions?.selectors?.() || [];
+    } catch {
+      return [];
+    }
+  }
+
+  function _siteInteractionText(el) {
+    try {
+      const descriptor = window.__wbSiteInteractions?.describe?.(el);
+      if (descriptor?.name) return descriptor.name;
+    } catch {}
+    return (el?.innerText || el?.value || el?.placeholder || el?.title || el?.ariaLabel || '').trim();
+  }
+
+  function _isSiteInteractive(el) {
+    try {
+      return !!window.__wbSiteInteractions?.isInteractive?.(el);
+    } catch {
+      return false;
+    }
+  }
+
   function isVisiblyInteractive(el) {
     if (!el || el.tagName === 'BODY' || el.tagName === 'HTML') return false;
     // aria-hidden / inert subtrees are non-interactive for assistive tech
@@ -339,7 +363,7 @@
   }
 
   function queryInteractive() {
-    const all = document.querySelectorAll(INTERACTIVE_SELECTORS.join(', '));
+    const all = document.querySelectorAll([...INTERACTIVE_SELECTORS, ..._siteInteractiveSelectors()].join(', '));
     const modal = _findTopmostModal();
     const out = [];
     for (const el of all) {
@@ -433,7 +457,7 @@
         tag: el.tagName.toLowerCase(),
         type: el.type || '',
         role: el.getAttribute('role') || '',
-        text: (el.innerText || el.value || el.placeholder || el.title || el.ariaLabel || '').trim().slice(0, 100),
+        text: _siteInteractionText(el).slice(0, 100),
         id: el.id || '',
         name: el.name || '',
         href: el.href || '',
@@ -468,7 +492,7 @@
     // Compact snapshot — first ~40 elements, just the fields a model
     // needs to pick the right one: index, tag, role, text.
     const available = interactive.slice(0, 40).map((el, i) => {
-      const text = (el.innerText || el.value || el.placeholder || el.title || el.ariaLabel || '').trim().slice(0, 80);
+      const text = _siteInteractionText(el).slice(0, 80);
       return {
         index: i,
         tag: el.tagName.toLowerCase(),
@@ -493,6 +517,7 @@
 
   function _isInteractive(node) {
     if (_INTERACTIVE_TAGS.has(node.tagName)) return true;
+    if (_isSiteInteractive(node)) return true;
     const role = (node.getAttribute && node.getAttribute('role')) || '';
     if (_INTERACTIVE_ROLES.has(role)) return true;
     if (node.hasAttribute && (node.hasAttribute('onclick') || node.hasAttribute('data-action'))) return true;
@@ -867,7 +892,12 @@
       const needle = params.text.toLowerCase();
       const explicit = params.textMatch || '';
       // Include inputs/select/textarea so we can match by placeholder, value, or aria-label
-      const sels = 'a, button, [role="button"], [role="link"], [role="tab"], [role="menuitem"], input:not([type="hidden"]), textarea, select, input[type="button"], input[type="submit"], summary, label, [onclick], [data-action]';
+      const sels = [
+        'a', 'button', '[role="button"]', '[role="link"]', '[role="tab"]', '[role="menuitem"]',
+        'input:not([type="hidden"])', 'textarea', 'select', 'input[type="button"]',
+        'input[type="submit"]', 'summary', 'label', '[onclick]', '[data-action]',
+        ..._siteInteractiveSelectors(),
+      ].join(', ');
       // Modal scoping: if a topmost modal/dialog is open, restrict the search
       // to elements inside it. Without this, click({text: "Create"}) can land
       // on a background button (GitHub's "Create new tag" dialog over the
@@ -878,7 +908,7 @@
       const all = Array.from(_scope.querySelectorAll(sels));
       const normalized = all.map(e => ({
         e,
-        txt: (e.innerText || e.value || e.placeholder || e.ariaLabel || '').trim().toLowerCase(),
+        txt: _siteInteractionText(e).toLowerCase(),
       })).filter(x => !!x.txt);
 
       // Build label→input map so we can match label text and resolve to associated input
@@ -935,7 +965,7 @@
           const allRetry = Array.from(_retryScope.querySelectorAll(sels));
           const normRetry = allRetry.map(e => ({
             e,
-            txt: (e.innerText || e.value || e.placeholder || e.ariaLabel || '').trim().toLowerCase(),
+            txt: _siteInteractionText(e).toLowerCase(),
           })).filter(x => !!x.txt);
           for (const m of modes) {
             if (m === 'exact') matches = normRetry.filter(x => x.txt === needle);
@@ -2278,7 +2308,7 @@
       const selectors = [
         'a[href]', 'button', 'input:not([type="hidden"])', 'textarea', 'select',
         '[role="button"]', '[role="link"]', '[role="tab"]', '[role="menuitem"]',
-        '[onclick]', '[data-action]', 'summary',
+        '[onclick]', '[data-action]', 'summary', ..._siteInteractiveSelectors(),
       ];
       selectors.forEach(sel => {
         try {
@@ -2326,7 +2356,7 @@
         tag: el.tagName.toLowerCase(),
         type: el.type || '',
         role: el.getAttribute('role') || '',
-        text: (el.innerText || el.value || el.placeholder || el.title || el.ariaLabel || '').trim().slice(0, 100),
+        text: _siteInteractionText(el).slice(0, 100),
         id: el.id || '',
         name: el.name || '',
         href: el.href || '',

--- a/src/firefox/src/agent/adapters.js
+++ b/src/firefox/src/agent/adapters.js
@@ -131,6 +131,40 @@ function isFacebookInfiniteScrollUrl(url) {
   return /^\/(?:watch|groups|marketplace|search)(?:\/|$)/.test(path);
 }
 
+function isBilibiliUrl(url) {
+  const parts = adapterUrlParts(url);
+  if (!parts) return false;
+  const hostname = normalizedHostname(parts.parsed.hostname);
+  return hostname === 'bilibili.com' || hostname.endsWith('.bilibili.com');
+}
+
+function isBilibiliInfiniteScrollUrl(url) {
+  const parts = adapterUrlParts(url);
+  if (!parts || !isBilibiliUrl(url)) return false;
+  const hostname = normalizedHostname(parts.parsed.hostname);
+  if (hostname === 't.bilibili.com') return true;
+  if (hostname === 'bilibili.com' && parts.path === '/') return true;
+  return hostname === 'space.bilibili.com'
+    && /^\/\d+\/dynamic(?:\/|$)/.test(parts.path);
+}
+
+function isXiaohongshuUrl(url) {
+  const parts = adapterUrlParts(url);
+  if (!parts) return false;
+  const hostname = normalizedHostname(parts.parsed.hostname);
+  return hostname === 'xiaohongshu.com' || hostname.endsWith('.xiaohongshu.com');
+}
+
+function isXiaohongshuInfiniteScrollUrl(url) {
+  const parts = adapterUrlParts(url);
+  if (!parts || !isXiaohongshuUrl(url)) return false;
+  if (normalizedHostname(parts.parsed.hostname) !== 'xiaohongshu.com') return false;
+  return parts.path === '/'
+    || parts.path === '/explore'
+    || parts.path === '/search_result'
+    || /^\/user\/profile\/[^/]+(?:\/|$)/.test(parts.path);
+}
+
 function isMastodonInfiniteScrollUrl(url) {
   const { path } = adapterUrlParts(url) || {};
   if (!path) return false;
@@ -16365,6 +16399,34 @@ const ADAPTERS = [
   },
 
   // ─── Social (gaps) ────────────────────────────────────────────────────
+  {
+    name: 'bilibili',
+    category: 'general',
+    matches: isBilibiliUrl,
+    fullPageCapture: { infiniteScroll: isBilibiliInfiniteScrollUrl },
+    notes: `
+- Video pages (/video/BV...) may contain a multi-part playlist ("视频选集" / "分P"). Confirm the active part and the ?p= value before summarizing or seeking; the page title and description may describe the whole submission.
+- Player-only controls such as "字幕" (subtitles), "弹幕" (danmaku), speed, and episode selection may appear only after the player is focused or hovered. Use the visible tree or screenshot after revealing the controls; do not assume the description is a transcript.
+- Search runs on search.bilibili.com. Result tabs such as "综合", "视频", "番剧", "直播", and "用户" change the result type; re-read the page after switching tabs instead of reusing card indices.
+- Creator profiles live at space.bilibili.com/<uid>. "动态", "投稿", "合集和列表", and "收藏" are separate lazy-loaded views; collect exact video links before scrolling because card order can change.
+- Distinguish scrolling "弹幕" over the player from threaded "评论" below it. Comments and dynamic feeds load incrementally, and pinned comments can remain above newer replies.
+- "关注", "点赞", "投币", "收藏", "弹幕", "评论", and "一键三连" are state-changing. Do not activate them during read-only tasks; after an explicit request, verify the resulting state instead of trusting the click alone.
+- These interactions require sign-in and may open QR-code or SMS verification. Surface the QR/code step to the user rather than retrying or claiming the action succeeded.`,
+  },
+  {
+    name: 'xiaohongshu',
+    category: 'general',
+    matches: isXiaohongshuUrl,
+    fullPageCapture: { infiniteScroll: isXiaohongshuInfiniteScrollUrl },
+    notes: `
+- "发现" (/explore), search results, and profile note grids are infinite, reflowing masonry feeds. Extract each visible card's title, author, and exact link before scrolling; card positions and indices are not stable.
+- Note and profile links commonly carry xsec_token / xsec_source query parameters. Follow or preserve the page's actual href; do not synthesize a URL from the visible note ID or author name.
+- Opening a note from a feed may show it in a topmost modal over the still-mounted feed. Scope reads and actions to that dialog, and scroll the note/comment pane rather than the background page.
+- Note text, hashtags, and comments load incrementally. Expand visible "展开" controls and re-read after scrolling; do not mix neighboring feed-card text into the active note.
+- Profiles at /user/profile/<id> separate "笔记" and "收藏". A missing collection may be private ("收藏内容不可见"), not an empty or failed page.
+- "关注", "点赞", "收藏", "评论", and "发布" are state-changing and normally require sign-in. If a QR-code or phone verification prompt appears, ask the user to complete it.
+- "发布" opens the separate Creator Center on creator.xiaohongshu.com. Filling media, title, and body is not proof of publication; after an explicit publish request, verify the success state and final public note URL.`,
+  },
   {
     name: 'instagram',
     category: 'general',

--- a/src/firefox/src/content/accessibility-tree.js
+++ b/src/firefox/src/content/accessibility-tree.js
@@ -113,7 +113,74 @@
     label: 'label',
   };
 
+  // Some high-traffic media sites render their primary actions as plain
+  // div/span wrappers with delegated Vue event handlers. They are genuinely
+  // clickable, but expose none of the native/ARIA signals used below. Keep
+  // this list intentionally narrow and hostname-scoped so generic page
+  // containers are not promoted to buttons elsewhere.
+  const SITE_INTERACTION_RULES = {
+    bilibili: [
+      ['.video-like', '点赞'],
+      ['.video-coin', '投币'],
+      ['.video-fav', '收藏'],
+      ['.video-share', '分享'],
+      ['.follow-btn', '关注'],
+      ['.bpx-player-follow', '关注'],
+      ['.reply-box-send', '发布评论'],
+    ],
+    xiaohongshu: [
+      ['.like-wrapper', '点赞'],
+      ['.collect-wrapper', '收藏'],
+      ['.chat-wrapper', '评论'],
+      ['.share-wrapper', '分享'],
+      ['.follow-wrapper', '关注'],
+      ['.follow-btn', '关注'],
+      ['.follow-button', '关注'],
+      ['.send-btn', '发布评论'],
+      ['.publish-btn', '发布'],
+      ['.publish-button', '发布'],
+    ],
+  };
+
+  function currentSiteInteractionConfig() {
+    const hostname = String(location.hostname || '').toLowerCase().replace(/\.$/, '');
+    const onHost = (domain) => hostname === domain || hostname.endsWith(`.${domain}`);
+    if (onHost('bilibili.com')) return { key: 'bilibili', rules: SITE_INTERACTION_RULES.bilibili };
+    if (onHost('xiaohongshu.com')) return { key: 'xiaohongshu', rules: SITE_INTERACTION_RULES.xiaohongshu };
+    return { key: '', rules: [] };
+  }
+
+  function getSiteInteractionDescriptor(el) {
+    if (!el || typeof el.matches !== 'function') return null;
+    for (const [selector, label] of currentSiteInteractionConfig().rules) {
+      try {
+        if (!el.matches(selector)) continue;
+      } catch {
+        continue;
+      }
+      const explicit = String(
+        el.getAttribute('aria-label') || el.getAttribute('title') || ''
+      ).replace(/\s+/g, ' ').trim();
+      const rendered = String(el.innerText || el.textContent || '')
+        .replace(/\s+/g, ' ').trim().slice(0, 80);
+      const name = explicit || (
+        rendered && rendered.includes(label) ? rendered
+          : rendered ? `${label} ${rendered}` : label
+      );
+      return { selector, label, name };
+    }
+    return null;
+  }
+
+  window.__wbSiteInteractions = Object.freeze({
+    selectors: () => currentSiteInteractionConfig().rules.map(([selector]) => selector),
+    describe: getSiteInteractionDescriptor,
+    isInteractive: (el) => !!getSiteInteractionDescriptor(el),
+    shouldPierceShadowRoots: () => currentSiteInteractionConfig().key === 'bilibili',
+  });
+
   function getRole(el) {
+    if (getSiteInteractionDescriptor(el)) return 'button';
     const explicit = el.getAttribute('role');
     if (explicit) return explicit;
     const tag = el.tagName.toLowerCase();
@@ -179,6 +246,9 @@
   // ── Accessible name (matches Claude's priority order) ───────────────────
   function getAccessibleName(el) {
     const tag = el.tagName.toLowerCase();
+
+    const siteInteraction = getSiteInteractionDescriptor(el);
+    if (siteInteraction) return siteInteraction.name;
 
     // <select> — prefer the currently selected option's label.
     if (tag === 'select') {
@@ -361,6 +431,7 @@
   function isInteractive(el) {
     const tag = el.tagName.toLowerCase();
     if (INTERACTIVE_TAGS.has(tag)) return true;
+    if (getSiteInteractionDescriptor(el)) return true;
     if (el.getAttribute('onclick') !== null) return true;
     if (el.getAttribute('tabindex') !== null) return true;
     const role = el.getAttribute('role');
@@ -538,6 +609,14 @@
       const nextDepth = included ? depth + 1 : depth;
       for (const child of el.children) {
         walk(child, nextDepth, opts, lines);
+      }
+      // Bilibili's current comment system is a hierarchy of open custom-
+      // element shadow roots. Traverse it here so the comment editor and
+      // Publish/Reply buttons receive the same stable ref_ids as light DOM.
+      if (window.__wbSiteInteractions.shouldPierceShadowRoots() && el.shadowRoot) {
+        for (const child of el.shadowRoot.children || []) {
+          walk(child, nextDepth, opts, lines);
+        }
       }
     }
   }

--- a/src/firefox/src/content/content.js
+++ b/src/firefox/src/content/content.js
@@ -457,6 +457,30 @@
     'label',
   ];
 
+  function _siteInteractiveSelectors() {
+    try {
+      return window.__wbSiteInteractions?.selectors?.() || [];
+    } catch {
+      return [];
+    }
+  }
+
+  function _siteInteractionText(el) {
+    try {
+      const descriptor = window.__wbSiteInteractions?.describe?.(el);
+      if (descriptor?.name) return descriptor.name;
+    } catch {}
+    return (el?.innerText || el?.value || el?.placeholder || el?.title || el?.ariaLabel || '').trim();
+  }
+
+  function _isSiteInteractive(el) {
+    try {
+      return !!window.__wbSiteInteractions?.isInteractive?.(el);
+    } catch {
+      return false;
+    }
+  }
+
   function _composedParent(node) {
     if (!node) return null;
     const parent = node.parentNode;
@@ -653,7 +677,7 @@
   }
 
   function queryInteractive() {
-    const all = document.querySelectorAll(INTERACTIVE_SELECTORS.join(', '));
+    const all = document.querySelectorAll([...INTERACTIVE_SELECTORS, ..._siteInteractiveSelectors()].join(', '));
     const modal = _findTopmostBlockingModal();
     const out = [];
     for (const el of all) {
@@ -727,7 +751,7 @@
         tag: el.tagName.toLowerCase(),
         type: el.type || '',
         role: el.getAttribute('role') || '',
-        text: (el.innerText || el.value || el.placeholder || el.title || el.ariaLabel || '').trim().slice(0, 100),
+        text: _siteInteractionText(el).slice(0, 100),
         id: el.id || '',
         name: el.name || '',
         href: el.href || '',
@@ -777,7 +801,7 @@
       const selectors = [
         'a[href]', 'button', 'input:not([type="hidden"])', 'textarea', 'select',
         '[role="button"]', '[role="link"]', '[role="tab"]', '[role="menuitem"]',
-        '[onclick]', '[data-action]', 'summary',
+        '[onclick]', '[data-action]', 'summary', ..._siteInteractiveSelectors(),
       ];
       selectors.forEach(sel => {
         try {
@@ -831,7 +855,7 @@
         tag: el.tagName.toLowerCase(),
         type: el.type || '',
         role: el.getAttribute('role') || '',
-        text: (el.innerText || el.value || el.placeholder || el.title || el.ariaLabel || '').trim().slice(0, 100),
+        text: _siteInteractionText(el).slice(0, 100),
         id: el.id || '',
         name: el.name || '',
         href: el.href || '',
@@ -853,7 +877,7 @@
   function _staleIndexError(requestedIndex, interactive) {
     const total = interactive.length;
     const available = interactive.slice(0, 40).map((el, i) => {
-      const text = (el.innerText || el.value || el.placeholder || el.title || el.ariaLabel || '').trim().slice(0, 80);
+      const text = _siteInteractionText(el).slice(0, 80);
       return {
         index: i,
         tag: el.tagName.toLowerCase(),
@@ -878,6 +902,7 @@
 
   function _isInteractive(node) {
     if (_INTERACTIVE_TAGS.has(node.tagName)) return true;
+    if (_isSiteInteractive(node)) return true;
     const role = (node.getAttribute && node.getAttribute('role')) || '';
     if (_INTERACTIVE_ROLES.has(role)) return true;
     if (node.hasAttribute && (node.hasAttribute('onclick') || node.hasAttribute('data-action'))) return true;
@@ -1085,7 +1110,13 @@
       const needle = params.text.toLowerCase();
       const explicit = params.textMatch || '';
       // Include inputs/select/textarea so we can match by placeholder, value, or aria-label
-      const sels = 'a, button, [role="button"], [role="link"], [role="tab"], [role="menuitem"], [role="option"], [role="menuitemradio"], [role="menuitemcheckbox"], [role="treeitem"], input:not([type="hidden"]), textarea, select, input[type="button"], input[type="submit"], summary, label, [onclick], [data-action]';
+      const sels = [
+        'a', 'button', '[role="button"]', '[role="link"]', '[role="tab"]', '[role="menuitem"]',
+        '[role="option"]', '[role="menuitemradio"]', '[role="menuitemcheckbox"]', '[role="treeitem"]',
+        'input:not([type="hidden"])', 'textarea', 'select', 'input[type="button"]',
+        'input[type="submit"]', 'summary', 'label', '[onclick]', '[data-action]',
+        ..._siteInteractiveSelectors(),
+      ].join(', ');
       // Modal scoping: if a topmost modal/dialog is open, restrict the search
       // to elements inside it. Prevents the classic failure where the model
       // types "Publish release" and the resolver clicks the dimmed Publish
@@ -1124,7 +1155,10 @@
         const t = (el.getAttribute('type') || 'text').toLowerCase();
         return t === 'button' || t === 'submit' || t === 'reset';
       };
-      const _normTxt = (el) => (el.innerText || (_valIsLabel(el) ? el.value : '') || el.placeholder || el.ariaLabel || '').trim().toLowerCase();
+      const _normTxt = (el) => {
+        const siteText = _isSiteInteractive(el) ? _siteInteractionText(el) : '';
+        return (siteText || el.innerText || (_valIsLabel(el) ? el.value : '') || el.placeholder || el.ariaLabel || '').trim().toLowerCase();
+      };
       const all = Array.from(_scope.querySelectorAll(sels)).filter(_keepCandidate);
       const normalized = all.map(e => ({ e, txt: _normTxt(e) })).filter(x => !!x.txt);
 

--- a/test/run.js
+++ b/test/run.js
@@ -1693,6 +1693,111 @@ test('matches youtube video URLs and includes transcript guidance', () => {
   assert.match(a?.notes || '', /Do NOT invent transcript URLs/i);
 });
 
+test('matches Bilibili surfaces with mirrored regional guidance', () => {
+  const urls = [
+    'https://www.bilibili.com/video/BV1FD4y147uH/?p=2',
+    'https://search.bilibili.com/all?keyword=WebBrain',
+    'https://space.bilibili.com/2/dynamic',
+    'https://t.bilibili.com/',
+  ];
+  for (const url of urls) {
+    assert.equal(getActiveAdapter(url)?.name, 'bilibili', `chrome did not match ${url}`);
+    assert.equal(getActiveAdapterFx(url)?.name, 'bilibili', `firefox did not match ${url}`);
+  }
+  assert.notEqual(getActiveAdapter('https://bilibili.com.evil.example/video/BV1')?.name, 'bilibili');
+  assert.notEqual(getActiveAdapter('https://example.com/?next=https://www.bilibili.com/')?.name, 'bilibili');
+
+  const chromeAdapter = getActiveAdapter(urls[0]);
+  const firefoxAdapter = getActiveAdapterFx(urls[0]);
+  assert.equal(firefoxAdapter?.notes, chromeAdapter?.notes);
+  assert.match(chromeAdapter?.notes || '', /视频选集.*分P/s);
+  assert.match(chromeAdapter?.notes || '', /字幕.*弹幕/s);
+  assert.match(chromeAdapter?.notes || '', /search\.bilibili\.com/);
+  assert.match(chromeAdapter?.notes || '', /一键三连.*state-changing/s);
+  assert.match(chromeAdapter?.notes || '', /QR-code or SMS verification/);
+});
+
+test('matches Xiaohongshu surfaces with mirrored regional guidance', () => {
+  const urls = [
+    'https://www.xiaohongshu.com/explore',
+    'https://www.xiaohongshu.com/explore/63f9b8b700000000120335d8?xsec_token=example',
+    'https://www.xiaohongshu.com/search_result?keyword=WebBrain',
+    'https://www.xiaohongshu.com/user/profile/5e92d7f20000000001004bc0',
+    'https://creator.xiaohongshu.com/publish/publish?source=official',
+  ];
+  for (const url of urls) {
+    assert.equal(getActiveAdapter(url)?.name, 'xiaohongshu', `chrome did not match ${url}`);
+    assert.equal(getActiveAdapterFx(url)?.name, 'xiaohongshu', `firefox did not match ${url}`);
+  }
+  assert.notEqual(getActiveAdapter('https://xiaohongshu.com.evil.example/explore')?.name, 'xiaohongshu');
+  assert.notEqual(getActiveAdapter('https://example.com/xiaohongshu.com/explore')?.name, 'xiaohongshu');
+
+  const chromeAdapter = getActiveAdapter(urls[0]);
+  const firefoxAdapter = getActiveAdapterFx(urls[0]);
+  assert.equal(firefoxAdapter?.notes, chromeAdapter?.notes);
+  assert.match(chromeAdapter?.notes || '', /infinite, reflowing masonry feeds/);
+  assert.match(chromeAdapter?.notes || '', /xsec_token \/ xsec_source/);
+  assert.match(chromeAdapter?.notes || '', /topmost modal/);
+  assert.match(chromeAdapter?.notes || '', /收藏内容不可见/);
+  assert.match(chromeAdapter?.notes || '', /Creator Center.*final public note URL/s);
+});
+
+test('regional social action shims expose Bilibili and Xiaohongshu custom controls', () => {
+  const axChrome = fs.readFileSync(path.join(ROOT, 'src/chrome/src/content/accessibility-tree.js'), 'utf8');
+  const axFirefox = fs.readFileSync(path.join(ROOT, 'src/firefox/src/content/accessibility-tree.js'), 'utf8');
+  assert.equal(axChrome, axFirefox, 'site interaction accessibility shims must remain byte-identical');
+
+  const start = axChrome.indexOf('const SITE_INTERACTION_RULES = {');
+  const end = axChrome.indexOf('\n\n  function getRole(el) {', start);
+  assert.ok(start >= 0 && end > start, 'site interaction helper should remain independently testable');
+  const location = { hostname: 'www.bilibili.com' };
+  const context = { window: {}, location };
+  vm.runInNewContext(axChrome.slice(start, end), context);
+  const api = context.window.__wbSiteInteractions;
+  const fakeElement = (selector, { text = '', title = '', ariaLabel = '' } = {}) => ({
+    innerText: text,
+    textContent: text,
+    matches: candidate => candidate === selector,
+    getAttribute: name => name === 'title' ? title : name === 'aria-label' ? ariaLabel : null,
+  });
+
+  assert.ok(api.selectors().includes('.video-like'), 'Bilibili like wrapper should be discoverable');
+  assert.ok(api.selectors().includes('.reply-box-send'), 'legacy Bilibili comment submit wrapper should be discoverable');
+  assert.equal(api.describe(fakeElement('.video-like', { text: '563', title: '\u70b9\u8d5e\uff08Q\uff09' })).name, '\u70b9\u8d5e\uff08Q\uff09');
+  assert.equal(api.isInteractive(fakeElement('.video-fav', { text: '306' })), true);
+  assert.equal(api.shouldPierceShadowRoots(), true, 'Bilibili comment custom elements require open-shadow traversal');
+
+  location.hostname = 'www.xiaohongshu.com';
+  assert.ok(api.selectors().includes('.like-wrapper'), 'Xiaohongshu like wrapper should be discoverable');
+  assert.ok(api.selectors().includes('.collect-wrapper'), 'Xiaohongshu collect wrapper should be discoverable');
+  assert.ok(api.selectors().includes('.chat-wrapper'), 'Xiaohongshu comment wrapper should be discoverable');
+  assert.equal(api.describe(fakeElement('.like-wrapper', { text: '128' })).name, '\u70b9\u8d5e 128');
+  assert.equal(api.describe(fakeElement('.chat-wrapper', { text: '7' })).name, '\u8bc4\u8bba 7');
+  assert.equal(api.shouldPierceShadowRoots(), false);
+
+  location.hostname = 'bilibili.com.example.org';
+  assert.deepEqual(Array.from(api.selectors()), [], 'lookalike hostnames must not activate site controls');
+
+  assert.match(axChrome, /if \(getSiteInteractionDescriptor\(el\)\) return 'button'/, 'custom controls should be rendered as buttons');
+  assert.match(axChrome, /if \(getSiteInteractionDescriptor\(el\)\) return true/, 'custom controls should pass the interactive filter');
+  assert.match(axChrome, /shouldPierceShadowRoots\(\) && el\.shadowRoot/, 'Bilibili shadow roots should be traversed by the accessibility tree');
+
+  for (const [label, rel] of [
+    ['chrome', 'src/chrome/src/content/content.js'],
+    ['firefox', 'src/firefox/src/content/content.js'],
+  ]) {
+    const content = fs.readFileSync(path.join(ROOT, rel), 'utf8');
+    assert.match(content, /\.\.\._siteInteractiveSelectors\(\)/, `${label}: discovery selectors must include site controls`);
+    assert.match(content, /text: _siteInteractionText\(el\)\.slice\(0, 100\)/, `${label}: indexed controls need semantic action names`);
+    assert.match(content, /if \(_isSiteInteractive\(node\)\) return true/, `${label}: text-click ambiguity resolution must prefer site controls`);
+  }
+
+  const cdp = fs.readFileSync(path.join(ROOT, 'src/chrome/src/cdp/cdp-client.js'), 'utf8');
+  assert.match(cdp, /const SITE_RULES = onHost\('bilibili\.com'\)/, 'Chrome CDP discovery should be hostname-scoped');
+  assert.match(cdp, /onHost\('xiaohongshu\.com'\)/, 'Chrome CDP discovery should cover Xiaohongshu');
+  assert.match(cdp, /text: interactiveText\(el\)\.slice\(0, 100\)/, 'Chrome CDP results need semantic action names');
+});
+
 test('matches nytimes.com and scopes article-fetch guidance to that adapter', () => {
   const articleUrl = 'https://www.nytimes.com/2026/07/12/us/politics/example.html';
   const chromeAdapter = getActiveAdapter(articleUrl);
@@ -1964,6 +2069,12 @@ test('social adapters expose URL-specific infinite-scroll capture policy in both
     ['reddit', 'https://www.reddit.com/r/javascript/'],
     ['youtube', 'https://www.youtube.com/watch?v=abc123'],
     ['youtube', 'https://www.youtube.com/@OpenAI/videos'],
+    ['bilibili', 'https://www.bilibili.com/'],
+    ['bilibili', 'https://t.bilibili.com/'],
+    ['bilibili', 'https://space.bilibili.com/2/dynamic'],
+    ['xiaohongshu', 'https://www.xiaohongshu.com/explore'],
+    ['xiaohongshu', 'https://www.xiaohongshu.com/search_result?keyword=WebBrain'],
+    ['xiaohongshu', 'https://www.xiaohongshu.com/user/profile/abc123'],
     ['instagram', 'https://www.instagram.com/openai/'],
     ['instagram', 'https://www.instagram.com/explore/'],
     ['tiktok', 'https://www.tiktok.com/@openai'],
@@ -1978,6 +2089,10 @@ test('social adapters expose URL-specific infinite-scroll capture policy in both
     'https://old.reddit.com/r/javascript/',
     'https://www.reddit.com/r/javascript/comments/abc123/example/',
     'https://youtu.be/abc123',
+    'https://www.bilibili.com/video/BV1FD4y147uH/',
+    'https://search.bilibili.com/all?keyword=WebBrain',
+    'https://www.xiaohongshu.com/explore/63f9b8b700000000120335d8?xsec_token=example',
+    'https://creator.xiaohongshu.com/publish/publish?source=official',
     'https://www.instagram.com/p/ABC123/',
     'https://www.instagram.com/reel/ABC123/',
     'https://www.tiktok.com/@openai/video/1234567890123456789',
@@ -1990,6 +2105,8 @@ test('social adapters expose URL-specific infinite-scroll capture policy in both
     'https://linkedin.com.evil.example/feed/',
     'https://reddit.com.evil.example/r/javascript/',
     'https://youtube.com.evil.example/watch?v=abc123',
+    'https://bilibili.com.evil.example/',
+    'https://xiaohongshu.com.evil.example/explore',
     'https://instagram.com.evil.example/explore/',
     'https://tiktok.com.evil.example/@openai',
     'https://facebook.com.evil.example/groups/12345/',


### PR DESCRIPTION
Adds mirrored Chrome and Firefox adapters for Bilibili and Xiaohongshu.

Prevents a real interaction failure where custom `div`/`span` controls for Like, Follow, Favorite, Comment, and Publish were absent from the accessibility tree and interactive-element list. Bilibili's open-shadow-root comment controls are now discoverable as stable accessibility refs, and Xiaohongshu's wrapper controls receive semantic action names.

Validation:
- `node test/run.js`: 999 passed; 2 unrelated pre-existing baseline failures remain (CHANGELOG version and localized Tweet recommendation label)
- `node test/security/injection-corpus.mjs`: 60/60 passed
- Live Bilibili DOM/accessibility verification for Like, Coin, Favorite, Share, Follow, Login, and Reply
- Synthetic Xiaohongshu DOM verification for semantic discovery and text-based clicking