### PR TITLE
fix(linkedin): reach the shadow-DOM post composer (interop shell)

### DIFF
--- a/src/chrome/src/agent/adapters.js
+++ b/src/chrome/src/agent/adapters.js
@@ -15865,6 +15865,7 @@ const ADAPTERS = [
     fullPageCapture: { infiniteScroll: isLinkedInInfiniteScrollUrl },
     notes: `
 - LinkedIn aggressively lazy-loads everything; scroll to populate the feed/profile, but most content lives in modal-style detail panes.
+- The post composer ("Start a post") opens a dialog rendered inside an open shadow root (#interop-outlet). If it is missing from get_accessibility_tree / click({text}) results even though the screenshot shows it open, do NOT coordinate-click inside it — clicks often hit the dialog backdrop and CLOSE it (the next screenshot shows the regular feed again). Reliable path: click({text: "Start a post"}) to open it, then type_text({selector: '[contenteditable]:not([contenteditable="false"])', text: "...", clear: true}) — this focuses the editor directly without a click. Then click the Post button (find it via get_interactive_elements or shadow_dom_query({selector: "button", shadowPath: "div#interop-outlet"}) if a plain text click matches "Post impressions" instead).
 - "Connect" button on profiles often has a "Send without a note" prompt — read it before clicking.
 - Messages are at /messaging — the message composer is a contenteditable with image/file upload icons.
 - In Messaging, after filling the composer, the reliable send path is usually Enter. If the composer footer says "Press Enter to Send" or the send-options popover shows "Press Enter to Send", call press_keys({key:"Enter"}) from the composer. Do NOT keep scrolling to find a Send button that is already visible/implicit.

--- a/src/chrome/src/agent/agent.js
+++ b/src/chrome/src/agent/agent.js
@@ -2979,7 +2979,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
     const cssBoxHint = this._canUseToolInCurrentBatch(allowedToolNames, 'inspect_element_styles')
       ? 'then use get_accessibility_tree or inspect_element_styles to get CSS-pixel boxes'
       : 'then use get_accessibility_tree or get_interactive_elements to choose a reachable target';
-    return `[COORDINATE CLICK WARNING: You've clicked at or near (${args.x}, ${args.y}) several times with no visible page change. The click may be missing its target. Try: (a) call get_interactive_elements to find a real selector, (b) click({text: "..."}) to target by visible text, or (c) inspect the latest injected auto_screenshot/visual context for element positions, ${cssBoxHint}. Try a different approach before clicking these coordinates again.]`;
+    return `[COORDINATE CLICK WARNING: You've clicked at or near (${args.x}, ${args.y}) several times with no visible page change. The click may be missing its target. Try: (a) call get_interactive_elements to find a real selector, (b) click({text: "..."}) to target by visible text, (c) inspect the latest injected auto_screenshot/visual context for element positions, ${cssBoxHint}, or (d) if you are trying to focus a text editor in a dialog, STOP clicking — dialogs on some sites render in a shadow root where coordinate clicks hit the backdrop and CLOSE the dialog. Reopen it if needed, then call type_text({selector: '[contenteditable]:not([contenteditable=\"false\"])', text: "..."}) directly; it focuses the editor without a click. Try a different approach before clicking these coordinates again.]`;
   }
 
   _noProgressRecoveryWarning(allowedToolNames = AGENT_TOOL_NAMES) {
@@ -15875,10 +15875,29 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
                       return true;
                     } catch(e) { return false; }
                   }
-                  const all = Array.from(document.querySelectorAll(sels)).filter(vis);
+                  // Last-resort scan also pierces open shadow roots: sites
+                  // like LinkedIn render entire dialogs inside one (the
+                  // interop shell), where document.querySelectorAll is blind.
+                  function collectDeep(sel) {
+                    const out = [];
+                    const scan = (root, depth) => {
+                      try { out.push(...root.querySelectorAll(sel)); } catch(e) {}
+                      if (depth > 4) return;
+                      let els;
+                      try { els = root.querySelectorAll('*'); } catch(e) { return; }
+                      for (const host of els) { if (host.shadowRoot) scan(host.shadowRoot, depth + 1); }
+                    };
+                    scan(document, 0);
+                    return out;
+                  }
+                  const all = collectDeep(sels).filter(vis);
+                  // Quill/ProseMirror-style editors show their placeholder via
+                  // data-placeholder / aria-placeholder (CSS pseudo-element),
+                  // not text content — match those too so "click the 'What do
+                  // you want to talk about?' box" resolves.
                   const norm = all.map(el => ({
                     el,
-                    txt: (el.innerText || el.getAttribute('aria-label') || el.getAttribute('placeholder') || '').trim().toLowerCase(),
+                    txt: (el.innerText || el.getAttribute('aria-label') || el.getAttribute('placeholder') || el.getAttribute('data-placeholder') || el.getAttribute('aria-placeholder') || '').trim().toLowerCase(),
                   })).filter(x => !!x.txt);
                   const modes = explicit ? [explicit] : ['exact', 'prefix', 'contains'];
                   for (const m of modes) {

--- a/src/chrome/src/content/accessibility-tree.js
+++ b/src/chrome/src/content/accessibility-tree.js
@@ -161,6 +161,11 @@
     const onHost = (domain) => hostname === domain || hostname.endsWith(`.${domain}`);
     if (onHost('bilibili.com')) return { key: 'bilibili', rules: SITE_INTERACTION_RULES.bilibili };
     if (onHost('xiaohongshu.com')) return { key: 'xiaohongshu', rules: SITE_INTERACTION_RULES.xiaohongshu };
+    // LinkedIn's interop shell renders major surfaces (the post composer
+    // dialog among them) inside the open #interop-outlet shadow root. No
+    // custom interaction rules needed — piercing alone makes the dialog's
+    // contenteditable + Post button visible to the tree walk.
+    if (onHost('linkedin.com')) return { key: 'linkedin', rules: [] };
     return { key: '', rules: [] };
   }
 
@@ -190,7 +195,7 @@
     selectors: () => currentSiteInteractionConfig().rules.map(([selector]) => selector),
     describe: getSiteInteractionDescriptor,
     isInteractive: (el) => !!getSiteInteractionDescriptor(el),
-    shouldPierceShadowRoots: () => currentSiteInteractionConfig().key === 'bilibili',
+    shouldPierceShadowRoots: () => ['bilibili', 'linkedin'].includes(currentSiteInteractionConfig().key),
   });
 
   function getRole(el) {
@@ -875,28 +880,51 @@
         ];
         const overlayEls = [];
         const seen = new WeakSet();
+        // On pierce-enabled sites (LinkedIn's interop shell, Bilibili), the
+        // dialog we must hoist can live inside an open shadow root where
+        // document.querySelectorAll can't see it. Collect those roots so the
+        // overlay scan covers them too — without piercing, a freshly-opened
+        // composer dialog is completely absent from the tree output and the
+        // model falls back to blind coordinate clicks.
+        const overlayRoots = [document];
+        if (window.__wbSiteInteractions.shouldPierceShadowRoots()) {
+          const collectShadowRoots = (root, depth) => {
+            if (depth > 4) return;
+            let hosts;
+            try { hosts = root.querySelectorAll('*'); } catch (e) { return; }
+            for (const host of hosts) {
+              if (host.shadowRoot) {
+                overlayRoots.push(host.shadowRoot);
+                collectShadowRoots(host.shadowRoot, depth + 1);
+              }
+            }
+          };
+          collectShadowRoots(document, 0);
+        }
         try {
           for (const sel of overlaySelectors) {
-            const nodes = document.querySelectorAll(sel);
-            for (const n of nodes) {
-              if (seen.has(n)) continue;
-              if (!n.isConnected) continue;
-              // Skip if ancestor already collected — avoids emitting a
-              // nested listbox twice when its ancestor dialog is also hit.
-              let ancIsOverlay = false;
-              for (let p = n.parentElement; p; p = p.parentElement) {
-                if (seen.has(p)) { ancIsOverlay = true; break; }
+            for (const root of overlayRoots) {
+              const nodes = root.querySelectorAll(sel);
+              for (const n of nodes) {
+                if (seen.has(n)) continue;
+                if (!n.isConnected) continue;
+                // Skip if ancestor already collected — avoids emitting a
+                // nested listbox twice when its ancestor dialog is also hit.
+                let ancIsOverlay = false;
+                for (let p = n.parentElement; p; p = p.parentElement) {
+                  if (seen.has(p)) { ancIsOverlay = true; break; }
+                }
+                if (ancIsOverlay) continue;
+                // Quick visibility gate — don't emit hidden overlay shells.
+                try {
+                  const r = n.getBoundingClientRect();
+                  if (r.width < 1 || r.height < 1) continue;
+                  const s = window.getComputedStyle(n);
+                  if (s.visibility === 'hidden' || s.display === 'none' || parseFloat(s.opacity) === 0) continue;
+                } catch (e) { continue; }
+                seen.add(n);
+                overlayEls.push(n);
               }
-              if (ancIsOverlay) continue;
-              // Quick visibility gate — don't emit hidden overlay shells.
-              try {
-                const r = n.getBoundingClientRect();
-                if (r.width < 1 || r.height < 1) continue;
-                const s = window.getComputedStyle(n);
-                if (s.visibility === 'hidden' || s.display === 'none' || parseFloat(s.opacity) === 0) continue;
-              } catch (e) { continue; }
-              seen.add(n);
-              overlayEls.push(n);
             }
           }
         } catch (e) {}

--- a/src/firefox/src/agent/adapters.js
+++ b/src/firefox/src/agent/adapters.js
@@ -15864,6 +15864,7 @@ const ADAPTERS = [
     fullPageCapture: { infiniteScroll: isLinkedInInfiniteScrollUrl },
     notes: `
 - LinkedIn aggressively lazy-loads everything; scroll to populate the feed/profile, but most content lives in modal-style detail panes.
+- The post composer ("Start a post") opens a dialog rendered inside an open shadow root (#interop-outlet). If it is missing from get_accessibility_tree / click({text}) results even though the screenshot shows it open, do NOT coordinate-click inside it — clicks often hit the dialog backdrop and CLOSE it (the next screenshot shows the regular feed again). Reliable path: click({text: "Start a post"}) to open it, then type_text({selector: '[contenteditable]:not([contenteditable="false"])', text: "...", clear: true}) — this focuses the editor directly without a click. Then click the Post button (find it via get_interactive_elements or shadow_dom_query({selector: "button", shadowPath: "div#interop-outlet"}) if a plain text click matches "Post impressions" instead).
 - "Connect" button on profiles often has a "Send without a note" prompt — read it before clicking.
 - Messages are at /messaging — the message composer is a contenteditable with image/file upload icons.
 - In Messaging, after filling the composer, the reliable send path is usually Enter. If the composer footer says "Press Enter to Send" or the send-options popover shows "Press Enter to Send", call press_keys({key:"Enter"}) from the composer. Do NOT keep scrolling to find a Send button that is already visible/implicit.

--- a/src/firefox/src/agent/agent.js
+++ b/src/firefox/src/agent/agent.js
@@ -2671,7 +2671,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
     const cssBoxHint = this._canUseToolInCurrentBatch(allowedToolNames, 'inspect_element_styles')
       ? 'then use get_accessibility_tree or inspect_element_styles to get CSS-pixel boxes'
       : 'then use get_accessibility_tree or get_interactive_elements to choose a reachable target';
-    return `[COORDINATE CLICK WARNING: You've clicked at or near (${args.x}, ${args.y}) several times with no visible page change. The click may be missing its target. Try: (a) call get_interactive_elements to find a real selector, (b) click({text: "..."}) to target by visible text, or (c) inspect the latest injected auto_screenshot/visual context for element positions, ${cssBoxHint}. Try a different approach before clicking these coordinates again.]`;
+    return `[COORDINATE CLICK WARNING: You've clicked at or near (${args.x}, ${args.y}) several times with no visible page change. The click may be missing its target. Try: (a) call get_interactive_elements to find a real selector, (b) click({text: "..."}) to target by visible text, (c) inspect the latest injected auto_screenshot/visual context for element positions, ${cssBoxHint}, or (d) if you are trying to focus a text editor in a dialog, STOP clicking — dialogs on some sites render in a shadow root where coordinate clicks hit the backdrop and CLOSE the dialog. Reopen it if needed, then call type_text({selector: '[contenteditable]:not([contenteditable=\"false\"])', text: "..."}) directly; it focuses the editor without a click. Try a different approach before clicking these coordinates again.]`;
   }
 
   _devStyleInspectionAvailableForTab(tabId) {

--- a/src/firefox/src/content/accessibility-tree.js
+++ b/src/firefox/src/content/accessibility-tree.js
@@ -161,6 +161,11 @@
     const onHost = (domain) => hostname === domain || hostname.endsWith(`.${domain}`);
     if (onHost('bilibili.com')) return { key: 'bilibili', rules: SITE_INTERACTION_RULES.bilibili };
     if (onHost('xiaohongshu.com')) return { key: 'xiaohongshu', rules: SITE_INTERACTION_RULES.xiaohongshu };
+    // LinkedIn's interop shell renders major surfaces (the post composer
+    // dialog among them) inside the open #interop-outlet shadow root. No
+    // custom interaction rules needed — piercing alone makes the dialog's
+    // contenteditable + Post button visible to the tree walk.
+    if (onHost('linkedin.com')) return { key: 'linkedin', rules: [] };
     return { key: '', rules: [] };
   }
 
@@ -190,7 +195,7 @@
     selectors: () => currentSiteInteractionConfig().rules.map(([selector]) => selector),
     describe: getSiteInteractionDescriptor,
     isInteractive: (el) => !!getSiteInteractionDescriptor(el),
-    shouldPierceShadowRoots: () => currentSiteInteractionConfig().key === 'bilibili',
+    shouldPierceShadowRoots: () => ['bilibili', 'linkedin'].includes(currentSiteInteractionConfig().key),
   });
 
   function getRole(el) {
@@ -875,28 +880,51 @@
         ];
         const overlayEls = [];
         const seen = new WeakSet();
+        // On pierce-enabled sites (LinkedIn's interop shell, Bilibili), the
+        // dialog we must hoist can live inside an open shadow root where
+        // document.querySelectorAll can't see it. Collect those roots so the
+        // overlay scan covers them too — without piercing, a freshly-opened
+        // composer dialog is completely absent from the tree output and the
+        // model falls back to blind coordinate clicks.
+        const overlayRoots = [document];
+        if (window.__wbSiteInteractions.shouldPierceShadowRoots()) {
+          const collectShadowRoots = (root, depth) => {
+            if (depth > 4) return;
+            let hosts;
+            try { hosts = root.querySelectorAll('*'); } catch (e) { return; }
+            for (const host of hosts) {
+              if (host.shadowRoot) {
+                overlayRoots.push(host.shadowRoot);
+                collectShadowRoots(host.shadowRoot, depth + 1);
+              }
+            }
+          };
+          collectShadowRoots(document, 0);
+        }
         try {
           for (const sel of overlaySelectors) {
-            const nodes = document.querySelectorAll(sel);
-            for (const n of nodes) {
-              if (seen.has(n)) continue;
-              if (!n.isConnected) continue;
-              // Skip if ancestor already collected — avoids emitting a
-              // nested listbox twice when its ancestor dialog is also hit.
-              let ancIsOverlay = false;
-              for (let p = n.parentElement; p; p = p.parentElement) {
-                if (seen.has(p)) { ancIsOverlay = true; break; }
+            for (const root of overlayRoots) {
+              const nodes = root.querySelectorAll(sel);
+              for (const n of nodes) {
+                if (seen.has(n)) continue;
+                if (!n.isConnected) continue;
+                // Skip if ancestor already collected — avoids emitting a
+                // nested listbox twice when its ancestor dialog is also hit.
+                let ancIsOverlay = false;
+                for (let p = n.parentElement; p; p = p.parentElement) {
+                  if (seen.has(p)) { ancIsOverlay = true; break; }
+                }
+                if (ancIsOverlay) continue;
+                // Quick visibility gate — don't emit hidden overlay shells.
+                try {
+                  const r = n.getBoundingClientRect();
+                  if (r.width < 1 || r.height < 1) continue;
+                  const s = window.getComputedStyle(n);
+                  if (s.visibility === 'hidden' || s.display === 'none' || parseFloat(s.opacity) === 0) continue;
+                } catch (e) { continue; }
+                seen.add(n);
+                overlayEls.push(n);
               }
-              if (ancIsOverlay) continue;
-              // Quick visibility gate — don't emit hidden overlay shells.
-              try {
-                const r = n.getBoundingClientRect();
-                if (r.width < 1 || r.height < 1) continue;
-                const s = window.getComputedStyle(n);
-                if (s.visibility === 'hidden' || s.display === 'none' || parseFloat(s.opacity) === 0) continue;
-              } catch (e) { continue; }
-              seen.add(n);
-              overlayEls.push(n);
             }
           }
         } catch (e) {}

--- a/src/firefox/src/content/content.js
+++ b/src/firefox/src/content/content.js
@@ -1466,7 +1466,22 @@
           // Honor modal scoping here too.
           const _fbScope = _findTopmostModal() || document;
           const fbSels = '[contenteditable="true"],[contenteditable=""],[role="option"],[role="listbox"],[role="combobox"],[role="textbox"],[role="switch"],[role="checkbox"],[role="radio"],[tabindex]:not([tabindex="-1"])';
-          const fbAll = Array.from(_fbScope.querySelectorAll(fbSels)).filter(e => {
+          // Last-resort scan also pierces open shadow roots: sites like
+          // LinkedIn render entire dialogs inside one (the interop shell),
+          // where querySelectorAll on the document is blind.
+          const _fbCollectDeep = (sel) => {
+            const out = [];
+            const scan = (root, depth) => {
+              try { out.push(...root.querySelectorAll(sel)); } catch(err) {}
+              if (depth > 4) return;
+              let els;
+              try { els = root.querySelectorAll('*'); } catch(err) { return; }
+              for (const host of els) { if (host.shadowRoot) scan(host.shadowRoot, depth + 1); }
+            };
+            scan(_fbScope, 0);
+            return out;
+          };
+          const fbAll = _fbCollectDeep(fbSels).filter(e => {
             try {
               const r = e.getBoundingClientRect();
               if (r.width < 1 || r.height < 1) return false;
@@ -1475,9 +1490,12 @@
               return true;
             } catch(err) { return false; }
           });
+          // Quill/ProseMirror-style editors show their placeholder via
+          // data-placeholder / aria-placeholder (CSS pseudo-element), not
+          // text content — match those too.
           const fbNorm = fbAll.map(e => ({
             e,
-            txt: (e.innerText || e.getAttribute('aria-label') || e.getAttribute('placeholder') || '').trim().toLowerCase(),
+            txt: (e.innerText || e.getAttribute('aria-label') || e.getAttribute('placeholder') || e.getAttribute('data-placeholder') || e.getAttribute('aria-placeholder') || '').trim().toLowerCase(),
           })).filter(x => !!x.txt);
           for (const m of modes) {
             const found = fbNorm.filter(x =>

--- a/test/run.js
+++ b/test/run.js
@@ -47670,4 +47670,37 @@ test('profile sync reset does not re-unlock after an in-flight lock', async () =
   assert.equal(manager.status, 'locked');
 });
 
+test('linkedin shadow-dom reachability: pierce, overlay hoist, placeholder match, adapter route', () => {
+  // LinkedIn's interop shell renders the post composer dialog inside the open
+  // #interop-outlet shadow root. Structural checks that every layer that must
+  // reach it actually pierces: tree walk, overlay hoist, widened text-click
+  // scan, plus the adapter/loop-warning guidance that keeps weak models off
+  // the backdrop-click-close loop.
+  for (const build of ['chrome', 'firefox']) {
+    const tree = fs.readFileSync(path.join(ROOT, `src/${build}/src/content/accessibility-tree.js`), 'utf8');
+    assert.match(tree, /onHost\('linkedin\.com'\)/,
+      `${build}: linkedin registered in site interaction config`);
+    assert.match(tree, /\['bilibili', 'linkedin'\]\.includes\(currentSiteInteractionConfig\(\)\.key\)/,
+      `${build}: shadow piercing enabled for linkedin`);
+    assert.match(tree, /const overlayRoots = \[document\];[\s\S]*?shouldPierceShadowRoots\(\)[\s\S]*?collectShadowRoots\(document, 0\);[\s\S]*?for \(const root of overlayRoots\)/,
+      `${build}: overlay hoist scans open shadow roots on pierce-enabled sites`);
+
+    const clickSrc = build === 'chrome'
+      ? fs.readFileSync(path.join(ROOT, 'src/chrome/src/agent/agent.js'), 'utf8')
+      : fs.readFileSync(path.join(ROOT, 'src/firefox/src/content/content.js'), 'utf8');
+    assert.match(clickSrc, /data-placeholder'\) \|\| \w+\.getAttribute\('aria-placeholder/,
+      `${build}: widened click scan matches Quill-style placeholder attributes`);
+    assert.match(clickSrc, /shadowRoot\) scan\(host\.shadowRoot, depth \+ 1\)/,
+      `${build}: widened click scan pierces open shadow roots`);
+
+    const agent = fs.readFileSync(path.join(ROOT, `src/${build}/src/agent/agent.js`), 'utf8');
+    assert.match(agent, /focuses the editor without a click/,
+      `${build}: coordinate-loop warning nudges selector-based type_text`);
+
+    const adapters = fs.readFileSync(path.join(ROOT, `src/${build}/src/agent/adapters.js`), 'utf8');
+    assert.match(adapters, /interop-outlet[\s\S]*?type_text\(\{selector: '\[contenteditable\]/,
+      `${build}: linkedin adapter teaches the shadow composer route`);
+  }
+});
+
 await run();


### PR DESCRIPTION
## Problem

LinkedIn's interop shell renders the post composer dialog inside the open `#interop-outlet` shadow root (host div has zero height; the modal paints via fixed positioning from shadow content). This made the composer invisible to every collector even while clearly visible on screen:

- `get_accessibility_tree` never surfaced the dialog — no `ref_id` for the editor, even with overlay hoisting
- `click({text: "What do you want to talk about?"})` failed — Quill renders the placeholder via `data-placeholder`, not text content
- coordinate clicks inside the visually-open dialog hit the backdrop and **closed it**, producing an open→click→closed→reopen loop until the loop detector stopped the run

Traces from 2026-07-22 show MiniMax and Gemma both failing in exactly this loop, while gpt-5.6-terra succeeded only by discovering the selector route (`type_text({selector: '[contenteditable]...'})` + `shadow_dom_query`) on its own. These fixes lower that difficulty floor so mid-tier models succeed too.

## Changes (mirrored in Chrome + Firefox builds)

- **accessibility-tree**: register `linkedin.com` in the existing shadow-pierce gate (built for Bilibili), and extend the **overlay hoist** to scan open shadow roots on pierce-enabled sites — a freshly-opened dialog now gets `ref_id`s and renders first so it survives truncation
- **`click({text})` widened scan** (chrome agent / firefox content): pierce open shadow roots and match `data-placeholder` / `aria-placeholder`, so Quill/ProseMirror-style editors resolve by their visible placeholder text
- **coordinate-loop warning**: new option (d) — stop clicking dialog editors (backdrop clicks close the dialog) and use selector-based `type_text`, which focuses the editor without a click
- **linkedin adapter**: teach the reliable composer route up front (open by text → type by contenteditable selector → find Post via `get_interactive_elements` / `shadow_dom_query`), including the "Post" vs "Post impressions" prefix-match trap

Shadow piercing stays opt-in per site (LinkedIn + Bilibili), so tree-walk cost is unchanged everywhere else; the placeholder/shadow additions to the click scan live in the last-resort fallback only.

## Testing

- New structural test asserting all four layers in both builds: `linkedin shadow-dom reachability: pierce, overlay hoist, placeholder match, adapter route`
- Full suite: 1222 passed + security injection corpus (60/60). The single pre-existing failure on main (`repository changelog retains complete, non-empty release history`: package.json 25.7.2 vs CHANGELOG 25.7.0) is unrelated release housekeeping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)