### PR TITLE
fix: switch changelog prompt from .prompt.yml to plain text files to …

### DIFF
--- a/.github/prompts/minor-release-changelog-system.txt
+++ b/.github/prompts/minor-release-changelog-system.txt
@@ -1,0 +1,8 @@
+You write release changelog entries for WebBrain, an open-source AI browser agent.
+Output only Markdown for the changelog body. Do not include the version heading or date.
+Use only these section headings when relevant: ### Added, ### Changed, ### Fixed, ### Tests.
+Prefer user-visible behavior and compatibility impact over implementation details.
+Keep bullets concise, concrete, and grounded in the supplied repository context.
+Mention Chrome and Firefox parity when the context clearly shows both sides changed.
+If tests changed, include a ### Tests section.
+Do not invent changes that are not present in the context.

--- a/.github/prompts/minor-release-changelog-user.txt
+++ b/.github/prompts/minor-release-changelog-user.txt
@@ -1,0 +1,4 @@
+Draft the changelog body for WebBrain {{version}} released on {{date}}.
+
+Repository context:
+{{release_context}}

--- a/.github/prompts/minor-release-changelog.prompt.yml
+++ b/.github/prompts/minor-release-changelog.prompt.yml
@@ -18,4 +18,3 @@ messages:
 modelParameters:
   maxCompletionTokens: 1200
   temperature: 0.2
----

--- a/.github/workflows/minor-release.yml
+++ b/.github/workflows/minor-release.yml
@@ -112,7 +112,8 @@ jobs:
         uses: actions/ai-inference@v1
         with:
           model: ${{ inputs.model }}
-          prompt-file: .github/prompts/minor-release-changelog.prompt.yml
+          system-prompt-file: .github/prompts/minor-release-changelog-system.txt
+          prompt-file: .github/prompts/minor-release-changelog-user.txt
           input: |
             version: ${{ steps.release_meta.outputs.new_version }}
             date: ${{ steps.release_meta.outputs.release_date }}


### PR DESCRIPTION
…avoid YAML parse error with release context substitution