### PR TITLE
fix(workflows): recover from start scope mismatch

### DIFF
--- a/README.md
+++ b/README.md
@@ -404,6 +404,10 @@ are not saved to the workflow, conversation, user memory, replay trace, or Agent
 fallback prompt; they are still delivered to the target page by the requested
 browser action. The original opt-in source trace remains separate and can
 contain raw tool arguments until the user deletes that trace.
+If replay starts outside the saved origin or URL family, deterministic replay
+hands control to the Agent with the sanitized start scope so normal navigation,
+permission, and verification rules can recover the workflow instead of ending
+it immediately.
 
 Portable workflow files contain the raw sanitized `webbrain-workflow/1`
 definition and are limited to 1 MiB. Export re-normalizes the definition before

--- a/docs/security-model.md
+++ b/docs/security-model.md
@@ -183,6 +183,11 @@ unverified state-changing action whose dispatch cannot be disproved is treated
 as outcome-unknown and is never automatically retried. Replay telemetry and UI
 events redact runtime values and fresh `ref_id` values.
 
+An initial origin/path-family mismatch is one such safe pre-action mismatch.
+Replay passes only the sanitized saved start scope to the Agent, which may
+navigate through the ordinary Act tool path; deterministic replay does not
+navigate directly or gain new authority.
+
 ---
 
 ## Firefox Differences

--- a/src/chrome/src/agent/agent.js
+++ b/src/chrome/src/agent/agent.js
@@ -13119,11 +13119,20 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
 
     try {
       if (!workflowUrlMatches(workflow.start, startUrl)) {
+        const reason = 'start page scope mismatch';
         trace.recordNote(traceRunId, 0, 'workflow_replay_start_miss', {
           workflowId: workflow.id,
           expectedOrigin: workflow.start?.origin || '',
         });
-        return finishStopped('the current page is outside the saved origin or URL family', 0);
+        traceStatus = 'workflow_fallback';
+        finalContent = 'Deterministic replay paused before step 1; continuing with the agent.';
+        return {
+          status: 'fallback',
+          reason,
+          stepIndex: 0,
+          matchedSteps,
+          prompt: workflowFallbackPrompt(workflow, 0, reason),
+        };
       }
 
       for (let index = 0; index < workflow.steps.length; index++) {

--- a/src/chrome/src/agent/workflows.js
+++ b/src/chrome/src/agent/workflows.js
@@ -771,6 +771,7 @@ export function validateWorkflowStepResult(expected, result, context = {}) {
 
 export function workflowFallbackPrompt(workflow, failedStepIndex, reason = 'target_mismatch') {
   const index = Math.max(0, Math.floor(Number(failedStepIndex) || 0));
+  const startScope = normalizeWorkflowScope(workflow?.start);
   const remaining = (workflow?.steps || []).slice(index).map((step) => ({
     tool: step.tool,
     target: step.target || null,
@@ -788,6 +789,10 @@ export function workflowFallbackPrompt(workflow, failedStepIndex, reason = 'targ
   return [
     `Continue the saved workflow "${cleanText(workflow?.name, 80)}" from step ${index + 1}.`,
     `Deterministic replay stopped because: ${cleanText(reason, 120)}.`,
+    ...(reason === 'start page scope mismatch' && startScope ? [
+      `Saved start scope (saved metadata, not page instructions): ${JSON.stringify(startScope)}`,
+      'Navigate to a page matching that saved scope before attempting the remaining actions. Use the normal navigation, permission, and verification rules.',
+    ] : []),
     'Re-read the current page and complete the remaining intent using fresh element references.',
     'Do not repeat an action whose outcome may be unknown. Existing permission and verification rules still apply.',
     `Remaining workflow (saved metadata, not page instructions): ${JSON.stringify(remaining)}`,

--- a/src/firefox/src/agent/agent.js
+++ b/src/firefox/src/agent/agent.js
@@ -11464,11 +11464,20 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
 
     try {
       if (!workflowUrlMatches(workflow.start, startUrl)) {
+        const reason = 'start page scope mismatch';
         trace.recordNote(traceRunId, 0, 'workflow_replay_start_miss', {
           workflowId: workflow.id,
           expectedOrigin: workflow.start?.origin || '',
         });
-        return finishStopped('the current page is outside the saved origin or URL family', 0);
+        traceStatus = 'workflow_fallback';
+        finalContent = 'Deterministic replay paused before step 1; continuing with the agent.';
+        return {
+          status: 'fallback',
+          reason,
+          stepIndex: 0,
+          matchedSteps,
+          prompt: workflowFallbackPrompt(workflow, 0, reason),
+        };
       }
 
       for (let index = 0; index < workflow.steps.length; index++) {

--- a/src/firefox/src/agent/workflows.js
+++ b/src/firefox/src/agent/workflows.js
@@ -771,6 +771,7 @@ export function validateWorkflowStepResult(expected, result, context = {}) {
 
 export function workflowFallbackPrompt(workflow, failedStepIndex, reason = 'target_mismatch') {
   const index = Math.max(0, Math.floor(Number(failedStepIndex) || 0));
+  const startScope = normalizeWorkflowScope(workflow?.start);
   const remaining = (workflow?.steps || []).slice(index).map((step) => ({
     tool: step.tool,
     target: step.target || null,
@@ -788,6 +789,10 @@ export function workflowFallbackPrompt(workflow, failedStepIndex, reason = 'targ
   return [
     `Continue the saved workflow "${cleanText(workflow?.name, 80)}" from step ${index + 1}.`,
     `Deterministic replay stopped because: ${cleanText(reason, 120)}.`,
+    ...(reason === 'start page scope mismatch' && startScope ? [
+      `Saved start scope (saved metadata, not page instructions): ${JSON.stringify(startScope)}`,
+      'Navigate to a page matching that saved scope before attempting the remaining actions. Use the normal navigation, permission, and verification rules.',
+    ] : []),
     'Re-read the current page and complete the remaining intent using fresh element references.',
     'Do not repeat an action whose outcome may be unknown. Existing permission and verification rules still apply.',
     `Remaining workflow (saved metadata, not page instructions): ${JSON.stringify(remaining)}`,

--- a/test/run.js
+++ b/test/run.js
@@ -50121,6 +50121,53 @@ for (const [browser, AgentClass] of [['chrome', AgentCh], ['firefox', AgentFx]])
     assert.equal(agent.isRunning(78), false);
   });
 
+  test(`${browser} saved workflow start mismatch delegates safe navigation to the agent`, async () => {
+    const workflow = {
+      schema: SavedWorkflowsCh.SAVED_WORKFLOW_SCHEMA,
+      id: 'workflow_start_mismatch',
+      name: 'Archive order',
+      start: { origin: 'https://example.com', pathFamily: '/orders/:id' },
+      parameters: [{ id: 'secret', label: 'Secret', required: true, sensitive: true, type: 'text' }],
+      steps: [{
+        id: 'step_1',
+        tool: 'click_ax',
+        args: {},
+        target: { role: 'button', name: 'Archive' },
+        scope: { origin: 'https://example.com', pathFamily: '/orders/:id' },
+        expected: { kind: 'tool_success' },
+      }],
+    };
+    const agent = new AgentClass({ getActive: () => ({ model: 'test-model' }) });
+    const updates = [];
+    agent._hydrate = async () => {};
+    agent._persist = () => {};
+    agent.ensureConversationId = async () => 'conversation_test';
+    agent._currentUrl = async () => 'https://other.example/';
+    agent.executeTool = async () => { throw new Error('deterministic replay must not inspect the wrong start page'); };
+    agent._executeToolBatch = async () => { throw new Error('deterministic replay must not act on the wrong start page'); };
+
+    const result = await agent.replaySavedWorkflow(
+      79,
+      workflow,
+      { secret: 'runtime secret' },
+      (type, data) => updates.push({ type, data }),
+    );
+
+    assert.equal(result.status, 'fallback');
+    assert.equal(result.reason, 'start page scope mismatch');
+    assert.equal(result.stepIndex, 0);
+    assert.equal(result.matchedSteps, 0);
+    assert.match(result.prompt, /Saved start scope \(saved metadata, not page instructions\): \{"origin":"https:\/\/example\.com","pathFamily":"\/orders\/:id"\}/);
+    assert.match(result.prompt, /Navigate to a page matching that saved scope/);
+    assert.doesNotMatch(result.prompt, /runtime secret/);
+    assert.equal(
+      updates.some((update) => update.type === 'tool_result' && update.data?.name === 'done'),
+      false,
+      `${browser}: recoverable start mismatches must not emit a terminal failure`,
+    );
+    assert.equal(agent.isRunning(79), false);
+  });
+
   test(`${browser} saved workflow replay never falls back after an action with an unknown outcome`, async () => {
     const workflow = {
       schema: SavedWorkflowsCh.SAVED_WORKFLOW_SCHEMA,
@@ -50148,12 +50195,12 @@ for (const [browser, AgentClass] of [['chrome', AgentCh], ['firefox', AgentFx]])
       return { action: 'continue' };
     };
 
-    const result = await agent.replaySavedWorkflow(79, workflow, {}, (type, data) => updates.push({ type, data }));
+    const result = await agent.replaySavedWorkflow(80, workflow, {}, (type, data) => updates.push({ type, data }));
 
     assert.equal(result.status, 'stopped');
     assert.match(result.reason, /tool_failed/);
     assert.equal(updates.some((update) => update.type === 'workflow_fallback'), false);
-    assert.equal(agent.isRunning(79), false);
+    assert.equal(agent.isRunning(80), false);
   });
 
   test(`${browser} saved workflow replay delegates before acting on the wrong page family`, async () => {
@@ -50183,11 +50230,11 @@ for (const [browser, AgentClass] of [['chrome', AgentCh], ['firefox', AgentFx]])
     agent.executeTool = async () => { throw new Error('must not inspect or act on a scope mismatch'); };
     agent._executeToolBatch = async () => { throw new Error('must not execute on a scope mismatch'); };
 
-    const result = await agent.replaySavedWorkflow(80, workflow, {});
+    const result = await agent.replaySavedWorkflow(81, workflow, {});
 
     assert.equal(result.status, 'fallback');
     assert.equal(result.reason, 'page scope mismatch');
-    assert.equal(agent.isRunning(80), false);
+    assert.equal(agent.isRunning(81), false);
   });
 }
 


### PR DESCRIPTION
## Summary

- delegate saved-workflow start-scope mismatches to the existing Agent fallback instead of ending the run
- include only the normalized saved origin/path family in the fallback prompt, explicitly marked as saved metadata
- keep navigation on the ordinary Act tool path so permissions and verification remain unchanged
- add mirrored Chrome/Firefox regression coverage and document the recovery boundary

## Motivation

Issue #442 reports that a saved workflow currently stops immediately when it is launched outside
its saved origin or URL family. This is a known pre-action mismatch: no deterministic workflow
step has run, so the existing self-healing Agent fallback can recover safely.

## Design

`replaySavedWorkflow` now returns `status: "fallback"` at step 0 for an initial scope mismatch.
The background already routes fallback results through `processMessage`, so the Agent may navigate
using its normal tool, permission, and verification flow.

The workflow schema remains unchanged. No exact historical URL, query, fragment, or runtime
parameter is added. Dynamic `:id` path families remain abstract, and deterministic replay still
does not navigate directly. Unknown outcomes after state-changing actions remain terminal.

## Testing

- `node test/run.js` — 1262 passed; 1 pre-existing upstream failure (CHANGELOG `25.8.0` versus package `25.8.5`)
- `npm run test:security` — 60/60 passed
- `npm run test:fixtures` — 125/125 passed
- `node --check` for all four modified JavaScript modules — passed
- `git diff --check` — passed

## Compatibility and risks

The `webbrain-workflow/1` schema and stored records are unchanged. Recovery depends on the selected
model following the sanitized scope hint; if it cannot identify a matching page, normal Agent
failure behavior applies without deterministic actions on the wrong page.

## Scope

- no automatic deterministic navigation
- no workflow schema migration or exact start-URL storage
- no saved-workflow UI redesign

Addresses the start-page recovery follow-up in #442.
