### PR TITLE
agent: add adapter for foodpanda

### DIFF
--- a/src/chrome/src/agent/adapters.js
+++ b/src/chrome/src/agent/adapters.js
@@ -16302,6 +16302,18 @@ const ADAPTERS = [
 - Availability gates: a restaurant may be "Kapalı" (closed — can't order now) and each has a "minimum sepet tutarı" (minimum order total) plus a delivery fee. Check the open status and the minimum before promising delivery.
 - "Yemeksepeti Mahalle" (grocery/market quick delivery) is a separate flow from restaurant food ordering — don't expect restaurant menus there.`,
   },
+  {
+    name: 'foodpanda',
+    category: 'general',
+    matches: (url) => /^https?:\/\/(www\.)?foodpanda\.pk\//.test(url),
+    notes: `
+- foodpanda.pk is Pakistan's main FOOD + GROCERY delivery site (English UI). The top tabs are separate flows, each with its own cart: "Delivery" (restaurant food), "Pick-up", "pandamart" (grocery), and "Shops" (retail). Pick the tab that matches the task — groceries are in pandamart, not restaurant menus.
+- LOCATION-FIRST trap: the site loads a GENERIC city location by default and still lists restaurants, so a shown restaurant may not actually deliver to the user. Set the real delivery address first via the header "Select your address" control (its tooltip reads "You're viewing a generic location…") — which restaurants, prices, and delivery fees appear all depend on it.
+- Per-restaurant carts: each restaurant has its OWN cart and OWN checkout. Adding items from a second restaurant starts a second separate cart — you CANNOT combine two restaurants into one order or delivery. Finish one restaurant's order before starting another.
+- Open/closed status shows on the listing: a "Closed" restaurant can't take an order now, so order from an open one instead of trying to add from a closed page.
+- The menu price is NOT the final total: delivery charges are added at CHECKOUT, so only quote a total after the cart shows the delivery fee. Items sell in fixed portions (e.g. one plate minimum, no half plate) — order whole units.
+- Use the on-page search ("Search for restaurants, cuisines, and dishes") and the left-rail sort/filters (Relevance / Fastest delivery / Distance / Top rated, "Ratings 4+") rather than guessing URL params.`,
+  },
 
   // ─── Regional — Digitec Galaxus (CH + EU: one in-house platform) ──────
   // galaxus.* (CH/DE/AT/FR/IT/BE/NL) and digitec.ch share product IDs, slugs, and

--- a/src/firefox/src/agent/adapters.js
+++ b/src/firefox/src/agent/adapters.js
@@ -16301,6 +16301,18 @@ const ADAPTERS = [
 - Availability gates: a restaurant may be "Kapalı" (closed — can't order now) and each has a "minimum sepet tutarı" (minimum order total) plus a delivery fee. Check the open status and the minimum before promising delivery.
 - "Yemeksepeti Mahalle" (grocery/market quick delivery) is a separate flow from restaurant food ordering — don't expect restaurant menus there.`,
   },
+  {
+    name: 'foodpanda',
+    category: 'general',
+    matches: (url) => /^https?:\/\/(www\.)?foodpanda\.pk\//.test(url),
+    notes: `
+- foodpanda.pk is Pakistan's main FOOD + GROCERY delivery site (English UI). The top tabs are separate flows, each with its own cart: "Delivery" (restaurant food), "Pick-up", "pandamart" (grocery), and "Shops" (retail). Pick the tab that matches the task — groceries are in pandamart, not restaurant menus.
+- LOCATION-FIRST trap: the site loads a GENERIC city location by default and still lists restaurants, so a shown restaurant may not actually deliver to the user. Set the real delivery address first via the header "Select your address" control (its tooltip reads "You're viewing a generic location…") — which restaurants, prices, and delivery fees appear all depend on it.
+- Per-restaurant carts: each restaurant has its OWN cart and OWN checkout. Adding items from a second restaurant starts a second separate cart — you CANNOT combine two restaurants into one order or delivery. Finish one restaurant's order before starting another.
+- Open/closed status shows on the listing: a "Closed" restaurant can't take an order now, so order from an open one instead of trying to add from a closed page.
+- The menu price is NOT the final total: delivery charges are added at CHECKOUT, so only quote a total after the cart shows the delivery fee. Items sell in fixed portions (e.g. one plate minimum, no half plate) — order whole units.
+- Use the on-page search ("Search for restaurants, cuisines, and dishes") and the left-rail sort/filters (Relevance / Fastest delivery / Distance / Top rated, "Ratings 4+") rather than guessing URL params.`,
+  },
 
   // ─── Regional — Digitec Galaxus (CH + EU: one in-house platform) ──────
   // galaxus.* (CH/DE/AT/FR/IT/BE/NL) and digitec.ch share product IDs, slugs, and

--- a/test/run.js
+++ b/test/run.js
@@ -1750,6 +1750,19 @@ test('matches yemeksepeti.com and includes food-delivery guidance', () => {
   assert.match(a?.notes || '', /Restoran/);
 });
 
+test('matches foodpanda.pk and includes food-delivery guidance', () => {
+  assert.equal(getActiveAdapter('https://www.foodpanda.pk/')?.name, 'foodpanda');
+  assert.equal(getActiveAdapter('https://foodpanda.pk/restaurants')?.name, 'foodpanda');
+  // lookalike / suffix domains must NOT match
+  assert.notEqual(getActiveAdapter('https://foodpanda.pk.phishing.example/')?.name, 'foodpanda');
+  // other foodpanda country TLDs are intentionally out of scope for this .pk-only adapter
+  assert.notEqual(getActiveAdapter('https://www.foodpanda.com.bd/')?.name, 'foodpanda');
+  const a = getActiveAdapter('https://www.foodpanda.pk/');
+  assert.match(a?.notes || '', /LOCATION-FIRST/);
+  assert.match(a?.notes || '', /pandamart/);
+  assert.equal(getActiveAdapterFx('https://www.foodpanda.pk/')?.name, 'foodpanda');   // firefox parity
+});
+
 test('matches galaxus + digitec and includes anti-bot fetch guidance', () => {
   assert.equal(getActiveAdapter('https://www.galaxus.ch/de/s1/product/x-123')?.name, 'galaxus');
   assert.equal(getActiveAdapter('https://www.digitec.ch/de/s1/product/x-123')?.name, 'galaxus');

--- a/test/run.js
+++ b/test/run.js
@@ -1760,7 +1760,13 @@ test('matches foodpanda.pk and includes food-delivery guidance', () => {
   const a = getActiveAdapter('https://www.foodpanda.pk/');
   assert.match(a?.notes || '', /LOCATION-FIRST/);
   assert.match(a?.notes || '', /pandamart/);
-  assert.equal(getActiveAdapterFx('https://www.foodpanda.pk/')?.name, 'foodpanda');   // firefox parity
+  // firefox parity
+  const fx = getActiveAdapterFx('https://www.foodpanda.pk/');
+  assert.equal(fx?.name, a?.name);
+  assert.equal(fx?.notes, a?.notes);
+  assert.equal(getActiveAdapterFx('https://foodpanda.pk/restaurants')?.name, 'foodpanda');
+  assert.notEqual(getActiveAdapterFx('https://foodpanda.pk.phishing.example/')?.name, 'foodpanda');
+  assert.notEqual(getActiveAdapterFx('https://www.foodpanda.com.bd/')?.name, 'foodpanda');
 });
 
 test('matches galaxus + digitec and includes anti-bot fetch guidance', () => {


### PR DESCRIPTION
# PR: agent: add adapter for foodpanda

## Summary

Adds a site adapter for **foodpanda.pk**, Pakistan's main food + grocery delivery platform — the
food-delivery sibling of the merged Turkish set (yemeksepeti #280). Continues the regional-adapter
coverage `CONTRIBUTING.md` lists as the most-wanted contribution.

## What it encodes (each bullet live-verified or in-market-user-confirmed)

- **Location-first / generic-location trap.** The site loads a *generic* city location by default and
  still lists restaurants, so a shown restaurant may not actually deliver to the user. Set the real
  delivery address first via the header "Select your address" control (tooltip: "You're viewing a
  generic location…").
- **Separate verticals.** Top tabs **Delivery** (restaurant food) / **Pick-up** / **pandamart**
  (grocery) / **Shops** (retail) are distinct flows, each with its own cart.
- **Per-restaurant carts.** Each restaurant has its own cart and checkout; adding items from a second
  restaurant starts a second separate cart — you can't combine two restaurants into one order.
- **Open/closed + pricing.** Closed restaurants are marked on the listing; delivery charges are added
  at checkout (menu price isn't the final total); items sell in fixed portions (one plate min, no
  half plate).
- **Search + sort/filter via the UI** (Relevance / Fastest delivery / Distance / Top rated,
  "Ratings 4+"), not guessed URL params.

## How it was verified (honest scope)

- **Homepage observed live** (HTTP 200, `en-PK` locale): the location trap, vertical tabs, English
  labels, and sort/filter rail — quoted verbatim from the live page.
- **Deeper pages were not scrapeable** (an anti-bot wall triggered on automated navigation — an
  artifact of scraping, not a trap for WebBrain's real-browser operation). The cart-scope,
  closed-status, checkout-delivery-fee, fixed-portion, and pandamart-separateness bullets are
  **confirmed first-hand by an in-market foodpanda.pk user**, not agent-trace-verified.
- **Scope: `foodpanda.pk` only.** Other foodpanda country TLDs (`.com.bd`, `.sg`, …) run the same
  platform but were not tested; the matcher is deliberately `.pk`-only. Happy to broaden if preferred.

## Chrome / Firefox

Byte-identical entry added to both `src/chrome/src/agent/adapters.js` and
`src/firefox/src/agent/adapters.js`.

## Test plan

- Adds a `getActiveAdapter` test in `test/run.js`: positive match (`www.` + bare-with-path), look-alike
  rejection (`foodpanda.pk.phishing.example`), out-of-scope TLD rejection (`foodpanda.com.bd`), notes
  content (`LOCATION-FIRST`, `pandamart`), and **Firefox parity** via `getActiveAdapterFx`.
- `node test/run.js` → **922 passed, 0 failed** (921 baseline + 1 new).
- `node --check` clean on both `adapters.js` files and `test/run.js`.

There is no tracking issue for this adapter.
