### PR TITLE
fix(webmcp): discover pre-registered iframe tools

### DIFF
--- a/src/chrome/src/cdp/cdp-client.js
+++ b/src/chrome/src/cdp/cdp-client.js
@@ -341,11 +341,13 @@ export class CDPClient {
     }
   }
 
-  _removeWebMCPTools(state, tools) {
+  _removeWebMCPTools(state, tools, sessionId = '') {
+    const owningSessionId = String(sessionId || '');
     for (const rawTool of Array.isArray(tools) ? tools : []) {
       const key = this._webMCPToolKey(rawTool?.frameId, rawTool?.name);
       const toolId = state.idsByKey.get(key);
       if (!toolId) continue;
+      if (state.toolsById.get(toolId)?.sessionId !== owningSessionId) continue;
       state.idsByKey.delete(key);
       state.toolsById.delete(toolId);
     }
@@ -536,7 +538,9 @@ export class CDPClient {
     register('WebMCP.toolsAdded', (params, source) => {
       this._storeWebMCPTools(state, params?.tools, source?.sessionId);
     });
-    register('WebMCP.toolsRemoved', params => this._removeWebMCPTools(state, params?.tools));
+    register('WebMCP.toolsRemoved', (params, source) => (
+      this._removeWebMCPTools(state, params?.tools, source?.sessionId)
+    ));
     register('WebMCP.toolResponded', (params, source) => (
       this._handleWebMCPResponse(state, params, source?.sessionId)
     ));

--- a/src/chrome/src/cdp/cdp-client.js
+++ b/src/chrome/src/cdp/cdp-client.js
@@ -273,6 +273,10 @@ export class CDPClient {
       nextToolId: 1,
       toolsById: new Map(),
       idsByKey: new Map(),
+      // Per tool-key generation bumped on store and remove. Discovery snapshots
+      // this map so a stale Runtime.evaluate result cannot resurrect or
+      // overwrite a concurrent registration change.
+      toolMutationGens: new Map(),
       pendingInvocations: new Map(),
       completedResponses: new Map(),
       childSessions: new Map(),
@@ -280,6 +284,16 @@ export class CDPClient {
       discoveryContextsUsed: 0,
       handlers: [],
     };
+  }
+
+  _webMCPToolMutationGen(state, key) {
+    return state.toolMutationGens.get(key) || 0;
+  }
+
+  _bumpWebMCPToolMutation(state, key) {
+    const next = this._webMCPToolMutationGen(state, key) + 1;
+    state.toolMutationGens.set(key, next);
+    return next;
   }
 
   _dropWebMCPSession(tabId, reason = 'WebMCP session closed') {
@@ -305,13 +319,21 @@ export class CDPClient {
     if (state) state.handlers = [];
   }
 
-  _storeWebMCPTools(state, tools, sessionId = '') {
+  _storeWebMCPTools(state, tools, sessionId = '', options = {}) {
     const owningSessionId = String(sessionId || '');
+    const mutationGuard = options.mutationGuard instanceof Map ? options.mutationGuard : null;
     for (const rawTool of Array.isArray(tools) ? tools : []) {
       const name = String(rawTool?.name || '').trim().slice(0, 300);
       const frameId = String(rawTool?.frameId || '').trim().slice(0, 300);
       if (!name || !frameId) continue;
       const key = this._webMCPToolKey(frameId, name);
+      // Drop discovery results whose key was stored or removed while evaluate
+      // was pending; otherwise a stale snapshot can resurrect a deleted tool
+      // or overwrite a fresher re-registration.
+      if (mutationGuard) {
+        const expectedGen = mutationGuard.get(key) || 0;
+        if (this._webMCPToolMutationGen(state, key) !== expectedGen) continue;
+      }
       let toolId = state.idsByKey.get(key);
       if (!toolId) {
         if (state.toolsById.size >= WEBMCP_MAX_REGISTERED_TOOLS) continue;
@@ -329,6 +351,7 @@ export class CDPClient {
       const sanitizedSchema = this._sanitizeWebMCPValue(rawTool?.inputSchema || {
         type: 'object', properties: {}, required: [],
       });
+      this._bumpWebMCPToolMutation(state, key);
       state.toolsById.set(toolId, {
         toolId,
         name,
@@ -351,6 +374,7 @@ export class CDPClient {
       const toolId = state.idsByKey.get(key);
       if (!toolId) continue;
       if (state.toolsById.get(toolId)?.sessionId !== owningSessionId) continue;
+      this._bumpWebMCPToolMutation(state, key);
       state.idsByKey.delete(key);
       state.toolsById.delete(toolId);
     }
@@ -362,8 +386,10 @@ export class CDPClient {
     let removed = 0;
     for (const [toolId, tool] of state.toolsById) {
       if (tool.frameId !== targetFrameId) continue;
+      const key = this._webMCPToolKey(tool.frameId, tool.name);
+      this._bumpWebMCPToolMutation(state, key);
       state.toolsById.delete(toolId);
-      state.idsByKey.delete(this._webMCPToolKey(tool.frameId, tool.name));
+      state.idsByKey.delete(key);
       removed++;
     }
     return removed;
@@ -374,8 +400,10 @@ export class CDPClient {
     let removed = 0;
     for (const [toolId, tool] of state.toolsById) {
       if (tool.sessionId !== targetSessionId) continue;
+      const key = this._webMCPToolKey(tool.frameId, tool.name);
+      this._bumpWebMCPToolMutation(state, key);
       state.toolsById.delete(toolId);
-      state.idsByKey.delete(this._webMCPToolKey(tool.frameId, tool.name));
+      state.idsByKey.delete(key);
       removed++;
     }
     return removed;
@@ -445,6 +473,9 @@ export class CDPClient {
     );
     const selectedContexts = [...contextsByFrame].slice(0, remainingContextBudget);
     state.discoveryContextsUsed += selectedContexts.length;
+    // Capture generations before evaluate so concurrent toolsRemoved /
+    // toolsAdded / frame cleanup invalidate these results at merge time.
+    const mutationGuard = new Map(state.toolMutationGens);
     const discovered = await Promise.allSettled(
       selectedContexts.map(async ([frameId, contextId]) => {
         const evaluated = await this.sendCommand(tabId, 'Runtime.evaluate', {
@@ -463,7 +494,7 @@ export class CDPClient {
     let count = 0;
     for (const result of discovered) {
       if (result.status !== 'fulfilled') continue;
-      this._storeWebMCPTools(state, result.value, owningSessionId);
+      this._storeWebMCPTools(state, result.value, owningSessionId, { mutationGuard });
       count += result.value.length;
     }
     return count;
@@ -776,13 +807,10 @@ export class CDPClient {
         if (frameId) frameUrls.set(frameId, this._webMCPSafeFrameUrl(frame));
       }
     }
-    // TargetInfo is a trusted fallback for the OOPIF root only. Descendant
-    // frame IDs must come from Page.getFrameTree so a different-origin child
-    // can never inherit its target root's permission host.
-    for (const child of childSessions) {
-      if (!child.targetId || frameUrls.has(child.targetId)) continue;
-      frameUrls.set(child.targetId, this._webMCPSafeFrameUrl({ url: child.url }));
-    }
+    // Fail closed when Page.getFrameTree is unavailable. TargetInfo.url is only
+    // the document URL and carries no effective securityOrigin; a sandboxed
+    // opaque frame can still report an HTTPS URL and must not borrow that host
+    // for permission grants. Permission hosts come only from frame-tree records.
     return frameUrls;
   }
 

--- a/src/chrome/src/cdp/cdp-client.js
+++ b/src/chrome/src/cdp/cdp-client.js
@@ -58,6 +58,7 @@ export class CDPClient {
     this.eventHandlers = new Map(); // tabId -> { eventName -> [handlers] }
     this.devDiagnostics = new Map(); // tabId -> bounded console/network buffers
     this.webMcpSessions = new Map(); // tabId -> WebMCP tools + pending invocations
+    this.runtimeContexts = new Map(); // tabId -> session/context key -> default context
     this.fileChooserGuards = new Map(); // tabId -> temporary protocol interception
   }
 
@@ -81,6 +82,7 @@ export class CDPClient {
 
         chrome.debugger.onEvent.addListener((source, method, params) => {
           if (source.tabId !== tabId) return;
+          this._trackRuntimeContextEvent(tabId, source, method, params);
           const handlers = this.eventHandlers.get(tabId)?.[method];
           if (handlers) {
             handlers.forEach(h => h(params, source));
@@ -93,6 +95,7 @@ export class CDPClient {
             this.sessions.delete(tabId);
             this.eventHandlers.delete(tabId);
             this.devDiagnostics.delete(tabId);
+            this.runtimeContexts.delete(tabId);
             const fileChooserGuard = this.fileChooserGuards.get(tabId);
             if (fileChooserGuard?.timer) clearTimeout(fileChooserGuard.timer);
             this.fileChooserGuards.delete(tabId);
@@ -117,6 +120,7 @@ export class CDPClient {
         this.sessions.delete(tabId);
         this.eventHandlers.delete(tabId);
         this.devDiagnostics.delete(tabId);
+        this.runtimeContexts.delete(tabId);
         this.fileChooserGuards.delete(tabId);
         resolve();
       });
@@ -218,6 +222,44 @@ export class CDPClient {
 
   _webMCPInvocationKey(sessionId, invocationId) {
     return `${String(sessionId || '').slice(0, 300)}\u0000${String(invocationId || '').slice(0, 300)}`;
+  }
+
+  _runtimeContextKey(sessionId, contextId) {
+    return `${String(sessionId || '').slice(0, 300)}\u0000${String(contextId ?? '').slice(0, 100)}`;
+  }
+
+  _trackRuntimeContextEvent(tabId, source = {}, method = '', params = {}) {
+    const sessionId = String(source.sessionId || '');
+    let contexts = this.runtimeContexts.get(tabId);
+    if (method === 'Runtime.executionContextCreated') {
+      const context = params.context;
+      const frameId = String(context?.auxData?.frameId || '');
+      if (!context?.auxData?.isDefault || !frameId || context.id == null) return;
+      if (!contexts) {
+        contexts = new Map();
+        this.runtimeContexts.set(tabId, contexts);
+      }
+      contexts.set(this._runtimeContextKey(sessionId, context.id), {
+        contextId: context.id,
+        frameId,
+        sessionId,
+      });
+      return;
+    }
+    if (!contexts) return;
+    if (method === 'Runtime.executionContextDestroyed') {
+      contexts.delete(this._runtimeContextKey(sessionId, params.executionContextId));
+    } else if (method === 'Runtime.executionContextsCleared') {
+      for (const [key, context] of contexts) {
+        if (context.sessionId === sessionId) contexts.delete(key);
+      }
+    } else if (method === 'Target.detachedFromTarget') {
+      const detachedSessionId = String(params.sessionId || '');
+      for (const [key, context] of contexts) {
+        if (context.sessionId === detachedSessionId) contexts.delete(key);
+      }
+    }
+    if (!contexts.size) this.runtimeContexts.delete(tabId);
   }
 
   _newWebMCPSession(tabId) {
@@ -376,6 +418,10 @@ export class CDPClient {
       contextsByFrame.set(frameId, context.id);
     };
     this.on(tabId, 'Runtime.executionContextCreated', onContextCreated);
+    for (const context of this.runtimeContexts.get(tabId)?.values() || []) {
+      if (context.sessionId !== owningSessionId) continue;
+      contextsByFrame.set(context.frameId, context.contextId);
+    }
     try {
       await this.sendCommand(tabId, 'Runtime.enable', {}, owningSessionId);
       // Runtime.enable reports existing contexts asynchronously. Keep this

--- a/src/chrome/src/cdp/cdp-client.js
+++ b/src/chrome/src/cdp/cdp-client.js
@@ -261,6 +261,7 @@ export class CDPClient {
   }
 
   _storeWebMCPTools(state, tools, sessionId = '') {
+    const owningSessionId = String(sessionId || '');
     for (const rawTool of Array.isArray(tools) ? tools : []) {
       const name = String(rawTool?.name || '').trim().slice(0, 300);
       const frameId = String(rawTool?.frameId || '').trim().slice(0, 300);
@@ -292,8 +293,9 @@ export class CDPClient {
           : { type: 'object', properties: {}, required: [] },
         annotations,
         frameId,
-        sessionId: String(sessionId || ''),
+        sessionId: owningSessionId,
       });
+      state.childSessions.get(owningSessionId)?.frameIds.add(frameId);
     }
   }
 
@@ -320,6 +322,33 @@ export class CDPClient {
     return removed;
   }
 
+  _removeWebMCPSessionTools(state, sessionId = '') {
+    const targetSessionId = String(sessionId || '');
+    let removed = 0;
+    for (const [toolId, tool] of state.toolsById) {
+      if (tool.sessionId !== targetSessionId) continue;
+      state.toolsById.delete(toolId);
+      state.idsByKey.delete(this._webMCPToolKey(tool.frameId, tool.name));
+      removed++;
+    }
+    return removed;
+  }
+
+  _finishWebMCPSessionInvocations(state, sessionId, reason) {
+    const targetSessionId = String(sessionId || '');
+    for (const pending of [...state.pendingInvocations.values()]) {
+      if (pending.sessionId !== targetSessionId) continue;
+      try {
+        pending.finish({
+          success: false,
+          dispatched: true,
+          outcomeUnknown: true,
+          error: reason,
+        });
+      } catch {}
+    }
+  }
+
   _handleWebMCPResponse(state, params = {}, sessionId = '') {
     const invocationId = String(params.invocationId || '');
     if (!invocationId) return;
@@ -336,9 +365,11 @@ export class CDPClient {
     }
   }
 
-  async _discoverExistingWebMCPFrameTools(tabId, state) {
+  async _discoverExistingWebMCPFrameTools(tabId, state, sessionId = '') {
+    const owningSessionId = String(sessionId || '');
     const contextsByFrame = new Map();
-    const onContextCreated = (params = {}) => {
+    const onContextCreated = (params = {}, source = {}) => {
+      if (String(source.sessionId || '') !== owningSessionId) return;
       const context = params.context;
       const frameId = String(context?.auxData?.frameId || '');
       if (!context?.auxData?.isDefault || !frameId || context.id == null) return;
@@ -346,7 +377,7 @@ export class CDPClient {
     };
     this.on(tabId, 'Runtime.executionContextCreated', onContextCreated);
     try {
-      await this.sendCommand(tabId, 'Runtime.enable');
+      await this.sendCommand(tabId, 'Runtime.enable', {}, owningSessionId);
       // Runtime.enable reports existing contexts asynchronously. Keep this
       // bounded: live registrations are still delivered by WebMCP.toolsAdded.
       await new Promise(resolve => setTimeout(resolve, WEBMCP_DISCOVERY_SETTLE_MS));
@@ -364,7 +395,7 @@ export class CDPClient {
           awaitPromise: true,
           returnByValue: true,
           timeout: WEBMCP_CONTEXT_DISCOVERY_TIMEOUT_MS,
-        });
+        }, owningSessionId);
         if (evaluated?.exceptionDetails) return [];
         return (Array.isArray(evaluated?.result?.value) ? evaluated.result.value : [])
           .map(tool => ({ ...tool, frameId }));
@@ -374,7 +405,7 @@ export class CDPClient {
     let count = 0;
     for (const result of discovered) {
       if (result.status !== 'fulfilled') continue;
-      this._storeWebMCPTools(state, result.value);
+      this._storeWebMCPTools(state, result.value, owningSessionId);
       count += result.value.length;
     }
     return count;
@@ -404,6 +435,15 @@ export class CDPClient {
           filter: WEBMCP_IFRAME_TARGET_FILTER,
         }, sessionId),
       ]);
+      if (
+        state.closed
+        || this.webMcpSessions.get(tabId) !== state
+        || !state.childSessions.has(sessionId)
+      ) return;
+      // WebMCP.enable currently enumerates only the root document of each
+      // target. Recover pre-registered tools from same-process descendants of
+      // this OOPIF target just as we do for the top-level target.
+      await this._discoverExistingWebMCPFrameTools(tabId, state, sessionId);
     })().finally(() => state.childEnablePromises.delete(enabling));
     state.childEnablePromises.add(enabling);
   }
@@ -449,12 +489,6 @@ export class CDPClient {
     };
     register('WebMCP.toolsAdded', (params, source) => {
       this._storeWebMCPTools(state, params?.tools, source?.sessionId);
-      const child = state.childSessions.get(String(source?.sessionId || ''));
-      if (!child) return;
-      for (const tool of Array.isArray(params?.tools) ? params.tools : []) {
-        const frameId = String(tool?.frameId || '');
-        if (frameId) child.frameIds.add(frameId);
-      }
     });
     register('WebMCP.toolsRemoved', params => this._removeWebMCPTools(state, params?.tools));
     register('WebMCP.toolResponded', (params, source) => (
@@ -465,7 +499,12 @@ export class CDPClient {
       const sessionId = String(params?.sessionId || '');
       const child = state.childSessions.get(sessionId);
       if (!child) return;
-      for (const frameId of child.frameIds) this._removeWebMCPFrameTools(state, frameId);
+      this._removeWebMCPSessionTools(state, sessionId);
+      this._finishWebMCPSessionInvocations(
+        state,
+        sessionId,
+        'The WebMCP frame detached before Chrome reported the invocation outcome.',
+      );
       state.childSessions.delete(sessionId);
     });
     register('Target.targetInfoChanged', params => {
@@ -478,12 +517,32 @@ export class CDPClient {
       const frame = params?.frame || {};
       const frameId = String(frame.id || '');
       if (!frameId) return;
+      const sessionId = String(source?.sessionId || '');
+      const child = state.childSessions.get(sessionId);
+      if (!frame.parentId) {
+        const affectedSessionIds = sessionId
+          ? [sessionId]
+          : ['', ...state.childSessions.keys()];
+        for (const affectedSessionId of affectedSessionIds) {
+          this._removeWebMCPSessionTools(state, affectedSessionId);
+          this._finishWebMCPSessionInvocations(
+            state,
+            affectedSessionId,
+            'The WebMCP document navigated before Chrome reported the invocation outcome.',
+          );
+        }
+        if (!sessionId) {
+          for (const nestedChild of state.childSessions.values()) nestedChild.frameIds.clear();
+        }
+        if (child) {
+          child.frameIds.clear();
+          child.frameIds.add(frameId);
+          child.url = String(frame.url || child.url || '');
+        }
+        return;
+      }
       this._removeWebMCPFrameTools(state, frameId);
-      const child = state.childSessions.get(String(source?.sessionId || ''));
-      if (!child) return;
-      child.frameIds.clear();
-      child.frameIds.add(frameId);
-      child.url = String(frame.url || child.url || '');
+      child?.frameIds.delete(frameId);
     });
     register('Page.frameDetached', (params, source) => {
       const frameId = String(params?.frameId || '');
@@ -537,9 +596,14 @@ export class CDPClient {
     }
     if (state.enabled && this.sessions.has(tabId)) {
       await Promise.allSettled(
-        [...state.childSessions].map(([sessionId]) => (
-          this.sendCommand(tabId, 'WebMCP.disable', {}, sessionId)
-        )),
+        [...state.childSessions].flatMap(([sessionId]) => [
+          this.sendCommand(tabId, 'Target.setAutoAttach', {
+            autoAttach: false,
+            waitForDebuggerOnStart: false,
+            flatten: true,
+          }, sessionId),
+          this.sendCommand(tabId, 'WebMCP.disable', {}, sessionId),
+        ]),
       );
       await this.sendCommand(tabId, 'Target.setAutoAttach', {
         autoAttach: false,
@@ -560,44 +624,55 @@ export class CDPClient {
     return tabIds.length;
   }
 
-  async _webMCPFrameUrls(tabId) {
-    const frames = await this.getAllFrames(tabId).catch(() => []);
-    const frameUrls = new Map(frames.map(frame => {
-      const frameId = String(frame.id || '');
-      const rawUrl = String(frame.url || '');
-      const securityOrigin = String(frame.securityOrigin || '');
-      // Prefer Chrome's effective security origin. Sandboxed/opaque frames may
-      // retain an https-looking document URL but must not borrow that host's
-      // grant. Older test doubles omit securityOrigin, so a valid network URL
-      // remains a compatible fallback.
-      if (securityOrigin) {
+  _webMCPSafeFrameUrl(frame = {}) {
+    const rawUrl = String(frame.url || '');
+    const securityOrigin = String(frame.securityOrigin || '');
+    // Prefer Chrome's effective security origin. Sandboxed/opaque frames may
+    // retain an https-looking document URL but must not borrow that host's
+    // grant. Older test doubles omit securityOrigin, so a valid network URL
+    // remains a compatible fallback.
+    if (securityOrigin) {
+      try {
+        const origin = new URL(securityOrigin);
+        if (origin.protocol !== 'http:' && origin.protocol !== 'https:') return '';
         try {
-          const origin = new URL(securityOrigin);
-          if (origin.protocol !== 'http:' && origin.protocol !== 'https:') return [frameId, ''];
-          try {
-            const url = new URL(rawUrl);
-            if (url.origin === origin.origin) return [frameId, url.href];
-          } catch {}
-          return [frameId, origin.origin];
-        } catch {
-          return [frameId, ''];
-        }
-      }
-      try {
-        const url = new URL(rawUrl);
-        return [frameId, url.protocol === 'http:' || url.protocol === 'https:' ? url.href : ''];
+          const url = new URL(rawUrl);
+          if (url.origin === origin.origin) return url.href;
+        } catch {}
+        return origin.origin;
       } catch {
-        return [frameId, ''];
+        return '';
       }
-    }));
+    }
+    try {
+      const url = new URL(rawUrl);
+      return url.protocol === 'http:' || url.protocol === 'https:' ? url.href : '';
+    } catch {
+      return '';
+    }
+  }
+
+  async _webMCPFrameUrls(tabId) {
     const state = this.webMcpSessions.get(tabId);
-    for (const child of state?.childSessions?.values() || []) {
-      let safeUrl = '';
-      try {
-        const url = new URL(child.url);
-        if (url.protocol === 'http:' || url.protocol === 'https:') safeUrl = url.href;
-      } catch {}
-      for (const frameId of child.frameIds) frameUrls.set(frameId, safeUrl);
+    const childSessions = [...(state?.childSessions?.values() || [])];
+    const frameResults = await Promise.allSettled([
+      this.getAllFrames(tabId),
+      ...childSessions.map(child => this.getAllFrames(tabId, child.sessionId)),
+    ]);
+    const frameUrls = new Map();
+    for (const result of frameResults) {
+      if (result.status !== 'fulfilled') continue;
+      for (const frame of result.value) {
+        const frameId = String(frame.id || '');
+        if (frameId) frameUrls.set(frameId, this._webMCPSafeFrameUrl(frame));
+      }
+    }
+    // TargetInfo is a trusted fallback for the OOPIF root only. Descendant
+    // frame IDs must come from Page.getFrameTree so a different-origin child
+    // can never inherit its target root's permission host.
+    for (const child of childSessions) {
+      if (!child.targetId || frameUrls.has(child.targetId)) continue;
+      frameUrls.set(child.targetId, this._webMCPSafeFrameUrl({ url: child.url }));
     }
     return frameUrls;
   }
@@ -1401,9 +1476,9 @@ export class CDPClient {
   /**
    * Get all frames including cross-origin iframes.
    */
-  async getAllFrames(tabId) {
-    await this.sendCommand(tabId, 'Page.enable');
-    const result = await this.sendCommand(tabId, 'Page.getFrameTree');
+  async getAllFrames(tabId, sessionId = '') {
+    await this.sendCommand(tabId, 'Page.enable', {}, sessionId);
+    const result = await this.sendCommand(tabId, 'Page.getFrameTree', {}, sessionId);
     
     const frames = [];
     const collectFrames = (frameTree) => {

--- a/src/chrome/src/cdp/cdp-client.js
+++ b/src/chrome/src/cdp/cdp-client.js
@@ -20,6 +20,8 @@ const WEBMCP_MAX_INVOCATION_TIMEOUT_MS = 60000;
 const WEBMCP_MAX_VALUE_NODES = 500;
 const WEBMCP_MAX_VALUE_CHARS = 20000;
 const WEBMCP_CONTEXT_DISCOVERY_TIMEOUT_MS = 1000;
+const WEBMCP_MAX_DISCOVERY_CONTEXTS = 500;
+const WEBMCP_MAX_CHILD_SESSIONS = 100;
 const WEBMCP_MAX_TARGET_ATTACH_PASSES = 10;
 const WEBMCP_IFRAME_TARGET_FILTER = [
   { type: 'iframe', exclude: false },
@@ -275,6 +277,7 @@ export class CDPClient {
       completedResponses: new Map(),
       childSessions: new Map(),
       childEnablePromises: new Set(),
+      discoveryContextsUsed: 0,
       handlers: [],
     };
   }
@@ -435,8 +438,14 @@ export class CDPClient {
       this.off(tabId, 'Runtime.executionContextCreated', onContextCreated);
     }
 
+    const remainingContextBudget = Math.max(
+      0,
+      WEBMCP_MAX_DISCOVERY_CONTEXTS - state.discoveryContextsUsed,
+    );
+    const selectedContexts = [...contextsByFrame].slice(0, remainingContextBudget);
+    state.discoveryContextsUsed += selectedContexts.length;
     const discovered = await Promise.allSettled(
-      [...contextsByFrame].map(async ([frameId, contextId]) => {
+      selectedContexts.map(async ([frameId, contextId]) => {
         const evaluated = await this.sendCommand(tabId, 'Runtime.evaluate', {
           expression: WEBMCP_CONTEXT_DISCOVERY_EXPRESSION,
           contextId,
@@ -459,10 +468,19 @@ export class CDPClient {
     return count;
   }
 
-  _enableWebMCPChildSession(tabId, state, params = {}) {
+  _enableWebMCPChildSession(tabId, state, params = {}, source = {}) {
     const sessionId = String(params.sessionId || '');
     const targetInfo = params.targetInfo || {};
     if (!sessionId || targetInfo.type !== 'iframe' || state.childSessions.has(sessionId)) return;
+    if (state.childSessions.size >= WEBMCP_MAX_CHILD_SESSIONS) {
+      this.sendCommand(
+        tabId,
+        'Target.detachFromTarget',
+        { sessionId },
+        source.sessionId,
+      ).catch(() => {});
+      return;
+    }
     const child = {
       sessionId,
       targetId: String(targetInfo.targetId || ''),
@@ -544,7 +562,9 @@ export class CDPClient {
     register('WebMCP.toolResponded', (params, source) => (
       this._handleWebMCPResponse(state, params, source?.sessionId)
     ));
-    register('Target.attachedToTarget', params => this._enableWebMCPChildSession(tabId, state, params));
+    register('Target.attachedToTarget', (params, source) => (
+      this._enableWebMCPChildSession(tabId, state, params, source)
+    ));
     register('Target.detachedFromTarget', params => {
       const sessionId = String(params?.sessionId || '');
       const child = state.childSessions.get(sessionId);

--- a/src/chrome/src/cdp/cdp-client.js
+++ b/src/chrome/src/cdp/cdp-client.js
@@ -21,6 +21,7 @@ const WEBMCP_MAX_VALUE_NODES = 500;
 const WEBMCP_MAX_VALUE_CHARS = 20000;
 const WEBMCP_CONTEXT_DISCOVERY_TIMEOUT_MS = 1000;
 const WEBMCP_MAX_DISCOVERY_CONTEXTS = 500;
+const WEBMCP_MAX_DISCOVERY_CONCURRENCY = 16;
 const WEBMCP_MAX_CHILD_SESSIONS = 100;
 const WEBMCP_MAX_TARGET_ATTACH_PASSES = 10;
 const WEBMCP_IFRAME_TARGET_FILTER = [
@@ -277,11 +278,16 @@ export class CDPClient {
       // this map so a stale Runtime.evaluate result cannot resurrect or
       // overwrite a concurrent registration change.
       toolMutationGens: new Map(),
+      // Per-frame generation bumped on navigate/detach/session cleanup so
+      // discovery cannot insert tools for a document that already left.
+      frameMutationGens: new Map(),
       pendingInvocations: new Map(),
       completedResponses: new Map(),
       childSessions: new Map(),
       childEnablePromises: new Set(),
       discoveryContextsUsed: 0,
+      discoveryInFlight: 0,
+      discoveryWaiters: [],
       handlers: [],
     };
   }
@@ -294,6 +300,46 @@ export class CDPClient {
     const next = this._webMCPToolMutationGen(state, key) + 1;
     state.toolMutationGens.set(key, next);
     return next;
+  }
+
+  _webMCPFrameMutationGen(state, frameId) {
+    return state.frameMutationGens.get(String(frameId || '')) || 0;
+  }
+
+  _bumpWebMCPFrameMutation(state, frameId) {
+    const key = String(frameId || '');
+    if (!key) return 0;
+    const next = this._webMCPFrameMutationGen(state, key) + 1;
+    state.frameMutationGens.set(key, next);
+    return next;
+  }
+
+  async _acquireWebMCPDiscoverySlot(state) {
+    if (state.discoveryInFlight < WEBMCP_MAX_DISCOVERY_CONCURRENCY) {
+      state.discoveryInFlight++;
+      return;
+    }
+    await new Promise(resolve => state.discoveryWaiters.push(resolve));
+    state.discoveryInFlight++;
+  }
+
+  _releaseWebMCPDiscoverySlot(state) {
+    state.discoveryInFlight = Math.max(0, state.discoveryInFlight - 1);
+    const next = state.discoveryWaiters.shift();
+    if (next) next();
+  }
+
+  async _teardownWebMCPChildSession(tabId, sessionId) {
+    const sid = String(sessionId || '');
+    if (!sid) return;
+    await Promise.allSettled([
+      this.sendCommand(tabId, 'Target.setAutoAttach', {
+        autoAttach: false,
+        waitForDebuggerOnStart: false,
+        flatten: true,
+      }, sid),
+      this.sendCommand(tabId, 'WebMCP.disable', {}, sid),
+    ]);
   }
 
   _dropWebMCPSession(tabId, reason = 'WebMCP session closed') {
@@ -321,7 +367,12 @@ export class CDPClient {
 
   _storeWebMCPTools(state, tools, sessionId = '', options = {}) {
     const owningSessionId = String(sessionId || '');
+    // Child-session tools must not re-enter the catalog after detach.
+    if (owningSessionId && !state.childSessions.has(owningSessionId)) return;
     const mutationGuard = options.mutationGuard instanceof Map ? options.mutationGuard : null;
+    const frameMutationGuard = options.frameMutationGuard instanceof Map
+      ? options.frameMutationGuard
+      : null;
     for (const rawTool of Array.isArray(tools) ? tools : []) {
       const name = String(rawTool?.name || '').trim().slice(0, 300);
       const frameId = String(rawTool?.frameId || '').trim().slice(0, 300);
@@ -333,6 +384,12 @@ export class CDPClient {
       if (mutationGuard) {
         const expectedGen = mutationGuard.get(key) || 0;
         if (this._webMCPToolMutationGen(state, key) !== expectedGen) continue;
+      }
+      // Frame-level guard covers keys that never existed yet: navigate/detach
+      // bumps the frame gen even when toolsById had nothing to remove.
+      if (frameMutationGuard) {
+        const expectedFrameGen = frameMutationGuard.get(frameId) || 0;
+        if (this._webMCPFrameMutationGen(state, frameId) !== expectedFrameGen) continue;
       }
       let toolId = state.idsByKey.get(key);
       if (!toolId) {
@@ -383,6 +440,9 @@ export class CDPClient {
   _removeWebMCPFrameTools(state, frameId) {
     const targetFrameId = String(frameId || '');
     if (!targetFrameId) return 0;
+    // Always bump even when no tools were registered so discovery cannot insert
+    // a pre-navigate snapshot for this frame id.
+    this._bumpWebMCPFrameMutation(state, targetFrameId);
     let removed = 0;
     for (const [toolId, tool] of state.toolsById) {
       if (tool.frameId !== targetFrameId) continue;
@@ -402,6 +462,7 @@ export class CDPClient {
       if (tool.sessionId !== targetSessionId) continue;
       const key = this._webMCPToolKey(tool.frameId, tool.name);
       this._bumpWebMCPToolMutation(state, key);
+      this._bumpWebMCPFrameMutation(state, tool.frameId);
       state.toolsById.delete(toolId);
       state.idsByKey.delete(key);
       removed++;
@@ -413,6 +474,22 @@ export class CDPClient {
     const targetSessionId = String(sessionId || '');
     for (const pending of [...state.pendingInvocations.values()]) {
       if (pending.sessionId !== targetSessionId) continue;
+      try {
+        pending.finish({
+          success: false,
+          dispatched: true,
+          outcomeUnknown: true,
+          error: reason,
+        });
+      } catch {}
+    }
+  }
+
+  _finishWebMCPFrameInvocations(state, frameId, reason) {
+    const targetFrameId = String(frameId || '');
+    if (!targetFrameId) return;
+    for (const pending of [...state.pendingInvocations.values()]) {
+      if (pending.frameId !== targetFrameId) continue;
       try {
         pending.finish({
           success: false,
@@ -442,6 +519,7 @@ export class CDPClient {
 
   async _discoverExistingWebMCPFrameTools(tabId, state, sessionId = '') {
     const owningSessionId = String(sessionId || '');
+    if (owningSessionId && !state.childSessions.has(owningSessionId)) return 0;
     const contextsByFrame = new Map();
     const onContextCreated = (params = {}, source = {}) => {
       if (String(source.sessionId || '') !== owningSessionId) return;
@@ -466,6 +544,7 @@ export class CDPClient {
       this.off(tabId, 'Runtime.executionContextCreated', onContextCreated);
     }
     if (state.closed || this.webMcpSessions.get(tabId) !== state) return 0;
+    if (owningSessionId && !state.childSessions.has(owningSessionId)) return 0;
 
     const remainingContextBudget = Math.max(
       0,
@@ -476,25 +555,60 @@ export class CDPClient {
     // Capture generations before evaluate so concurrent toolsRemoved /
     // toolsAdded / frame cleanup invalidate these results at merge time.
     const mutationGuard = new Map(state.toolMutationGens);
-    const discovered = await Promise.allSettled(
-      selectedContexts.map(async ([frameId, contextId]) => {
-        const evaluated = await this.sendCommand(tabId, 'Runtime.evaluate', {
-          expression: WEBMCP_CONTEXT_DISCOVERY_EXPRESSION,
-          contextId,
-          awaitPromise: true,
-          returnByValue: true,
-          timeout: WEBMCP_CONTEXT_DISCOVERY_TIMEOUT_MS,
-        }, owningSessionId);
-        if (evaluated?.exceptionDetails) return [];
-        return (Array.isArray(evaluated?.result?.value) ? evaluated.result.value : [])
-          .map(tool => ({ ...tool, frameId }));
-      }),
+    const frameMutationGuard = new Map(state.frameMutationGens);
+    const discovered = [];
+    let nextIndex = 0;
+    const workers = Array.from(
+      { length: Math.min(WEBMCP_MAX_DISCOVERY_CONCURRENCY, selectedContexts.length) },
+      async () => {
+        while (nextIndex < selectedContexts.length) {
+          const index = nextIndex;
+          nextIndex++;
+          const [frameId, contextId] = selectedContexts[index];
+          await this._acquireWebMCPDiscoverySlot(state);
+          try {
+            if (
+              state.closed
+              || this.webMcpSessions.get(tabId) !== state
+              || (owningSessionId && !state.childSessions.has(owningSessionId))
+            ) {
+              discovered[index] = { status: 'fulfilled', value: [] };
+              continue;
+            }
+            const evaluated = await this.sendCommand(tabId, 'Runtime.evaluate', {
+              expression: WEBMCP_CONTEXT_DISCOVERY_EXPRESSION,
+              contextId,
+              awaitPromise: true,
+              returnByValue: true,
+              timeout: WEBMCP_CONTEXT_DISCOVERY_TIMEOUT_MS,
+            }, owningSessionId);
+            if (evaluated?.exceptionDetails) {
+              discovered[index] = { status: 'fulfilled', value: [] };
+              continue;
+            }
+            discovered[index] = {
+              status: 'fulfilled',
+              value: (Array.isArray(evaluated?.result?.value) ? evaluated.result.value : [])
+                .map(tool => ({ ...tool, frameId })),
+            };
+          } catch (reason) {
+            discovered[index] = { status: 'rejected', reason };
+          } finally {
+            this._releaseWebMCPDiscoverySlot(state);
+          }
+        }
+      },
     );
+    await Promise.all(workers);
     if (state.closed || this.webMcpSessions.get(tabId) !== state) return 0;
+    if (owningSessionId && !state.childSessions.has(owningSessionId)) return 0;
     let count = 0;
     for (const result of discovered) {
-      if (result.status !== 'fulfilled') continue;
-      this._storeWebMCPTools(state, result.value, owningSessionId, { mutationGuard });
+      if (!result || result.status !== 'fulfilled') continue;
+      this._storeWebMCPTools(state, result.value, owningSessionId, {
+        mutationGuard,
+        frameMutationGuard,
+      });
       count += result.value.length;
     }
     return count;
@@ -529,28 +643,44 @@ export class CDPClient {
       frameIds: new Set(),
     };
     state.childSessions.set(sessionId, child);
+    const childStillOwned = () => (
+      !state.closed
+      && this.webMcpSessions.get(tabId) === state
+      && state.childSessions.has(sessionId)
+    );
     const enabling = (async () => {
-      await Promise.allSettled([
-        this.sendCommand(tabId, 'WebMCP.enable', {}, sessionId),
-        this.sendCommand(tabId, 'Page.enable', {}, sessionId),
+      // Enable domains one at a time so a concurrent disableWebMCP can abort
+      // before setAutoAttach(true) re-arms a session we already tore down.
+      const steps = [
+        ['WebMCP.enable', {}],
+        ['Page.enable', {}],
         // Auto-attach is not recursive. Arm each OOPIF session so nested
         // cross-process frames join the same WebMCP catalog as well.
-        this.sendCommand(tabId, 'Target.setAutoAttach', {
+        ['Target.setAutoAttach', {
           autoAttach: true,
           waitForDebuggerOnStart: false,
           flatten: true,
           filter: WEBMCP_IFRAME_TARGET_FILTER,
-        }, sessionId),
-      ]);
-      if (
-        state.closed
-        || this.webMcpSessions.get(tabId) !== state
-        || !state.childSessions.has(sessionId)
-      ) return;
+        }],
+      ];
+      for (const [method, commandParams] of steps) {
+        if (!childStillOwned()) {
+          await this._teardownWebMCPChildSession(tabId, sessionId);
+          return;
+        }
+        await this.sendCommand(tabId, method, commandParams, sessionId).catch(() => {});
+      }
+      if (!childStillOwned()) {
+        await this._teardownWebMCPChildSession(tabId, sessionId);
+        return;
+      }
       // WebMCP.enable currently enumerates only the root document of each
       // target. Recover pre-registered tools from same-process descendants of
       // this OOPIF target just as we do for the top-level target.
       await this._discoverExistingWebMCPFrameTools(tabId, state, sessionId);
+      if (!childStillOwned()) {
+        await this._teardownWebMCPChildSession(tabId, sessionId);
+      }
     })().finally(() => state.childEnablePromises.delete(enabling));
     state.childEnablePromises.add(enabling);
   }
@@ -625,6 +755,7 @@ export class CDPClient {
       const sessionId = String(params?.sessionId || '');
       const child = state.childSessions.get(sessionId);
       if (!child) return;
+      for (const frameId of child.frameIds) this._bumpWebMCPFrameMutation(state, frameId);
       this._removeWebMCPSessionTools(state, sessionId);
       this._finishWebMCPSessionInvocations(
         state,
@@ -657,7 +788,11 @@ export class CDPClient {
             'The WebMCP document navigated before Chrome reported the invocation outcome.',
           );
         }
+        this._bumpWebMCPFrameMutation(state, frameId);
         if (!sessionId) {
+          // Root document navigation starts a new discovery wave for later
+          // OOPIF re-attach cycles; without this the context budget stays spent.
+          state.discoveryContextsUsed = 0;
           for (const nestedChild of state.childSessions.values()) nestedChild.frameIds.clear();
         }
         if (child) {
@@ -668,11 +803,21 @@ export class CDPClient {
         return;
       }
       this._removeWebMCPFrameTools(state, frameId);
+      this._finishWebMCPFrameInvocations(
+        state,
+        frameId,
+        'The WebMCP frame navigated before Chrome reported the invocation outcome.',
+      );
       child?.frameIds.delete(frameId);
     });
     register('Page.frameDetached', (params, source) => {
       const frameId = String(params?.frameId || '');
       this._removeWebMCPFrameTools(state, frameId);
+      this._finishWebMCPFrameInvocations(
+        state,
+        frameId,
+        'The WebMCP frame detached before Chrome reported the invocation outcome.',
+      );
       const child = state.childSessions.get(String(source?.sessionId || ''));
       child?.frameIds.delete(frameId);
     });
@@ -680,6 +825,9 @@ export class CDPClient {
     state.enablingPromise = (async () => {
       try {
         await this.sendCommand(tabId, 'WebMCP.enable');
+        // Page domain is required for frameNavigated/frameDetached on the main
+        // target. Child OOPIF sessions enable Page separately when attached.
+        await this.sendCommand(tabId, 'Page.enable').catch(() => {});
         if (state.closed || this.webMcpSessions.get(tabId) !== state) {
           if (!this.webMcpSessions.has(tabId)) {
             await this.sendCommand(tabId, 'WebMCP.disable').catch(() => {});
@@ -734,23 +882,28 @@ export class CDPClient {
         pending.sessionId,
       ).catch(() => {});
     }
-    if (state.enabled && this.sessions.has(tabId)) {
-      await Promise.allSettled(
-        [...state.childSessions].flatMap(([sessionId]) => [
-          this.sendCommand(tabId, 'Target.setAutoAttach', {
-            autoAttach: false,
-            waitForDebuggerOnStart: false,
-            flatten: true,
-          }, sessionId),
-          this.sendCommand(tabId, 'WebMCP.disable', {}, sessionId),
-        ]),
-      );
+    // Drain child-enable work so it observes closed and tears down any
+    // setAutoAttach(true) it may have issued after our first cleanup pass.
+    await Promise.allSettled([...state.childEnablePromises]);
+    if (this.sessions.has(tabId)) {
+      const disableChild = sessionId => this._teardownWebMCPChildSession(tabId, sessionId);
+      await Promise.allSettled([...state.childSessions.keys()].map(disableChild));
+      // A late-finishing enable may re-insert itself into childSessions briefly;
+      // wait again and disable anything still tracked.
+      await Promise.allSettled([...state.childEnablePromises]);
+      await Promise.allSettled([...state.childSessions.keys()].map(disableChild));
       await this.sendCommand(tabId, 'Target.setAutoAttach', {
         autoAttach: false,
         waitForDebuggerOnStart: false,
         flatten: true,
       }).catch(() => {});
-      await this.sendCommand(tabId, 'WebMCP.disable').catch(() => {});
+      if (state.enabled) {
+        await this.sendCommand(tabId, 'WebMCP.disable').catch(() => {});
+      }
+    }
+    // Unblock any discovery workers still waiting on the concurrency gate.
+    for (const waiter of state.discoveryWaiters.splice(0)) {
+      try { waiter(); } catch {}
     }
     state.childSessions.clear();
     this._removeWebMCPHandlers(tabId, state);
@@ -1026,6 +1179,7 @@ export class CDPClient {
       state.pendingInvocations.set(invocationKey, {
         invocationId,
         sessionId: tool.sessionId,
+        frameId: tool.frameId,
         finish,
         respond,
       });

--- a/src/chrome/src/cdp/cdp-client.js
+++ b/src/chrome/src/cdp/cdp-client.js
@@ -19,6 +19,33 @@ const WEBMCP_DEFAULT_INVOCATION_TIMEOUT_MS = 30000;
 const WEBMCP_MAX_INVOCATION_TIMEOUT_MS = 60000;
 const WEBMCP_MAX_VALUE_NODES = 500;
 const WEBMCP_MAX_VALUE_CHARS = 20000;
+const WEBMCP_CONTEXT_DISCOVERY_TIMEOUT_MS = 1000;
+const WEBMCP_CONTEXT_DISCOVERY_EXPRESSION = `
+  (async () => {
+    const context = document.modelContext;
+    if (typeof context?.getTools !== 'function') return [];
+    const tools = await context.getTools();
+    return tools
+      .filter(tool => tool?.window === window)
+      .slice(0, ${WEBMCP_MAX_REGISTERED_TOOLS})
+      .map(tool => {
+        let inputSchema = tool.inputSchema;
+        if (typeof inputSchema === 'string') {
+          try { inputSchema = JSON.parse(inputSchema); } catch { inputSchema = null; }
+        }
+        return {
+          name: tool.name,
+          description: tool.description,
+          inputSchema,
+          annotations: {
+            readOnly: tool.annotations?.readOnlyHint === true,
+            untrustedContent: tool.annotations?.untrustedContentHint === true,
+            autosubmit: false,
+          },
+        };
+      });
+  })()
+`;
 
 export class CDPClient {
   constructor() {
@@ -278,6 +305,50 @@ export class CDPClient {
     }
   }
 
+  async _discoverExistingWebMCPFrameTools(tabId, state) {
+    const contextsByFrame = new Map();
+    const onContextCreated = (params = {}) => {
+      const context = params.context;
+      const frameId = String(context?.auxData?.frameId || '');
+      if (!context?.auxData?.isDefault || !frameId || context.id == null) return;
+      contextsByFrame.set(frameId, context.id);
+    };
+    this.on(tabId, 'Runtime.executionContextCreated', onContextCreated);
+    try {
+      await this.sendCommand(tabId, 'Runtime.enable');
+      // Runtime.enable reports existing contexts asynchronously. Keep this
+      // bounded: live registrations are still delivered by WebMCP.toolsAdded.
+      await new Promise(resolve => setTimeout(resolve, WEBMCP_DISCOVERY_SETTLE_MS));
+    } catch {
+      return 0;
+    } finally {
+      this.off(tabId, 'Runtime.executionContextCreated', onContextCreated);
+    }
+
+    const discovered = await Promise.allSettled(
+      [...contextsByFrame].map(async ([frameId, contextId]) => {
+        const evaluated = await this.sendCommand(tabId, 'Runtime.evaluate', {
+          expression: WEBMCP_CONTEXT_DISCOVERY_EXPRESSION,
+          contextId,
+          awaitPromise: true,
+          returnByValue: true,
+          timeout: WEBMCP_CONTEXT_DISCOVERY_TIMEOUT_MS,
+        });
+        if (evaluated?.exceptionDetails) return [];
+        return (Array.isArray(evaluated?.result?.value) ? evaluated.result.value : [])
+          .map(tool => ({ ...tool, frameId }));
+      }),
+    );
+    if (state.closed || this.webMcpSessions.get(tabId) !== state) return 0;
+    let count = 0;
+    for (const result of discovered) {
+      if (result.status !== 'fulfilled') continue;
+      this._storeWebMCPTools(state, result.value);
+      count += result.value.length;
+    }
+    return count;
+  }
+
   /**
    * Enable Chrome's experimental WebMCP CDP domain. Tool descriptions,
    * schemas, and outputs remain page-controlled; callers must keep them on an
@@ -314,6 +385,11 @@ export class CDPClient {
         // The protocol reports the initial catalog through toolsAdded rather
         // than the command result. Give that event one short task turn to land.
         await new Promise(resolve => setTimeout(resolve, WEBMCP_DISCOVERY_SETTLE_MS));
+        // Chrome currently enumerates only the root frame when WebMCP.enable
+        // runs. Query each already-live default execution context through the
+        // browser's ModelContext API so tools registered earlier in child
+        // frames enter the same opaque, untrusted CDP-backed registry.
+        await this._discoverExistingWebMCPFrameTools(tabId, state);
         return state;
       } catch (error) {
         this._removeWebMCPHandlers(tabId, state);

--- a/src/chrome/src/cdp/cdp-client.js
+++ b/src/chrome/src/cdp/cdp-client.js
@@ -437,6 +437,7 @@ export class CDPClient {
     } finally {
       this.off(tabId, 'Runtime.executionContextCreated', onContextCreated);
     }
+    if (state.closed || this.webMcpSessions.get(tabId) !== state) return 0;
 
     const remainingContextBudget = Math.max(
       0,
@@ -472,6 +473,15 @@ export class CDPClient {
     const sessionId = String(params.sessionId || '');
     const targetInfo = params.targetInfo || {};
     if (!sessionId || targetInfo.type !== 'iframe' || state.childSessions.has(sessionId)) return;
+    if (state.closed || this.webMcpSessions.get(tabId) !== state) {
+      this.sendCommand(
+        tabId,
+        'Target.detachFromTarget',
+        { sessionId },
+        source.sessionId,
+      ).catch(() => {});
+      return;
+    }
     if (state.childSessions.size >= WEBMCP_MAX_CHILD_SESSIONS) {
       this.sendCommand(
         tabId,
@@ -515,6 +525,7 @@ export class CDPClient {
   }
 
   async _enableWebMCPOOPIFTargets(tabId, state) {
+    if (state.closed || this.webMcpSessions.get(tabId) !== state) return 0;
     try {
       await this.sendCommand(tabId, 'Target.setAutoAttach', {
         autoAttach: true,
@@ -525,7 +536,18 @@ export class CDPClient {
     } catch {
       return 0;
     }
+    if (state.closed || this.webMcpSessions.get(tabId) !== state) {
+      if (this.webMcpSessions.get(tabId) === state) {
+        await this.sendCommand(tabId, 'Target.setAutoAttach', {
+          autoAttach: false,
+          waitForDebuggerOnStart: false,
+          flatten: true,
+        }).catch(() => {});
+      }
+      return 0;
+    }
     for (let pass = 0; pass < WEBMCP_MAX_TARGET_ATTACH_PASSES; pass++) {
+      if (state.closed || this.webMcpSessions.get(tabId) !== state) break;
       await new Promise(resolve => setTimeout(resolve, WEBMCP_DISCOVERY_SETTLE_MS));
       const pending = [...state.childEnablePromises];
       if (!pending.length) break;
@@ -542,6 +564,9 @@ export class CDPClient {
   async enableWebMCP(tabId) {
     await this.attach(tabId);
     let state = this.webMcpSessions.get(tabId);
+    if (state?.closed) {
+      throw new Error('WebMCP session is closing; retry after cleanup completes.');
+    }
     if (state?.enabled) return state;
     if (state?.enablingPromise) return await state.enablingPromise;
     if (!state) {
@@ -634,16 +659,27 @@ export class CDPClient {
         // The protocol reports the initial catalog through toolsAdded rather
         // than the command result. Give that event one short task turn to land.
         await new Promise(resolve => setTimeout(resolve, WEBMCP_DISCOVERY_SETTLE_MS));
+        if (state.closed || this.webMcpSessions.get(tabId) !== state) {
+          throw new Error('WebMCP session closed while it was enabling');
+        }
         // Chrome currently enumerates only the root frame when WebMCP.enable
         // runs. Query each already-live default execution context through the
         // browser's ModelContext API so tools registered earlier in child
         // frames enter the same opaque, untrusted CDP-backed registry.
         await this._discoverExistingWebMCPFrameTools(tabId, state);
+        if (state.closed || this.webMcpSessions.get(tabId) !== state) {
+          throw new Error('WebMCP session closed while it was enabling');
+        }
         await this._enableWebMCPOOPIFTargets(tabId, state);
+        if (state.closed || this.webMcpSessions.get(tabId) !== state) {
+          throw new Error('WebMCP session closed while it was enabling');
+        }
         return state;
       } catch (error) {
         this._removeWebMCPHandlers(tabId, state);
-        if (this.webMcpSessions.get(tabId) === state) this.webMcpSessions.delete(tabId);
+        if (!state.closed && this.webMcpSessions.get(tabId) === state) {
+          this.webMcpSessions.delete(tabId);
+        }
         const message = String(error?.message || error || 'unknown CDP error');
         throw new Error(`WebMCP is unavailable in this Chrome/page context: ${message}`);
       } finally {
@@ -656,6 +692,9 @@ export class CDPClient {
   async disableWebMCP(tabId) {
     const state = this.webMcpSessions.get(tabId);
     if (!state) return false;
+    // Close the state before awaiting protocol cleanup so in-flight discovery
+    // and attached-target events cannot re-arm child sessions.
+    state.closed = true;
     for (const pending of state.pendingInvocations.values()) {
       this.sendCommand(
         tabId,
@@ -876,6 +915,14 @@ export class CDPClient {
         dispatched: false,
         noDispatch: true,
         error: 'execute_webmcp_tool: input must be JSON-serializable.',
+      };
+    }
+    if (state.closed || this.webMcpSessions.get(tabId) !== state) {
+      return {
+        success: false,
+        dispatched: false,
+        noDispatch: true,
+        error: 'The WebMCP session closed before the tool could be dispatched.',
       };
     }
     let invocation;

--- a/src/chrome/src/cdp/cdp-client.js
+++ b/src/chrome/src/cdp/cdp-client.js
@@ -281,6 +281,9 @@ export class CDPClient {
       // Per-frame generation bumped on navigate/detach/session cleanup so
       // discovery cannot insert tools for a document that already left.
       frameMutationGens: new Map(),
+      // Session-wide epoch bumped on main-target root navigation so in-flight
+      // discovery cannot reinsert tools for frames that never had a gen entry.
+      discoveryEpoch: 0,
       pendingInvocations: new Map(),
       completedResponses: new Map(),
       childSessions: new Map(),
@@ -312,6 +315,75 @@ export class CDPClient {
     const next = this._webMCPFrameMutationGen(state, key) + 1;
     state.frameMutationGens.set(key, next);
     return next;
+  }
+
+  _bumpWebMCPDiscoveryEpoch(state) {
+    state.discoveryEpoch = (state.discoveryEpoch || 0) + 1;
+    return state.discoveryEpoch;
+  }
+
+  /**
+   * Drop mutation gens that no longer back a live tool/frame after a catalog
+   * wipe. Safe only once discoveryEpoch has already invalidated in-flight
+   * discovery (clearing gens alone would reset them to 0 and re-admit stale
+   * snapshots).
+   */
+  _pruneWebMCPMutationMaps(state) {
+    const liveToolKeys = new Set(state.idsByKey.keys());
+    for (const key of state.toolMutationGens.keys()) {
+      if (!liveToolKeys.has(key)) state.toolMutationGens.delete(key);
+    }
+    const liveFrameIds = new Set();
+    for (const tool of state.toolsById.values()) {
+      if (tool.frameId) liveFrameIds.add(tool.frameId);
+    }
+    for (const child of state.childSessions.values()) {
+      for (const frameId of child.frameIds) liveFrameIds.add(frameId);
+    }
+    for (const frameId of state.frameMutationGens.keys()) {
+      if (!liveFrameIds.has(frameId)) state.frameMutationGens.delete(frameId);
+    }
+  }
+
+  /**
+   * Main-document navigation: wipe the catalog, invalidate in-flight discovery,
+   * and tear down OOPIF child sessions so late toolsAdded/discovery cannot
+   * repopulate tools from the previous page.
+   */
+  _handleWebMCPMainRootNavigation(tabId, state, rootFrameId) {
+    this._bumpWebMCPDiscoveryEpoch(state);
+    // Bump every frame gen we already know about, plus main-session runtime
+    // contexts discovery may still be evaluating (including never-registered
+    // frames whose gen is still the default 0).
+    for (const frameId of [...state.frameMutationGens.keys()]) {
+      this._bumpWebMCPFrameMutation(state, frameId);
+    }
+    for (const context of this.runtimeContexts.get(tabId)?.values() || []) {
+      if (context.sessionId) continue;
+      this._bumpWebMCPFrameMutation(state, context.frameId);
+    }
+    if (rootFrameId) this._bumpWebMCPFrameMutation(state, rootFrameId);
+
+    const childSessionIds = [...state.childSessions.keys()];
+    const affectedSessionIds = ['', ...childSessionIds];
+    for (const affectedSessionId of affectedSessionIds) {
+      this._removeWebMCPSessionTools(state, affectedSessionId);
+      this._finishWebMCPSessionInvocations(
+        state,
+        affectedSessionId,
+        'The WebMCP document navigated before Chrome reported the invocation outcome.',
+      );
+    }
+
+    // Drop children from the map first so store/discovery fail closed, then
+    // best-effort tear down their CDP sessions (disable + autoAttach off).
+    for (const childSessionId of childSessionIds) {
+      state.childSessions.delete(childSessionId);
+      this._teardownWebMCPChildSession(tabId, childSessionId).catch(() => {});
+    }
+
+    state.discoveryContextsUsed = 0;
+    this._pruneWebMCPMutationMaps(state);
   }
 
   async _acquireWebMCPDiscoverySlot(state) {
@@ -369,6 +441,13 @@ export class CDPClient {
     const owningSessionId = String(sessionId || '');
     // Child-session tools must not re-enter the catalog after detach.
     if (owningSessionId && !state.childSessions.has(owningSessionId)) return;
+    // Root navigation bumps discoveryEpoch; drop snapshots captured earlier.
+    if (
+      options.discoveryEpoch != null
+      && options.discoveryEpoch !== state.discoveryEpoch
+    ) {
+      return;
+    }
     const mutationGuard = options.mutationGuard instanceof Map ? options.mutationGuard : null;
     const frameMutationGuard = options.frameMutationGuard instanceof Map
       ? options.frameMutationGuard
@@ -553,7 +632,9 @@ export class CDPClient {
     const selectedContexts = [...contextsByFrame].slice(0, remainingContextBudget);
     state.discoveryContextsUsed += selectedContexts.length;
     // Capture generations before evaluate so concurrent toolsRemoved /
-    // toolsAdded / frame cleanup invalidate these results at merge time.
+    // toolsAdded / frame cleanup / root navigation invalidate these results
+    // at merge time.
+    const discoveryEpoch = state.discoveryEpoch;
     const mutationGuard = new Map(state.toolMutationGens);
     const frameMutationGuard = new Map(state.frameMutationGens);
     const discovered = [];
@@ -606,6 +687,7 @@ export class CDPClient {
     for (const result of discovered) {
       if (!result || result.status !== 'fulfilled') continue;
       this._storeWebMCPTools(state, result.value, owningSessionId, {
+        discoveryEpoch,
         mutationGuard,
         frameMutationGuard,
       });
@@ -668,7 +750,23 @@ export class CDPClient {
           await this._teardownWebMCPChildSession(tabId, sessionId);
           return;
         }
-        await this.sendCommand(tabId, method, commandParams, sessionId).catch(() => {});
+        try {
+          await this.sendCommand(tabId, method, commandParams, sessionId);
+        } catch {
+          // WebMCP.enable is required to dispatch invoke/cancel. Page.enable
+          // and setAutoAttach remain best-effort on children when unavailable.
+          if (method === 'WebMCP.enable') {
+            state.childSessions.delete(sessionId);
+            await this._teardownWebMCPChildSession(tabId, sessionId);
+            this.sendCommand(
+              tabId,
+              'Target.detachFromTarget',
+              { sessionId },
+              source.sessionId,
+            ).catch(() => {});
+            return;
+          }
+        }
       }
       if (!childStillOwned()) {
         await this._teardownWebMCPChildSession(tabId, sessionId);
@@ -777,24 +875,22 @@ export class CDPClient {
       const sessionId = String(source?.sessionId || '');
       const child = state.childSessions.get(sessionId);
       if (!frame.parentId) {
-        const affectedSessionIds = sessionId
-          ? [sessionId]
-          : ['', ...state.childSessions.keys()];
-        for (const affectedSessionId of affectedSessionIds) {
-          this._removeWebMCPSessionTools(state, affectedSessionId);
-          this._finishWebMCPSessionInvocations(
-            state,
-            affectedSessionId,
-            'The WebMCP document navigated before Chrome reported the invocation outcome.',
-          );
-        }
-        this._bumpWebMCPFrameMutation(state, frameId);
         if (!sessionId) {
-          // Root document navigation starts a new discovery wave for later
-          // OOPIF re-attach cycles; without this the context budget stays spent.
-          state.discoveryContextsUsed = 0;
-          for (const nestedChild of state.childSessions.values()) nestedChild.frameIds.clear();
+          // Main-document root navigation: invalidate discovery epoch, wipe
+          // tools, and tear down OOPIF children so pre-nav sessions cannot
+          // repopulate the catalog.
+          this._handleWebMCPMainRootNavigation(tabId, state, frameId);
+          return;
         }
+        // OOPIF document root navigation: clear only that child session's
+        // tools/invocations and re-seed its root frame id.
+        this._removeWebMCPSessionTools(state, sessionId);
+        this._finishWebMCPSessionInvocations(
+          state,
+          sessionId,
+          'The WebMCP document navigated before Chrome reported the invocation outcome.',
+        );
+        this._bumpWebMCPFrameMutation(state, frameId);
         if (child) {
           child.frameIds.clear();
           child.frameIds.add(frameId);
@@ -826,8 +922,10 @@ export class CDPClient {
       try {
         await this.sendCommand(tabId, 'WebMCP.enable');
         // Page domain is required for frameNavigated/frameDetached on the main
-        // target. Child OOPIF sessions enable Page separately when attached.
-        await this.sendCommand(tabId, 'Page.enable').catch(() => {});
+        // target. Fail enable without it so we never mark the session healthy
+        // without lifecycle cleanup. Child OOPIF sessions enable Page
+        // separately when attached (best-effort there).
+        await this.sendCommand(tabId, 'Page.enable');
         if (state.closed || this.webMcpSessions.get(tabId) !== state) {
           if (!this.webMcpSessions.has(tabId)) {
             await this.sendCommand(tabId, 'WebMCP.disable').catch(() => {});

--- a/src/chrome/src/cdp/cdp-client.js
+++ b/src/chrome/src/cdp/cdp-client.js
@@ -20,6 +20,11 @@ const WEBMCP_MAX_INVOCATION_TIMEOUT_MS = 60000;
 const WEBMCP_MAX_VALUE_NODES = 500;
 const WEBMCP_MAX_VALUE_CHARS = 20000;
 const WEBMCP_CONTEXT_DISCOVERY_TIMEOUT_MS = 1000;
+const WEBMCP_MAX_TARGET_ATTACH_PASSES = 10;
+const WEBMCP_IFRAME_TARGET_FILTER = [
+  { type: 'iframe', exclude: false },
+  { exclude: true },
+];
 const WEBMCP_CONTEXT_DISCOVERY_EXPRESSION = `
   (async () => {
     const context = document.modelContext;
@@ -78,7 +83,7 @@ export class CDPClient {
           if (source.tabId !== tabId) return;
           const handlers = this.eventHandlers.get(tabId)?.[method];
           if (handlers) {
-            handlers.forEach(h => h(params));
+            handlers.forEach(h => h(params, source));
           }
         });
 
@@ -121,24 +126,29 @@ export class CDPClient {
   /**
    * Send a CDP command and get the result.
    */
-  async sendCommand(tabId, method, params = {}) {
+  async sendCommand(tabId, method, params = {}, sessionId = '') {
     if (!this.sessions.has(tabId)) {
       throw new Error(`Not attached to tab ${tabId}`);
     }
 
     return new Promise((resolve, reject) => {
-      chrome.debugger.sendCommand({ tabId }, method, params, (result) => {
-        // Chrome extension APIs expose callback failures through
-        // chrome.runtime.lastError, not a second callback argument. Read it
-        // synchronously while the callback is active; Chrome clears it after
-        // the callback returns.
-        const error = chrome.runtime.lastError;
-        if (error) {
-          reject(new Error(error.message || String(error)));
-          return;
-        }
-        resolve(result);
-      });
+      chrome.debugger.sendCommand(
+        { tabId, ...(sessionId ? { sessionId } : {}) },
+        method,
+        params,
+        (result) => {
+          // Chrome extension APIs expose callback failures through
+          // chrome.runtime.lastError, not a second callback argument. Read it
+          // synchronously while the callback is active; Chrome clears it after
+          // the callback returns.
+          const error = chrome.runtime.lastError;
+          if (error) {
+            reject(new Error(error.message || String(error)));
+            return;
+          }
+          resolve(result);
+        },
+      );
     });
   }
 
@@ -206,6 +216,10 @@ export class CDPClient {
     return `${String(frameId || '').slice(0, 300)}\u0000${String(name || '').slice(0, 300)}`;
   }
 
+  _webMCPInvocationKey(sessionId, invocationId) {
+    return `${String(sessionId || '').slice(0, 300)}\u0000${String(invocationId || '').slice(0, 300)}`;
+  }
+
   _newWebMCPSession(tabId) {
     return {
       tabId,
@@ -217,6 +231,8 @@ export class CDPClient {
       idsByKey: new Map(),
       pendingInvocations: new Map(),
       completedResponses: new Map(),
+      childSessions: new Map(),
+      childEnablePromises: new Set(),
       handlers: [],
     };
   }
@@ -244,7 +260,7 @@ export class CDPClient {
     if (state) state.handlers = [];
   }
 
-  _storeWebMCPTools(state, tools) {
+  _storeWebMCPTools(state, tools, sessionId = '') {
     for (const rawTool of Array.isArray(tools) ? tools : []) {
       const name = String(rawTool?.name || '').trim().slice(0, 300);
       const frameId = String(rawTool?.frameId || '').trim().slice(0, 300);
@@ -276,6 +292,7 @@ export class CDPClient {
           : { type: 'object', properties: {}, required: [] },
         annotations,
         frameId,
+        sessionId: String(sessionId || ''),
       });
     }
   }
@@ -290,15 +307,29 @@ export class CDPClient {
     }
   }
 
-  _handleWebMCPResponse(state, params = {}) {
+  _removeWebMCPFrameTools(state, frameId) {
+    const targetFrameId = String(frameId || '');
+    if (!targetFrameId) return 0;
+    let removed = 0;
+    for (const [toolId, tool] of state.toolsById) {
+      if (tool.frameId !== targetFrameId) continue;
+      state.toolsById.delete(toolId);
+      state.idsByKey.delete(this._webMCPToolKey(tool.frameId, tool.name));
+      removed++;
+    }
+    return removed;
+  }
+
+  _handleWebMCPResponse(state, params = {}, sessionId = '') {
     const invocationId = String(params.invocationId || '');
     if (!invocationId) return;
-    const pending = state.pendingInvocations.get(invocationId);
+    const invocationKey = this._webMCPInvocationKey(sessionId, invocationId);
+    const pending = state.pendingInvocations.get(invocationKey);
     if (pending) {
       pending.respond(params);
       return;
     }
-    state.completedResponses.set(invocationId, params);
+    state.completedResponses.set(invocationKey, params);
     if (state.completedResponses.size > 20) {
       const oldest = state.completedResponses.keys().next().value;
       state.completedResponses.delete(oldest);
@@ -349,6 +380,54 @@ export class CDPClient {
     return count;
   }
 
+  _enableWebMCPChildSession(tabId, state, params = {}) {
+    const sessionId = String(params.sessionId || '');
+    const targetInfo = params.targetInfo || {};
+    if (!sessionId || targetInfo.type !== 'iframe' || state.childSessions.has(sessionId)) return;
+    const child = {
+      sessionId,
+      targetId: String(targetInfo.targetId || ''),
+      url: String(targetInfo.url || ''),
+      frameIds: new Set(),
+    };
+    state.childSessions.set(sessionId, child);
+    const enabling = (async () => {
+      await Promise.allSettled([
+        this.sendCommand(tabId, 'WebMCP.enable', {}, sessionId),
+        this.sendCommand(tabId, 'Page.enable', {}, sessionId),
+        // Auto-attach is not recursive. Arm each OOPIF session so nested
+        // cross-process frames join the same WebMCP catalog as well.
+        this.sendCommand(tabId, 'Target.setAutoAttach', {
+          autoAttach: true,
+          waitForDebuggerOnStart: false,
+          flatten: true,
+          filter: WEBMCP_IFRAME_TARGET_FILTER,
+        }, sessionId),
+      ]);
+    })().finally(() => state.childEnablePromises.delete(enabling));
+    state.childEnablePromises.add(enabling);
+  }
+
+  async _enableWebMCPOOPIFTargets(tabId, state) {
+    try {
+      await this.sendCommand(tabId, 'Target.setAutoAttach', {
+        autoAttach: true,
+        waitForDebuggerOnStart: false,
+        flatten: true,
+        filter: WEBMCP_IFRAME_TARGET_FILTER,
+      });
+    } catch {
+      return 0;
+    }
+    for (let pass = 0; pass < WEBMCP_MAX_TARGET_ATTACH_PASSES; pass++) {
+      await new Promise(resolve => setTimeout(resolve, WEBMCP_DISCOVERY_SETTLE_MS));
+      const pending = [...state.childEnablePromises];
+      if (!pending.length) break;
+      await Promise.allSettled(pending);
+    }
+    return state.childSessions.size;
+  }
+
   /**
    * Enable Chrome's experimental WebMCP CDP domain. Tool descriptions,
    * schemas, and outputs remain page-controlled; callers must keep them on an
@@ -368,9 +447,50 @@ export class CDPClient {
       this.on(tabId, event, handler);
       state.handlers.push({ event, handler });
     };
-    register('WebMCP.toolsAdded', params => this._storeWebMCPTools(state, params?.tools));
+    register('WebMCP.toolsAdded', (params, source) => {
+      this._storeWebMCPTools(state, params?.tools, source?.sessionId);
+      const child = state.childSessions.get(String(source?.sessionId || ''));
+      if (!child) return;
+      for (const tool of Array.isArray(params?.tools) ? params.tools : []) {
+        const frameId = String(tool?.frameId || '');
+        if (frameId) child.frameIds.add(frameId);
+      }
+    });
     register('WebMCP.toolsRemoved', params => this._removeWebMCPTools(state, params?.tools));
-    register('WebMCP.toolResponded', params => this._handleWebMCPResponse(state, params));
+    register('WebMCP.toolResponded', (params, source) => (
+      this._handleWebMCPResponse(state, params, source?.sessionId)
+    ));
+    register('Target.attachedToTarget', params => this._enableWebMCPChildSession(tabId, state, params));
+    register('Target.detachedFromTarget', params => {
+      const sessionId = String(params?.sessionId || '');
+      const child = state.childSessions.get(sessionId);
+      if (!child) return;
+      for (const frameId of child.frameIds) this._removeWebMCPFrameTools(state, frameId);
+      state.childSessions.delete(sessionId);
+    });
+    register('Target.targetInfoChanged', params => {
+      const targetInfo = params?.targetInfo || {};
+      const child = [...state.childSessions.values()]
+        .find(candidate => candidate.targetId === String(targetInfo.targetId || ''));
+      if (child) child.url = String(targetInfo.url || child.url || '');
+    });
+    register('Page.frameNavigated', (params, source) => {
+      const frame = params?.frame || {};
+      const frameId = String(frame.id || '');
+      if (!frameId) return;
+      this._removeWebMCPFrameTools(state, frameId);
+      const child = state.childSessions.get(String(source?.sessionId || ''));
+      if (!child) return;
+      child.frameIds.clear();
+      child.frameIds.add(frameId);
+      child.url = String(frame.url || child.url || '');
+    });
+    register('Page.frameDetached', (params, source) => {
+      const frameId = String(params?.frameId || '');
+      this._removeWebMCPFrameTools(state, frameId);
+      const child = state.childSessions.get(String(source?.sessionId || ''));
+      child?.frameIds.delete(frameId);
+    });
 
     state.enablingPromise = (async () => {
       try {
@@ -390,6 +510,7 @@ export class CDPClient {
         // browser's ModelContext API so tools registered earlier in child
         // frames enter the same opaque, untrusted CDP-backed registry.
         await this._discoverExistingWebMCPFrameTools(tabId, state);
+        await this._enableWebMCPOOPIFTargets(tabId, state);
         return state;
       } catch (error) {
         this._removeWebMCPHandlers(tabId, state);
@@ -406,12 +527,28 @@ export class CDPClient {
   async disableWebMCP(tabId) {
     const state = this.webMcpSessions.get(tabId);
     if (!state) return false;
-    for (const invocationId of state.pendingInvocations.keys()) {
-      this.sendCommand(tabId, 'WebMCP.cancelInvocation', { invocationId }).catch(() => {});
+    for (const pending of state.pendingInvocations.values()) {
+      this.sendCommand(
+        tabId,
+        'WebMCP.cancelInvocation',
+        { invocationId: pending.invocationId },
+        pending.sessionId,
+      ).catch(() => {});
     }
     if (state.enabled && this.sessions.has(tabId)) {
+      await Promise.allSettled(
+        [...state.childSessions].map(([sessionId]) => (
+          this.sendCommand(tabId, 'WebMCP.disable', {}, sessionId)
+        )),
+      );
+      await this.sendCommand(tabId, 'Target.setAutoAttach', {
+        autoAttach: false,
+        waitForDebuggerOnStart: false,
+        flatten: true,
+      }).catch(() => {});
       await this.sendCommand(tabId, 'WebMCP.disable').catch(() => {});
     }
+    state.childSessions.clear();
     this._removeWebMCPHandlers(tabId, state);
     this._dropWebMCPSession(tabId, 'WebMCP disabled');
     return true;
@@ -425,7 +562,7 @@ export class CDPClient {
 
   async _webMCPFrameUrls(tabId) {
     const frames = await this.getAllFrames(tabId).catch(() => []);
-    return new Map(frames.map(frame => {
+    const frameUrls = new Map(frames.map(frame => {
       const frameId = String(frame.id || '');
       const rawUrl = String(frame.url || '');
       const securityOrigin = String(frame.securityOrigin || '');
@@ -453,6 +590,16 @@ export class CDPClient {
         return [frameId, ''];
       }
     }));
+    const state = this.webMcpSessions.get(tabId);
+    for (const child of state?.childSessions?.values() || []) {
+      let safeUrl = '';
+      try {
+        const url = new URL(child.url);
+        if (url.protocol === 'http:' || url.protocol === 'https:') safeUrl = url.href;
+      } catch {}
+      for (const frameId of child.frameIds) frameUrls.set(frameId, safeUrl);
+    }
+    return frameUrls;
   }
 
   _webMCPPermissionHost(value) {
@@ -592,7 +739,7 @@ export class CDPClient {
         frameId: tool.frameId,
         toolName: tool.name,
         input: safeInput,
-      });
+      }, tool.sessionId);
     } catch (error) {
       return {
         success: false,
@@ -616,6 +763,7 @@ export class CDPClient {
       ? Math.min(WEBMCP_MAX_INVOCATION_TIMEOUT_MS, Math.round(requestedTimeout))
       : WEBMCP_DEFAULT_INVOCATION_TIMEOUT_MS;
     const abortCheck = typeof options.abortCheck === 'function' ? options.abortCheck : null;
+    const invocationKey = this._webMCPInvocationKey(tool.sessionId, invocationId);
     return await new Promise(resolve => {
       let timer = null;
       let abortTimer = null;
@@ -625,8 +773,8 @@ export class CDPClient {
         settled = true;
         if (timer) clearTimeout(timer);
         if (abortTimer) clearInterval(abortTimer);
-        state.pendingInvocations.delete(invocationId);
-        state.completedResponses.delete(invocationId);
+        state.pendingInvocations.delete(invocationKey);
+        state.completedResponses.delete(invocationKey);
         resolve({
           ...result,
           tool_id: tool.toolId,
@@ -655,19 +803,26 @@ export class CDPClient {
           error: String(params.errorText || exceptionText || `WebMCP tool finished with status ${status}`).slice(0, 2000),
         });
       };
-      state.pendingInvocations.set(invocationId, {
+      state.pendingInvocations.set(invocationKey, {
+        invocationId,
+        sessionId: tool.sessionId,
         finish,
         respond,
       });
 
-      const earlyResponse = state.completedResponses.get(invocationId);
+      const earlyResponse = state.completedResponses.get(invocationKey);
       if (earlyResponse) {
         respond(earlyResponse);
         return;
       }
       timer = setTimeout(() => {
-        state.pendingInvocations.delete(invocationId);
-        this.sendCommand(tabId, 'WebMCP.cancelInvocation', { invocationId }).catch(() => {});
+        state.pendingInvocations.delete(invocationKey);
+        this.sendCommand(
+          tabId,
+          'WebMCP.cancelInvocation',
+          { invocationId },
+          tool.sessionId,
+        ).catch(() => {});
         finish({
           success: false,
           dispatched: true,
@@ -681,8 +836,13 @@ export class CDPClient {
           let aborted = false;
           try { aborted = abortCheck() === true; } catch {}
           if (!aborted) return;
-          state.pendingInvocations.delete(invocationId);
-          this.sendCommand(tabId, 'WebMCP.cancelInvocation', { invocationId }).catch(() => {});
+          state.pendingInvocations.delete(invocationKey);
+          this.sendCommand(
+            tabId,
+            'WebMCP.cancelInvocation',
+            { invocationId },
+            tool.sessionId,
+          ).catch(() => {});
           finish({
             success: false,
             dispatched: true,

--- a/test/run.js
+++ b/test/run.js
@@ -21292,6 +21292,8 @@ test('CDP WebMCP recovers tools registered in child frames before enable', async
 test('CDP WebMCP aggregates OOPIF sessions and removes their detached tools', async () => {
   const cdp = new CDPClient();
   const commands = [];
+  let oopifUrl = 'https://embed.test/';
+  let includeNestedFrame = true;
   const emit = (event, params, source = { tabId: 58 }) => {
     for (const handler of cdp.eventHandlers.get(58)?.[event] || []) handler(params, source);
   };
@@ -21307,7 +21309,27 @@ test('CDP WebMCP aggregates OOPIF sessions and removes their detached tools', as
       });
       return {};
     }
+    if (method === 'Runtime.enable' && sessionId === 'oopif-session') {
+      emit('Runtime.executionContextCreated', {
+        context: { id: 21, auxData: { isDefault: true, frameId: 'oopif-frame' } },
+      }, { tabId: 58, sessionId });
+      emit('Runtime.executionContextCreated', {
+        context: { id: 22, auxData: { isDefault: true, frameId: 'same-process-frame' } },
+      }, { tabId: 58, sessionId });
+      return {};
+    }
     if (method === 'Runtime.enable') return {};
+    if (method === 'Runtime.evaluate' && sessionId === 'oopif-session') {
+      if (params.contextId === 21) {
+        return { result: { value: [{ name: 'child_tool', description: 'child duplicate' }] } };
+      }
+      assert.equal(params.contextId, 22);
+      return {
+        result: {
+          value: [{ name: 'nested_tool', description: 'pre-registered same-process descendant' }],
+        },
+      };
+    }
     if (method === 'Target.setAutoAttach' && !sessionId && params.autoAttach) {
       emit('Target.attachedToTarget', {
         sessionId: 'oopif-session',
@@ -21325,14 +21347,35 @@ test('CDP WebMCP aggregates OOPIF sessions and removes their detached tools', as
     if (method === 'Target.setAutoAttach' && sessionId === 'oopif-session') return {};
     if (method === 'Page.enable') return {};
     if (method === 'Page.getFrameTree') {
+      if (sessionId === 'oopif-session') {
+        return {
+          frameTree: {
+            frame: {
+              id: 'oopif-frame',
+              url: oopifUrl,
+              securityOrigin: new URL(oopifUrl).origin,
+            },
+            childFrames: includeNestedFrame ? [{
+              frame: {
+                id: 'same-process-frame',
+                parentId: 'oopif-frame',
+                url: 'https://nested.embed.test/tool-frame',
+                securityOrigin: 'https://nested.embed.test',
+              },
+            }] : [],
+          },
+        };
+      }
       return {
         frameTree: {
           frame: { id: 'main-frame', url: 'https://example.com/' },
-          childFrames: [{ frame: { id: 'oopif-frame', url: 'https://embed.test/' } }],
         },
       };
     }
     if (method === 'WebMCP.invokeTool' && sessionId === 'oopif-session') {
+      if (params.toolName === 'next_child_tool') {
+        return { invocationId: 'detached-invocation' };
+      }
       assert.deepEqual(params, {
         frameId: 'oopif-frame',
         toolName: 'child_tool',
@@ -21349,9 +21392,13 @@ test('CDP WebMCP aggregates OOPIF sessions and removes their detached tools', as
   };
 
   const catalog = await cdp.listWebMCPTools(58);
-  assert.equal(catalog.total, 2);
+  assert.equal(catalog.total, 3);
   const child = catalog.tools.find(tool => tool.name === 'child_tool');
   assert.equal(child?.frame_url, 'https://embed.test/');
+  assert.equal(
+    catalog.tools.find(tool => tool.name === 'nested_tool')?.frame_url,
+    'https://nested.embed.test/tool-frame',
+  );
   assert.ok(commands.some(command => (
     command.method === 'WebMCP.enable' && command.sessionId === 'oopif-session'
   )));
@@ -21362,8 +21409,10 @@ test('CDP WebMCP aggregates OOPIF sessions and removes their detached tools', as
   assert.equal(invocation.success, true);
   assert.deepEqual(invocation.output, { frame: 'oopif' });
 
+  oopifUrl = 'https://embed.test/next';
+  includeNestedFrame = false;
   emit('Page.frameNavigated', {
-    frame: { id: 'oopif-frame', url: 'https://embed.test/next' },
+    frame: { id: 'oopif-frame', url: oopifUrl },
   }, { tabId: 58, sessionId: 'oopif-session' });
   const afterNavigation = await cdp.listWebMCPTools(58);
   assert.equal(afterNavigation.total, 1);
@@ -21371,14 +21420,25 @@ test('CDP WebMCP aggregates OOPIF sessions and removes their detached tools', as
     tools: [{ name: 'next_child_tool', description: 'next child', frameId: 'oopif-frame' }],
   }, { tabId: 58, sessionId: 'oopif-session' });
   const afterNewRegistration = await cdp.listWebMCPTools(58);
+  const nextChild = afterNewRegistration.tools.find(tool => tool.name === 'next_child_tool');
   assert.equal(
-    afterNewRegistration.tools.find(tool => tool.name === 'next_child_tool')?.frame_url,
+    nextChild?.frame_url,
     'https://embed.test/next',
   );
+  const detachedInvocation = cdp.invokeWebMCPTool(58, nextChild.tool_id, {});
+  await new Promise(resolve => setTimeout(resolve, 0));
   emit('Target.detachedFromTarget', { sessionId: 'oopif-session' });
+  const detachedResult = await detachedInvocation;
+  assert.equal(detachedResult.success, false);
+  assert.equal(detachedResult.outcomeUnknown, true);
+  assert.match(detachedResult.error, /frame detached/);
   const afterDetach = await cdp.listWebMCPTools(58);
   assert.equal(afterDetach.total, 1);
   assert.equal(afterDetach.tools[0].name, 'parent_tool');
+  emit('Page.frameNavigated', {
+    frame: { id: 'next-main-frame', url: 'https://example.com/next' },
+  });
+  assert.equal((await cdp.listWebMCPTools(58)).total, 0);
 });
 
 test('CDP WebMCP bounds hostile catalogs and cleans up after unsupported-domain errors', async () => {

--- a/test/run.js
+++ b/test/run.js
@@ -21289,6 +21289,44 @@ test('CDP WebMCP recovers tools registered in child frames before enable', async
   assert.ok(commands.some(command => command.method === 'Runtime.evaluate' && command.params.contextId === 12));
 });
 
+test('CDP WebMCP reuses default execution contexts reported before discovery starts', async () => {
+  const cdp = new CDPClient();
+  const commands = [];
+  cdp.attach = async tabId => {
+    cdp.sessions.set(tabId, { tabId, attached: true });
+    return cdp.sessions.get(tabId);
+  };
+  cdp._trackRuntimeContextEvent(59, {}, 'Runtime.executionContextCreated', {
+    context: { id: 31, auxData: { isDefault: true, frameId: 'cached-frame' } },
+  });
+  cdp.sendCommand = async (tabId, method, params = {}, sessionId = '') => {
+    commands.push({ tabId, method, params, sessionId });
+    if (method === 'Runtime.evaluate') {
+      assert.equal(params.contextId, 31);
+      return {
+        result: {
+          value: [{ name: 'cached_tool', description: 'discovered from the context cache' }],
+        },
+      };
+    }
+    if (method === 'Page.getFrameTree') {
+      return {
+        frameTree: {
+          frame: { id: 'cached-frame', url: 'https://cached.example/' },
+        },
+      };
+    }
+    return {};
+  };
+
+  const catalog = await cdp.listWebMCPTools(59);
+  assert.equal(catalog.total, 1);
+  assert.equal(catalog.tools[0].name, 'cached_tool');
+  assert.equal(catalog.tools[0].frame_url, 'https://cached.example/');
+  assert.ok(commands.some(command => command.method === 'Runtime.enable'));
+  assert.ok(commands.some(command => command.method === 'Runtime.evaluate'));
+});
+
 test('CDP WebMCP aggregates OOPIF sessions and removes their detached tools', async () => {
   const cdp = new CDPClient();
   const commands = [];

--- a/test/run.js
+++ b/test/run.js
@@ -21910,6 +21910,281 @@ test('CDP WebMCP discovery does not overwrite a re-registration that raced evalu
   assert.equal(catalog.tools[0].annotations.readOnly, true);
 });
 
+test('CDP WebMCP enables Page domain on the main session for frame lifecycle', async () => {
+  const cdp = new CDPClient();
+  const commands = [];
+  cdp.attach = async tabId => {
+    cdp.sessions.set(tabId, { tabId, attached: true });
+    return cdp.sessions.get(tabId);
+  };
+  cdp.sendCommand = async (tabId, method, params = {}, sessionId = '') => {
+    commands.push({ tabId, method, params, sessionId });
+    return {};
+  };
+  await cdp.enableWebMCP(65);
+  assert.ok(commands.some(command => (
+    command.method === 'Page.enable' && !command.sessionId
+  )), 'main target must Page.enable so frameNavigated/frameDetached fire');
+});
+
+test('CDP WebMCP finishes pending invocations when a child frame navigates', async () => {
+  const cdp = new CDPClient();
+  const emit = (event, params, source = { tabId: 66 }) => {
+    for (const handler of cdp.eventHandlers.get(66)?.[event] || []) handler(params, source);
+  };
+  cdp.attach = async tabId => {
+    cdp.sessions.set(tabId, { tabId, attached: true });
+    return cdp.sessions.get(tabId);
+  };
+  cdp.sendCommand = async (tabId, method, params = {}) => {
+    if (method === 'WebMCP.enable') {
+      emit('WebMCP.toolsAdded', {
+        tools: [{
+          name: 'slow_child',
+          description: 'hangs until frame is gone',
+          frameId: 'child-frame',
+        }],
+      });
+      return {};
+    }
+    if (method === 'Page.getFrameTree') {
+      return {
+        frameTree: {
+          frame: { id: 'main-frame', url: 'https://example.com/' },
+          childFrames: [{
+            frame: {
+              id: 'child-frame',
+              parentId: 'main-frame',
+              url: 'https://example.com/embed',
+            },
+          }],
+        },
+      };
+    }
+    if (method === 'WebMCP.invokeTool') return { invocationId: 'frame-nav-inv' };
+    return {};
+  };
+
+  const catalog = await cdp.listWebMCPTools(66);
+  const toolId = catalog.tools[0].tool_id;
+  const pending = cdp.invokeWebMCPTool(66, toolId, {}, { timeoutMs: 5000 });
+  await new Promise(resolve => setTimeout(resolve, 0));
+  emit('Page.frameNavigated', {
+    frame: {
+      id: 'child-frame',
+      parentId: 'main-frame',
+      url: 'https://example.com/embed-next',
+    },
+  });
+  const result = await pending;
+  assert.equal(result.success, false);
+  assert.equal(result.outcomeUnknown, true);
+  assert.match(result.error, /frame navigated/i);
+  assert.equal((await cdp.listWebMCPTools(66)).total, 0);
+});
+
+test('CDP WebMCP discovery does not reinsert tools after child session detach', async () => {
+  const cdp = new CDPClient();
+  const emit = (event, params, source = { tabId: 67 }) => {
+    for (const handler of cdp.eventHandlers.get(67)?.[event] || []) handler(params, source);
+  };
+  cdp.attach = async tabId => {
+    cdp.sessions.set(tabId, { tabId, attached: true });
+    return cdp.sessions.get(tabId);
+  };
+  cdp.sendCommand = async (tabId, method, params = {}, sessionId = '') => {
+    if (method === 'WebMCP.enable' && !sessionId) return {};
+    if (method === 'Target.setAutoAttach' && !sessionId && params.autoAttach) {
+      emit('Target.attachedToTarget', {
+        sessionId: 'oopif-session',
+        targetInfo: {
+          targetId: 'oopif-frame',
+          type: 'iframe',
+          url: 'https://embed.test/',
+        },
+      });
+      return {};
+    }
+    if (method === 'WebMCP.enable' && sessionId === 'oopif-session') return {};
+    if (method === 'Page.enable') return {};
+    if (method === 'Target.setAutoAttach' && sessionId === 'oopif-session') return {};
+    if (method === 'Runtime.enable' && sessionId === 'oopif-session') {
+      emit('Runtime.executionContextCreated', {
+        context: { id: 91, auxData: { isDefault: true, frameId: 'oopif-frame' } },
+      }, { tabId: 67, sessionId });
+      return {};
+    }
+    if (method === 'Runtime.evaluate' && sessionId === 'oopif-session') {
+      emit('Target.detachedFromTarget', { sessionId: 'oopif-session' });
+      return {
+        result: {
+          value: [{ name: 'ghost_tool', description: 'should not reappear after detach' }],
+        },
+      };
+    }
+    if (method === 'Page.getFrameTree') {
+      return { frameTree: { frame: { id: 'main-frame', url: 'https://example.com/' } } };
+    }
+    return {};
+  };
+
+  const catalog = await cdp.listWebMCPTools(67);
+  assert.equal(catalog.total, 0, 'detached OOPIF tools must not re-enter from stale discovery');
+});
+
+test('CDP WebMCP discovery ignores frames navigated before evaluate results merge', async () => {
+  const cdp = new CDPClient();
+  const emit = (event, params) => {
+    for (const handler of cdp.eventHandlers.get(68)?.[event] || []) handler(params);
+  };
+  cdp.attach = async tabId => {
+    cdp.sessions.set(tabId, { tabId, attached: true });
+    return cdp.sessions.get(tabId);
+  };
+  cdp.sendCommand = async (tabId, method, params = {}) => {
+    if (method === 'WebMCP.enable') return {};
+    if (method === 'Runtime.enable') {
+      emit('Runtime.executionContextCreated', {
+        context: { id: 101, auxData: { isDefault: true, frameId: 'nav-frame' } },
+      });
+      return {};
+    }
+    if (method === 'Runtime.evaluate') {
+      // Frame never had a registered tool, so toolsRemoved cannot bump tool gens.
+      // Frame mutation must still invalidate the discovery snapshot.
+      emit('Page.frameNavigated', {
+        frame: {
+          id: 'nav-frame',
+          parentId: 'main-frame',
+          url: 'https://example.com/after',
+        },
+      });
+      return {
+        result: {
+          value: [{ name: 'pre_nav_tool', description: 'from previous document' }],
+        },
+      };
+    }
+    if (method === 'Page.getFrameTree') {
+      return {
+        frameTree: {
+          frame: { id: 'main-frame', url: 'https://example.com/' },
+          childFrames: [{
+            frame: {
+              id: 'nav-frame',
+              parentId: 'main-frame',
+              url: 'https://example.com/after',
+            },
+          }],
+        },
+      };
+    }
+    return {};
+  };
+
+  const catalog = await cdp.listWebMCPTools(68);
+  assert.equal(catalog.total, 0, 'frame navigation must invalidate discovery without prior tools');
+});
+
+test('CDP WebMCP resets discovery context budget after top-level navigation', async () => {
+  const cdp = new CDPClient();
+  const state = cdp._newWebMCPSession(69);
+  cdp.webMcpSessions.set(69, state);
+  const commands = [];
+  for (let index = 0; index < 500; index++) {
+    cdp._trackRuntimeContextEvent(69, {}, 'Runtime.executionContextCreated', {
+      context: {
+        id: 2000 + index,
+        auxData: { isDefault: true, frameId: `wave1-${index}` },
+      },
+    });
+  }
+  cdp.sendCommand = async (tabId, method, params = {}, sessionId = '') => {
+    commands.push({ tabId, method, params, sessionId });
+    if (method === 'Runtime.evaluate') return { result: { value: [] } };
+    return {};
+  };
+  await cdp._discoverExistingWebMCPFrameTools(69, state);
+  assert.equal(commands.filter(command => command.method === 'Runtime.evaluate').length, 500);
+
+  // Simulate main-session root navigation handler.
+  state.discoveryContextsUsed = 0;
+  cdp.runtimeContexts.set(69, new Map());
+  for (let index = 0; index < 3; index++) {
+    cdp._trackRuntimeContextEvent(69, {}, 'Runtime.executionContextCreated', {
+      context: {
+        id: 3000 + index,
+        auxData: { isDefault: true, frameId: `wave2-${index}` },
+      },
+    });
+  }
+  await cdp._discoverExistingWebMCPFrameTools(69, state);
+  assert.equal(
+    commands.filter(command => command.method === 'Runtime.evaluate').length,
+    503,
+    'a new document wave should discover again after budget reset',
+  );
+});
+
+test('CDP WebMCP disable tears down child enable that races setAutoAttach', async () => {
+  const cdp = new CDPClient();
+  const commands = [];
+  let releaseChildEnable = null;
+  const childEnableGate = new Promise(resolve => { releaseChildEnable = resolve; });
+  let childEnableStarted = null;
+  const childEnableStartedPromise = new Promise(resolve => { childEnableStarted = resolve; });
+  cdp.attach = async tabId => {
+    cdp.sessions.set(tabId, { tabId, attached: true });
+    return cdp.sessions.get(tabId);
+  };
+  cdp.sendCommand = async (tabId, method, params = {}, sessionId = '') => {
+    commands.push({ tabId, method, params, sessionId });
+    if (method === 'WebMCP.enable' && !sessionId) return {};
+    if (method === 'Page.enable' && !sessionId) return {};
+    if (method === 'Target.setAutoAttach' && !sessionId && params.autoAttach) {
+      for (const handler of cdp.eventHandlers.get(tabId)?.['Target.attachedToTarget'] || []) {
+        handler({
+          sessionId: 'late-child',
+          targetInfo: { targetId: 'late-frame', type: 'iframe', url: 'https://late.test/' },
+        }, { tabId });
+      }
+      return {};
+    }
+    if (sessionId === 'late-child' && method === 'WebMCP.enable') {
+      childEnableStarted();
+      await childEnableGate;
+      return {};
+    }
+    return {};
+  };
+
+  const enablePromise = cdp.enableWebMCP(70);
+  // Attach a rejection handler before disable can make enable throw, otherwise
+  // Node treats the mid-race rejection as unhandled and aborts the suite.
+  const enableOutcome = enablePromise.then(() => null, error => error);
+  await childEnableStartedPromise;
+  const disablePromise = cdp.disableWebMCP(70);
+  // Let disable mark closed and begin awaiting childEnablePromises first.
+  await new Promise(resolve => setTimeout(resolve, 0));
+  releaseChildEnable();
+  const [enableError, disabled] = await Promise.all([enableOutcome, disablePromise]);
+  assert.ok(enableError instanceof Error);
+  assert.match(enableError.message, /session closed while it was enabling/);
+  assert.equal(disabled, true);
+  assert.equal(cdp.webMcpSessions.has(70), false);
+  const childTeardowns = commands.filter(command => (
+    command.sessionId === 'late-child'
+    && (
+      (command.method === 'Target.setAutoAttach' && command.params.autoAttach === false)
+      || command.method === 'WebMCP.disable'
+    )
+  ));
+  assert.ok(
+    childTeardowns.length >= 1,
+    'disable must tear down a child enable that raced past the closed flag',
+  );
+});
+
 test('WebMCP page annotations never bypass Act mode or frame-scoped permission', async () => {
   assert.equal(capabilityForCh('execute_webmcp_tool', { _webMcpDeclaredReadOnly: true }), CapabilityCh.CLICK);
   assert.equal(capabilityForCh('execute_webmcp_tool', { _webMcpDeclaredReadOnly: false }), CapabilityCh.CLICK);

--- a/test/run.js
+++ b/test/run.js
@@ -21701,6 +21701,215 @@ test('CDP WebMCP fails closed when a registration frame changes origin before di
   assert.equal(opaqueContext.targetUrl, '', 'opaque frame origins must not borrow a URL-looking host grant');
 });
 
+test('CDP WebMCP does not authorize tools from TargetInfo URL when frame tree is unavailable', async () => {
+  const cdp = new CDPClient();
+  const emit = (event, params, source = { tabId: 62 }) => {
+    for (const handler of cdp.eventHandlers.get(62)?.[event] || []) handler(params, source);
+  };
+  cdp.attach = async tabId => {
+    cdp.sessions.set(tabId, { tabId, attached: true });
+    return cdp.sessions.get(tabId);
+  };
+  cdp.sendCommand = async (tabId, method, params = {}, sessionId = '') => {
+    if (method === 'WebMCP.enable' && !sessionId) return {};
+    if (method === 'Target.setAutoAttach' && !sessionId && params.autoAttach) {
+      emit('Target.attachedToTarget', {
+        sessionId: 'sandbox-oopif',
+        targetInfo: {
+          targetId: 'sandbox-frame',
+          type: 'iframe',
+          // Document URL looks trusted, but without a browser-reported
+          // securityOrigin this must not become a permission host.
+          url: 'https://trusted-pay.example/checkout',
+        },
+      });
+      return {};
+    }
+    if (method === 'WebMCP.enable' && sessionId === 'sandbox-oopif') {
+      emit('WebMCP.toolsAdded', {
+        tools: [{
+          name: 'charge_card',
+          description: 'Charge',
+          frameId: 'sandbox-frame',
+        }],
+      }, { tabId: 62, sessionId });
+      return {};
+    }
+    if (method === 'Page.enable') return {};
+    if (method === 'Target.setAutoAttach' && sessionId === 'sandbox-oopif') return {};
+    if (method === 'Runtime.enable') return {};
+    if (method === 'Page.getFrameTree') {
+      if (sessionId === 'sandbox-oopif') {
+        throw new Error('Page.getFrameTree failed for detached sandbox target');
+      }
+      return {
+        frameTree: {
+          frame: {
+            id: 'main-frame',
+            url: 'https://shop.example/',
+            securityOrigin: 'https://shop.example',
+          },
+        },
+      };
+    }
+    if (method === 'WebMCP.invokeTool') return { invocationId: 'must-not-dispatch' };
+    return {};
+  };
+
+  const catalog = await cdp.listWebMCPTools(62);
+  const charge = catalog.tools.find(tool => tool.name === 'charge_card');
+  assert.ok(charge, 'OOPIF tool should still be listed');
+  assert.equal(
+    charge.frame_url,
+    '',
+    'TargetInfo URL must not fill frame_url when the frame tree is unavailable',
+  );
+  const context = await cdp.getWebMCPToolContext(62, charge.tool_id);
+  assert.equal(context.targetUrl, '', 'permission target must stay empty without a frame-tree origin');
+  const result = await cdp.invokeWebMCPTool(62, charge.tool_id, {}, {
+    expectedFrameId: 'sandbox-frame',
+    expectedTargetUrl: 'https://trusted-pay.example/checkout',
+  });
+  assert.equal(result.success, false);
+  assert.equal(result.noDispatch, true);
+  assert.equal(result.contextChanged, true);
+});
+
+test('CDP WebMCP discovery ignores tools removed while Runtime.evaluate is pending', async () => {
+  const cdp = new CDPClient();
+  const emit = (event, params) => {
+    for (const handler of cdp.eventHandlers.get(63)?.[event] || []) handler(params);
+  };
+  cdp.attach = async tabId => {
+    cdp.sessions.set(tabId, { tabId, attached: true });
+    return cdp.sessions.get(tabId);
+  };
+  cdp.sendCommand = async (tabId, method, params = {}) => {
+    if (method === 'WebMCP.enable') {
+      emit('WebMCP.toolsAdded', {
+        tools: [{
+          name: 'stale_tool',
+          description: 'registered before discovery',
+          frameId: 'child-frame',
+        }],
+      });
+      return {};
+    }
+    if (method === 'Runtime.enable') {
+      emit('Runtime.executionContextCreated', {
+        context: { id: 71, auxData: { isDefault: true, frameId: 'child-frame' } },
+      });
+      return {};
+    }
+    if (method === 'Runtime.evaluate') {
+      // Removal lands while evaluate is still outstanding; the returned
+      // snapshot must not resurrect the deleted registration.
+      emit('WebMCP.toolsRemoved', {
+        tools: [{ name: 'stale_tool', frameId: 'child-frame' }],
+      });
+      return {
+        result: {
+          value: [{
+            name: 'stale_tool',
+            description: 'stale snapshot from getTools()',
+            annotations: { readOnly: true },
+          }],
+        },
+      };
+    }
+    if (method === 'Page.getFrameTree') {
+      return {
+        frameTree: {
+          frame: { id: 'main-frame', url: 'https://example.com/' },
+          childFrames: [{
+            frame: {
+              id: 'child-frame',
+              parentId: 'main-frame',
+              url: 'https://example.com/embed',
+            },
+          }],
+        },
+      };
+    }
+    return {};
+  };
+
+  const catalog = await cdp.listWebMCPTools(63);
+  assert.equal(catalog.total, 0, 'discovery must not resurrect a tool removed mid-evaluate');
+  assert.equal(await cdp.getWebMCPToolContext(63, 'wmcp_1'), null);
+});
+
+test('CDP WebMCP discovery does not overwrite a re-registration that raced evaluate', async () => {
+  const cdp = new CDPClient();
+  const emit = (event, params) => {
+    for (const handler of cdp.eventHandlers.get(64)?.[event] || []) handler(params);
+  };
+  cdp.attach = async tabId => {
+    cdp.sessions.set(tabId, { tabId, attached: true });
+    return cdp.sessions.get(tabId);
+  };
+  cdp.sendCommand = async (tabId, method, params = {}) => {
+    if (method === 'WebMCP.enable') {
+      emit('WebMCP.toolsAdded', {
+        tools: [{
+          name: 'live_tool',
+          description: 'original description',
+          frameId: 'child-frame',
+        }],
+      });
+      return {};
+    }
+    if (method === 'Runtime.enable') {
+      emit('Runtime.executionContextCreated', {
+        context: { id: 81, auxData: { isDefault: true, frameId: 'child-frame' } },
+      });
+      return {};
+    }
+    if (method === 'Runtime.evaluate') {
+      emit('WebMCP.toolsRemoved', {
+        tools: [{ name: 'live_tool', frameId: 'child-frame' }],
+      });
+      emit('WebMCP.toolsAdded', {
+        tools: [{
+          name: 'live_tool',
+          description: 'fresh re-registration',
+          frameId: 'child-frame',
+          annotations: { readOnly: true },
+        }],
+      });
+      return {
+        result: {
+          value: [{
+            name: 'live_tool',
+            description: 'stale snapshot should lose',
+            annotations: { readOnly: false },
+          }],
+        },
+      };
+    }
+    if (method === 'Page.getFrameTree') {
+      return {
+        frameTree: {
+          frame: { id: 'main-frame', url: 'https://example.com/' },
+          childFrames: [{
+            frame: {
+              id: 'child-frame',
+              parentId: 'main-frame',
+              url: 'https://example.com/embed',
+            },
+          }],
+        },
+      };
+    }
+    return {};
+  };
+
+  const catalog = await cdp.listWebMCPTools(64);
+  assert.equal(catalog.total, 1);
+  assert.equal(catalog.tools[0].description, 'fresh re-registration');
+  assert.equal(catalog.tools[0].annotations.readOnly, true);
+});
+
 test('WebMCP page annotations never bypass Act mode or frame-scoped permission', async () => {
   assert.equal(capabilityForCh('execute_webmcp_tool', { _webMcpDeclaredReadOnly: true }), CapabilityCh.CLICK);
   assert.equal(capabilityForCh('execute_webmcp_tool', { _webMcpDeclaredReadOnly: false }), CapabilityCh.CLICK);

--- a/test/run.js
+++ b/test/run.js
@@ -21463,6 +21463,10 @@ test('CDP WebMCP aggregates OOPIF sessions and removes their detached tools', as
     nextChild?.frame_url,
     'https://embed.test/next',
   );
+  emit('WebMCP.toolsRemoved', {
+    tools: [{ name: 'next_child_tool', frameId: 'oopif-frame' }],
+  }, { tabId: 58, sessionId: 'stale-oopif-session' });
+  assert.equal((await cdp.listWebMCPTools(58)).total, 2);
   const detachedInvocation = cdp.invokeWebMCPTool(58, nextChild.tool_id, {});
   await new Promise(resolve => setTimeout(resolve, 0));
   emit('Target.detachedFromTarget', { sessionId: 'oopif-session' });

--- a/test/run.js
+++ b/test/run.js
@@ -21327,6 +21327,45 @@ test('CDP WebMCP reuses default execution contexts reported before discovery sta
   assert.ok(commands.some(command => command.method === 'Runtime.evaluate'));
 });
 
+test('CDP WebMCP bounds context discovery and detaches excess OOPIF sessions', async () => {
+  const cdp = new CDPClient();
+  const state = cdp._newWebMCPSession(60);
+  const commands = [];
+  cdp.webMcpSessions.set(60, state);
+  for (let index = 0; index < 505; index++) {
+    cdp._trackRuntimeContextEvent(60, {}, 'Runtime.executionContextCreated', {
+      context: {
+        id: 1000 + index,
+        auxData: { isDefault: true, frameId: `frame-${index}` },
+      },
+    });
+  }
+  cdp.sendCommand = async (tabId, method, params = {}, sessionId = '') => {
+    commands.push({ tabId, method, params, sessionId });
+    if (method === 'Runtime.evaluate') return { result: { value: [] } };
+    return {};
+  };
+
+  await cdp._discoverExistingWebMCPFrameTools(60, state);
+  assert.equal(commands.filter(command => command.method === 'Runtime.evaluate').length, 500);
+  await cdp._discoverExistingWebMCPFrameTools(60, state);
+  assert.equal(commands.filter(command => command.method === 'Runtime.evaluate').length, 500);
+
+  for (let index = 0; index < 100; index++) {
+    state.childSessions.set(`child-${index}`, { frameIds: new Set() });
+  }
+  cdp._enableWebMCPChildSession(60, state, {
+    sessionId: 'excess-child',
+    targetInfo: { type: 'iframe', targetId: 'excess-frame' },
+  }, { sessionId: 'parent-session' });
+  assert.equal(state.childSessions.has('excess-child'), false);
+  assert.ok(commands.some(command => (
+    command.method === 'Target.detachFromTarget'
+    && command.params.sessionId === 'excess-child'
+    && command.sessionId === 'parent-session'
+  )));
+});
+
 test('CDP WebMCP aggregates OOPIF sessions and removes their detached tools', async () => {
   const cdp = new CDPClient();
   const commands = [];

--- a/test/run.js
+++ b/test/run.js
@@ -21191,6 +21191,104 @@ test('CDP WebMCP discovery uses opaque IDs, tracks frames, and invokes asynchron
   assert.ok(commands.some(command => command.method === 'WebMCP.disable'));
 });
 
+test('CDP WebMCP recovers tools registered in child frames before enable', async () => {
+  const cdp = new CDPClient();
+  const commands = [];
+  const emit = (event, params) => {
+    for (const handler of cdp.eventHandlers.get(57)?.[event] || []) handler(params);
+  };
+  cdp.attach = async tabId => {
+    cdp.sessions.set(tabId, { tabId, attached: true });
+    return cdp.sessions.get(tabId);
+  };
+  cdp.sendCommand = async (tabId, method, params = {}) => {
+    commands.push({ tabId, method, params });
+    if (method === 'WebMCP.enable') {
+      emit('WebMCP.toolsAdded', {
+        tools: [{
+          name: 'parent_tool',
+          description: 'Top-level tool',
+          inputSchema: { type: 'object' },
+          frameId: 'main-frame',
+        }],
+      });
+      return {};
+    }
+    if (method === 'Runtime.enable') {
+      emit('Runtime.executionContextCreated', {
+        context: { id: 11, auxData: { isDefault: true, frameId: 'main-frame' } },
+      });
+      emit('Runtime.executionContextCreated', {
+        context: { id: 12, auxData: { isDefault: true, frameId: 'child-frame' } },
+      });
+      emit('Runtime.executionContextCreated', {
+        context: { id: 13, auxData: { isDefault: false, frameId: 'child-frame' } },
+      });
+      return {};
+    }
+    if (method === 'Runtime.evaluate') {
+      if (params.contextId === 11) {
+        return { result: { value: [{ name: 'parent_tool', description: 'Top-level tool' }] } };
+      }
+      assert.equal(params.contextId, 12);
+      assert.equal(params.awaitPromise, true);
+      assert.equal(params.returnByValue, true);
+      return {
+        result: {
+          value: [{
+            name: 'child_tool',
+            description: 'Pre-registered child tool',
+            inputSchema: { type: 'object', properties: { value: { type: 'string' } } },
+            annotations: { readOnly: true, untrustedContent: true, autosubmit: false },
+          }],
+        },
+      };
+    }
+    if (method === 'Page.enable') return {};
+    if (method === 'Page.getFrameTree') {
+      return {
+        frameTree: {
+          frame: { id: 'main-frame', url: 'https://example.com/app' },
+          childFrames: [{
+            frame: {
+              id: 'child-frame',
+              parentId: 'main-frame',
+              url: 'https://example.com/embed',
+            },
+          }],
+        },
+      };
+    }
+    if (method === 'WebMCP.invokeTool') {
+      assert.deepEqual(params, {
+        frameId: 'child-frame',
+        toolName: 'child_tool',
+        input: { value: 'ok' },
+      });
+      emit('WebMCP.toolResponded', {
+        invocationId: 'child-invocation',
+        status: 'Completed',
+        output: { frame: 'child' },
+      });
+      return { invocationId: 'child-invocation' };
+    }
+    return {};
+  };
+
+  const catalog = await cdp.listWebMCPTools(57, { page_size: 10 });
+  assert.equal(catalog.total, 2);
+  assert.deepEqual(catalog.tools.map(tool => tool.name), ['parent_tool', 'child_tool']);
+  const child = catalog.tools.find(tool => tool.name === 'child_tool');
+  assert.equal(child.frame_url, 'https://example.com/embed');
+  assert.equal(child.annotations.readOnly, true);
+  assert.match(child.tool_id, /^wmcp_[a-z0-9]+$/);
+
+  const result = await cdp.invokeWebMCPTool(57, child.tool_id, { value: 'ok' });
+  assert.equal(result.success, true);
+  assert.deepEqual(result.output, { frame: 'child' });
+  assert.ok(commands.some(command => command.method === 'Runtime.evaluate' && command.params.contextId === 12));
+});
+
 test('CDP WebMCP bounds hostile catalogs and cleans up after unsupported-domain errors', async () => {
   const cdp = new CDPClient();
   const emit = (event, params) => {

--- a/test/run.js
+++ b/test/run.js
@@ -21289,6 +21289,98 @@ test('CDP WebMCP recovers tools registered in child frames before enable', async
   assert.ok(commands.some(command => command.method === 'Runtime.evaluate' && command.params.contextId === 12));
 });
 
+test('CDP WebMCP aggregates OOPIF sessions and removes their detached tools', async () => {
+  const cdp = new CDPClient();
+  const commands = [];
+  const emit = (event, params, source = { tabId: 58 }) => {
+    for (const handler of cdp.eventHandlers.get(58)?.[event] || []) handler(params, source);
+  };
+  cdp.attach = async tabId => {
+    cdp.sessions.set(tabId, { tabId, attached: true });
+    return cdp.sessions.get(tabId);
+  };
+  cdp.sendCommand = async (tabId, method, params = {}, sessionId = '') => {
+    commands.push({ tabId, method, params, sessionId });
+    if (method === 'WebMCP.enable' && !sessionId) {
+      emit('WebMCP.toolsAdded', {
+        tools: [{ name: 'parent_tool', description: 'parent', frameId: 'main-frame' }],
+      });
+      return {};
+    }
+    if (method === 'Runtime.enable') return {};
+    if (method === 'Target.setAutoAttach' && !sessionId && params.autoAttach) {
+      emit('Target.attachedToTarget', {
+        sessionId: 'oopif-session',
+        targetInfo: { targetId: 'oopif-frame', type: 'iframe', url: 'https://embed.test/' },
+      });
+      return {};
+    }
+    if (method === 'WebMCP.enable' && sessionId === 'oopif-session') {
+      emit('WebMCP.toolsAdded', {
+        tools: [{ name: 'child_tool', description: 'child', frameId: 'oopif-frame' }],
+      }, { tabId: 58, sessionId });
+      return {};
+    }
+    if (method === 'Page.enable' && sessionId === 'oopif-session') return {};
+    if (method === 'Target.setAutoAttach' && sessionId === 'oopif-session') return {};
+    if (method === 'Page.enable') return {};
+    if (method === 'Page.getFrameTree') {
+      return {
+        frameTree: {
+          frame: { id: 'main-frame', url: 'https://example.com/' },
+          childFrames: [{ frame: { id: 'oopif-frame', url: 'https://embed.test/' } }],
+        },
+      };
+    }
+    if (method === 'WebMCP.invokeTool' && sessionId === 'oopif-session') {
+      assert.deepEqual(params, {
+        frameId: 'oopif-frame',
+        toolName: 'child_tool',
+        input: { value: 'from-child' },
+      });
+      emit('WebMCP.toolResponded', {
+        invocationId: 'oopif-invocation',
+        status: 'Completed',
+        output: { frame: 'oopif' },
+      }, { tabId: 58, sessionId });
+      return { invocationId: 'oopif-invocation' };
+    }
+    return {};
+  };
+
+  const catalog = await cdp.listWebMCPTools(58);
+  assert.equal(catalog.total, 2);
+  const child = catalog.tools.find(tool => tool.name === 'child_tool');
+  assert.equal(child?.frame_url, 'https://embed.test/');
+  assert.ok(commands.some(command => (
+    command.method === 'WebMCP.enable' && command.sessionId === 'oopif-session'
+  )));
+  assert.ok(commands.some(command => (
+    command.method === 'Target.setAutoAttach' && command.sessionId === 'oopif-session'
+  )));
+  const invocation = await cdp.invokeWebMCPTool(58, child.tool_id, { value: 'from-child' });
+  assert.equal(invocation.success, true);
+  assert.deepEqual(invocation.output, { frame: 'oopif' });
+
+  emit('Page.frameNavigated', {
+    frame: { id: 'oopif-frame', url: 'https://embed.test/next' },
+  }, { tabId: 58, sessionId: 'oopif-session' });
+  const afterNavigation = await cdp.listWebMCPTools(58);
+  assert.equal(afterNavigation.total, 1);
+  emit('WebMCP.toolsAdded', {
+    tools: [{ name: 'next_child_tool', description: 'next child', frameId: 'oopif-frame' }],
+  }, { tabId: 58, sessionId: 'oopif-session' });
+  const afterNewRegistration = await cdp.listWebMCPTools(58);
+  assert.equal(
+    afterNewRegistration.tools.find(tool => tool.name === 'next_child_tool')?.frame_url,
+    'https://embed.test/next',
+  );
+  emit('Target.detachedFromTarget', { sessionId: 'oopif-session' });
+  const afterDetach = await cdp.listWebMCPTools(58);
+  assert.equal(afterDetach.total, 1);
+  assert.equal(afterDetach.tools[0].name, 'parent_tool');
+});
+
 test('CDP WebMCP bounds hostile catalogs and cleans up after unsupported-domain errors', async () => {
   const cdp = new CDPClient();
   const emit = (event, params) => {

--- a/test/run.js
+++ b/test/run.js
@@ -21366,6 +21366,37 @@ test('CDP WebMCP bounds context discovery and detaches excess OOPIF sessions', a
   )));
 });
 
+test('CDP WebMCP disable during discovery cannot re-arm target auto-attach', async () => {
+  const cdp = new CDPClient();
+  const commands = [];
+  let disablePromise = null;
+  cdp.attach = async tabId => {
+    cdp.sessions.set(tabId, { tabId, attached: true });
+    return cdp.sessions.get(tabId);
+  };
+  cdp.sendCommand = async (tabId, method, params = {}, sessionId = '') => {
+    commands.push({ tabId, method, params, sessionId });
+    if (method === 'Runtime.enable') {
+      disablePromise = cdp.disableWebMCP(tabId);
+    }
+    return {};
+  };
+
+  await assert.rejects(
+    () => cdp.enableWebMCP(61),
+    /WebMCP session closed while it was enabling/,
+  );
+  await disablePromise;
+  assert.equal(cdp.webMcpSessions.has(61), false);
+  assert.ok(commands.some(command => (
+    command.method === 'Target.setAutoAttach' && command.params.autoAttach === false
+  )));
+  assert.equal(commands.some(command => (
+    command.method === 'Target.setAutoAttach' && command.params.autoAttach === true
+  )), false);
+  assert.ok(commands.some(command => command.method === 'WebMCP.disable'));
+});
+
 test('CDP WebMCP aggregates OOPIF sessions and removes their detached tools', async () => {
   const cdp = new CDPClient();
   const commands = [];

--- a/test/run.js
+++ b/test/run.js
@@ -22086,6 +22086,203 @@ test('CDP WebMCP discovery ignores frames navigated before evaluate results merg
   assert.equal(catalog.total, 0, 'frame navigation must invalidate discovery without prior tools');
 });
 
+test('CDP WebMCP root navigation invalidates in-flight discovery for tool-less child frames', async () => {
+  const cdp = new CDPClient();
+  const emit = (event, params, source = { tabId: 71 }) => {
+    for (const handler of cdp.eventHandlers.get(71)?.[event] || []) handler(params, source);
+  };
+  cdp.attach = async tabId => {
+    cdp.sessions.set(tabId, { tabId, attached: true });
+    return cdp.sessions.get(tabId);
+  };
+  cdp.sendCommand = async (tabId, method, params = {}) => {
+    if (method === 'WebMCP.enable') return {};
+    if (method === 'Page.enable') return {};
+    if (method === 'Runtime.enable') {
+      emit('Runtime.executionContextCreated', {
+        context: { id: 201, auxData: { isDefault: true, frameId: 'never-registered-child' } },
+      });
+      return {};
+    }
+    if (method === 'Runtime.evaluate') {
+      // Top-level navigation while evaluate is pending for a child frame that
+      // never had tools (so remove-by-tool cannot bump its gen).
+      emit('Page.frameNavigated', {
+        frame: {
+          id: 'main-frame',
+          url: 'https://example.com/next',
+        },
+      });
+      return {
+        result: {
+          value: [{ name: 'stale_child_tool', description: 'from previous page child frame' }],
+        },
+      };
+    }
+    if (method === 'Page.getFrameTree') {
+      return { frameTree: { frame: { id: 'main-frame', url: 'https://example.com/next' } } };
+    }
+    if (method === 'Target.setAutoAttach') return {};
+    return {};
+  };
+
+  const catalog = await cdp.listWebMCPTools(71);
+  assert.equal(
+    catalog.total,
+    0,
+    'root navigation must drop discovery for never-registered child frames',
+  );
+});
+
+test('CDP WebMCP root navigation tears down OOPIF child sessions', async () => {
+  const cdp = new CDPClient();
+  const commands = [];
+  const emit = (event, params, source = { tabId: 72 }) => {
+    for (const handler of cdp.eventHandlers.get(72)?.[event] || []) handler(params, source);
+  };
+  cdp.attach = async tabId => {
+    cdp.sessions.set(tabId, { tabId, attached: true });
+    return cdp.sessions.get(tabId);
+  };
+  cdp.sendCommand = async (tabId, method, params = {}, sessionId = '') => {
+    commands.push({ tabId, method, params, sessionId });
+    if (method === 'WebMCP.enable' && !sessionId) return {};
+    if (method === 'Page.enable') return {};
+    if (method === 'Target.setAutoAttach' && !sessionId && params.autoAttach) {
+      emit('Target.attachedToTarget', {
+        sessionId: 'oopif-session',
+        targetInfo: {
+          targetId: 'oopif-frame',
+          type: 'iframe',
+          url: 'https://embed.test/',
+        },
+      });
+      return {};
+    }
+    if (method === 'WebMCP.enable' && sessionId === 'oopif-session') {
+      emit('WebMCP.toolsAdded', {
+        tools: [{
+          name: 'embed_tool',
+          description: 'from OOPIF',
+          frameId: 'oopif-frame',
+        }],
+      }, { tabId: 72, sessionId: 'oopif-session' });
+      return {};
+    }
+    if (method === 'Runtime.enable') return {};
+    if (method === 'Page.getFrameTree') {
+      return { frameTree: { frame: { id: 'main-frame', url: 'https://example.com/' } } };
+    }
+    return {};
+  };
+
+  const before = await cdp.listWebMCPTools(72);
+  assert.equal(before.total, 1);
+  assert.equal(cdp.webMcpSessions.get(72).childSessions.has('oopif-session'), true);
+
+  emit('Page.frameNavigated', {
+    frame: { id: 'main-frame', url: 'https://example.com/next' },
+  });
+
+  const state = cdp.webMcpSessions.get(72);
+  assert.equal(state.childSessions.has('oopif-session'), false, 'root nav must drop childSessions');
+  assert.equal((await cdp.listWebMCPTools(72)).total, 0);
+
+  // Late toolsAdded from the detached pre-nav OOPIF must not re-enter.
+  emit('WebMCP.toolsAdded', {
+    tools: [{
+      name: 'late_embed_tool',
+      description: 'should be rejected',
+      frameId: 'oopif-frame',
+    }],
+  }, { tabId: 72, sessionId: 'oopif-session' });
+  assert.equal((await cdp.listWebMCPTools(72)).total, 0, 'late OOPIF toolsAdded must fail closed');
+
+  assert.ok(commands.some(command => (
+    command.sessionId === 'oopif-session'
+    && (
+      command.method === 'WebMCP.disable'
+      || (command.method === 'Target.setAutoAttach' && command.params.autoAttach === false)
+    )
+  )), 'root nav must tear down the OOPIF CDP session');
+});
+
+test('CDP WebMCP skips discovery when child WebMCP.enable fails', async () => {
+  const cdp = new CDPClient();
+  const commands = [];
+  const emit = (event, params, source = { tabId: 73 }) => {
+    for (const handler of cdp.eventHandlers.get(73)?.[event] || []) handler(params, source);
+  };
+  cdp.attach = async tabId => {
+    cdp.sessions.set(tabId, { tabId, attached: true });
+    return cdp.sessions.get(tabId);
+  };
+  cdp.sendCommand = async (tabId, method, params = {}, sessionId = '') => {
+    commands.push({ tabId, method, params, sessionId });
+    if (method === 'WebMCP.enable' && !sessionId) return {};
+    if (method === 'Page.enable' && !sessionId) return {};
+    if (method === 'Target.setAutoAttach' && !sessionId && params.autoAttach) {
+      emit('Target.attachedToTarget', {
+        sessionId: 'broken-oopif',
+        targetInfo: {
+          targetId: 'broken-frame',
+          type: 'iframe',
+          url: 'https://broken.test/',
+        },
+      });
+      return {};
+    }
+    if (method === 'WebMCP.enable' && sessionId === 'broken-oopif') {
+      throw new Error('WebMCP domain unavailable in child');
+    }
+    if (method === 'Runtime.evaluate' && sessionId === 'broken-oopif') {
+      return {
+        result: {
+          value: [{ name: 'undeliverable', description: 'enable failed' }],
+        },
+      };
+    }
+    if (method === 'Page.getFrameTree') {
+      return { frameTree: { frame: { id: 'main-frame', url: 'https://example.com/' } } };
+    }
+    return {};
+  };
+
+  const catalog = await cdp.listWebMCPTools(73);
+  assert.equal(catalog.total, 0, 'failed child enable must not catalog tools via discovery');
+  assert.equal(
+    cdp.webMcpSessions.get(73)?.childSessions.has('broken-oopif'),
+    false,
+    'failed child enable must drop the child session',
+  );
+  assert.equal(
+    commands.some(command => (
+      command.sessionId === 'broken-oopif' && command.method === 'Runtime.evaluate'
+    )),
+    false,
+    'failed child enable must skip Runtime discovery',
+  );
+});
+
+test('CDP WebMCP fails enable when main Page.enable is unavailable', async () => {
+  const cdp = new CDPClient();
+  cdp.attach = async tabId => {
+    cdp.sessions.set(tabId, { tabId, attached: true });
+    return cdp.sessions.get(tabId);
+  };
+  cdp.sendCommand = async (tabId, method) => {
+    if (method === 'WebMCP.enable') return {};
+    if (method === 'Page.enable') throw new Error('Page domain unavailable');
+    return {};
+  };
+
+  await assert.rejects(
+    () => cdp.enableWebMCP(74),
+    /Page domain unavailable|WebMCP is unavailable/,
+  );
+  assert.equal(cdp.webMcpSessions.has(74), false, 'failed Page.enable must not leave a session');
+});
+
 test('CDP WebMCP resets discovery context budget after top-level navigation', async () => {
   const cdp = new CDPClient();
   const state = cdp._newWebMCPSession(69);


### PR DESCRIPTION
## Summary

- recover WebMCP tools registered before `WebMCP.enable` from same-process child frames
- recursively aggregate out-of-process iframe targets and route invocation, cancellation, response, and removal events through the owning CDP session
- derive permission URLs from each target's trusted frame tree and clean stale tools on navigation, detach, disable, or debugger teardown
- retain already-reported execution contexts and bound discovery/OOPIF fan-out

## Why

The WebMCP protocol says enabling the domain reports all currently registered tools, but current Chromium enumerates only the inspected target's root frame. That leaves tools registered earlier in child frames invisible unless they register again dynamically.

- Protocol: https://chromedevtools.github.io/devtools-protocol/tot/WebMCP/
- Current Chromium implementation: https://chromium.googlesource.com/chromium/src/+/refs/heads/main/third_party/blink/renderer/core/inspector/inspector_web_mcp_agent.cc

## Validation

- real Chrome 151 unpacked-extension probe: parent, cross-site child, and nested cross-site grandchild tools were discovered and invoked; child navigation removed the complete child subtree
- `node test/run.js`: 1125 passed, 2 pre-existing baseline failures (changelog version mismatch and localized promotion assertion)
- `npm run test:security`: 60/60 passed
- `npm run test:ci`: 9 scenarios plus cloud capture passed
- merge-tree audit against current upstream `main`: no conflicts