### PR TITLE
refactor(agent): test production loop detector

### DIFF
--- a/TODOs.md
+++ b/TODOs.md
@@ -194,15 +194,15 @@ parity regressions likely.
 
 ## 9. Test the real shared logic instead of copied shims
 
-`test/run.js` duplicates pieces of `Agent` logic in `LoopDetectorShim` because
-`agent.js` imports browser-only modules. That means tests can pass while the real
-agent implementation drifts.
+**Status:** Partially resolved. Loop detection now lives in the browser-free
+`agent/loop-detector.js` module in both builds. `Agent` inherits that production
+class, `test/run.js` imports it directly, and a parity assertion keeps the
+Chrome and Firefox copies byte-identical.
 
 **Concrete next steps:**
-1. Move loop detection, coordinate-click bucketing, image budget sizing, and
-   other pure logic into browser-free modules.
-2. Import those modules directly from both `agent.js` and `test/run.js`.
-3. Add regression tests for the text tool-call parser and context trimming,
+1. Move image budget sizing and other remaining pure logic into browser-free
+   modules and import those modules directly from `agent.js` and `test/run.js`.
+2. Add regression tests for the text tool-call parser and context trimming,
    since both are high-impact agent reliability code.
 
 ---

--- a/src/chrome/ARCHITECTURE.md
+++ b/src/chrome/ARCHITECTURE.md
@@ -41,6 +41,7 @@ src/chrome/
 │   ├── run-ui-journal.js       # Detached-run replay + streamed-text snapshots
 │   ├── agent/
 │   │   ├── agent.js            # Core agent loop + tool dispatch
+│   │   ├── loop-detector.js     # Browser-free loop detection, directly unit-tested
 │   │   ├── tools.js            # Tool schemas + system prompts
 │   │   ├── skills.js           # Settings skills + dynamic skill tool manifests
 │   │   ├── planner.js          # Plan-before-Act structured planner
@@ -562,6 +563,9 @@ OpenAI format → Anthropic blocks: system → separate `system` field; `assista
 ---
 
 ## Loop Detection
+
+The browser-free implementation lives in `agent/loop-detector.js`; `Agent`
+inherits it, and the unit suite imports the same production class directly.
 
 Three independent detectors, strongest action wins:
 

--- a/src/chrome/ARCHITECTURE.md
+++ b/src/chrome/ARCHITECTURE.md
@@ -42,6 +42,7 @@ src/chrome/
 │   ├── agent/
 │   │   ├── agent.js            # Core agent loop + tool dispatch
 │   │   ├── loop-detector.js     # Browser-free loop detection, directly unit-tested
+│   │   ├── mutation-tools.js    # This build's state-change + mutating tool sets
 │   │   ├── tools.js            # Tool schemas + system prompts
 │   │   ├── skills.js           # Settings skills + dynamic skill tool manifests
 │   │   ├── planner.js          # Plan-before-Act structured planner
@@ -566,6 +567,8 @@ OpenAI format → Anthropic blocks: system → separate `system` field; `assista
 
 The browser-free implementation lives in `agent/loop-detector.js`; `Agent`
 inherits it, and the unit suite imports the same production class directly.
+That module is byte-identical across builds, so the per-build tool surface it
+classifies against lives in `agent/mutation-tools.js` instead.
 
 Three independent detectors, strongest action wins:
 

--- a/src/chrome/src/agent/agent.js
+++ b/src/chrome/src/agent/agent.js
@@ -1,6 +1,7 @@
 import { AGENT_TOOLS, AGENT_TOOL_NAMES, RESERVED_AGENT_TOOL_NAMES, getToolsForMode, SYSTEM_PROMPT_ASK, SYSTEM_PROMPT_ACT, SYSTEM_PROMPT_ACT_COMPACT, SYSTEM_PROMPT_ACT_MID, SYSTEM_PROMPT_DEV_APPENDIX, SYSTEM_PROMPT_WEBMCP_ASK, SYSTEM_PROMPT_WEBMCP_ACT } from './tools.js';
 import { handleDoneJson } from './cloud-output.js';
-import { URL_FAMILY_TOOLS, resourceBucket, bucketArgsKey } from './loop-bucket.js';
+import { resourceBucket, bucketArgsKey } from './loop-bucket.js';
+import { LoopDetector } from './loop-detector.js';
 import { isCredentialField, CREDENTIAL_NOTE_STRICT, STRICT_SECRET_SYSTEM_NOTE } from './credential-fields.js';
 import { detectProgressAction, formatLedgerRow, formatLedgerSummary, isBlockedLedgerDowngrade, isTerminalLedgerStatus, isValidLedgerStatus, ledgerDoneBlock, ledgerRowKey, normalizeLedgerStatus, progressCounts, selectLedgerRows, unresolvedLedgerRows, upsertLedgerItems } from './progress-ledger.js';
 import { buildGithubStargazerProgressItems } from './observers/github-stargazers.js';
@@ -116,8 +117,9 @@ function isBrowserNewTabUrl(url) {
 /**
  * The WebBrain Agent — orchestrates multi-step LLM + tool-use loops.
  */
-export class Agent {
+export class Agent extends LoopDetector {
   constructor(providerManager) {
+    super();
     this.providerManager = providerManager;
     this.conversations = new Map(); // tabId -> messages[]
     this.progressLedgers = new Map(); // tabId -> structured progress rows, projected into a pinned note
@@ -253,22 +255,6 @@ export class Agent {
     this._lastClickProgress = new Map(); // tabId -> { ident, snapshot }
     this._clickAxCdpFallbacks = new Map(); // tabId -> Set(documentToken|ref_id), one trusted fallback per document target
     this._lastAxScopes = new Map(); // tabId -> { documentToken, pageUrl }, captured by the latest AX read
-    // Loop detection: per-tab ring buffer of recent tool calls + nudge count.
-    this.recentCalls = new Map(); // tabId -> [{ key, name, ts }]
-    this.loopNudges = new Map();  // tabId -> consecutive-nudge counter
-    this.healthyCallsSinceLoop = new Map(); // tabId -> count of clean calls since last nudge
-    this.failedActionLoops = new Map(); // tabId -> Map(stable failure scope -> count)
-    // Last few normalized URLs each tab arrived at during the active run.
-    // Deliberately NOT cleared by _clearLoopState: it gates those intra-run
-    // resets, so it must survive them until the outer run boundary.
-    this.recentNavUrls = new Map(); // tabId -> [normalized URL, ...]
-    // A model can walk ref_1, ref_2, … forever while every call looks unique
-    // to the exact-argument loop detector. Track that semantic read pattern.
-    this.axReadStates = new Map(); // tabId -> { total, suspicious, nextPage, seenPages, warned }
-    // Scroll calls can keep returning success even when no pane moved. Track
-    // repeated dead-end attempts separately so changing the amount or
-    // interleaving reads cannot evade the generic loop detector.
-    this.noProgressScrolls = new Map(); // tabId -> { key, count }
     // Productive browsing often mixes reads and scrolling, so exact-call loop
     // detection cannot tell when the agent already has enough evidence to
     // answer. Track long observation-only streaks and remind it to deliver a
@@ -276,14 +262,6 @@ export class Agent {
     this.deliveryObservationStreaks = new Map(); // tabId -> count
     this.lastAutoScreenshotTs = new Map(); // tabId -> ms — defensive debounce
     this.lastSeenAdapter = new Map(); // tabId -> adapter name from last enrichment
-    // Separate buffer for coordinate-based click attempts. The general loop
-    // detector keys on JSON.stringify(args), so when the model interleaves
-    // execute_js with different code strings between clicks, the same
-    // (x,y) click never accumulates to the threshold inside its window.
-    // This buffer tracks ONLY coord clicks and survives any amount of
-    // unrelated noise between them, catching the "click missing its target,
-    // model retries forever" failure mode in 2-3 attempts instead of never.
-    this.recentCoordClicks = new Map(); // tabId -> [{ key, ts }]
     // Per-tab opt-in: when true, the agent is allowed to use API mutations
     // (POST/PUT/PATCH/DELETE via fetch_url, mutation fetch() via execute_js)
     // for steps where it judges API to be more reliable than UI. Set via
@@ -1374,140 +1352,8 @@ export class Agent {
     }
   }
 
-  // ---- Loop detection ----
-  // Catches the agent stuck repeating an ineffective action or oscillating
-  // between two calls. Cheap, runs after every tool execution. On first
-  // detection we soft-nudge by injecting a [LOOP DETECTED] note into the
-  // tool result the model sees. On second detection within the same loop,
-  // we hard-stop the run with a clear final message.
-
-  _isToolResultErroredForLoop(name, _args, result) {
-    if (!result || typeof result !== 'object') return false;
-    if (result.error || result.success === false || result.noProgress) return true;
-    const status = Number(result.status);
-    return URL_FAMILY_TOOLS.has(name) && Number.isFinite(status) && status >= 400;
-  }
-
-  _fetchUsesHttpByteRange(args) {
-    if (!args?.headers || typeof args.headers !== 'object') return false;
-    for (const [name, value] of Object.entries(args.headers)) {
-      if (String(name).toLowerCase() === 'range' && /^\s*bytes\s*=/i.test(String(value || ''))) {
-        return true;
-      }
-    }
-    return false;
-  }
-
-  _findTextMatchLoopIdentity(result) {
-    if (result?.success !== true || result?.verified === false || !result?.rect || typeof result.rect !== 'object') return '';
-    const rect = result.rect;
-    const pageX = typeof rect.pageX === 'number' ? rect.pageX : NaN;
-    const pageY = typeof rect.pageY === 'number' ? rect.pageY : NaN;
-    const viewportX = typeof rect.x === 'number' ? rect.x : NaN;
-    const viewportY = typeof rect.y === 'number' ? rect.y : NaN;
-    const width = typeof rect.width === 'number' ? rect.width : NaN;
-    const height = typeof rect.height === 'number' ? rect.height : NaN;
-    const x = Number.isFinite(pageX) ? pageX : viewportX;
-    const y = Number.isFinite(pageY) ? pageY : viewportY;
-    if (![x, y, width, height].every(Number.isFinite) || width <= 0 || height <= 0) return '';
-    let selectionIdentity = 'document';
-    if (result.selectionSource === 'text_control') {
-      const selectionStart = result.selectionStart;
-      const selectionEnd = result.selectionEnd;
-      if (
-        !Number.isInteger(selectionStart)
-        || !Number.isInteger(selectionEnd)
-        || selectionStart < 0
-        || selectionEnd <= selectionStart
-      ) return '';
-      selectionIdentity = `text_control:${selectionStart}:${selectionEnd}`;
-    }
-    const rectIdentity = [x, y, width, height]
-      .map(value => Math.round(value * 2) / 2)
-      .join(',');
-    return `${selectionIdentity}|${rectIdentity}`;
-  }
-
-  _noteHealthyLoopCall(tabId) {
-    // Do not reset the nudge counter immediately: one healthy call between
-    // two stuck actions must not launder the surrounding loop.
-    const healthy = (this.healthyCallsSinceLoop.get(tabId) || 0) + 1;
-    this.healthyCallsSinceLoop.set(tabId, healthy);
-    if (healthy >= 2) {
-      this.loopNudges.delete(tabId);
-      this.healthyCallsSinceLoop.delete(tabId);
-    }
-    return { kind: 'none' };
-  }
-
-  _loopCallKey(name, args, result) {
-    if (result?.nonRetryableScope) {
-      // Definitive platform/permission failures keep one identity across
-      // tools and URL variants, so changing fetch strategies cannot evade
-      // the stop condition.
-      return `nonretryable|${String(result.nonRetryableScope).slice(0, 240)}|err`;
-    }
-    const checkboxState = result?.checkboxState;
-    if (
-      checkboxState
-      && typeof checkboxState.desiredChecked === 'boolean'
-      && typeof checkboxState.actualChecked === 'boolean'
-      && checkboxState.desiredChecked !== checkboxState.actualChecked
-    ) {
-      const identity = String(
-        checkboxState.identity
-        || result.checkboxIdentity
-        || result.ref_id
-        || '',
-      ).trim().slice(0, 240);
-      if (identity) {
-        return `checkbox|${identity}|desired:${checkboxState.desiredChecked}|actual:${checkboxState.actualChecked}`;
-      }
-    }
-    // URL-family tools (fetch_url, research_url, …) bucket by resource
-    // identity so the agent can't escape loop detection by fetching the
-    // same logical file via 8 different API endpoints. See loop-bucket.js.
-    const errored = this._isToolResultErroredForLoop(name, args, result);
-    const argsHash = bucketArgsKey(name, args);
-    if (name === 'find_text' && !errored) {
-      const matchIdentity = this._findTextMatchLoopIdentity(result);
-      if (matchIdentity) return `${name}|${argsHash}|match:${matchIdentity}`;
-    }
-    return `${name}|${argsHash}|${errored ? 'err' : 'ok'}`;
-  }
-
-  _recordCall(tabId, name, args, result) {
-    const key = this._loopCallKey(name, args, result);
-    const buf = this.recentCalls.get(tabId) || [];
-    buf.push({ key, name, ts: Date.now() });
-    if (buf.length > 6) buf.shift();
-    this.recentCalls.set(tabId, buf);
-    return { buf, key };
-  }
-
-  _detectLoop(buf, activeKey = null) {
-    if (!buf || buf.length < 3) return null;
-    // 1. Same key 3+ times in the window.
-    const counts = new Map();
-    for (const e of buf) counts.set(e.key, (counts.get(e.key) || 0) + 1);
-    for (const [key, n] of counts) {
-      if (n >= 3 && (!activeKey || key === activeKey)) {
-        return { type: 'repeat', key, name: key.split('|')[0], count: n };
-      }
-    }
-    // 2. ABAB oscillation in the last 4.
-    if (buf.length >= 4) {
-      const last4 = buf.slice(-4);
-      if (
-        last4[0].key === last4[2].key &&
-        last4[1].key === last4[3].key &&
-        last4[0].key !== last4[1].key
-      ) {
-        return { type: 'oscillation', a: last4[0].name, b: last4[1].name };
-      }
-    }
-    return null;
-  }
+  // Browser-free loop detection is inherited from LoopDetector. These
+  // methods integrate Agent-owned API replay and page-scoped cleanup.
 
   _isFailedApiMutationForLoop(name, args, result) {
     return isNetworkMutation(name, args) && this._isToolResultErroredForLoop(name, args, result);
@@ -1611,144 +1457,6 @@ export class Agent {
     this._lastAxScopes.set(tabId, next);
   }
 
-  /**
-   * Record that `tabId` arrived at `url` and report whether that URL was
-   * already seen in the last few arrivals. A first visit is page-state
-   * progress and justifies resetting loop counters; a quick revisit is the
-   * signature of a navigation loop and must leave them intact.
-   */
-  _noteNavArrival(tabId, url) {
-    const normalized = this._normalizeUrl(url);
-    if (!normalized) return false;
-    const seen = this.recentNavUrls.get(tabId) || [];
-    const revisited = seen.includes(normalized);
-    seen.push(normalized);
-    if (seen.length > 5) seen.shift();
-    this.recentNavUrls.set(tabId, seen);
-    return revisited;
-  }
-
-  _isRecentNavUrl(tabId, url) {
-    const normalized = this._normalizeUrl(url);
-    return !!normalized && (this.recentNavUrls.get(tabId) || []).includes(normalized);
-  }
-
-  _checkAccessibilityReadLoop(tabId, name, args, result) {
-    if (name !== 'get_accessibility_tree') {
-      this.axReadStates.delete(tabId);
-      return { kind: 'none' };
-    }
-
-    const previous = this.axReadStates.get(tabId) || {
-      total: 0,
-      suspicious: 0,
-      nextPage: null,
-      seenPages: new Set(),
-      warned: false,
-    };
-    const page = Number(args?.page || 1);
-    const hasRef = typeof args?.ref_id === 'string' && args.ref_id.trim() !== '';
-    const sequentialPage = !hasRef
-      && previous.total > 0
-      && Number.isFinite(previous.nextPage)
-      && page === previous.nextPage
-      && !previous.seenPages.has(page);
-    const repeatedRootOrPage = !hasRef && previous.total > 0 && !sequentialPage;
-    const content = String(result?.pageContent || '').trim();
-    const meaningfulLines = content ? content.split(/\r?\n/).filter(line => line.trim()).length : 0;
-    const suspicious = hasRef || repeatedRootOrPage || (hasRef && meaningfulLines <= 1);
-
-    const state = {
-      total: previous.total + 1,
-      suspicious: previous.suspicious + (suspicious ? 1 : 0),
-      nextPage: Number.isFinite(Number(result?.nextPage)) ? Number(result.nextPage) : null,
-      seenPages: new Set(previous.seenPages),
-      warned: previous.warned,
-    };
-    state.seenPages.add(page);
-    this.axReadStates.set(tabId, state);
-
-    // A root read followed by the exact returned nextPage can legitimately span
-    // large applications. Keep the consecutive-read cap for every other AX
-    // pattern, but do not stop a valid sequential pagination step.
-    if (state.suspicious >= 6 || (state.total >= 12 && (state.suspicious > 0 || !sequentialPage))) {
-      this.axReadStates.delete(tabId);
-      return {
-        kind: 'stop',
-        message: 'Stopped: I kept reading accessibility-tree nodes without taking an action or changing approach. The tree is not meant to be enumerated ref-by-ref. Use an element already found, request the returned nextPage, switch to read_page/extract_data, or ask for help.',
-      };
-    }
-    if (!state.warned && state.suspicious >= 3) {
-      state.warned = true;
-      return {
-        kind: 'nudge',
-        warning: '[ACCESSIBILITY READ LOOP: Stop enumerating sibling or generic ref_ids. If the result has hasMore/nextPage, request exactly that page. If the needed textbox/button is already visible, use set_field, type_ax, or click_ax now. Otherwise switch once to read_page/extract_data or finish with what you have. Do not call another arbitrary ref_id subtree.]',
-      };
-    }
-    return { kind: 'none' };
-  }
-
-  _noProgressScrollKey(args = {}, result = {}) {
-    const direction = String(args?.direction || '').trim().toLowerCase() || 'unspecified';
-    const refId = String(args?.ref_id || '').trim();
-    if (refId) return `${direction}|ref:${refId}`;
-
-    const x = Number(args?.x);
-    const y = Number(args?.y);
-    if (args?.x != null && args?.y != null && Number.isFinite(x) && Number.isFinite(y)) {
-      return `${direction}|xy:${Math.round(x)},${Math.round(y)}`;
-    }
-
-    // For implicit scrolling, distinguish panes using the element that
-    // supplied the runtime's last-interaction origin. This avoids combining
-    // no-movement results from two different panes while deliberately
-    // ignoring `amount`, which is not a meaningful recovery at a hard edge.
-    const origin = result?.originElement;
-    if (origin && typeof origin === 'object') {
-      const rect = origin.rect || {};
-      const text = String(origin.text || '').trim().replace(/\s+/g, ' ').slice(0, 80);
-      return `${direction}|origin:${String(result?.origin || '')}:${String(origin.tag || '')}:${String(origin.role || '')}:${Math.round(Number(rect.x) || 0)},${Math.round(Number(rect.y) || 0)},${Math.round(Number(rect.w) || 0)},${Math.round(Number(rect.h) || 0)}:${text}`;
-    }
-    return `${direction}|auto`;
-  }
-
-  _checkNoProgressScroll(tabId, name, args, result) {
-    // Preserve a dead-scroll streak across reads or other unrelated calls;
-    // only a successful scroll or a different scroll target/direction proves
-    // that this particular recovery path changed.
-    if (name !== 'scroll') {
-      // Accessibility refs and coordinate targets are document-scoped. A
-      // successful navigation can reuse the same ref_id/coordinates for a
-      // completely different page, so it must break the old scroll streak.
-      if (result?.pageUrlChanged === true) this.noProgressScrolls.delete(tabId);
-      return { kind: 'none' };
-    }
-    if (result?.moved !== false) {
-      this.noProgressScrolls.delete(tabId);
-      return { kind: 'none' };
-    }
-
-    const key = this._noProgressScrollKey(args, result);
-    const previous = this.noProgressScrolls.get(tabId);
-    const count = previous?.key === key ? previous.count + 1 : 1;
-    this.noProgressScrolls.set(tabId, { key, count });
-
-    if (count >= 3) {
-      this.noProgressScrolls.delete(tabId);
-      return {
-        kind: 'stop',
-        message: 'Stopped: I repeated the same scroll direction on the same target three times, but the page or pane did not move. That scroll surface is already at its limit. Re-read the current view, choose a different pane or direction, act on an element already visible, or ask for help.',
-      };
-    }
-    if (count >= 2) {
-      return {
-        kind: 'nudge',
-        warning: '[NO-PROGRESS SCROLL: The same target did not move twice. Do not repeat this scroll direction or merely change the amount. Re-read the current view, use the opposite direction or a different ref_id/x/y pane, act on an element already visible, or finish.]',
-      };
-    }
-    return { kind: 'none' };
-  }
-
   _checkDeliveryObservationStreak(tabId, name, args = {}) {
     if (!this.constructor.DELIVERY_OBSERVATION_TOOLS.has(name) || isNetworkMutation(name, args)) {
       this.deliveryObservationStreaks.delete(tabId);
@@ -1762,58 +1470,6 @@ export class Agent {
     return {
       kind: 'nudge',
       warning: `[DELIVERY CHECKPOINT: You have made ${count} consecutive read, scroll, or wait observations without a state-changing action. Do not keep observing merely to make the answer exhaustive. If the current evidence satisfies the request, call done now. For list or research tasks, deliver useful partial results rather than risk shipping nothing. Continue only when you can name a specific missing fact or control and the next tool will obtain it.]`,
-    };
-  }
-
-  /**
-   * Issue #189 — mutation API observer shortcutter. When _checkLoop flags a
-   * repeated click (e.g. "Next Page" clicked 3x), check whether each click
-   * fired the same background XHR/fetch (captured by the webRequest
-   * listener in background.js). If so, surface the URL/method so the model
-   * can call fetch_url directly instead of clicking again.
-   *
-   * Strict matching only: same tab, exact url+method repeated, and request
-   * must land within WINDOW_MS after the click that triggered it. No fuzzy
-   * param-pattern matching.
-   */
-  _detectApiShortcut(tabId, loop, buf) {
-    if (loop.type !== 'repeat') return null;
-    if (!['click', 'click_ax'].includes(loop.name)) return null;
-    const apiRequests = globalThis.__webbrainApiRequests?.get(tabId);
-    if (!apiRequests || apiRequests.length === 0) return null;
-
-    const clickTimes = buf.filter(e => e.key === loop.key).map(e => e.ts);
-    if (clickTimes.length < 2) return null;
-
-    const WINDOW_MS = 3000;
-    let candidate = null;
-    let matches = 0;
-    const usedRequestIndexes = new Set();
-    for (const clickTs of clickTimes) {
-      const hitIndex = apiRequests.findIndex((r, idx) =>
-        !usedRequestIndexes.has(idx) &&
-        r.ts >= clickTs && r.ts <= clickTs + WINDOW_MS &&
-        (!candidate || (r.url === candidate.url && String(r.method || '').toUpperCase() === candidate.method))
-      );
-      if (hitIndex < 0) continue;
-      const hit = apiRequests[hitIndex];
-      if (!hit) continue;
-      if (!candidate) {
-        candidate = {
-          url: hit.url,
-          method: String(hit.method || '').toUpperCase(),
-          replayRequestId: hit.replayRequestId,
-        };
-      }
-      usedRequestIndexes.add(hitIndex);
-      matches++;
-    }
-    if (!candidate || matches < 2) return null;
-    return {
-      url: candidate.url,
-      method: candidate.method,
-      occurrences: matches,
-      replayRequestId: candidate.replayRequestId,
     };
   }
 
@@ -2334,32 +1990,6 @@ export class Agent {
   }
 
   /**
-   * Coordinate-click loop detector. Buckets to nearest 5px so a click that
-   * drifts by a pixel or two between attempts still hashes the same. Window
-   * of 8 — generous, since the goal is to survive interleaved noise like
-   * execute_js / type_text / read_page calls between coord retries.
-   *
-   * Returns 'nudge' on the 3rd repeat and 'stop' on the 5th. Gives the
-   * agent more room to retry on pages with loading states or animations.
-   */
-  _checkCoordClickLoop(tabId, x, y) {
-    const bx = Math.round(x / 5) * 5;
-    const by = Math.round(y / 5) * 5;
-    const key = `${bx},${by}`;
-    const buf = this.recentCoordClicks.get(tabId) || [];
-    buf.push({ key, ts: Date.now() });
-    if (buf.length > 12) buf.shift();
-    this.recentCoordClicks.set(tabId, buf);
-
-    const counts = new Map();
-    for (const e of buf) counts.set(e.key, (counts.get(e.key) || 0) + 1);
-    const n = counts.get(key) || 0;
-    if (n >= 8) return { kind: 'stop', x: bx, y: by };
-    if (n >= 5) return { kind: 'nudge', x: bx, y: by };
-    return { kind: 'none' };
-  }
-
-  /**
    * Add a tab to the "WebBrain" tab group — reused by both the explicit
    * `new_tab` tool and the click handler's target=_blank redirect fallback.
    *
@@ -2513,154 +2143,6 @@ export class Agent {
     } catch (_) {
       return null;
     }
-  }
-
-  /**
-   * Run loop detection on a freshly recorded call. Returns one of:
-   *   { kind: 'none' }
-   *   { kind: 'nudge', warning: string }   // soft warning to inject into tool result
-   *   { kind: 'stop',  message: string }   // hard stop, abort the run
-   */
-  _checkLoop(tabId, toolName, toolArgs, toolResult) {
-    // A navigation result is authoritative page-state evidence. Clear before
-    // recording this call so same-looking controls on the new page start at
-    // attempt one instead of inheriting an old third-strike counter. Arriving
-    // back on a recently seen URL is the exception: a click/go_back ping-pong
-    // would otherwise reset the detector on every hop and never be caught.
-    if (toolResult?.pageUrlChanged === true && !this._noteNavArrival(tabId, toolResult.currentUrl)) {
-      this._clearLoopState(tabId);
-    }
-    if (
-      toolName === 'find_text'
-      && toolResult?.success === true
-      && !this._findTextMatchLoopIdentity(toolResult)
-    ) {
-      // A cross-origin frame match can be selected by window.find while its
-      // range is unavailable to the top document. Successful same-query calls
-      // intentionally advance to the next match, so an unlocated match is not
-      // safe evidence of a repeat loop.
-      return this._noteHealthyLoopCall(tabId);
-    }
-    const { buf, key } = this._recordCall(tabId, toolName, toolArgs, toolResult);
-    if (this._isBrowserMutationTool(toolName)) {
-      const normalizeFailureScope = value => String(value).slice(0, 320);
-      const defaultFailureScope = normalizeFailureScope(`${toolName}|${bucketArgsKey(toolName, toolArgs)}`);
-      const failureScope = normalizeFailureScope(toolResult?.failureScope || defaultFailureScope);
-      const equivalentFailureScopes = new Set([failureScope, defaultFailureScope]);
-      if ((toolName === 'set_field' || toolName === 'type_ax') && typeof toolArgs?.ref_id === 'string') {
-        equivalentFailureScopes.add(normalizeFailureScope(`field-value:${toolArgs.ref_id}`));
-      }
-      if (toolName === 'click' && typeof toolArgs?.text === 'string') {
-        equivalentFailureScopes.add(normalizeFailureScope(`ambiguous-click:${toolArgs.text.trim().toLowerCase()}`));
-      }
-      const failures = this.failedActionLoops.get(tabId) || new Map();
-      if (this._isToolResultErroredForLoop(toolName, toolArgs, toolResult)) {
-        const attempts = (failures.get(failureScope) || 0) + 1;
-        failures.set(failureScope, attempts);
-        if (failures.size > 32) failures.delete(failures.keys().next().value);
-        this.failedActionLoops.set(tabId, failures);
-        if (attempts >= 3) {
-          this._clearLoopState(tabId);
-          return {
-            kind: 'stop',
-            message: `Stopped: ${toolName} failed or made no progress three times for the same target. Repeating it or switching to a precomputed fallback cannot make progress without fresh page evidence.`,
-          };
-        }
-        if (attempts === 2) {
-          return {
-            kind: 'nudge',
-            warning: `[FAILED ACTION LOOP: ${toolName} has failed or made no progress twice for the same target. Do not retry it or use a queued fallback. Re-read the page/tree and choose a new action from current evidence.]`,
-          };
-        }
-      } else if (toolResult?.success === true && toolResult?.verified !== false) {
-        for (const scope of equivalentFailureScopes) failures.delete(scope);
-        if (failures.size) this.failedActionLoops.set(tabId, failures);
-        else this.failedActionLoops.delete(tabId);
-      }
-    }
-    if (toolResult?.nonRetryable) {
-      const repeats = buf.filter(entry => entry.key === key).length;
-      if (repeats >= 2) {
-        this._clearLoopState(tabId);
-        return {
-          kind: 'stop',
-          message: toolResult.stopMessage || `Stopped: ${toolName} hit the same non-retryable failure twice. Retrying or switching to an equivalent tool will not make progress.`,
-        };
-      }
-    }
-    if (key.startsWith('checkbox|')) {
-      const repeats = buf.filter(entry => entry.key === key).length;
-      if (repeats >= 3) {
-        this._clearLoopState(tabId);
-        return {
-          kind: 'stop',
-          message: 'Stopped: the same checkbox is still in the wrong checked state after three attempts. Changing tools or arguments does not change that semantic state. Re-read the form or ask the user instead of toggling it again.',
-        };
-      }
-      if (repeats >= 2) {
-        return {
-          kind: 'nudge',
-          warning: '[CHECKBOX STATE UNCHANGED: The same checkbox is still in the wrong checked state. Do not toggle it again and do not evade this by switching tools. Call set_checked(ref_id, desiredState) once; if its trusted selector-backed attempt also fails, re-read the form or ask the user.]',
-        };
-      }
-    }
-    const loop = this._detectLoop(buf, key);
-    if (loop?.type === 'oscillation' && loop.a === 'find_text' && loop.b === 'find_text') {
-      // Alternating match positions is normal when a finite page search wraps.
-      return this._noteHealthyLoopCall(tabId);
-    }
-    if (!loop) {
-      return this._noteHealthyLoopCall(tabId);
-    }
-
-    const method = String(toolArgs?.method || 'GET').toUpperCase();
-    if (
-      loop.type === 'repeat' &&
-      URL_FAMILY_TOOLS.has(toolName) &&
-      method === 'GET' &&
-      this._isToolResultErroredForLoop(toolName, toolArgs, toolResult)
-    ) {
-      this._clearLoopState(tabId);
-      const rangedFetch = toolName === 'fetch_url' && this._fetchUsesHttpByteRange(toolArgs);
-      return {
-        kind: 'stop',
-        message: rangedFetch
-          ? 'Stopped: fetch_url failed three times while probing HTTP byte ranges for the same read-only resource. Use find or semantic offset:nextOffset pagination in a new run, or ask for a partial answer from the evidence already collected.'
-          : `Stopped: ${loop.name} failed three times for the same read-only resource. Repeating it or changing URL variants will not make progress. Please give a different instruction or inspect the page manually.`,
-      };
-    }
-
-    // Any new loop detection resets the healthy-streak counter.
-    this.healthyCallsSinceLoop.delete(tabId);
-    const nudges = (this.loopNudges.get(tabId) || 0) + 1;
-    this.loopNudges.set(tabId, nudges);
-
-    if (nudges >= 8) {
-      this._clearLoopState(tabId);
-      const desc = loop.type === 'repeat'
-        ? `the same call to ${loop.name}`
-        : `between ${loop.a} and ${loop.b}`;
-      return {
-        kind: 'stop',
-        message: `Stopped: I detected I was looping on ${desc} without making progress after multiple warnings. Please tell me what's blocking, give me a different instruction, or take a look at the page yourself.`,
-      };
-    }
-
-    let warning;
-    if (loop.type === 'repeat') {
-      const shortcut = this._detectApiShortcut(tabId, loop, buf);
-      const rangedFetch = toolName === 'fetch_url'
-        && method === 'GET'
-        && this._fetchUsesHttpByteRange(toolArgs);
-      warning = rangedFetch
-        ? '[LOOP DETECTED: You are repeatedly probing the same resource with HTTP byte ranges. Stop guessing byte offsets or file size. Use fetch_url({url, find:"literal"}) to search the full decoded response, continue semantic text pagination with offset:nextOffset, or answer now with the evidence already collected. Do not send another Range header for this resource.]'
-        : shortcut
-        ? `[LOOP DETECTED + API SHORTCUT FOUND: You've called ${loop.name} ${loop.count} times. Each click triggered the same background request pattern: ${shortcut.method} ${shortcut.url}. Instead of clicking again, consider fetch_url({url: "${shortcut.url}", method: "${shortcut.method}"${shortcut.replayRequestId ? `, replayRequestId: "${shortcut.replayRequestId}"` : ''}}) with the same method; follow the UI/API mutation policy for mutating methods.]`
-        : `[LOOP DETECTED: You've just called ${loop.name} ${loop.count} times with the same arguments and the same outcome. The current approach is NOT working. Try something fundamentally different: a different selector, a different tool, scroll to find a different element, or re-read the page/tree to see what's actually on screen. DO NOT repeat this exact call again — try a creative alternative.]`;
-    } else {
-      warning = `[LOOP DETECTED: You're oscillating between ${loop.a} and ${loop.b} without making progress. Stop. Re-read the page/tree to see what's actually happening, then try a completely different approach.]`;
-    }
-    return { kind: 'nudge', warning };
   }
 
   // Tools whose successful completion should trigger an auto-screenshot when
@@ -2956,19 +2438,6 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
       this._rememberProgressPageScope(tabId, url);
       return url;
     } catch (e) { return ''; }
-  }
-
-  /**
-   * Normalize URLs for navigation-change checks. Keep query and hash so
-   * history entries that differ only by search params or anchors still count as
-   * successful back/forward movement.
-   */
-  _normalizeUrl(url) {
-    if (!url) return '';
-    try {
-      const u = new URL(url);
-      return u.origin + u.pathname + u.search + u.hash;
-    } catch (e) { return url; }
   }
 
   /**

--- a/src/chrome/src/agent/agent.js
+++ b/src/chrome/src/agent/agent.js
@@ -1,7 +1,7 @@
 import { AGENT_TOOLS, AGENT_TOOL_NAMES, RESERVED_AGENT_TOOL_NAMES, getToolsForMode, SYSTEM_PROMPT_ASK, SYSTEM_PROMPT_ACT, SYSTEM_PROMPT_ACT_COMPACT, SYSTEM_PROMPT_ACT_MID, SYSTEM_PROMPT_DEV_APPENDIX, SYSTEM_PROMPT_WEBMCP_ASK, SYSTEM_PROMPT_WEBMCP_ACT } from './tools.js';
 import { handleDoneJson } from './cloud-output.js';
-import { resourceBucket, bucketArgsKey } from './loop-bucket.js';
 import { LoopDetector } from './loop-detector.js';
+import { BROWSER_MUTATION_TOOLS, STATE_CHANGE_TOOLS as SHARED_STATE_CHANGE_TOOLS } from './mutation-tools.js';
 import { isCredentialField, CREDENTIAL_NOTE_STRICT, STRICT_SECRET_SYSTEM_NOTE } from './credential-fields.js';
 import { detectProgressAction, formatLedgerRow, formatLedgerSummary, isBlockedLedgerDowngrade, isTerminalLedgerStatus, isValidLedgerStatus, ledgerDoneBlock, ledgerRowKey, normalizeLedgerStatus, progressCounts, selectLedgerRows, unresolvedLedgerRows, upsertLedgerItems } from './progress-ledger.js';
 import { buildGithubStargazerProgressItems } from './observers/github-stargazers.js';
@@ -1399,12 +1399,14 @@ export class Agent extends LoopDetector {
     return { method, requestShape, failed };
   }
 
+  /**
+   * Extends the detector's own page-scoped cleanup with the Agent-owned state
+   * that is equally invalidated by a page replacement: the delivery-checkpoint
+   * streak and the bulk API replay bookkeeping keyed on this tab.
+   */
   _clearPageLoopState(tabId) {
-    this.failedActionLoops.delete(tabId);
-    this.axReadStates.delete(tabId);
-    this.noProgressScrolls.delete(tabId);
+    super._clearPageLoopState(tabId);
     this.deliveryObservationStreaks.delete(tabId);
-    this.recentCoordClicks.delete(tabId);
     this.bulkApiMutationClicks.delete(tabId);
     this.bulkApiMutationHints.delete(tabId);
     const replayFailurePrefix = `${tabId}|`;
@@ -1413,18 +1415,6 @@ export class Agent extends LoopDetector {
         this.failedBulkApiReplayShapes.delete(key);
       }
     }
-  }
-
-  _clearLoopState(tabId) {
-    this.recentCalls.delete(tabId);
-    this.loopNudges.delete(tabId);
-    this.healthyCallsSinceLoop.delete(tabId);
-    this._clearPageLoopState(tabId);
-  }
-
-  _clearRunLoopState(tabId) {
-    this.recentNavUrls.delete(tabId);
-    this._clearLoopState(tabId);
   }
 
   _rememberAxScope(tabId, documentToken, pageUrl = '') {
@@ -2148,7 +2138,7 @@ export class Agent extends LoopDetector {
   // Tools whose successful completion should trigger an auto-screenshot when
   // the corresponding mode is active.
   static NAV_TOOLS = new Set(['navigate', 'new_tab', 'go_back', 'go_forward']);
-  static STATE_CHANGE_TOOLS = new Set(['navigate', 'new_tab', 'go_back', 'go_forward', 'click', 'click_ax', 'set_checked', 'type_text', 'type_ax', 'set_field', 'press_keys', 'scroll', 'hover', 'drag_drop', 'inject_css', 'remove_injected_css', 'patch_element', 'revert_patch', 'execute_js', 'inspect_event_listeners', 'highlight_element', 'execute_webmcp_tool']);
+  static STATE_CHANGE_TOOLS = SHARED_STATE_CHANGE_TOOLS;
   static EXECUTION_META_TOOLS = new Set(['clarify', 'scratchpad_write', 'scratchpad_read', 'progress_update', 'progress_read']);
   static EXECUTION_APP_STATE_TOOLS = new Set(['scratchpad_write', 'scratchpad_read', 'progress_update', 'progress_read']);
   static EXECUTION_APP_STATE_WRITE_TOOLS = new Set(['scratchpad_write', 'progress_update']);
@@ -2669,11 +2659,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
   }
 
   _isBrowserMutationTool(toolName) {
-    return Agent.STATE_CHANGE_TOOLS.has(toolName)
-      || toolName === 'iframe_click'
-      || toolName === 'iframe_type'
-      || toolName === 'upload_file'
-      || toolName === 'solve_captcha';
+    return BROWSER_MUTATION_TOOLS.has(toolName);
   }
 
   _browserActionFreshTurnReason(tier, toolName, toolResult) {

--- a/src/chrome/src/agent/loop-detector.js
+++ b/src/chrome/src/agent/loop-detector.js
@@ -1,0 +1,481 @@
+import { URL_FAMILY_TOOLS, bucketArgsKey } from './loop-bucket.js';
+
+/**
+ * Browser-free loop detection used by Agent and the unit tests.
+ *
+ * Subclasses may override _clearPageLoopState() to clear related page-scoped
+ * state alongside the detector's own maps.
+ */
+export class LoopDetector {
+  constructor({ isBrowserMutationTool = () => false } = {}) {
+    this._loopMutationTool = isBrowserMutationTool;
+    this.recentCalls = new Map();
+    this.loopNudges = new Map();
+    this.healthyCallsSinceLoop = new Map();
+    this.failedActionLoops = new Map();
+    this.recentNavUrls = new Map();
+    this.axReadStates = new Map();
+    this.noProgressScrolls = new Map();
+    this.recentCoordClicks = new Map();
+  }
+
+  _isBrowserMutationTool(toolName) {
+    return this._loopMutationTool(toolName);
+  }
+
+  _isToolResultErroredForLoop(name, _args, result) {
+    if (!result || typeof result !== 'object') return false;
+    if (result.error || result.success === false || result.noProgress) return true;
+    const status = Number(result.status);
+    return URL_FAMILY_TOOLS.has(name) && Number.isFinite(status) && status >= 400;
+  }
+
+  _fetchUsesHttpByteRange(args) {
+    if (!args?.headers || typeof args.headers !== 'object') return false;
+    for (const [name, value] of Object.entries(args.headers)) {
+      if (String(name).toLowerCase() === 'range' && /^\s*bytes\s*=/i.test(String(value || ''))) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  _findTextMatchLoopIdentity(result) {
+    if (result?.success !== true || result?.verified === false || !result?.rect || typeof result.rect !== 'object') return '';
+    const rect = result.rect;
+    const pageX = typeof rect.pageX === 'number' ? rect.pageX : NaN;
+    const pageY = typeof rect.pageY === 'number' ? rect.pageY : NaN;
+    const viewportX = typeof rect.x === 'number' ? rect.x : NaN;
+    const viewportY = typeof rect.y === 'number' ? rect.y : NaN;
+    const width = typeof rect.width === 'number' ? rect.width : NaN;
+    const height = typeof rect.height === 'number' ? rect.height : NaN;
+    const x = Number.isFinite(pageX) ? pageX : viewportX;
+    const y = Number.isFinite(pageY) ? pageY : viewportY;
+    if (![x, y, width, height].every(Number.isFinite) || width <= 0 || height <= 0) return '';
+    let selectionIdentity = 'document';
+    if (result.selectionSource === 'text_control') {
+      const selectionStart = result.selectionStart;
+      const selectionEnd = result.selectionEnd;
+      if (
+        !Number.isInteger(selectionStart)
+        || !Number.isInteger(selectionEnd)
+        || selectionStart < 0
+        || selectionEnd <= selectionStart
+      ) return '';
+      selectionIdentity = `text_control:${selectionStart}:${selectionEnd}`;
+    }
+    const rectIdentity = [x, y, width, height]
+      .map(value => Math.round(value * 2) / 2)
+      .join(',');
+    return `${selectionIdentity}|${rectIdentity}`;
+  }
+
+  _noteHealthyLoopCall(tabId) {
+    // Do not reset the nudge counter immediately: one healthy call between
+    // two stuck actions must not launder the surrounding loop.
+    const healthy = (this.healthyCallsSinceLoop.get(tabId) || 0) + 1;
+    this.healthyCallsSinceLoop.set(tabId, healthy);
+    if (healthy >= 2) {
+      this.loopNudges.delete(tabId);
+      this.healthyCallsSinceLoop.delete(tabId);
+    }
+    return { kind: 'none' };
+  }
+
+  _loopCallKey(name, args, result) {
+    if (result?.nonRetryableScope) {
+      return `nonretryable|${String(result.nonRetryableScope).slice(0, 240)}|err`;
+    }
+    const checkboxState = result?.checkboxState;
+    if (
+      checkboxState
+      && typeof checkboxState.desiredChecked === 'boolean'
+      && typeof checkboxState.actualChecked === 'boolean'
+      && checkboxState.desiredChecked !== checkboxState.actualChecked
+    ) {
+      const identity = String(
+        checkboxState.identity
+        || result.checkboxIdentity
+        || result.ref_id
+        || '',
+      ).trim().slice(0, 240);
+      if (identity) {
+        return `checkbox|${identity}|desired:${checkboxState.desiredChecked}|actual:${checkboxState.actualChecked}`;
+      }
+    }
+    const errored = this._isToolResultErroredForLoop(name, args, result);
+    const argsHash = bucketArgsKey(name, args);
+    if (name === 'find_text' && !errored) {
+      const matchIdentity = this._findTextMatchLoopIdentity(result);
+      if (matchIdentity) return `${name}|${argsHash}|match:${matchIdentity}`;
+    }
+    return `${name}|${argsHash}|${errored ? 'err' : 'ok'}`;
+  }
+
+  _recordCall(tabId, name, args, result) {
+    const key = this._loopCallKey(name, args, result);
+    const buf = this.recentCalls.get(tabId) || [];
+    buf.push({ key, name, ts: Date.now() });
+    if (buf.length > 6) buf.shift();
+    this.recentCalls.set(tabId, buf);
+    return { buf, key };
+  }
+
+  _detectLoop(buf, activeKey = null) {
+    if (!buf || buf.length < 3) return null;
+    const counts = new Map();
+    for (const e of buf) counts.set(e.key, (counts.get(e.key) || 0) + 1);
+    for (const [key, n] of counts) {
+      if (n >= 3 && (!activeKey || key === activeKey)) {
+        return { type: 'repeat', key, name: key.split('|')[0], count: n };
+      }
+    }
+    if (buf.length >= 4) {
+      const last4 = buf.slice(-4);
+      if (
+        last4[0].key === last4[2].key
+        && last4[1].key === last4[3].key
+        && last4[0].key !== last4[1].key
+      ) {
+        return { type: 'oscillation', a: last4[0].name, b: last4[1].name };
+      }
+    }
+    return null;
+  }
+
+  _clearPageLoopState(tabId) {
+    this.failedActionLoops.delete(tabId);
+    this.axReadStates.delete(tabId);
+    this.noProgressScrolls.delete(tabId);
+    this.recentCoordClicks.delete(tabId);
+  }
+
+  _clearLoopState(tabId) {
+    this.recentCalls.delete(tabId);
+    this.loopNudges.delete(tabId);
+    this.healthyCallsSinceLoop.delete(tabId);
+    this._clearPageLoopState(tabId);
+  }
+
+  _clearRunLoopState(tabId) {
+    this.recentNavUrls.delete(tabId);
+    this._clearLoopState(tabId);
+  }
+
+  _normalizeUrl(url) {
+    if (!url) return '';
+    try {
+      const u = new URL(url);
+      return u.origin + u.pathname + u.search + u.hash;
+    } catch (e) { return url; }
+  }
+
+  _noteNavArrival(tabId, url) {
+    const normalized = this._normalizeUrl(url);
+    if (!normalized) return false;
+    const seen = this.recentNavUrls.get(tabId) || [];
+    const revisited = seen.includes(normalized);
+    seen.push(normalized);
+    if (seen.length > 5) seen.shift();
+    this.recentNavUrls.set(tabId, seen);
+    return revisited;
+  }
+
+  _isRecentNavUrl(tabId, url) {
+    const normalized = this._normalizeUrl(url);
+    return !!normalized && (this.recentNavUrls.get(tabId) || []).includes(normalized);
+  }
+
+  _checkAccessibilityReadLoop(tabId, name, args, result) {
+    if (name !== 'get_accessibility_tree') {
+      this.axReadStates.delete(tabId);
+      return { kind: 'none' };
+    }
+
+    const previous = this.axReadStates.get(tabId) || {
+      total: 0,
+      suspicious: 0,
+      nextPage: null,
+      seenPages: new Set(),
+      warned: false,
+    };
+    const page = Number(args?.page || 1);
+    const hasRef = typeof args?.ref_id === 'string' && args.ref_id.trim() !== '';
+    const sequentialPage = !hasRef
+      && previous.total > 0
+      && Number.isFinite(previous.nextPage)
+      && page === previous.nextPage
+      && !previous.seenPages.has(page);
+    const repeatedRootOrPage = !hasRef && previous.total > 0 && !sequentialPage;
+    const content = String(result?.pageContent || '').trim();
+    const meaningfulLines = content ? content.split(/\r?\n/).filter(line => line.trim()).length : 0;
+    const suspicious = hasRef || repeatedRootOrPage || (hasRef && meaningfulLines <= 1);
+
+    const state = {
+      total: previous.total + 1,
+      suspicious: previous.suspicious + (suspicious ? 1 : 0),
+      nextPage: Number.isFinite(Number(result?.nextPage)) ? Number(result.nextPage) : null,
+      seenPages: new Set(previous.seenPages),
+      warned: previous.warned,
+    };
+    state.seenPages.add(page);
+    this.axReadStates.set(tabId, state);
+
+    if (state.suspicious >= 6 || (state.total >= 12 && (state.suspicious > 0 || !sequentialPage))) {
+      this.axReadStates.delete(tabId);
+      return {
+        kind: 'stop',
+        message: 'Stopped: I kept reading accessibility-tree nodes without taking an action or changing approach. The tree is not meant to be enumerated ref-by-ref. Use an element already found, request the returned nextPage, switch to read_page/extract_data, or ask for help.',
+      };
+    }
+    if (!state.warned && state.suspicious >= 3) {
+      state.warned = true;
+      return {
+        kind: 'nudge',
+        warning: '[ACCESSIBILITY READ LOOP: Stop enumerating sibling or generic ref_ids. If the result has hasMore/nextPage, request exactly that page. If the needed textbox/button is already visible, use set_field, type_ax, or click_ax now. Otherwise switch once to read_page/extract_data or finish with what you have. Do not call another arbitrary ref_id subtree.]',
+      };
+    }
+    return { kind: 'none' };
+  }
+
+  _noProgressScrollKey(args = {}, result = {}) {
+    const direction = String(args?.direction || '').trim().toLowerCase() || 'unspecified';
+    const refId = String(args?.ref_id || '').trim();
+    if (refId) return `${direction}|ref:${refId}`;
+
+    const x = Number(args?.x);
+    const y = Number(args?.y);
+    if (args?.x != null && args?.y != null && Number.isFinite(x) && Number.isFinite(y)) {
+      return `${direction}|xy:${Math.round(x)},${Math.round(y)}`;
+    }
+
+    const origin = result?.originElement;
+    if (origin && typeof origin === 'object') {
+      const rect = origin.rect || {};
+      const text = String(origin.text || '').trim().replace(/\s+/g, ' ').slice(0, 80);
+      return `${direction}|origin:${String(result?.origin || '')}:${String(origin.tag || '')}:${String(origin.role || '')}:${Math.round(Number(rect.x) || 0)},${Math.round(Number(rect.y) || 0)},${Math.round(Number(rect.w) || 0)},${Math.round(Number(rect.h) || 0)}:${text}`;
+    }
+    return `${direction}|auto`;
+  }
+
+  _checkNoProgressScroll(tabId, name, args, result) {
+    if (name !== 'scroll') {
+      if (result?.pageUrlChanged === true) this.noProgressScrolls.delete(tabId);
+      return { kind: 'none' };
+    }
+    if (result?.moved !== false) {
+      this.noProgressScrolls.delete(tabId);
+      return { kind: 'none' };
+    }
+
+    const key = this._noProgressScrollKey(args, result);
+    const previous = this.noProgressScrolls.get(tabId);
+    const count = previous?.key === key ? previous.count + 1 : 1;
+    this.noProgressScrolls.set(tabId, { key, count });
+
+    if (count >= 3) {
+      this.noProgressScrolls.delete(tabId);
+      return {
+        kind: 'stop',
+        message: 'Stopped: I repeated the same scroll direction on the same target three times, but the page or pane did not move. That scroll surface is already at its limit. Re-read the current view, choose a different pane or direction, act on an element already visible, or ask for help.',
+      };
+    }
+    if (count >= 2) {
+      return {
+        kind: 'nudge',
+        warning: '[NO-PROGRESS SCROLL: The same target did not move twice. Do not repeat this scroll direction or merely change the amount. Re-read the current view, use the opposite direction or a different ref_id/x/y pane, act on an element already visible, or finish.]',
+      };
+    }
+    return { kind: 'none' };
+  }
+
+  _detectApiShortcut(tabId, loop, buf) {
+    if (loop.type !== 'repeat') return null;
+    if (!['click', 'click_ax'].includes(loop.name)) return null;
+    const apiRequests = globalThis.__webbrainApiRequests?.get(tabId);
+    if (!apiRequests || apiRequests.length === 0) return null;
+
+    const clickTimes = buf.filter(e => e.key === loop.key).map(e => e.ts);
+    if (clickTimes.length < 2) return null;
+
+    const WINDOW_MS = 3000;
+    let candidate = null;
+    let matches = 0;
+    const usedRequestIndexes = new Set();
+    for (const clickTs of clickTimes) {
+      const hitIndex = apiRequests.findIndex((r, idx) =>
+        !usedRequestIndexes.has(idx)
+        && r.ts >= clickTs
+        && r.ts <= clickTs + WINDOW_MS
+        && (!candidate || (r.url === candidate.url && String(r.method || '').toUpperCase() === candidate.method))
+      );
+      if (hitIndex < 0) continue;
+      const hit = apiRequests[hitIndex];
+      if (!hit) continue;
+      if (!candidate) {
+        candidate = {
+          url: hit.url,
+          method: String(hit.method || '').toUpperCase(),
+          replayRequestId: hit.replayRequestId,
+        };
+      }
+      usedRequestIndexes.add(hitIndex);
+      matches++;
+    }
+    if (!candidate || matches < 2) return null;
+    return {
+      url: candidate.url,
+      method: candidate.method,
+      occurrences: matches,
+      replayRequestId: candidate.replayRequestId,
+    };
+  }
+
+  _checkCoordClickLoop(tabId, x, y) {
+    const bx = Math.round(x / 5) * 5;
+    const by = Math.round(y / 5) * 5;
+    const key = `${bx},${by}`;
+    const buf = this.recentCoordClicks.get(tabId) || [];
+    buf.push({ key, ts: Date.now() });
+    if (buf.length > 12) buf.shift();
+    this.recentCoordClicks.set(tabId, buf);
+
+    const counts = new Map();
+    for (const e of buf) counts.set(e.key, (counts.get(e.key) || 0) + 1);
+    const n = counts.get(key) || 0;
+    if (n >= 8) return { kind: 'stop', x: bx, y: by };
+    if (n >= 5) return { kind: 'nudge', x: bx, y: by };
+    return { kind: 'none' };
+  }
+
+  _checkLoop(tabId, toolName, toolArgs, toolResult) {
+    if (toolResult?.pageUrlChanged === true && !this._noteNavArrival(tabId, toolResult.currentUrl)) {
+      this._clearLoopState(tabId);
+    }
+    if (
+      toolName === 'find_text'
+      && toolResult?.success === true
+      && !this._findTextMatchLoopIdentity(toolResult)
+    ) {
+      return this._noteHealthyLoopCall(tabId);
+    }
+    const { buf, key } = this._recordCall(tabId, toolName, toolArgs, toolResult);
+    if (this._isBrowserMutationTool(toolName)) {
+      const normalizeFailureScope = value => String(value).slice(0, 320);
+      const defaultFailureScope = normalizeFailureScope(`${toolName}|${bucketArgsKey(toolName, toolArgs)}`);
+      const failureScope = normalizeFailureScope(toolResult?.failureScope || defaultFailureScope);
+      const equivalentFailureScopes = new Set([failureScope, defaultFailureScope]);
+      if ((toolName === 'set_field' || toolName === 'type_ax') && typeof toolArgs?.ref_id === 'string') {
+        equivalentFailureScopes.add(normalizeFailureScope(`field-value:${toolArgs.ref_id}`));
+      }
+      if (toolName === 'click' && typeof toolArgs?.text === 'string') {
+        equivalentFailureScopes.add(normalizeFailureScope(`ambiguous-click:${toolArgs.text.trim().toLowerCase()}`));
+      }
+      const failures = this.failedActionLoops.get(tabId) || new Map();
+      if (this._isToolResultErroredForLoop(toolName, toolArgs, toolResult)) {
+        const attempts = (failures.get(failureScope) || 0) + 1;
+        failures.set(failureScope, attempts);
+        if (failures.size > 32) failures.delete(failures.keys().next().value);
+        this.failedActionLoops.set(tabId, failures);
+        if (attempts >= 3) {
+          this._clearLoopState(tabId);
+          return {
+            kind: 'stop',
+            message: `Stopped: ${toolName} failed or made no progress three times for the same target. Repeating it or switching to a precomputed fallback cannot make progress without fresh page evidence.`,
+          };
+        }
+        if (attempts === 2) {
+          return {
+            kind: 'nudge',
+            warning: `[FAILED ACTION LOOP: ${toolName} has failed or made no progress twice for the same target. Do not retry it or use a queued fallback. Re-read the page/tree and choose a new action from current evidence.]`,
+          };
+        }
+      } else if (toolResult?.success === true && toolResult?.verified !== false) {
+        for (const scope of equivalentFailureScopes) failures.delete(scope);
+        if (failures.size) this.failedActionLoops.set(tabId, failures);
+        else this.failedActionLoops.delete(tabId);
+      }
+    }
+    if (toolResult?.nonRetryable) {
+      const repeats = buf.filter(entry => entry.key === key).length;
+      if (repeats >= 2) {
+        this._clearLoopState(tabId);
+        return {
+          kind: 'stop',
+          message: toolResult.stopMessage || `Stopped: ${toolName} hit the same non-retryable failure twice. Retrying or switching to an equivalent tool will not make progress.`,
+        };
+      }
+    }
+    if (key.startsWith('checkbox|')) {
+      const repeats = buf.filter(entry => entry.key === key).length;
+      if (repeats >= 3) {
+        this._clearLoopState(tabId);
+        return {
+          kind: 'stop',
+          message: 'Stopped: the same checkbox is still in the wrong checked state after three attempts. Changing tools or arguments does not change that semantic state. Re-read the form or ask the user instead of toggling it again.',
+        };
+      }
+      if (repeats >= 2) {
+        return {
+          kind: 'nudge',
+          warning: '[CHECKBOX STATE UNCHANGED: The same checkbox is still in the wrong checked state. Do not toggle it again and do not evade this by switching tools. Call set_checked(ref_id, desiredState) once; if its trusted selector-backed attempt also fails, re-read the form or ask the user.]',
+        };
+      }
+    }
+    const loop = this._detectLoop(buf, key);
+    if (loop?.type === 'oscillation' && loop.a === 'find_text' && loop.b === 'find_text') {
+      return this._noteHealthyLoopCall(tabId);
+    }
+    if (!loop) {
+      return this._noteHealthyLoopCall(tabId);
+    }
+
+    const method = String(toolArgs?.method || 'GET').toUpperCase();
+    if (
+      loop.type === 'repeat'
+      && URL_FAMILY_TOOLS.has(toolName)
+      && method === 'GET'
+      && this._isToolResultErroredForLoop(toolName, toolArgs, toolResult)
+    ) {
+      this._clearLoopState(tabId);
+      const rangedFetch = toolName === 'fetch_url' && this._fetchUsesHttpByteRange(toolArgs);
+      return {
+        kind: 'stop',
+        message: rangedFetch
+          ? 'Stopped: fetch_url failed three times while probing HTTP byte ranges for the same read-only resource. Use find or semantic offset:nextOffset pagination in a new run, or ask for a partial answer from the evidence already collected.'
+          : `Stopped: ${loop.name} failed three times for the same read-only resource. Repeating it or changing URL variants will not make progress. Please give a different instruction or inspect the page manually.`,
+      };
+    }
+
+    this.healthyCallsSinceLoop.delete(tabId);
+    const nudges = (this.loopNudges.get(tabId) || 0) + 1;
+    this.loopNudges.set(tabId, nudges);
+
+    if (nudges >= 8) {
+      this._clearLoopState(tabId);
+      const desc = loop.type === 'repeat'
+        ? `the same call to ${loop.name}`
+        : `between ${loop.a} and ${loop.b}`;
+      return {
+        kind: 'stop',
+        message: `Stopped: I detected I was looping on ${desc} without making progress after multiple warnings. Please tell me what's blocking, give me a different instruction, or take a look at the page yourself.`,
+      };
+    }
+
+    let warning;
+    if (loop.type === 'repeat') {
+      const shortcut = this._detectApiShortcut(tabId, loop, buf);
+      const rangedFetch = toolName === 'fetch_url'
+        && method === 'GET'
+        && this._fetchUsesHttpByteRange(toolArgs);
+      warning = rangedFetch
+        ? '[LOOP DETECTED: You are repeatedly probing the same resource with HTTP byte ranges. Stop guessing byte offsets or file size. Use fetch_url({url, find:"literal"}) to search the full decoded response, continue semantic text pagination with offset:nextOffset, or answer now with the evidence already collected. Do not send another Range header for this resource.]'
+        : shortcut
+        ? `[LOOP DETECTED + API SHORTCUT FOUND: You've called ${loop.name} ${loop.count} times. Each click triggered the same background request pattern: ${shortcut.method} ${shortcut.url}. Instead of clicking again, consider fetch_url({url: "${shortcut.url}", method: "${shortcut.method}"${shortcut.replayRequestId ? `, replayRequestId: "${shortcut.replayRequestId}"` : ''}}) with the same method; follow the UI/API mutation policy for mutating methods.]`
+        : `[LOOP DETECTED: You've just called ${loop.name} ${loop.count} times with the same arguments and the same outcome. The current approach is NOT working. Try something fundamentally different: a different selector, a different tool, scroll to find a different element, or re-read the page/tree to see what's actually on screen. DO NOT repeat this exact call again — try a creative alternative.]`;
+    } else {
+      warning = `[LOOP DETECTED: You're oscillating between ${loop.a} and ${loop.b} without making progress. Stop. Re-read the page/tree to see what's actually happening, then try a completely different approach.]`;
+    }
+    return { kind: 'nudge', warning };
+  }
+}

--- a/src/chrome/src/agent/loop-detector.js
+++ b/src/chrome/src/agent/loop-detector.js
@@ -3,24 +3,53 @@ import { URL_FAMILY_TOOLS, bucketArgsKey } from './loop-bucket.js';
 /**
  * Browser-free loop detection used by Agent and the unit tests.
  *
- * Subclasses may override _clearPageLoopState() to clear related page-scoped
- * state alongside the detector's own maps.
+ * Catches the agent stuck repeating an ineffective action or oscillating
+ * between two calls. Cheap, runs after every tool execution. On first
+ * detection we soft-nudge by injecting a [LOOP DETECTED] note into the
+ * tool result the model sees. On second detection within the same loop,
+ * we hard-stop the run with a clear final message.
+ *
+ * This module is deliberately browser-free so both extension builds and the
+ * unit suite exercise the same production class. Subclasses supply the
+ * browser-specific pieces: _isBrowserMutationTool() classifies tools, and
+ * _clearPageLoopState() may be extended to clear related page-scoped state
+ * alongside the detector's own maps.
  */
 export class LoopDetector {
-  constructor({ isBrowserMutationTool = () => false } = {}) {
-    this._loopMutationTool = isBrowserMutationTool;
-    this.recentCalls = new Map();
-    this.loopNudges = new Map();
-    this.healthyCallsSinceLoop = new Map();
-    this.failedActionLoops = new Map();
-    this.recentNavUrls = new Map();
-    this.axReadStates = new Map();
-    this.noProgressScrolls = new Map();
-    this.recentCoordClicks = new Map();
+  constructor() {
+    // Per-tab ring buffer of recent tool calls + nudge count.
+    this.recentCalls = new Map(); // tabId -> [{ key, name, ts }]
+    this.loopNudges = new Map();  // tabId -> consecutive-nudge counter
+    this.healthyCallsSinceLoop = new Map(); // tabId -> count of clean calls since last nudge
+    this.failedActionLoops = new Map(); // tabId -> Map(stable failure scope -> count)
+    // Last few normalized URLs each tab arrived at during the active run.
+    // Deliberately NOT cleared by _clearLoopState: it gates those intra-run
+    // resets, so it must survive them until the outer run boundary.
+    this.recentNavUrls = new Map(); // tabId -> [normalized URL, ...]
+    // A model can walk ref_1, ref_2, … forever while every call looks unique
+    // to the exact-argument loop detector. Track that semantic read pattern.
+    this.axReadStates = new Map(); // tabId -> { total, suspicious, nextPage, seenPages, warned }
+    // Scroll calls can keep returning success even when no pane moved. Track
+    // repeated dead-end attempts separately so changing the amount or
+    // interleaving reads cannot evade the generic loop detector.
+    this.noProgressScrolls = new Map(); // tabId -> { key, count }
+    // Separate buffer for coordinate-based click attempts. The general loop
+    // detector keys on JSON.stringify(args), so when the model interleaves
+    // execute_js with different code strings between clicks, the same
+    // (x,y) click never accumulates to the threshold inside its window.
+    // This buffer tracks ONLY coord clicks and survives any amount of
+    // unrelated noise between them, catching the "click missing its target,
+    // model retries forever" failure mode in 2-3 attempts instead of never.
+    this.recentCoordClicks = new Map(); // tabId -> [{ key, ts }]
   }
 
-  _isBrowserMutationTool(toolName) {
-    return this._loopMutationTool(toolName);
+  /**
+   * Whether `toolName` mutates browser/page state, which gates the stricter
+   * failed-action loop counters. Browser-neutral by default; each Agent build
+   * overrides it with that build's real tool surface.
+   */
+  _isBrowserMutationTool(_toolName) {
+    return false;
   }
 
   _isToolResultErroredForLoop(name, _args, result) {
@@ -84,6 +113,9 @@ export class LoopDetector {
 
   _loopCallKey(name, args, result) {
     if (result?.nonRetryableScope) {
+      // Definitive platform/permission failures keep one identity across
+      // tools and URL variants, so changing fetch strategies cannot evade
+      // the stop condition.
       return `nonretryable|${String(result.nonRetryableScope).slice(0, 240)}|err`;
     }
     const checkboxState = result?.checkboxState;
@@ -103,6 +135,9 @@ export class LoopDetector {
         return `checkbox|${identity}|desired:${checkboxState.desiredChecked}|actual:${checkboxState.actualChecked}`;
       }
     }
+    // URL-family tools (fetch_url, research_url, …) bucket by resource
+    // identity so the agent can't escape loop detection by fetching the
+    // same logical file via 8 different API endpoints. See loop-bucket.js.
     const errored = this._isToolResultErroredForLoop(name, args, result);
     const argsHash = bucketArgsKey(name, args);
     if (name === 'find_text' && !errored) {
@@ -123,6 +158,7 @@ export class LoopDetector {
 
   _detectLoop(buf, activeKey = null) {
     if (!buf || buf.length < 3) return null;
+    // 1. Same key 3+ times in the window.
     const counts = new Map();
     for (const e of buf) counts.set(e.key, (counts.get(e.key) || 0) + 1);
     for (const [key, n] of counts) {
@@ -130,6 +166,7 @@ export class LoopDetector {
         return { type: 'repeat', key, name: key.split('|')[0], count: n };
       }
     }
+    // 2. ABAB oscillation in the last 4.
     if (buf.length >= 4) {
       const last4 = buf.slice(-4);
       if (
@@ -143,6 +180,12 @@ export class LoopDetector {
     return null;
   }
 
+  /**
+   * Clear the state that is only meaningful for the page currently loaded in
+   * `tabId` — ref ids, coordinates, scroll surfaces, and per-target failure
+   * counters all stop describing reality once the page is replaced. Subclasses
+   * extend this (via super) to drop their own page-scoped state alongside it.
+   */
   _clearPageLoopState(tabId) {
     this.failedActionLoops.delete(tabId);
     this.axReadStates.delete(tabId);
@@ -150,6 +193,11 @@ export class LoopDetector {
     this.recentCoordClicks.delete(tabId);
   }
 
+  /**
+   * Clear everything the detector accumulated for `tabId` except the nav
+   * arrival history, which must outlive intra-run resets so navigation
+   * ping-pong is still catchable. See _clearRunLoopState for the run boundary.
+   */
   _clearLoopState(tabId) {
     this.recentCalls.delete(tabId);
     this.loopNudges.delete(tabId);
@@ -157,11 +205,20 @@ export class LoopDetector {
     this._clearPageLoopState(tabId);
   }
 
+  /**
+   * Run-boundary reset. Only here is the nav arrival history discarded, since
+   * a new run may legitimately revisit URLs the previous run already saw.
+   */
   _clearRunLoopState(tabId) {
     this.recentNavUrls.delete(tabId);
     this._clearLoopState(tabId);
   }
 
+  /**
+   * Normalize URLs for navigation-change checks. Keep query and hash so
+   * history entries that differ only by search params or anchors still count as
+   * successful back/forward movement.
+   */
   _normalizeUrl(url) {
     if (!url) return '';
     try {
@@ -170,6 +227,12 @@ export class LoopDetector {
     } catch (e) { return url; }
   }
 
+  /**
+   * Record that `tabId` arrived at `url` and report whether that URL was
+   * already seen in the last few arrivals. A first visit is page-state
+   * progress and justifies resetting loop counters; a quick revisit is the
+   * signature of a navigation loop and must leave them intact.
+   */
   _noteNavArrival(tabId, url) {
     const normalized = this._normalizeUrl(url);
     if (!normalized) return false;
@@ -221,6 +284,9 @@ export class LoopDetector {
     state.seenPages.add(page);
     this.axReadStates.set(tabId, state);
 
+    // A root read followed by the exact returned nextPage can legitimately span
+    // large applications. Keep the consecutive-read cap for every other AX
+    // pattern, but do not stop a valid sequential pagination step.
     if (state.suspicious >= 6 || (state.total >= 12 && (state.suspicious > 0 || !sequentialPage))) {
       this.axReadStates.delete(tabId);
       return {
@@ -249,6 +315,10 @@ export class LoopDetector {
       return `${direction}|xy:${Math.round(x)},${Math.round(y)}`;
     }
 
+    // For implicit scrolling, distinguish panes using the element that
+    // supplied the runtime's last-interaction origin. This avoids combining
+    // no-movement results from two different panes while deliberately
+    // ignoring `amount`, which is not a meaningful recovery at a hard edge.
     const origin = result?.originElement;
     if (origin && typeof origin === 'object') {
       const rect = origin.rect || {};
@@ -259,7 +329,13 @@ export class LoopDetector {
   }
 
   _checkNoProgressScroll(tabId, name, args, result) {
+    // Preserve a dead-scroll streak across reads or other unrelated calls;
+    // only a successful scroll or a different scroll target/direction proves
+    // that this particular recovery path changed.
     if (name !== 'scroll') {
+      // Accessibility refs and coordinate targets are document-scoped. A
+      // successful navigation can reuse the same ref_id/coordinates for a
+      // completely different page, so it must break the old scroll streak.
       if (result?.pageUrlChanged === true) this.noProgressScrolls.delete(tabId);
       return { kind: 'none' };
     }
@@ -289,6 +365,17 @@ export class LoopDetector {
     return { kind: 'none' };
   }
 
+  /**
+   * Issue #189 — mutation API observer shortcutter. When _checkLoop flags a
+   * repeated click (e.g. "Next Page" clicked 3x), check whether each click
+   * fired the same background XHR/fetch (captured by the webRequest
+   * listener in background.js). If so, surface the URL/method so the model
+   * can call fetch_url directly instead of clicking again.
+   *
+   * Strict matching only: same tab, exact url+method repeated, and request
+   * must land within WINDOW_MS after the click that triggered it. No fuzzy
+   * param-pattern matching.
+   */
   _detectApiShortcut(tabId, loop, buf) {
     if (loop.type !== 'repeat') return null;
     if (!['click', 'click_ax'].includes(loop.name)) return null;
@@ -331,6 +418,15 @@ export class LoopDetector {
     };
   }
 
+  /**
+   * Coordinate-click loop detector. Buckets to nearest 5px so a click that
+   * drifts by a pixel or two between attempts still hashes the same. Window
+   * of 8 — generous, since the goal is to survive interleaved noise like
+   * execute_js / type_text / read_page calls between coord retries.
+   *
+   * Returns 'nudge' on the 3rd repeat and 'stop' on the 5th. Gives the
+   * agent more room to retry on pages with loading states or animations.
+   */
   _checkCoordClickLoop(tabId, x, y) {
     const bx = Math.round(x / 5) * 5;
     const by = Math.round(y / 5) * 5;
@@ -348,7 +444,18 @@ export class LoopDetector {
     return { kind: 'none' };
   }
 
+  /**
+   * Run loop detection on a freshly recorded call. Returns one of:
+   *   { kind: 'none' }
+   *   { kind: 'nudge', warning: string }   // soft warning to inject into tool result
+   *   { kind: 'stop',  message: string }   // hard stop, abort the run
+   */
   _checkLoop(tabId, toolName, toolArgs, toolResult) {
+    // A navigation result is authoritative page-state evidence. Clear before
+    // recording this call so same-looking controls on the new page start at
+    // attempt one instead of inheriting an old third-strike counter. Arriving
+    // back on a recently seen URL is the exception: a click/go_back ping-pong
+    // would otherwise reset the detector on every hop and never be caught.
     if (toolResult?.pageUrlChanged === true && !this._noteNavArrival(tabId, toolResult.currentUrl)) {
       this._clearLoopState(tabId);
     }
@@ -357,6 +464,10 @@ export class LoopDetector {
       && toolResult?.success === true
       && !this._findTextMatchLoopIdentity(toolResult)
     ) {
+      // A cross-origin frame match can be selected by window.find while its
+      // range is unavailable to the top document. Successful same-query calls
+      // intentionally advance to the next match, so an unlocated match is not
+      // safe evidence of a repeat loop.
       return this._noteHealthyLoopCall(tabId);
     }
     const { buf, key } = this._recordCall(tabId, toolName, toolArgs, toolResult);
@@ -424,6 +535,7 @@ export class LoopDetector {
     }
     const loop = this._detectLoop(buf, key);
     if (loop?.type === 'oscillation' && loop.a === 'find_text' && loop.b === 'find_text') {
+      // Alternating match positions is normal when a finite page search wraps.
       return this._noteHealthyLoopCall(tabId);
     }
     if (!loop) {
@@ -447,6 +559,7 @@ export class LoopDetector {
       };
     }
 
+    // Any new loop detection resets the healthy-streak counter.
     this.healthyCallsSinceLoop.delete(tabId);
     const nudges = (this.loopNudges.get(tabId) || 0) + 1;
     this.loopNudges.set(tabId, nudges);

--- a/src/chrome/src/agent/mutation-tools.js
+++ b/src/chrome/src/agent/mutation-tools.js
@@ -1,0 +1,26 @@
+/**
+ * The Chrome build's mutating-tool surface, in a browser-free module so the
+ * Agent and the unit suite classify tools from one list instead of two.
+ *
+ * This file is deliberately NOT mirrored byte-for-byte with the Firefox copy:
+ * the two builds ship different tool sets, and that difference is exactly what
+ * the loop detector must see. Keep the shared, browser-neutral detection logic
+ * in loop-detector.js, which IS byte-identical across builds.
+ */
+
+/** Tools that change page or browser state, gating auto-screenshots and
+ *  unknown-outcome normalization as well as loop detection. */
+export const STATE_CHANGE_TOOLS = new Set(['navigate', 'new_tab', 'go_back', 'go_forward', 'click', 'click_ax', 'set_checked', 'type_text', 'type_ax', 'set_field', 'press_keys', 'scroll', 'hover', 'drag_drop', 'inject_css', 'remove_injected_css', 'patch_element', 'revert_patch', 'execute_js', 'inspect_event_listeners', 'highlight_element', 'execute_webmcp_tool']);
+
+/**
+ * Everything the failed-action loop counters treat as a browser mutation.
+ * Adds the frame- and upload-scoped tools that act on the page but are not
+ * part of the auto-screenshot state-change set.
+ */
+export const BROWSER_MUTATION_TOOLS = new Set([
+  ...STATE_CHANGE_TOOLS,
+  'iframe_click',
+  'iframe_type',
+  'upload_file',
+  'solve_captcha',
+]);

--- a/src/firefox/ARCHITECTURE.md
+++ b/src/firefox/ARCHITECTURE.md
@@ -55,6 +55,7 @@ src/firefox/
 │   ├── agent/
 │   │   ├── agent.js                # Core agent loop
 │   │   ├── loop-detector.js        # Browser-free loop detection, directly unit-tested
+│   │   ├── mutation-tools.js       # This build's state-change + mutating tool sets
 │   │   ├── tools.js                # Tool schemas + system prompts (incl. 4 AX tools)
 │   │   ├── skills.js               # Settings skills + dynamic skill tool manifests
 │   │   ├── planner.js              # Plan-before-Act structured planner
@@ -462,7 +463,8 @@ All identical to Chrome:
 - **Loop detection** — `agent/loop-detector.js` is inherited by `Agent` and
   imported directly by the unit suite; it contains the three detectors
   (general repeat, coordinate click, navigation) with the same thresholds and
-  nudge/stop behavior
+  nudge/stop behavior. It is byte-identical to the Chrome copy; the tool sets
+  it classifies against differ and live in `agent/mutation-tools.js`
 - **Context management** — auto-trim at >50 messages or >80,000 chars, LLM-powered summarization, emergency trim on context overflow, image pruning (last 4 only), tool-result cap at 8,000 chars
 - **Verbose mode** — three levels: Normal / Verbose ON / Deep verbose (Shift+click dumps the LLM-payload ring buffer to DevTools console). Deep verbose works identically; there's just no persisted trace UI to browse it from
 - **Site adapters** — same adapter set as Chrome (58 sites across code/dev, productivity, social, messaging, e-commerce, travel, finance, news paywalls, job portals, etc.); same `getActiveAdapter(url)` matching, same mid-conversation re-injection on navigation. Only ONE adapter fires at a time so prompt cost is fixed regardless of total count.

--- a/src/firefox/ARCHITECTURE.md
+++ b/src/firefox/ARCHITECTURE.md
@@ -54,6 +54,7 @@ src/firefox/
 │   ├── run-ui-journal.js           # Detached-run replay + streamed-text snapshots
 │   ├── agent/
 │   │   ├── agent.js                # Core agent loop
+│   │   ├── loop-detector.js        # Browser-free loop detection, directly unit-tested
 │   │   ├── tools.js                # Tool schemas + system prompts (incl. 4 AX tools)
 │   │   ├── skills.js               # Settings skills + dynamic skill tool manifests
 │   │   ├── planner.js              # Plan-before-Act structured planner
@@ -458,7 +459,10 @@ All job kinds (`resume`, `task`), lifecycle states, retry/deferral logic, schedu
 
 All identical to Chrome:
 
-- **Loop detection** — three detectors (general repeat, coordinate click, navigation) with the same thresholds and nudge/stop behavior
+- **Loop detection** — `agent/loop-detector.js` is inherited by `Agent` and
+  imported directly by the unit suite; it contains the three detectors
+  (general repeat, coordinate click, navigation) with the same thresholds and
+  nudge/stop behavior
 - **Context management** — auto-trim at >50 messages or >80,000 chars, LLM-powered summarization, emergency trim on context overflow, image pruning (last 4 only), tool-result cap at 8,000 chars
 - **Verbose mode** — three levels: Normal / Verbose ON / Deep verbose (Shift+click dumps the LLM-payload ring buffer to DevTools console). Deep verbose works identically; there's just no persisted trace UI to browse it from
 - **Site adapters** — same adapter set as Chrome (58 sites across code/dev, productivity, social, messaging, e-commerce, travel, finance, news paywalls, job portals, etc.); same `getActiveAdapter(url)` matching, same mid-conversation re-injection on navigation. Only ONE adapter fires at a time so prompt cost is fixed regardless of total count.

--- a/src/firefox/src/agent/agent.js
+++ b/src/firefox/src/agent/agent.js
@@ -1,6 +1,7 @@
 import { AGENT_TOOLS, AGENT_TOOL_NAMES, RESERVED_AGENT_TOOL_NAMES, getToolsForMode, SYSTEM_PROMPT_ASK, SYSTEM_PROMPT_ACT, SYSTEM_PROMPT_ACT_COMPACT, SYSTEM_PROMPT_ACT_MID, SYSTEM_PROMPT_DEV_APPENDIX } from './tools.js';
 import { handleDoneJson } from './cloud-output.js';
-import { URL_FAMILY_TOOLS, resourceBucket, bucketArgsKey } from './loop-bucket.js';
+import { resourceBucket, bucketArgsKey } from './loop-bucket.js';
+import { LoopDetector } from './loop-detector.js';
 import { isCredentialField, CREDENTIAL_NOTE_STRICT, STRICT_SECRET_SYSTEM_NOTE } from './credential-fields.js';
 import { detectProgressAction, formatLedgerRow, formatLedgerSummary, isBlockedLedgerDowngrade, isTerminalLedgerStatus, isValidLedgerStatus, ledgerDoneBlock, ledgerRowKey, normalizeLedgerStatus, progressCounts, selectLedgerRows, unresolvedLedgerRows, upsertLedgerItems } from './progress-ledger.js';
 import { buildGithubStargazerProgressItems } from './observers/github-stargazers.js';
@@ -111,8 +112,9 @@ function normalizeDoneOutcome(value) {
 /**
  * The WebBrain Agent — orchestrates multi-step LLM + tool-use loops.
  */
-export class Agent {
+export class Agent extends LoopDetector {
   constructor(providerManager) {
+    super();
     this.providerManager = providerManager;
     this.conversations = new Map(); // tabId -> messages[]
     this.progressLedgers = new Map(); // tabId -> structured progress rows, projected into a pinned note
@@ -211,22 +213,7 @@ export class Agent {
     // Strict secret-handling mode — see chrome/agent.js for rationale.
     // Default off; user opts in via Settings → "Strict secret handling".
     this.strictSecretMode = false;
-    this.recentCalls = new Map();
-    this.loopNudges = new Map();
-    this.healthyCallsSinceLoop = new Map();
-    this.failedActionLoops = new Map(); // tabId -> Map(stable failure scope -> count)
-    // Last few normalized URLs each tab arrived at during the active run.
-    // Deliberately NOT cleared by _clearLoopState: it gates those intra-run
-    // resets, so it must survive them until the outer run boundary.
-    this.recentNavUrls = new Map(); // tabId -> [normalized URL, ...]
     this._lastAxScopes = new Map(); // tabId -> { documentToken, pageUrl }, captured by the latest AX read
-    // A model can walk ref_1, ref_2, … forever while every call looks unique
-    // to the exact-argument loop detector. Track that semantic read pattern.
-    this.axReadStates = new Map();
-    // Scroll calls can keep returning success even when no pane moved. Track
-    // repeated dead-end attempts separately so changing the amount or
-    // interleaving reads cannot evade the generic loop detector.
-    this.noProgressScrolls = new Map();
     // Productive browsing often mixes reads and scrolling, so exact-call loop
     // detection cannot tell when the agent already has enough evidence to
     // answer. Track long observation-only streaks and remind it to deliver a
@@ -239,7 +226,6 @@ export class Agent {
     this.screenshotRedaction = false;
     this.lastAutoScreenshotTs = new Map();
     this.lastSeenAdapter = new Map();
-    this.recentCoordClicks = new Map();
     this.apiAllowedTabs = new Set();
     this.apiAllowedInjected = new Set();
     this.bulkApiMutationClicks = new Map();
@@ -1408,130 +1394,8 @@ export class Agent {
     }
   }
 
-  // ---- Loop detection ----
-  _isToolResultErroredForLoop(name, _args, result) {
-    if (!result || typeof result !== 'object') return false;
-    if (result.error || result.success === false || result.noProgress) return true;
-    const status = Number(result.status);
-    return URL_FAMILY_TOOLS.has(name) && Number.isFinite(status) && status >= 400;
-  }
-
-  _fetchUsesHttpByteRange(args) {
-    if (!args?.headers || typeof args.headers !== 'object') return false;
-    for (const [name, value] of Object.entries(args.headers)) {
-      if (String(name).toLowerCase() === 'range' && /^\s*bytes\s*=/i.test(String(value || ''))) {
-        return true;
-      }
-    }
-    return false;
-  }
-
-  _findTextMatchLoopIdentity(result) {
-    if (result?.success !== true || result?.verified === false || !result?.rect || typeof result.rect !== 'object') return '';
-    const rect = result.rect;
-    const pageX = typeof rect.pageX === 'number' ? rect.pageX : NaN;
-    const pageY = typeof rect.pageY === 'number' ? rect.pageY : NaN;
-    const viewportX = typeof rect.x === 'number' ? rect.x : NaN;
-    const viewportY = typeof rect.y === 'number' ? rect.y : NaN;
-    const width = typeof rect.width === 'number' ? rect.width : NaN;
-    const height = typeof rect.height === 'number' ? rect.height : NaN;
-    const x = Number.isFinite(pageX) ? pageX : viewportX;
-    const y = Number.isFinite(pageY) ? pageY : viewportY;
-    if (![x, y, width, height].every(Number.isFinite) || width <= 0 || height <= 0) return '';
-    let selectionIdentity = 'document';
-    if (result.selectionSource === 'text_control') {
-      const selectionStart = result.selectionStart;
-      const selectionEnd = result.selectionEnd;
-      if (
-        !Number.isInteger(selectionStart)
-        || !Number.isInteger(selectionEnd)
-        || selectionStart < 0
-        || selectionEnd <= selectionStart
-      ) return '';
-      selectionIdentity = `text_control:${selectionStart}:${selectionEnd}`;
-    }
-    const rectIdentity = [x, y, width, height]
-      .map(value => Math.round(value * 2) / 2)
-      .join(',');
-    return `${selectionIdentity}|${rectIdentity}`;
-  }
-
-  _noteHealthyLoopCall(tabId) {
-    // Do not reset the nudge counter immediately: one healthy call between
-    // two stuck actions must not launder the surrounding loop.
-    const healthy = (this.healthyCallsSinceLoop.get(tabId) || 0) + 1;
-    this.healthyCallsSinceLoop.set(tabId, healthy);
-    if (healthy >= 2) {
-      this.loopNudges.delete(tabId);
-      this.healthyCallsSinceLoop.delete(tabId);
-    }
-    return { kind: 'none' };
-  }
-
-  _loopCallKey(name, args, result) {
-    if (result?.nonRetryableScope) {
-      // Definitive platform/permission failures keep one identity across
-      // tools and URL variants, so changing fetch strategies cannot evade
-      // the stop condition.
-      return `nonretryable|${String(result.nonRetryableScope).slice(0, 240)}|err`;
-    }
-    const checkboxState = result?.checkboxState;
-    if (
-      checkboxState
-      && typeof checkboxState.desiredChecked === 'boolean'
-      && typeof checkboxState.actualChecked === 'boolean'
-      && checkboxState.desiredChecked !== checkboxState.actualChecked
-    ) {
-      const identity = String(
-        checkboxState.identity
-        || result.checkboxIdentity
-        || result.ref_id
-        || '',
-      ).trim().slice(0, 240);
-      if (identity) {
-        return `checkbox|${identity}|desired:${checkboxState.desiredChecked}|actual:${checkboxState.actualChecked}`;
-      }
-    }
-    // URL-family tools (fetch_url, research_url, …) bucket by resource
-    // identity so the agent can't escape loop detection by fetching the
-    // same logical file via 8 different API endpoints. See loop-bucket.js.
-    const errored = this._isToolResultErroredForLoop(name, args, result);
-    const argsHash = bucketArgsKey(name, args);
-    if (name === 'find_text' && !errored) {
-      const matchIdentity = this._findTextMatchLoopIdentity(result);
-      if (matchIdentity) return `${name}|${argsHash}|match:${matchIdentity}`;
-    }
-    return `${name}|${argsHash}|${errored ? 'err' : 'ok'}`;
-  }
-
-  _recordCall(tabId, name, args, result) {
-    const key = this._loopCallKey(name, args, result);
-    const buf = this.recentCalls.get(tabId) || [];
-    buf.push({ key, name, ts: Date.now() });
-    if (buf.length > 6) buf.shift();
-    this.recentCalls.set(tabId, buf);
-    return { buf, key };
-  }
-
-  _detectLoop(buf, activeKey = null) {
-    if (!buf || buf.length < 3) return null;
-    const counts = new Map();
-    for (const e of buf) counts.set(e.key, (counts.get(e.key) || 0) + 1);
-    for (const [key, n] of counts) {
-      if (n >= 3 && (!activeKey || key === activeKey)) return { type: 'repeat', key, name: key.split('|')[0], count: n };
-    }
-    if (buf.length >= 4) {
-      const last4 = buf.slice(-4);
-      if (
-        last4[0].key === last4[2].key &&
-        last4[1].key === last4[3].key &&
-        last4[0].key !== last4[1].key
-      ) {
-        return { type: 'oscillation', a: last4[0].name, b: last4[1].name };
-      }
-    }
-    return null;
-  }
+  // Browser-free loop detection is inherited from LoopDetector. These
+  // methods integrate Agent-owned API replay and page-scoped cleanup.
 
   _isFailedApiMutationForLoop(name, args, result) {
     return isNetworkMutation(name, args) && this._isToolResultErroredForLoop(name, args, result);
@@ -1635,144 +1499,6 @@ export class Agent {
     this._lastAxScopes.set(tabId, next);
   }
 
-  /**
-   * Record that `tabId` arrived at `url` and report whether that URL was
-   * already seen in the last few arrivals. A first visit is page-state
-   * progress and justifies resetting loop counters; a quick revisit is the
-   * signature of a navigation loop and must leave them intact.
-   */
-  _noteNavArrival(tabId, url) {
-    const normalized = this._normalizeUrl(url);
-    if (!normalized) return false;
-    const seen = this.recentNavUrls.get(tabId) || [];
-    const revisited = seen.includes(normalized);
-    seen.push(normalized);
-    if (seen.length > 5) seen.shift();
-    this.recentNavUrls.set(tabId, seen);
-    return revisited;
-  }
-
-  _isRecentNavUrl(tabId, url) {
-    const normalized = this._normalizeUrl(url);
-    return !!normalized && (this.recentNavUrls.get(tabId) || []).includes(normalized);
-  }
-
-  _checkAccessibilityReadLoop(tabId, name, args, result) {
-    if (name !== 'get_accessibility_tree') {
-      this.axReadStates.delete(tabId);
-      return { kind: 'none' };
-    }
-
-    const previous = this.axReadStates.get(tabId) || {
-      total: 0,
-      suspicious: 0,
-      nextPage: null,
-      seenPages: new Set(),
-      warned: false,
-    };
-    const page = Number(args?.page || 1);
-    const hasRef = typeof args?.ref_id === 'string' && args.ref_id.trim() !== '';
-    const sequentialPage = !hasRef
-      && previous.total > 0
-      && Number.isFinite(previous.nextPage)
-      && page === previous.nextPage
-      && !previous.seenPages.has(page);
-    const repeatedRootOrPage = !hasRef && previous.total > 0 && !sequentialPage;
-    const content = String(result?.pageContent || '').trim();
-    const meaningfulLines = content ? content.split(/\r?\n/).filter(line => line.trim()).length : 0;
-    const suspicious = hasRef || repeatedRootOrPage || (hasRef && meaningfulLines <= 1);
-
-    const state = {
-      total: previous.total + 1,
-      suspicious: previous.suspicious + (suspicious ? 1 : 0),
-      nextPage: Number.isFinite(Number(result?.nextPage)) ? Number(result.nextPage) : null,
-      seenPages: new Set(previous.seenPages),
-      warned: previous.warned,
-    };
-    state.seenPages.add(page);
-    this.axReadStates.set(tabId, state);
-
-    // A root read followed by the exact returned nextPage can legitimately span
-    // large applications. Keep the consecutive-read cap for every other AX
-    // pattern, but do not stop a valid sequential pagination step.
-    if (state.suspicious >= 6 || (state.total >= 12 && (state.suspicious > 0 || !sequentialPage))) {
-      this.axReadStates.delete(tabId);
-      return {
-        kind: 'stop',
-        message: 'Stopped: I kept reading accessibility-tree nodes without taking an action or changing approach. The tree is not meant to be enumerated ref-by-ref. Use an element already found, request the returned nextPage, switch to read_page/extract_data, or ask for help.',
-      };
-    }
-    if (!state.warned && state.suspicious >= 3) {
-      state.warned = true;
-      return {
-        kind: 'nudge',
-        warning: '[ACCESSIBILITY READ LOOP: Stop enumerating sibling or generic ref_ids. If the result has hasMore/nextPage, request exactly that page. If the needed textbox/button is already visible, use set_field, type_ax, or click_ax now. Otherwise switch once to read_page/extract_data or finish with what you have. Do not call another arbitrary ref_id subtree.]',
-      };
-    }
-    return { kind: 'none' };
-  }
-
-  _noProgressScrollKey(args = {}, result = {}) {
-    const direction = String(args?.direction || '').trim().toLowerCase() || 'unspecified';
-    const refId = String(args?.ref_id || '').trim();
-    if (refId) return `${direction}|ref:${refId}`;
-
-    const x = Number(args?.x);
-    const y = Number(args?.y);
-    if (args?.x != null && args?.y != null && Number.isFinite(x) && Number.isFinite(y)) {
-      return `${direction}|xy:${Math.round(x)},${Math.round(y)}`;
-    }
-
-    // For implicit scrolling, distinguish panes using the element that
-    // supplied the runtime's last-interaction origin. This avoids combining
-    // no-movement results from two different panes while deliberately
-    // ignoring `amount`, which is not a meaningful recovery at a hard edge.
-    const origin = result?.originElement;
-    if (origin && typeof origin === 'object') {
-      const rect = origin.rect || {};
-      const text = String(origin.text || '').trim().replace(/\s+/g, ' ').slice(0, 80);
-      return `${direction}|origin:${String(result?.origin || '')}:${String(origin.tag || '')}:${String(origin.role || '')}:${Math.round(Number(rect.x) || 0)},${Math.round(Number(rect.y) || 0)},${Math.round(Number(rect.w) || 0)},${Math.round(Number(rect.h) || 0)}:${text}`;
-    }
-    return `${direction}|auto`;
-  }
-
-  _checkNoProgressScroll(tabId, name, args, result) {
-    // Preserve a dead-scroll streak across reads or other unrelated calls;
-    // only a successful scroll or a different scroll target/direction proves
-    // that this particular recovery path changed.
-    if (name !== 'scroll') {
-      // Accessibility refs and coordinate targets are document-scoped. A
-      // successful navigation can reuse the same ref_id/coordinates for a
-      // completely different page, so it must break the old scroll streak.
-      if (result?.pageUrlChanged === true) this.noProgressScrolls.delete(tabId);
-      return { kind: 'none' };
-    }
-    if (result?.moved !== false) {
-      this.noProgressScrolls.delete(tabId);
-      return { kind: 'none' };
-    }
-
-    const key = this._noProgressScrollKey(args, result);
-    const previous = this.noProgressScrolls.get(tabId);
-    const count = previous?.key === key ? previous.count + 1 : 1;
-    this.noProgressScrolls.set(tabId, { key, count });
-
-    if (count >= 3) {
-      this.noProgressScrolls.delete(tabId);
-      return {
-        kind: 'stop',
-        message: 'Stopped: I repeated the same scroll direction on the same target three times, but the page or pane did not move. That scroll surface is already at its limit. Re-read the current view, choose a different pane or direction, act on an element already visible, or ask for help.',
-      };
-    }
-    if (count >= 2) {
-      return {
-        kind: 'nudge',
-        warning: '[NO-PROGRESS SCROLL: The same target did not move twice. Do not repeat this scroll direction or merely change the amount. Re-read the current view, use the opposite direction or a different ref_id/x/y pane, act on an element already visible, or finish.]',
-      };
-    }
-    return { kind: 'none' };
-  }
-
   _checkDeliveryObservationStreak(tabId, name, args = {}) {
     if (!this.constructor.DELIVERY_OBSERVATION_TOOLS.has(name) || isNetworkMutation(name, args)) {
       this.deliveryObservationStreaks.delete(tabId);
@@ -1786,58 +1512,6 @@ export class Agent {
     return {
       kind: 'nudge',
       warning: `[DELIVERY CHECKPOINT: You have made ${count} consecutive read, scroll, or wait observations without a state-changing action. Do not keep observing merely to make the answer exhaustive. If the current evidence satisfies the request, call done now. For list or research tasks, deliver useful partial results rather than risk shipping nothing. Continue only when you can name a specific missing fact or control and the next tool will obtain it.]`,
-    };
-  }
-
-  /**
-   * Issue #189 — mutation API observer shortcutter. When _checkLoop flags a
-   * repeated click (e.g. "Next Page" clicked 3x), check whether each click
-   * fired the same background XHR/fetch (captured by the webRequest
-   * listener in background.js). If so, surface the URL/method so the model
-   * can call fetch_url directly instead of clicking again.
-   *
-   * Strict matching only: same tab, exact url+method repeated, and request
-   * must land within WINDOW_MS after the click that triggered it. No fuzzy
-   * param-pattern matching.
-   */
-  _detectApiShortcut(tabId, loop, buf) {
-    if (loop.type !== 'repeat') return null;
-    if (!['click', 'click_ax'].includes(loop.name)) return null;
-    const apiRequests = globalThis.__webbrainApiRequests?.get(tabId);
-    if (!apiRequests || apiRequests.length === 0) return null;
-
-    const clickTimes = buf.filter(e => e.key === loop.key).map(e => e.ts);
-    if (clickTimes.length < 2) return null;
-
-    const WINDOW_MS = 3000;
-    let candidate = null;
-    let matches = 0;
-    const usedRequestIndexes = new Set();
-    for (const clickTs of clickTimes) {
-      const hitIndex = apiRequests.findIndex((r, idx) =>
-        !usedRequestIndexes.has(idx) &&
-        r.ts >= clickTs && r.ts <= clickTs + WINDOW_MS &&
-        (!candidate || (r.url === candidate.url && String(r.method || '').toUpperCase() === candidate.method))
-      );
-      if (hitIndex < 0) continue;
-      const hit = apiRequests[hitIndex];
-      if (!hit) continue;
-      if (!candidate) {
-        candidate = {
-          url: hit.url,
-          method: String(hit.method || '').toUpperCase(),
-          replayRequestId: hit.replayRequestId,
-        };
-      }
-      usedRequestIndexes.add(hitIndex);
-      matches++;
-    }
-    if (!candidate || matches < 2) return null;
-    return {
-      url: candidate.url,
-      method: candidate.method,
-      occurrences: matches,
-      replayRequestId: candidate.replayRequestId,
     };
   }
 
@@ -2354,158 +2028,7 @@ export class Agent {
     ].filter(Boolean).join('\n\n');
   }
 
-  _checkCoordClickLoop(tabId, x, y) {
-    const bx = Math.round(x / 5) * 5;
-    const by = Math.round(y / 5) * 5;
-    const key = `${bx},${by}`;
-    const buf = this.recentCoordClicks.get(tabId) || [];
-    buf.push({ key, ts: Date.now() });
-    if (buf.length > 12) buf.shift();
-    this.recentCoordClicks.set(tabId, buf);
-    const counts = new Map();
-    for (const e of buf) counts.set(e.key, (counts.get(e.key) || 0) + 1);
-    const n = counts.get(key) || 0;
-    if (n >= 8) return { kind: 'stop', x: bx, y: by };
-    if (n >= 5) return { kind: 'nudge', x: bx, y: by };
-    return { kind: 'none' };
-  }
 
-  _checkLoop(tabId, toolName, toolArgs, toolResult) {
-    // A navigation result is authoritative page-state evidence. Clear before
-    // recording this call so same-looking controls on the new page start at
-    // attempt one instead of inheriting an old third-strike counter. Arriving
-    // back on a recently seen URL is the exception: a click/go_back ping-pong
-    // would otherwise reset the detector on every hop and never be caught.
-    if (toolResult?.pageUrlChanged === true && !this._noteNavArrival(tabId, toolResult.currentUrl)) {
-      this._clearLoopState(tabId);
-    }
-    if (
-      toolName === 'find_text'
-      && toolResult?.success === true
-      && !this._findTextMatchLoopIdentity(toolResult)
-    ) {
-      // A cross-origin frame match can be selected by window.find while its
-      // range is unavailable to the top document. Successful same-query calls
-      // intentionally advance to the next match, so an unlocated match is not
-      // safe evidence of a repeat loop.
-      return this._noteHealthyLoopCall(tabId);
-    }
-    const { buf, key } = this._recordCall(tabId, toolName, toolArgs, toolResult);
-    if (this._isBrowserMutationTool(toolName)) {
-      const normalizeFailureScope = value => String(value).slice(0, 320);
-      const defaultFailureScope = normalizeFailureScope(`${toolName}|${bucketArgsKey(toolName, toolArgs)}`);
-      const failureScope = normalizeFailureScope(toolResult?.failureScope || defaultFailureScope);
-      const equivalentFailureScopes = new Set([failureScope, defaultFailureScope]);
-      if ((toolName === 'set_field' || toolName === 'type_ax') && typeof toolArgs?.ref_id === 'string') {
-        equivalentFailureScopes.add(normalizeFailureScope(`field-value:${toolArgs.ref_id}`));
-      }
-      if (toolName === 'click' && typeof toolArgs?.text === 'string') {
-        equivalentFailureScopes.add(normalizeFailureScope(`ambiguous-click:${toolArgs.text.trim().toLowerCase()}`));
-      }
-      const failures = this.failedActionLoops.get(tabId) || new Map();
-      if (this._isToolResultErroredForLoop(toolName, toolArgs, toolResult)) {
-        const attempts = (failures.get(failureScope) || 0) + 1;
-        failures.set(failureScope, attempts);
-        if (failures.size > 32) failures.delete(failures.keys().next().value);
-        this.failedActionLoops.set(tabId, failures);
-        if (attempts >= 3) {
-          this._clearLoopState(tabId);
-          return {
-            kind: 'stop',
-            message: `Stopped: ${toolName} failed or made no progress three times for the same target. Repeating it or switching to a precomputed fallback cannot make progress without fresh page evidence.`,
-          };
-        }
-        if (attempts === 2) {
-          return {
-            kind: 'nudge',
-            warning: `[FAILED ACTION LOOP: ${toolName} has failed or made no progress twice for the same target. Do not retry it or use a queued fallback. Re-read the page/tree and choose a new action from current evidence.]`,
-          };
-        }
-      } else if (toolResult?.success === true && toolResult?.verified !== false) {
-        for (const scope of equivalentFailureScopes) failures.delete(scope);
-        if (failures.size) this.failedActionLoops.set(tabId, failures);
-        else this.failedActionLoops.delete(tabId);
-      }
-    }
-    if (toolResult?.nonRetryable) {
-      const repeats = buf.filter(entry => entry.key === key).length;
-      if (repeats >= 2) {
-        this._clearLoopState(tabId);
-        return {
-          kind: 'stop',
-          message: toolResult.stopMessage || `Stopped: ${toolName} hit the same non-retryable failure twice. Retrying or switching to an equivalent tool will not make progress.`,
-        };
-      }
-    }
-    if (key.startsWith('checkbox|')) {
-      const repeats = buf.filter(entry => entry.key === key).length;
-      if (repeats >= 3) {
-        this._clearLoopState(tabId);
-        return {
-          kind: 'stop',
-          message: 'Stopped: the same checkbox is still in the wrong checked state after three attempts. Changing tools or arguments does not change that semantic state. Re-read the form or ask the user instead of toggling it again.',
-        };
-      }
-      if (repeats >= 2) {
-        return {
-          kind: 'nudge',
-          warning: '[CHECKBOX STATE UNCHANGED: The same checkbox is still in the wrong checked state. Do not toggle it again and do not evade this by switching tools. Call set_checked(ref_id, desiredState) once; if that verified attempt also fails, re-read the form or ask the user.]',
-        };
-      }
-    }
-    const loop = this._detectLoop(buf, key);
-    if (loop?.type === 'oscillation' && loop.a === 'find_text' && loop.b === 'find_text') {
-      // Alternating match positions is normal when a finite page search wraps.
-      return this._noteHealthyLoopCall(tabId);
-    }
-    if (!loop) {
-      return this._noteHealthyLoopCall(tabId);
-    }
-    const method = String(toolArgs?.method || 'GET').toUpperCase();
-    if (
-      loop.type === 'repeat' &&
-      URL_FAMILY_TOOLS.has(toolName) &&
-      method === 'GET' &&
-      this._isToolResultErroredForLoop(toolName, toolArgs, toolResult)
-    ) {
-      this._clearLoopState(tabId);
-      const rangedFetch = toolName === 'fetch_url' && this._fetchUsesHttpByteRange(toolArgs);
-      return {
-        kind: 'stop',
-        message: rangedFetch
-          ? 'Stopped: fetch_url failed three times while probing HTTP byte ranges for the same read-only resource. Use find or semantic offset:nextOffset pagination in a new run, or ask for a partial answer from the evidence already collected.'
-          : `Stopped: ${loop.name} failed three times for the same read-only resource. Repeating it or changing URL variants will not make progress. Please give a different instruction or inspect the page manually.`,
-      };
-    }
-    this.healthyCallsSinceLoop.delete(tabId);
-    const nudges = (this.loopNudges.get(tabId) || 0) + 1;
-    this.loopNudges.set(tabId, nudges);
-    if (nudges >= 8) {
-      this._clearLoopState(tabId);
-      const desc = loop.type === 'repeat'
-        ? `the same call to ${loop.name}`
-        : `between ${loop.a} and ${loop.b}`;
-      return {
-        kind: 'stop',
-        message: `Stopped: I detected I was looping on ${desc} without making progress after multiple warnings. Please tell me what's blocking, give me a different instruction, or take a look at the page yourself.`,
-      };
-    }
-    let warning;
-    if (loop.type === 'repeat') {
-      const shortcut = this._detectApiShortcut(tabId, loop, buf);
-      const rangedFetch = toolName === 'fetch_url'
-        && method === 'GET'
-        && this._fetchUsesHttpByteRange(toolArgs);
-      warning = rangedFetch
-        ? '[LOOP DETECTED: You are repeatedly probing the same resource with HTTP byte ranges. Stop guessing byte offsets or file size. Use fetch_url({url, find:"literal"}) to search the full decoded response, continue semantic text pagination with offset:nextOffset, or answer now with the evidence already collected. Do not send another Range header for this resource.]'
-        : shortcut
-        ? `[LOOP DETECTED + API SHORTCUT FOUND: You've called ${loop.name} ${loop.count} times. Each click triggered the same background request pattern: ${shortcut.method} ${shortcut.url}. Instead of clicking again, consider fetch_url({url: "${shortcut.url}", method: "${shortcut.method}"${shortcut.replayRequestId ? `, replayRequestId: "${shortcut.replayRequestId}"` : ''}}) with the same method; follow the UI/API mutation policy for mutating methods.]`
-        : `[LOOP DETECTED: You've just called ${loop.name} ${loop.count} times with the same arguments and the same outcome. The current approach is NOT working. Try something fundamentally different: a different selector, a different tool, scroll to find a different element, or re-read the page/tree to see what's actually on screen. DO NOT repeat this exact call again — try a creative alternative.]`;
-    } else {
-      warning = `[LOOP DETECTED: You're oscillating between ${loop.a} and ${loop.b} without making progress. Stop. Re-read the page/tree to see what's actually happening, then try a completely different approach.]`;
-    }
-    return { kind: 'nudge', warning };
-  }
 
   static NAV_TOOLS = new Set(['navigate', 'new_tab', 'go_back', 'go_forward']);
   static STATE_CHANGE_TOOLS = new Set(['navigate', 'new_tab', 'go_back', 'go_forward', 'click', 'click_ax', 'set_checked', 'type_text', 'type_ax', 'set_field', 'press_keys', 'scroll', 'hover', 'drag_drop', 'execute_js']);
@@ -2600,13 +2123,6 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
     } catch (e) { return ''; }
   }
 
-  _normalizeUrl(url) {
-    if (!url) return '';
-    try {
-      const u = new URL(url);
-      return u.origin + u.pathname + u.search + u.hash;
-    } catch (e) { return url; }
-  }
 
   /**
    * Path-level URL normalization for the click side-effect navigation notice.

--- a/src/firefox/src/agent/agent.js
+++ b/src/firefox/src/agent/agent.js
@@ -1,7 +1,7 @@
 import { AGENT_TOOLS, AGENT_TOOL_NAMES, RESERVED_AGENT_TOOL_NAMES, getToolsForMode, SYSTEM_PROMPT_ASK, SYSTEM_PROMPT_ACT, SYSTEM_PROMPT_ACT_COMPACT, SYSTEM_PROMPT_ACT_MID, SYSTEM_PROMPT_DEV_APPENDIX } from './tools.js';
 import { handleDoneJson } from './cloud-output.js';
-import { resourceBucket, bucketArgsKey } from './loop-bucket.js';
 import { LoopDetector } from './loop-detector.js';
+import { BROWSER_MUTATION_TOOLS, STATE_CHANGE_TOOLS as SHARED_STATE_CHANGE_TOOLS } from './mutation-tools.js';
 import { isCredentialField, CREDENTIAL_NOTE_STRICT, STRICT_SECRET_SYSTEM_NOTE } from './credential-fields.js';
 import { detectProgressAction, formatLedgerRow, formatLedgerSummary, isBlockedLedgerDowngrade, isTerminalLedgerStatus, isValidLedgerStatus, ledgerDoneBlock, ledgerRowKey, normalizeLedgerStatus, progressCounts, selectLedgerRows, unresolvedLedgerRows, upsertLedgerItems } from './progress-ledger.js';
 import { buildGithubStargazerProgressItems } from './observers/github-stargazers.js';
@@ -1441,12 +1441,14 @@ export class Agent extends LoopDetector {
     return { method, requestShape, failed };
   }
 
+  /**
+   * Extends the detector's own page-scoped cleanup with the Agent-owned state
+   * that is equally invalidated by a page replacement: the delivery-checkpoint
+   * streak and the bulk API replay bookkeeping keyed on this tab.
+   */
   _clearPageLoopState(tabId) {
-    this.failedActionLoops.delete(tabId);
-    this.axReadStates.delete(tabId);
-    this.noProgressScrolls.delete(tabId);
+    super._clearPageLoopState(tabId);
     this.deliveryObservationStreaks.delete(tabId);
-    this.recentCoordClicks.delete(tabId);
     this.bulkApiMutationClicks.delete(tabId);
     this.bulkApiMutationHints.delete(tabId);
     const replayFailurePrefix = `${tabId}|`;
@@ -1455,18 +1457,6 @@ export class Agent extends LoopDetector {
         this.failedBulkApiReplayShapes.delete(key);
       }
     }
-  }
-
-  _clearLoopState(tabId) {
-    this.recentCalls.delete(tabId);
-    this.loopNudges.delete(tabId);
-    this.healthyCallsSinceLoop.delete(tabId);
-    this._clearPageLoopState(tabId);
-  }
-
-  _clearRunLoopState(tabId) {
-    this.recentNavUrls.delete(tabId);
-    this._clearLoopState(tabId);
   }
 
   _rememberAxScope(tabId, documentToken, pageUrl = '') {
@@ -2028,10 +2018,8 @@ export class Agent extends LoopDetector {
     ].filter(Boolean).join('\n\n');
   }
 
-
-
   static NAV_TOOLS = new Set(['navigate', 'new_tab', 'go_back', 'go_forward']);
-  static STATE_CHANGE_TOOLS = new Set(['navigate', 'new_tab', 'go_back', 'go_forward', 'click', 'click_ax', 'set_checked', 'type_text', 'type_ax', 'set_field', 'press_keys', 'scroll', 'hover', 'drag_drop', 'execute_js']);
+  static STATE_CHANGE_TOOLS = SHARED_STATE_CHANGE_TOOLS;
   static EXECUTION_META_TOOLS = new Set(['clarify', 'scratchpad_write', 'scratchpad_read', 'progress_update', 'progress_read']);
   static EXECUTION_APP_STATE_TOOLS = new Set(['scratchpad_write', 'scratchpad_read', 'progress_update', 'progress_read']);
   static EXECUTION_APP_STATE_WRITE_TOOLS = new Set(['scratchpad_write', 'progress_update']);
@@ -2122,7 +2110,6 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
       return url;
     } catch (e) { return ''; }
   }
-
 
   /**
    * Path-level URL normalization for the click side-effect navigation notice.
@@ -2317,11 +2304,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
   }
 
   _isBrowserMutationTool(toolName) {
-    return Agent.STATE_CHANGE_TOOLS.has(toolName)
-      || toolName === 'iframe_click'
-      || toolName === 'iframe_type'
-      || toolName === 'upload_file'
-      || toolName === 'solve_captcha';
+    return BROWSER_MUTATION_TOOLS.has(toolName);
   }
 
   _browserActionFreshTurnReason(tier, toolName, toolResult) {

--- a/src/firefox/src/agent/loop-detector.js
+++ b/src/firefox/src/agent/loop-detector.js
@@ -1,0 +1,481 @@
+import { URL_FAMILY_TOOLS, bucketArgsKey } from './loop-bucket.js';
+
+/**
+ * Browser-free loop detection used by Agent and the unit tests.
+ *
+ * Subclasses may override _clearPageLoopState() to clear related page-scoped
+ * state alongside the detector's own maps.
+ */
+export class LoopDetector {
+  constructor({ isBrowserMutationTool = () => false } = {}) {
+    this._loopMutationTool = isBrowserMutationTool;
+    this.recentCalls = new Map();
+    this.loopNudges = new Map();
+    this.healthyCallsSinceLoop = new Map();
+    this.failedActionLoops = new Map();
+    this.recentNavUrls = new Map();
+    this.axReadStates = new Map();
+    this.noProgressScrolls = new Map();
+    this.recentCoordClicks = new Map();
+  }
+
+  _isBrowserMutationTool(toolName) {
+    return this._loopMutationTool(toolName);
+  }
+
+  _isToolResultErroredForLoop(name, _args, result) {
+    if (!result || typeof result !== 'object') return false;
+    if (result.error || result.success === false || result.noProgress) return true;
+    const status = Number(result.status);
+    return URL_FAMILY_TOOLS.has(name) && Number.isFinite(status) && status >= 400;
+  }
+
+  _fetchUsesHttpByteRange(args) {
+    if (!args?.headers || typeof args.headers !== 'object') return false;
+    for (const [name, value] of Object.entries(args.headers)) {
+      if (String(name).toLowerCase() === 'range' && /^\s*bytes\s*=/i.test(String(value || ''))) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  _findTextMatchLoopIdentity(result) {
+    if (result?.success !== true || result?.verified === false || !result?.rect || typeof result.rect !== 'object') return '';
+    const rect = result.rect;
+    const pageX = typeof rect.pageX === 'number' ? rect.pageX : NaN;
+    const pageY = typeof rect.pageY === 'number' ? rect.pageY : NaN;
+    const viewportX = typeof rect.x === 'number' ? rect.x : NaN;
+    const viewportY = typeof rect.y === 'number' ? rect.y : NaN;
+    const width = typeof rect.width === 'number' ? rect.width : NaN;
+    const height = typeof rect.height === 'number' ? rect.height : NaN;
+    const x = Number.isFinite(pageX) ? pageX : viewportX;
+    const y = Number.isFinite(pageY) ? pageY : viewportY;
+    if (![x, y, width, height].every(Number.isFinite) || width <= 0 || height <= 0) return '';
+    let selectionIdentity = 'document';
+    if (result.selectionSource === 'text_control') {
+      const selectionStart = result.selectionStart;
+      const selectionEnd = result.selectionEnd;
+      if (
+        !Number.isInteger(selectionStart)
+        || !Number.isInteger(selectionEnd)
+        || selectionStart < 0
+        || selectionEnd <= selectionStart
+      ) return '';
+      selectionIdentity = `text_control:${selectionStart}:${selectionEnd}`;
+    }
+    const rectIdentity = [x, y, width, height]
+      .map(value => Math.round(value * 2) / 2)
+      .join(',');
+    return `${selectionIdentity}|${rectIdentity}`;
+  }
+
+  _noteHealthyLoopCall(tabId) {
+    // Do not reset the nudge counter immediately: one healthy call between
+    // two stuck actions must not launder the surrounding loop.
+    const healthy = (this.healthyCallsSinceLoop.get(tabId) || 0) + 1;
+    this.healthyCallsSinceLoop.set(tabId, healthy);
+    if (healthy >= 2) {
+      this.loopNudges.delete(tabId);
+      this.healthyCallsSinceLoop.delete(tabId);
+    }
+    return { kind: 'none' };
+  }
+
+  _loopCallKey(name, args, result) {
+    if (result?.nonRetryableScope) {
+      return `nonretryable|${String(result.nonRetryableScope).slice(0, 240)}|err`;
+    }
+    const checkboxState = result?.checkboxState;
+    if (
+      checkboxState
+      && typeof checkboxState.desiredChecked === 'boolean'
+      && typeof checkboxState.actualChecked === 'boolean'
+      && checkboxState.desiredChecked !== checkboxState.actualChecked
+    ) {
+      const identity = String(
+        checkboxState.identity
+        || result.checkboxIdentity
+        || result.ref_id
+        || '',
+      ).trim().slice(0, 240);
+      if (identity) {
+        return `checkbox|${identity}|desired:${checkboxState.desiredChecked}|actual:${checkboxState.actualChecked}`;
+      }
+    }
+    const errored = this._isToolResultErroredForLoop(name, args, result);
+    const argsHash = bucketArgsKey(name, args);
+    if (name === 'find_text' && !errored) {
+      const matchIdentity = this._findTextMatchLoopIdentity(result);
+      if (matchIdentity) return `${name}|${argsHash}|match:${matchIdentity}`;
+    }
+    return `${name}|${argsHash}|${errored ? 'err' : 'ok'}`;
+  }
+
+  _recordCall(tabId, name, args, result) {
+    const key = this._loopCallKey(name, args, result);
+    const buf = this.recentCalls.get(tabId) || [];
+    buf.push({ key, name, ts: Date.now() });
+    if (buf.length > 6) buf.shift();
+    this.recentCalls.set(tabId, buf);
+    return { buf, key };
+  }
+
+  _detectLoop(buf, activeKey = null) {
+    if (!buf || buf.length < 3) return null;
+    const counts = new Map();
+    for (const e of buf) counts.set(e.key, (counts.get(e.key) || 0) + 1);
+    for (const [key, n] of counts) {
+      if (n >= 3 && (!activeKey || key === activeKey)) {
+        return { type: 'repeat', key, name: key.split('|')[0], count: n };
+      }
+    }
+    if (buf.length >= 4) {
+      const last4 = buf.slice(-4);
+      if (
+        last4[0].key === last4[2].key
+        && last4[1].key === last4[3].key
+        && last4[0].key !== last4[1].key
+      ) {
+        return { type: 'oscillation', a: last4[0].name, b: last4[1].name };
+      }
+    }
+    return null;
+  }
+
+  _clearPageLoopState(tabId) {
+    this.failedActionLoops.delete(tabId);
+    this.axReadStates.delete(tabId);
+    this.noProgressScrolls.delete(tabId);
+    this.recentCoordClicks.delete(tabId);
+  }
+
+  _clearLoopState(tabId) {
+    this.recentCalls.delete(tabId);
+    this.loopNudges.delete(tabId);
+    this.healthyCallsSinceLoop.delete(tabId);
+    this._clearPageLoopState(tabId);
+  }
+
+  _clearRunLoopState(tabId) {
+    this.recentNavUrls.delete(tabId);
+    this._clearLoopState(tabId);
+  }
+
+  _normalizeUrl(url) {
+    if (!url) return '';
+    try {
+      const u = new URL(url);
+      return u.origin + u.pathname + u.search + u.hash;
+    } catch (e) { return url; }
+  }
+
+  _noteNavArrival(tabId, url) {
+    const normalized = this._normalizeUrl(url);
+    if (!normalized) return false;
+    const seen = this.recentNavUrls.get(tabId) || [];
+    const revisited = seen.includes(normalized);
+    seen.push(normalized);
+    if (seen.length > 5) seen.shift();
+    this.recentNavUrls.set(tabId, seen);
+    return revisited;
+  }
+
+  _isRecentNavUrl(tabId, url) {
+    const normalized = this._normalizeUrl(url);
+    return !!normalized && (this.recentNavUrls.get(tabId) || []).includes(normalized);
+  }
+
+  _checkAccessibilityReadLoop(tabId, name, args, result) {
+    if (name !== 'get_accessibility_tree') {
+      this.axReadStates.delete(tabId);
+      return { kind: 'none' };
+    }
+
+    const previous = this.axReadStates.get(tabId) || {
+      total: 0,
+      suspicious: 0,
+      nextPage: null,
+      seenPages: new Set(),
+      warned: false,
+    };
+    const page = Number(args?.page || 1);
+    const hasRef = typeof args?.ref_id === 'string' && args.ref_id.trim() !== '';
+    const sequentialPage = !hasRef
+      && previous.total > 0
+      && Number.isFinite(previous.nextPage)
+      && page === previous.nextPage
+      && !previous.seenPages.has(page);
+    const repeatedRootOrPage = !hasRef && previous.total > 0 && !sequentialPage;
+    const content = String(result?.pageContent || '').trim();
+    const meaningfulLines = content ? content.split(/\r?\n/).filter(line => line.trim()).length : 0;
+    const suspicious = hasRef || repeatedRootOrPage || (hasRef && meaningfulLines <= 1);
+
+    const state = {
+      total: previous.total + 1,
+      suspicious: previous.suspicious + (suspicious ? 1 : 0),
+      nextPage: Number.isFinite(Number(result?.nextPage)) ? Number(result.nextPage) : null,
+      seenPages: new Set(previous.seenPages),
+      warned: previous.warned,
+    };
+    state.seenPages.add(page);
+    this.axReadStates.set(tabId, state);
+
+    if (state.suspicious >= 6 || (state.total >= 12 && (state.suspicious > 0 || !sequentialPage))) {
+      this.axReadStates.delete(tabId);
+      return {
+        kind: 'stop',
+        message: 'Stopped: I kept reading accessibility-tree nodes without taking an action or changing approach. The tree is not meant to be enumerated ref-by-ref. Use an element already found, request the returned nextPage, switch to read_page/extract_data, or ask for help.',
+      };
+    }
+    if (!state.warned && state.suspicious >= 3) {
+      state.warned = true;
+      return {
+        kind: 'nudge',
+        warning: '[ACCESSIBILITY READ LOOP: Stop enumerating sibling or generic ref_ids. If the result has hasMore/nextPage, request exactly that page. If the needed textbox/button is already visible, use set_field, type_ax, or click_ax now. Otherwise switch once to read_page/extract_data or finish with what you have. Do not call another arbitrary ref_id subtree.]',
+      };
+    }
+    return { kind: 'none' };
+  }
+
+  _noProgressScrollKey(args = {}, result = {}) {
+    const direction = String(args?.direction || '').trim().toLowerCase() || 'unspecified';
+    const refId = String(args?.ref_id || '').trim();
+    if (refId) return `${direction}|ref:${refId}`;
+
+    const x = Number(args?.x);
+    const y = Number(args?.y);
+    if (args?.x != null && args?.y != null && Number.isFinite(x) && Number.isFinite(y)) {
+      return `${direction}|xy:${Math.round(x)},${Math.round(y)}`;
+    }
+
+    const origin = result?.originElement;
+    if (origin && typeof origin === 'object') {
+      const rect = origin.rect || {};
+      const text = String(origin.text || '').trim().replace(/\s+/g, ' ').slice(0, 80);
+      return `${direction}|origin:${String(result?.origin || '')}:${String(origin.tag || '')}:${String(origin.role || '')}:${Math.round(Number(rect.x) || 0)},${Math.round(Number(rect.y) || 0)},${Math.round(Number(rect.w) || 0)},${Math.round(Number(rect.h) || 0)}:${text}`;
+    }
+    return `${direction}|auto`;
+  }
+
+  _checkNoProgressScroll(tabId, name, args, result) {
+    if (name !== 'scroll') {
+      if (result?.pageUrlChanged === true) this.noProgressScrolls.delete(tabId);
+      return { kind: 'none' };
+    }
+    if (result?.moved !== false) {
+      this.noProgressScrolls.delete(tabId);
+      return { kind: 'none' };
+    }
+
+    const key = this._noProgressScrollKey(args, result);
+    const previous = this.noProgressScrolls.get(tabId);
+    const count = previous?.key === key ? previous.count + 1 : 1;
+    this.noProgressScrolls.set(tabId, { key, count });
+
+    if (count >= 3) {
+      this.noProgressScrolls.delete(tabId);
+      return {
+        kind: 'stop',
+        message: 'Stopped: I repeated the same scroll direction on the same target three times, but the page or pane did not move. That scroll surface is already at its limit. Re-read the current view, choose a different pane or direction, act on an element already visible, or ask for help.',
+      };
+    }
+    if (count >= 2) {
+      return {
+        kind: 'nudge',
+        warning: '[NO-PROGRESS SCROLL: The same target did not move twice. Do not repeat this scroll direction or merely change the amount. Re-read the current view, use the opposite direction or a different ref_id/x/y pane, act on an element already visible, or finish.]',
+      };
+    }
+    return { kind: 'none' };
+  }
+
+  _detectApiShortcut(tabId, loop, buf) {
+    if (loop.type !== 'repeat') return null;
+    if (!['click', 'click_ax'].includes(loop.name)) return null;
+    const apiRequests = globalThis.__webbrainApiRequests?.get(tabId);
+    if (!apiRequests || apiRequests.length === 0) return null;
+
+    const clickTimes = buf.filter(e => e.key === loop.key).map(e => e.ts);
+    if (clickTimes.length < 2) return null;
+
+    const WINDOW_MS = 3000;
+    let candidate = null;
+    let matches = 0;
+    const usedRequestIndexes = new Set();
+    for (const clickTs of clickTimes) {
+      const hitIndex = apiRequests.findIndex((r, idx) =>
+        !usedRequestIndexes.has(idx)
+        && r.ts >= clickTs
+        && r.ts <= clickTs + WINDOW_MS
+        && (!candidate || (r.url === candidate.url && String(r.method || '').toUpperCase() === candidate.method))
+      );
+      if (hitIndex < 0) continue;
+      const hit = apiRequests[hitIndex];
+      if (!hit) continue;
+      if (!candidate) {
+        candidate = {
+          url: hit.url,
+          method: String(hit.method || '').toUpperCase(),
+          replayRequestId: hit.replayRequestId,
+        };
+      }
+      usedRequestIndexes.add(hitIndex);
+      matches++;
+    }
+    if (!candidate || matches < 2) return null;
+    return {
+      url: candidate.url,
+      method: candidate.method,
+      occurrences: matches,
+      replayRequestId: candidate.replayRequestId,
+    };
+  }
+
+  _checkCoordClickLoop(tabId, x, y) {
+    const bx = Math.round(x / 5) * 5;
+    const by = Math.round(y / 5) * 5;
+    const key = `${bx},${by}`;
+    const buf = this.recentCoordClicks.get(tabId) || [];
+    buf.push({ key, ts: Date.now() });
+    if (buf.length > 12) buf.shift();
+    this.recentCoordClicks.set(tabId, buf);
+
+    const counts = new Map();
+    for (const e of buf) counts.set(e.key, (counts.get(e.key) || 0) + 1);
+    const n = counts.get(key) || 0;
+    if (n >= 8) return { kind: 'stop', x: bx, y: by };
+    if (n >= 5) return { kind: 'nudge', x: bx, y: by };
+    return { kind: 'none' };
+  }
+
+  _checkLoop(tabId, toolName, toolArgs, toolResult) {
+    if (toolResult?.pageUrlChanged === true && !this._noteNavArrival(tabId, toolResult.currentUrl)) {
+      this._clearLoopState(tabId);
+    }
+    if (
+      toolName === 'find_text'
+      && toolResult?.success === true
+      && !this._findTextMatchLoopIdentity(toolResult)
+    ) {
+      return this._noteHealthyLoopCall(tabId);
+    }
+    const { buf, key } = this._recordCall(tabId, toolName, toolArgs, toolResult);
+    if (this._isBrowserMutationTool(toolName)) {
+      const normalizeFailureScope = value => String(value).slice(0, 320);
+      const defaultFailureScope = normalizeFailureScope(`${toolName}|${bucketArgsKey(toolName, toolArgs)}`);
+      const failureScope = normalizeFailureScope(toolResult?.failureScope || defaultFailureScope);
+      const equivalentFailureScopes = new Set([failureScope, defaultFailureScope]);
+      if ((toolName === 'set_field' || toolName === 'type_ax') && typeof toolArgs?.ref_id === 'string') {
+        equivalentFailureScopes.add(normalizeFailureScope(`field-value:${toolArgs.ref_id}`));
+      }
+      if (toolName === 'click' && typeof toolArgs?.text === 'string') {
+        equivalentFailureScopes.add(normalizeFailureScope(`ambiguous-click:${toolArgs.text.trim().toLowerCase()}`));
+      }
+      const failures = this.failedActionLoops.get(tabId) || new Map();
+      if (this._isToolResultErroredForLoop(toolName, toolArgs, toolResult)) {
+        const attempts = (failures.get(failureScope) || 0) + 1;
+        failures.set(failureScope, attempts);
+        if (failures.size > 32) failures.delete(failures.keys().next().value);
+        this.failedActionLoops.set(tabId, failures);
+        if (attempts >= 3) {
+          this._clearLoopState(tabId);
+          return {
+            kind: 'stop',
+            message: `Stopped: ${toolName} failed or made no progress three times for the same target. Repeating it or switching to a precomputed fallback cannot make progress without fresh page evidence.`,
+          };
+        }
+        if (attempts === 2) {
+          return {
+            kind: 'nudge',
+            warning: `[FAILED ACTION LOOP: ${toolName} has failed or made no progress twice for the same target. Do not retry it or use a queued fallback. Re-read the page/tree and choose a new action from current evidence.]`,
+          };
+        }
+      } else if (toolResult?.success === true && toolResult?.verified !== false) {
+        for (const scope of equivalentFailureScopes) failures.delete(scope);
+        if (failures.size) this.failedActionLoops.set(tabId, failures);
+        else this.failedActionLoops.delete(tabId);
+      }
+    }
+    if (toolResult?.nonRetryable) {
+      const repeats = buf.filter(entry => entry.key === key).length;
+      if (repeats >= 2) {
+        this._clearLoopState(tabId);
+        return {
+          kind: 'stop',
+          message: toolResult.stopMessage || `Stopped: ${toolName} hit the same non-retryable failure twice. Retrying or switching to an equivalent tool will not make progress.`,
+        };
+      }
+    }
+    if (key.startsWith('checkbox|')) {
+      const repeats = buf.filter(entry => entry.key === key).length;
+      if (repeats >= 3) {
+        this._clearLoopState(tabId);
+        return {
+          kind: 'stop',
+          message: 'Stopped: the same checkbox is still in the wrong checked state after three attempts. Changing tools or arguments does not change that semantic state. Re-read the form or ask the user instead of toggling it again.',
+        };
+      }
+      if (repeats >= 2) {
+        return {
+          kind: 'nudge',
+          warning: '[CHECKBOX STATE UNCHANGED: The same checkbox is still in the wrong checked state. Do not toggle it again and do not evade this by switching tools. Call set_checked(ref_id, desiredState) once; if its trusted selector-backed attempt also fails, re-read the form or ask the user.]',
+        };
+      }
+    }
+    const loop = this._detectLoop(buf, key);
+    if (loop?.type === 'oscillation' && loop.a === 'find_text' && loop.b === 'find_text') {
+      return this._noteHealthyLoopCall(tabId);
+    }
+    if (!loop) {
+      return this._noteHealthyLoopCall(tabId);
+    }
+
+    const method = String(toolArgs?.method || 'GET').toUpperCase();
+    if (
+      loop.type === 'repeat'
+      && URL_FAMILY_TOOLS.has(toolName)
+      && method === 'GET'
+      && this._isToolResultErroredForLoop(toolName, toolArgs, toolResult)
+    ) {
+      this._clearLoopState(tabId);
+      const rangedFetch = toolName === 'fetch_url' && this._fetchUsesHttpByteRange(toolArgs);
+      return {
+        kind: 'stop',
+        message: rangedFetch
+          ? 'Stopped: fetch_url failed three times while probing HTTP byte ranges for the same read-only resource. Use find or semantic offset:nextOffset pagination in a new run, or ask for a partial answer from the evidence already collected.'
+          : `Stopped: ${loop.name} failed three times for the same read-only resource. Repeating it or changing URL variants will not make progress. Please give a different instruction or inspect the page manually.`,
+      };
+    }
+
+    this.healthyCallsSinceLoop.delete(tabId);
+    const nudges = (this.loopNudges.get(tabId) || 0) + 1;
+    this.loopNudges.set(tabId, nudges);
+
+    if (nudges >= 8) {
+      this._clearLoopState(tabId);
+      const desc = loop.type === 'repeat'
+        ? `the same call to ${loop.name}`
+        : `between ${loop.a} and ${loop.b}`;
+      return {
+        kind: 'stop',
+        message: `Stopped: I detected I was looping on ${desc} without making progress after multiple warnings. Please tell me what's blocking, give me a different instruction, or take a look at the page yourself.`,
+      };
+    }
+
+    let warning;
+    if (loop.type === 'repeat') {
+      const shortcut = this._detectApiShortcut(tabId, loop, buf);
+      const rangedFetch = toolName === 'fetch_url'
+        && method === 'GET'
+        && this._fetchUsesHttpByteRange(toolArgs);
+      warning = rangedFetch
+        ? '[LOOP DETECTED: You are repeatedly probing the same resource with HTTP byte ranges. Stop guessing byte offsets or file size. Use fetch_url({url, find:"literal"}) to search the full decoded response, continue semantic text pagination with offset:nextOffset, or answer now with the evidence already collected. Do not send another Range header for this resource.]'
+        : shortcut
+        ? `[LOOP DETECTED + API SHORTCUT FOUND: You've called ${loop.name} ${loop.count} times. Each click triggered the same background request pattern: ${shortcut.method} ${shortcut.url}. Instead of clicking again, consider fetch_url({url: "${shortcut.url}", method: "${shortcut.method}"${shortcut.replayRequestId ? `, replayRequestId: "${shortcut.replayRequestId}"` : ''}}) with the same method; follow the UI/API mutation policy for mutating methods.]`
+        : `[LOOP DETECTED: You've just called ${loop.name} ${loop.count} times with the same arguments and the same outcome. The current approach is NOT working. Try something fundamentally different: a different selector, a different tool, scroll to find a different element, or re-read the page/tree to see what's actually on screen. DO NOT repeat this exact call again — try a creative alternative.]`;
+    } else {
+      warning = `[LOOP DETECTED: You're oscillating between ${loop.a} and ${loop.b} without making progress. Stop. Re-read the page/tree to see what's actually happening, then try a completely different approach.]`;
+    }
+    return { kind: 'nudge', warning };
+  }
+}

--- a/src/firefox/src/agent/loop-detector.js
+++ b/src/firefox/src/agent/loop-detector.js
@@ -3,24 +3,53 @@ import { URL_FAMILY_TOOLS, bucketArgsKey } from './loop-bucket.js';
 /**
  * Browser-free loop detection used by Agent and the unit tests.
  *
- * Subclasses may override _clearPageLoopState() to clear related page-scoped
- * state alongside the detector's own maps.
+ * Catches the agent stuck repeating an ineffective action or oscillating
+ * between two calls. Cheap, runs after every tool execution. On first
+ * detection we soft-nudge by injecting a [LOOP DETECTED] note into the
+ * tool result the model sees. On second detection within the same loop,
+ * we hard-stop the run with a clear final message.
+ *
+ * This module is deliberately browser-free so both extension builds and the
+ * unit suite exercise the same production class. Subclasses supply the
+ * browser-specific pieces: _isBrowserMutationTool() classifies tools, and
+ * _clearPageLoopState() may be extended to clear related page-scoped state
+ * alongside the detector's own maps.
  */
 export class LoopDetector {
-  constructor({ isBrowserMutationTool = () => false } = {}) {
-    this._loopMutationTool = isBrowserMutationTool;
-    this.recentCalls = new Map();
-    this.loopNudges = new Map();
-    this.healthyCallsSinceLoop = new Map();
-    this.failedActionLoops = new Map();
-    this.recentNavUrls = new Map();
-    this.axReadStates = new Map();
-    this.noProgressScrolls = new Map();
-    this.recentCoordClicks = new Map();
+  constructor() {
+    // Per-tab ring buffer of recent tool calls + nudge count.
+    this.recentCalls = new Map(); // tabId -> [{ key, name, ts }]
+    this.loopNudges = new Map();  // tabId -> consecutive-nudge counter
+    this.healthyCallsSinceLoop = new Map(); // tabId -> count of clean calls since last nudge
+    this.failedActionLoops = new Map(); // tabId -> Map(stable failure scope -> count)
+    // Last few normalized URLs each tab arrived at during the active run.
+    // Deliberately NOT cleared by _clearLoopState: it gates those intra-run
+    // resets, so it must survive them until the outer run boundary.
+    this.recentNavUrls = new Map(); // tabId -> [normalized URL, ...]
+    // A model can walk ref_1, ref_2, … forever while every call looks unique
+    // to the exact-argument loop detector. Track that semantic read pattern.
+    this.axReadStates = new Map(); // tabId -> { total, suspicious, nextPage, seenPages, warned }
+    // Scroll calls can keep returning success even when no pane moved. Track
+    // repeated dead-end attempts separately so changing the amount or
+    // interleaving reads cannot evade the generic loop detector.
+    this.noProgressScrolls = new Map(); // tabId -> { key, count }
+    // Separate buffer for coordinate-based click attempts. The general loop
+    // detector keys on JSON.stringify(args), so when the model interleaves
+    // execute_js with different code strings between clicks, the same
+    // (x,y) click never accumulates to the threshold inside its window.
+    // This buffer tracks ONLY coord clicks and survives any amount of
+    // unrelated noise between them, catching the "click missing its target,
+    // model retries forever" failure mode in 2-3 attempts instead of never.
+    this.recentCoordClicks = new Map(); // tabId -> [{ key, ts }]
   }
 
-  _isBrowserMutationTool(toolName) {
-    return this._loopMutationTool(toolName);
+  /**
+   * Whether `toolName` mutates browser/page state, which gates the stricter
+   * failed-action loop counters. Browser-neutral by default; each Agent build
+   * overrides it with that build's real tool surface.
+   */
+  _isBrowserMutationTool(_toolName) {
+    return false;
   }
 
   _isToolResultErroredForLoop(name, _args, result) {
@@ -84,6 +113,9 @@ export class LoopDetector {
 
   _loopCallKey(name, args, result) {
     if (result?.nonRetryableScope) {
+      // Definitive platform/permission failures keep one identity across
+      // tools and URL variants, so changing fetch strategies cannot evade
+      // the stop condition.
       return `nonretryable|${String(result.nonRetryableScope).slice(0, 240)}|err`;
     }
     const checkboxState = result?.checkboxState;
@@ -103,6 +135,9 @@ export class LoopDetector {
         return `checkbox|${identity}|desired:${checkboxState.desiredChecked}|actual:${checkboxState.actualChecked}`;
       }
     }
+    // URL-family tools (fetch_url, research_url, …) bucket by resource
+    // identity so the agent can't escape loop detection by fetching the
+    // same logical file via 8 different API endpoints. See loop-bucket.js.
     const errored = this._isToolResultErroredForLoop(name, args, result);
     const argsHash = bucketArgsKey(name, args);
     if (name === 'find_text' && !errored) {
@@ -123,6 +158,7 @@ export class LoopDetector {
 
   _detectLoop(buf, activeKey = null) {
     if (!buf || buf.length < 3) return null;
+    // 1. Same key 3+ times in the window.
     const counts = new Map();
     for (const e of buf) counts.set(e.key, (counts.get(e.key) || 0) + 1);
     for (const [key, n] of counts) {
@@ -130,6 +166,7 @@ export class LoopDetector {
         return { type: 'repeat', key, name: key.split('|')[0], count: n };
       }
     }
+    // 2. ABAB oscillation in the last 4.
     if (buf.length >= 4) {
       const last4 = buf.slice(-4);
       if (
@@ -143,6 +180,12 @@ export class LoopDetector {
     return null;
   }
 
+  /**
+   * Clear the state that is only meaningful for the page currently loaded in
+   * `tabId` — ref ids, coordinates, scroll surfaces, and per-target failure
+   * counters all stop describing reality once the page is replaced. Subclasses
+   * extend this (via super) to drop their own page-scoped state alongside it.
+   */
   _clearPageLoopState(tabId) {
     this.failedActionLoops.delete(tabId);
     this.axReadStates.delete(tabId);
@@ -150,6 +193,11 @@ export class LoopDetector {
     this.recentCoordClicks.delete(tabId);
   }
 
+  /**
+   * Clear everything the detector accumulated for `tabId` except the nav
+   * arrival history, which must outlive intra-run resets so navigation
+   * ping-pong is still catchable. See _clearRunLoopState for the run boundary.
+   */
   _clearLoopState(tabId) {
     this.recentCalls.delete(tabId);
     this.loopNudges.delete(tabId);
@@ -157,11 +205,20 @@ export class LoopDetector {
     this._clearPageLoopState(tabId);
   }
 
+  /**
+   * Run-boundary reset. Only here is the nav arrival history discarded, since
+   * a new run may legitimately revisit URLs the previous run already saw.
+   */
   _clearRunLoopState(tabId) {
     this.recentNavUrls.delete(tabId);
     this._clearLoopState(tabId);
   }
 
+  /**
+   * Normalize URLs for navigation-change checks. Keep query and hash so
+   * history entries that differ only by search params or anchors still count as
+   * successful back/forward movement.
+   */
   _normalizeUrl(url) {
     if (!url) return '';
     try {
@@ -170,6 +227,12 @@ export class LoopDetector {
     } catch (e) { return url; }
   }
 
+  /**
+   * Record that `tabId` arrived at `url` and report whether that URL was
+   * already seen in the last few arrivals. A first visit is page-state
+   * progress and justifies resetting loop counters; a quick revisit is the
+   * signature of a navigation loop and must leave them intact.
+   */
   _noteNavArrival(tabId, url) {
     const normalized = this._normalizeUrl(url);
     if (!normalized) return false;
@@ -221,6 +284,9 @@ export class LoopDetector {
     state.seenPages.add(page);
     this.axReadStates.set(tabId, state);
 
+    // A root read followed by the exact returned nextPage can legitimately span
+    // large applications. Keep the consecutive-read cap for every other AX
+    // pattern, but do not stop a valid sequential pagination step.
     if (state.suspicious >= 6 || (state.total >= 12 && (state.suspicious > 0 || !sequentialPage))) {
       this.axReadStates.delete(tabId);
       return {
@@ -249,6 +315,10 @@ export class LoopDetector {
       return `${direction}|xy:${Math.round(x)},${Math.round(y)}`;
     }
 
+    // For implicit scrolling, distinguish panes using the element that
+    // supplied the runtime's last-interaction origin. This avoids combining
+    // no-movement results from two different panes while deliberately
+    // ignoring `amount`, which is not a meaningful recovery at a hard edge.
     const origin = result?.originElement;
     if (origin && typeof origin === 'object') {
       const rect = origin.rect || {};
@@ -259,7 +329,13 @@ export class LoopDetector {
   }
 
   _checkNoProgressScroll(tabId, name, args, result) {
+    // Preserve a dead-scroll streak across reads or other unrelated calls;
+    // only a successful scroll or a different scroll target/direction proves
+    // that this particular recovery path changed.
     if (name !== 'scroll') {
+      // Accessibility refs and coordinate targets are document-scoped. A
+      // successful navigation can reuse the same ref_id/coordinates for a
+      // completely different page, so it must break the old scroll streak.
       if (result?.pageUrlChanged === true) this.noProgressScrolls.delete(tabId);
       return { kind: 'none' };
     }
@@ -289,6 +365,17 @@ export class LoopDetector {
     return { kind: 'none' };
   }
 
+  /**
+   * Issue #189 — mutation API observer shortcutter. When _checkLoop flags a
+   * repeated click (e.g. "Next Page" clicked 3x), check whether each click
+   * fired the same background XHR/fetch (captured by the webRequest
+   * listener in background.js). If so, surface the URL/method so the model
+   * can call fetch_url directly instead of clicking again.
+   *
+   * Strict matching only: same tab, exact url+method repeated, and request
+   * must land within WINDOW_MS after the click that triggered it. No fuzzy
+   * param-pattern matching.
+   */
   _detectApiShortcut(tabId, loop, buf) {
     if (loop.type !== 'repeat') return null;
     if (!['click', 'click_ax'].includes(loop.name)) return null;
@@ -331,6 +418,15 @@ export class LoopDetector {
     };
   }
 
+  /**
+   * Coordinate-click loop detector. Buckets to nearest 5px so a click that
+   * drifts by a pixel or two between attempts still hashes the same. Window
+   * of 8 — generous, since the goal is to survive interleaved noise like
+   * execute_js / type_text / read_page calls between coord retries.
+   *
+   * Returns 'nudge' on the 3rd repeat and 'stop' on the 5th. Gives the
+   * agent more room to retry on pages with loading states or animations.
+   */
   _checkCoordClickLoop(tabId, x, y) {
     const bx = Math.round(x / 5) * 5;
     const by = Math.round(y / 5) * 5;
@@ -348,7 +444,18 @@ export class LoopDetector {
     return { kind: 'none' };
   }
 
+  /**
+   * Run loop detection on a freshly recorded call. Returns one of:
+   *   { kind: 'none' }
+   *   { kind: 'nudge', warning: string }   // soft warning to inject into tool result
+   *   { kind: 'stop',  message: string }   // hard stop, abort the run
+   */
   _checkLoop(tabId, toolName, toolArgs, toolResult) {
+    // A navigation result is authoritative page-state evidence. Clear before
+    // recording this call so same-looking controls on the new page start at
+    // attempt one instead of inheriting an old third-strike counter. Arriving
+    // back on a recently seen URL is the exception: a click/go_back ping-pong
+    // would otherwise reset the detector on every hop and never be caught.
     if (toolResult?.pageUrlChanged === true && !this._noteNavArrival(tabId, toolResult.currentUrl)) {
       this._clearLoopState(tabId);
     }
@@ -357,6 +464,10 @@ export class LoopDetector {
       && toolResult?.success === true
       && !this._findTextMatchLoopIdentity(toolResult)
     ) {
+      // A cross-origin frame match can be selected by window.find while its
+      // range is unavailable to the top document. Successful same-query calls
+      // intentionally advance to the next match, so an unlocated match is not
+      // safe evidence of a repeat loop.
       return this._noteHealthyLoopCall(tabId);
     }
     const { buf, key } = this._recordCall(tabId, toolName, toolArgs, toolResult);
@@ -424,6 +535,7 @@ export class LoopDetector {
     }
     const loop = this._detectLoop(buf, key);
     if (loop?.type === 'oscillation' && loop.a === 'find_text' && loop.b === 'find_text') {
+      // Alternating match positions is normal when a finite page search wraps.
       return this._noteHealthyLoopCall(tabId);
     }
     if (!loop) {
@@ -447,6 +559,7 @@ export class LoopDetector {
       };
     }
 
+    // Any new loop detection resets the healthy-streak counter.
     this.healthyCallsSinceLoop.delete(tabId);
     const nudges = (this.loopNudges.get(tabId) || 0) + 1;
     this.loopNudges.set(tabId, nudges);

--- a/src/firefox/src/agent/mutation-tools.js
+++ b/src/firefox/src/agent/mutation-tools.js
@@ -1,0 +1,26 @@
+/**
+ * The Firefox build's mutating-tool surface, in a browser-free module so the
+ * Agent and the unit suite classify tools from one list instead of two.
+ *
+ * This file is deliberately NOT mirrored byte-for-byte with the Chrome copy:
+ * the two builds ship different tool sets, and that difference is exactly what
+ * the loop detector must see. Keep the shared, browser-neutral detection logic
+ * in loop-detector.js, which IS byte-identical across builds.
+ */
+
+/** Tools that change page or browser state, gating auto-screenshots and
+ *  unknown-outcome normalization as well as loop detection. */
+export const STATE_CHANGE_TOOLS = new Set(['navigate', 'new_tab', 'go_back', 'go_forward', 'click', 'click_ax', 'set_checked', 'type_text', 'type_ax', 'set_field', 'press_keys', 'scroll', 'hover', 'drag_drop', 'execute_js']);
+
+/**
+ * Everything the failed-action loop counters treat as a browser mutation.
+ * Adds the frame- and upload-scoped tools that act on the page but are not
+ * part of the auto-screenshot state-change set.
+ */
+export const BROWSER_MUTATION_TOOLS = new Set([
+  ...STATE_CHANGE_TOOLS,
+  'iframe_click',
+  'iframe_type',
+  'upload_file',
+  'solve_captcha',
+]);

--- a/test/run.js
+++ b/test/run.js
@@ -434,18 +434,21 @@ const { LoopDetector: LoopDetectorCh } = await import(
 const { LoopDetector: LoopDetectorFx } = await import(
   'file://' + path.join(ROOT, 'src/firefox/src/agent/loop-detector.js').replace(/\\/g, '/')
 );
-const LOOP_MUTATION_TOOLS_TEST = new Set([
-  'navigate', 'new_tab', 'go_back', 'go_forward', 'click', 'click_ax',
-  'set_checked', 'type_text', 'type_ax', 'set_field', 'press_keys', 'scroll',
-  'hover', 'drag_drop', 'execute_js', 'iframe_click', 'iframe_type',
-  'upload_file', 'solve_captcha',
-]);
+// The mutating-tool surface differs per build, so it lives outside the
+// byte-identical loop-detector module. Import the real sets rather than
+// restating them here — a hand-copied list is exactly the drift this suite
+// exists to prevent.
+const { BROWSER_MUTATION_TOOLS: MUTATION_TOOLS_CH, STATE_CHANGE_TOOLS: STATE_CHANGE_TOOLS_CH } = await import(
+  'file://' + path.join(ROOT, 'src/chrome/src/agent/mutation-tools.js').replace(/\\/g, '/')
+);
+const { BROWSER_MUTATION_TOOLS: MUTATION_TOOLS_FX, STATE_CHANGE_TOOLS: STATE_CHANGE_TOOLS_FX } = await import(
+  'file://' + path.join(ROOT, 'src/firefox/src/agent/mutation-tools.js').replace(/\\/g, '/')
+);
+// The standalone detector is exercised against Chrome's tool surface, which is
+// the superset of the two builds.
 class ConfiguredLoopDetector extends LoopDetectorCh {
-  constructor(options = {}) {
-    super({
-      isBrowserMutationTool: name => LOOP_MUTATION_TOOLS_TEST.has(name),
-      ...options,
-    });
+  _isBrowserMutationTool(toolName) {
+    return MUTATION_TOOLS_CH.has(toolName);
   }
 }
 const {
@@ -4102,12 +4105,20 @@ test('no-progress scroll is pane-, direction-, tab-, and run-scoped', () => {
 });
 
 test('no-progress scroll enforcement is wired into both agent loops', () => {
-  for (const browserName of ['chrome', 'firefox']) {
+  for (const [browserName, AgentClass] of [['chrome', AgentCh], ['firefox', AgentFx]]) {
     const source = fs.readFileSync(path.join(ROOT, `src/${browserName}/src/agent/agent.js`), 'utf8');
     assert.match(source, /const scrollCheck = this\._checkNoProgressScroll\(tabId, fnName, fnArgs, toolResult\)/, `${browserName}: evaluate each result`);
     assert.match(source, /scrollCheck\.kind === 'stop'/, `${browserName}: stop result must win`);
     assert.match(source, /scrollCheck\.kind === 'nudge'/, `${browserName}: warning must reach the model`);
-    assert.match(source, /this\.noProgressScrolls\.delete\(tabId\)/, `${browserName}: run cleanup must clear state`);
+    // Assert the cleanup behaviorally rather than by grepping agent.js: the
+    // detector state lives in loop-detector.js, so a source match would only
+    // prove where the line is written, not that run cleanup reaches it.
+    const agent = new AgentClass({});
+    const tab = `${browserName}-dead-scroll`;
+    assert.equal(agent._checkNoProgressScroll(tab, 'scroll', { direction: 'down' }, { moved: false }).kind, 'none');
+    assert.equal(agent.noProgressScrolls.has(tab), true, `${browserName}: streak must be tracked`);
+    agent._clearRunLoopState(tab);
+    assert.equal(agent.noProgressScrolls.has(tab), false, `${browserName}: run cleanup must clear state`);
   }
 });
 
@@ -4641,6 +4652,58 @@ test('LoopDetector is production code shared by both browser agents', () => {
     fs.readFileSync(path.join(ROOT, 'src/firefox/src/agent/loop-detector.js'), 'utf8'),
     'chrome and firefox LoopDetector copies must remain byte-identical',
   );
+  // The base class must stay browser-neutral: without a build's tool list it
+  // classifies nothing as a mutation, so an Agent that forgets to override
+  // this fails loudly here instead of silently skipping failed-action loops.
+  assert.equal(LoopDetectorCh.prototype._isBrowserMutationTool.call({}, 'click'), false);
+});
+
+test('loop detection classifies mutating tools from each build tool list, not a test copy', () => {
+  const builds = [
+    ['chrome', AgentCh, MUTATION_TOOLS_CH, STATE_CHANGE_TOOLS_CH],
+    ['firefox', AgentFx, MUTATION_TOOLS_FX, STATE_CHANGE_TOOLS_FX],
+  ];
+  for (const [label, AgentClass, mutationTools, stateChangeTools] of builds) {
+    const agent = new AgentClass({});
+    assert.equal(
+      AgentClass.STATE_CHANGE_TOOLS,
+      stateChangeTools,
+      `${label}: Agent.STATE_CHANGE_TOOLS must be the shared mutation-tools set`,
+    );
+    for (const name of mutationTools) {
+      assert.equal(agent._isBrowserMutationTool(name), true, `${label}: ${name} must count as a mutation`);
+    }
+    for (const name of ['read_page', 'extract_data', 'get_accessibility_tree', 'fetch_url', 'find_text', 'done']) {
+      assert.equal(agent._isBrowserMutationTool(name), false, `${label}: ${name} must not count as a mutation`);
+    }
+    // The frame/upload tools act on the page but are not auto-screenshot
+    // state changes, so the two sets must not be collapsed into one.
+    for (const name of ['iframe_click', 'iframe_type', 'upload_file', 'solve_captcha']) {
+      assert.equal(stateChangeTools.has(name), false, `${label}: ${name} must stay out of STATE_CHANGE_TOOLS`);
+      assert.equal(mutationTools.has(name), true, `${label}: ${name} must be a browser mutation`);
+    }
+  }
+  // The standalone detector used by this suite must track Chrome exactly.
+  const standalone = new ConfiguredLoopDetector();
+  for (const name of MUTATION_TOOLS_CH) {
+    assert.equal(standalone._isBrowserMutationTool(name), true, `standalone detector missing ${name}`);
+  }
+  // Chrome-only mutating tools must reach the failed-action counters.
+  for (const name of ['execute_webmcp_tool', 'patch_element', 'highlight_element']) {
+    assert.equal(MUTATION_TOOLS_CH.has(name), true, `chrome must treat ${name} as a mutation`);
+    assert.equal(MUTATION_TOOLS_FX.has(name), false, `firefox does not ship ${name}`);
+  }
+});
+
+test('chrome-only mutating tools reach the failed-action loop counters', () => {
+  const failure = { success: false, error: 'no matching element' };
+  for (const toolName of ['execute_webmcp_tool', 'patch_element', 'highlight_element']) {
+    const agent = new AgentCh({});
+    const tab = `chrome-only-${toolName}`;
+    assert.equal(agent._checkLoop(tab, toolName, { ref_id: 'ref_4' }, failure).kind, 'none');
+    assert.equal(agent._checkLoop(tab, toolName, { ref_id: 'ref_4' }, failure).kind, 'nudge');
+    assert.equal(agent._checkLoop(tab, toolName, { ref_id: 'ref_4' }, failure).kind, 'stop');
+  }
 });
 
 test('_detectBulkApiMutationShortcut: detects repeated same-action clicks with different refs', () => {

--- a/test/run.js
+++ b/test/run.js
@@ -420,14 +420,34 @@ const {
   'file://' + path.join(ROOT, 'src/chrome/src/agent/permission-gate.js').replace(/\\/g, '/')
 );
 
-// loop-bucket.js is pure JS — the URL-family loop-detector bucketing logic
-// lives here so both agent.js and the tests can exercise the same code.
+// Browser-free loop detection and its URL-family bucketing are imported from
+// the same production modules used by both Agent builds.
 const { resourceBucket, bucketArgsKey, URL_FAMILY_TOOLS } = await import(
   'file://' + path.join(ROOT, 'src/chrome/src/agent/loop-bucket.js').replace(/\\/g, '/')
 );
 const { resourceBucket: resourceBucketFx, bucketArgsKey: bucketArgsKeyFx } = await import(
   'file://' + path.join(ROOT, 'src/firefox/src/agent/loop-bucket.js').replace(/\\/g, '/')
 );
+const { LoopDetector: LoopDetectorCh } = await import(
+  'file://' + path.join(ROOT, 'src/chrome/src/agent/loop-detector.js').replace(/\\/g, '/')
+);
+const { LoopDetector: LoopDetectorFx } = await import(
+  'file://' + path.join(ROOT, 'src/firefox/src/agent/loop-detector.js').replace(/\\/g, '/')
+);
+const LOOP_MUTATION_TOOLS_TEST = new Set([
+  'navigate', 'new_tab', 'go_back', 'go_forward', 'click', 'click_ax',
+  'set_checked', 'type_text', 'type_ax', 'set_field', 'press_keys', 'scroll',
+  'hover', 'drag_drop', 'execute_js', 'iframe_click', 'iframe_type',
+  'upload_file', 'solve_captcha',
+]);
+class ConfiguredLoopDetector extends LoopDetectorCh {
+  constructor(options = {}) {
+    super({
+      isBrowserMutationTool: name => LOOP_MUTATION_TOOLS_TEST.has(name),
+      ...options,
+    });
+  }
+}
 const {
   detectProgressAction,
   isValidLedgerStatus,
@@ -806,382 +826,6 @@ const {
 } = await import(
   'file://' + path.join(ROOT, 'src/firefox/src/agent/sheets-tools.js').replace(/\\/g, '/')
 );
-
-// agent.js imports tools.js and cdp-client.js (which uses chrome.*). We need
-// only the loop-detection helpers, so we extract them via a tiny standalone
-// shim that mirrors the relevant Agent methods. Keep this in sync with
-// agent.js _loopCallKey / _recordCall / _detectLoop / _checkLoop / _detectApiShortcut.
-const STATE_CHANGE_TOOLS_TEST = new Set([
-  'navigate', 'new_tab', 'go_back', 'go_forward', 'click', 'click_ax',
-  'type_text', 'type_ax', 'set_field', 'press_keys', 'scroll', 'hover',
-  'drag_drop', 'execute_js',
-]);
-
-class LoopDetectorShim {
-  constructor() {
-    this.recentCalls = new Map();
-    this.loopNudges = new Map();
-    this.healthyCallsSinceLoop = new Map();
-    this.failedActionLoops = new Map();
-    this.recentCoordClicks = new Map();
-    this.axReadStates = new Map();
-    this.noProgressScrolls = new Map();
-    this.recentNavUrls = new Map();
-  }
-  _normalizeUrl(url) {
-    if (!url) return '';
-    try {
-      const u = new URL(url);
-      return u.origin + u.pathname + u.search + u.hash;
-    } catch { return url; }
-  }
-  _noteNavArrival(tabId, url) {
-    const normalized = this._normalizeUrl(url);
-    if (!normalized) return false;
-    const seen = this.recentNavUrls.get(tabId) || [];
-    const revisited = seen.includes(normalized);
-    seen.push(normalized);
-    if (seen.length > 5) seen.shift();
-    this.recentNavUrls.set(tabId, seen);
-    return revisited;
-  }
-  _checkCoordClickLoop(tabId, x, y) {
-    const bx = Math.round(x / 5) * 5;
-    const by = Math.round(y / 5) * 5;
-    const key = `${bx},${by}`;
-    const buf = this.recentCoordClicks.get(tabId) || [];
-    buf.push({ key, ts: Date.now() });
-    if (buf.length > 12) buf.shift();
-    this.recentCoordClicks.set(tabId, buf);
-    const counts = new Map();
-    for (const e of buf) counts.set(e.key, (counts.get(e.key) || 0) + 1);
-    const n = counts.get(key) || 0;
-    if (n >= 8) return { kind: 'stop', x: bx, y: by };
-    if (n >= 5) return { kind: 'nudge', x: bx, y: by };
-    return { kind: 'none' };
-  }
-  _isToolResultErroredForLoop(name, _args, result) {
-    if (!result || typeof result !== 'object') return false;
-    if (result.error || result.success === false || result.noProgress) return true;
-    const status = Number(result.status);
-    return URL_FAMILY_TOOLS.has(name) && Number.isFinite(status) && status >= 400;
-  }
-  _fetchUsesHttpByteRange(args) {
-    if (!args?.headers || typeof args.headers !== 'object') return false;
-    for (const [name, value] of Object.entries(args.headers)) {
-      if (String(name).toLowerCase() === 'range' && /^\s*bytes\s*=/i.test(String(value || ''))) {
-        return true;
-      }
-    }
-    return false;
-  }
-  _findTextMatchLoopIdentity(result) {
-    if (result?.success !== true || result?.verified === false || !result?.rect || typeof result.rect !== 'object') return '';
-    const rect = result.rect;
-    const pageX = typeof rect.pageX === 'number' ? rect.pageX : NaN;
-    const pageY = typeof rect.pageY === 'number' ? rect.pageY : NaN;
-    const viewportX = typeof rect.x === 'number' ? rect.x : NaN;
-    const viewportY = typeof rect.y === 'number' ? rect.y : NaN;
-    const width = typeof rect.width === 'number' ? rect.width : NaN;
-    const height = typeof rect.height === 'number' ? rect.height : NaN;
-    const x = Number.isFinite(pageX) ? pageX : viewportX;
-    const y = Number.isFinite(pageY) ? pageY : viewportY;
-    if (![x, y, width, height].every(Number.isFinite) || width <= 0 || height <= 0) return '';
-    let selectionIdentity = 'document';
-    if (result.selectionSource === 'text_control') {
-      const selectionStart = result.selectionStart;
-      const selectionEnd = result.selectionEnd;
-      if (
-        !Number.isInteger(selectionStart)
-        || !Number.isInteger(selectionEnd)
-        || selectionStart < 0
-        || selectionEnd <= selectionStart
-      ) return '';
-      selectionIdentity = `text_control:${selectionStart}:${selectionEnd}`;
-    }
-    const rectIdentity = [x, y, width, height]
-      .map(value => Math.round(value * 2) / 2)
-      .join(',');
-    return `${selectionIdentity}|${rectIdentity}`;
-  }
-  _noteHealthyLoopCall(tabId) {
-    const healthy = (this.healthyCallsSinceLoop.get(tabId) || 0) + 1;
-    this.healthyCallsSinceLoop.set(tabId, healthy);
-    if (healthy >= 2) {
-      this.loopNudges.delete(tabId);
-      this.healthyCallsSinceLoop.delete(tabId);
-    }
-    return { kind: 'none' };
-  }
-  _loopCallKey(name, args, result) {
-    if (result?.nonRetryableScope) {
-      return `nonretryable|${String(result.nonRetryableScope).slice(0, 240)}|err`;
-    }
-    const checkboxState = result?.checkboxState;
-    if (
-      checkboxState
-      && typeof checkboxState.desiredChecked === 'boolean'
-      && typeof checkboxState.actualChecked === 'boolean'
-      && checkboxState.desiredChecked !== checkboxState.actualChecked
-    ) {
-      const identity = String(
-        checkboxState.identity
-        || result.checkboxIdentity
-        || result.ref_id
-        || '',
-      ).trim().slice(0, 240);
-      if (identity) {
-        return `checkbox|${identity}|desired:${checkboxState.desiredChecked}|actual:${checkboxState.actualChecked}`;
-      }
-    }
-    // Mirror agent.js: URL-family tools bucket by resource identity so
-    // the agent can't escape loop detection by fetching the same file
-    // via 8 different API endpoints. Falls back to exact JSON for other
-    // tools.
-    const argsHash = bucketArgsKey(name, args);
-    const errored = this._isToolResultErroredForLoop(name, args, result);
-    if (name === 'find_text' && !errored) {
-      const matchIdentity = this._findTextMatchLoopIdentity(result);
-      if (matchIdentity) return `${name}|${argsHash}|match:${matchIdentity}`;
-    }
-    return `${name}|${argsHash}|${errored ? 'err' : 'ok'}`;
-  }
-  _recordCall(tabId, name, args, result) {
-    const key = this._loopCallKey(name, args, result);
-    const buf = this.recentCalls.get(tabId) || [];
-    buf.push({ key, name, ts: Date.now() });
-    if (buf.length > 6) buf.shift();
-    this.recentCalls.set(tabId, buf);
-    return { buf, key };
-  }
-  _detectLoop(buf, activeKey = null) {
-    if (!buf || buf.length < 3) return null;
-    const counts = new Map();
-    for (const e of buf) counts.set(e.key, (counts.get(e.key) || 0) + 1);
-    for (const [key, n] of counts) {
-      if (n >= 3 && (!activeKey || key === activeKey)) return { type: 'repeat', key, name: key.split('|')[0], count: n };
-    }
-    if (buf.length >= 4) {
-      const last4 = buf.slice(-4);
-      if (
-        last4[0].key === last4[2].key &&
-        last4[1].key === last4[3].key &&
-        last4[0].key !== last4[1].key
-      ) {
-        return { type: 'oscillation', a: last4[0].name, b: last4[1].name };
-      }
-    }
-    return null;
-  }
-  _checkLoop(tabId, name, args, result) {
-    if (result?.pageUrlChanged === true && !this._noteNavArrival(tabId, result.currentUrl)) {
-      this.recentCalls.delete(tabId);
-      this.loopNudges.delete(tabId);
-      this.healthyCallsSinceLoop.delete(tabId);
-      this.failedActionLoops.delete(tabId);
-      this.recentCoordClicks.delete(tabId);
-      this.axReadStates.delete(tabId);
-      this.noProgressScrolls.delete(tabId);
-    }
-    if (
-      name === 'find_text'
-      && result?.success === true
-      && !this._findTextMatchLoopIdentity(result)
-    ) {
-      return this._noteHealthyLoopCall(tabId);
-    }
-    const { buf, key } = this._recordCall(tabId, name, args, result);
-    if (STATE_CHANGE_TOOLS_TEST.has(name)) {
-      const normalizeFailureScope = value => String(value).slice(0, 320);
-      const defaultFailureScope = normalizeFailureScope(`${name}|${bucketArgsKey(name, args)}`);
-      const failureScope = normalizeFailureScope(result?.failureScope || defaultFailureScope);
-      const equivalentFailureScopes = new Set([failureScope, defaultFailureScope]);
-      if ((name === 'set_field' || name === 'type_ax') && typeof args?.ref_id === 'string') {
-        equivalentFailureScopes.add(normalizeFailureScope(`field-value:${args.ref_id}`));
-      }
-      if (name === 'click' && typeof args?.text === 'string') {
-        equivalentFailureScopes.add(normalizeFailureScope(`ambiguous-click:${args.text.trim().toLowerCase()}`));
-      }
-      const failures = this.failedActionLoops.get(tabId) || new Map();
-      if (this._isToolResultErroredForLoop(name, args, result)) {
-        const attempts = (failures.get(failureScope) || 0) + 1;
-        failures.set(failureScope, attempts);
-        this.failedActionLoops.set(tabId, failures);
-        if (attempts >= 3) {
-          this.failedActionLoops.delete(tabId);
-          return { kind: 'stop' };
-        }
-        if (attempts === 2) return { kind: 'nudge', warning: '[FAILED ACTION LOOP]' };
-      } else if (result?.success === true && result?.verified !== false) {
-        for (const scope of equivalentFailureScopes) failures.delete(scope);
-        if (failures.size) this.failedActionLoops.set(tabId, failures);
-        else this.failedActionLoops.delete(tabId);
-      }
-    }
-    if (result?.nonRetryable) {
-      const repeats = buf.filter(entry => entry.key === key).length;
-      if (repeats >= 2) return { kind: 'stop' };
-    }
-    if (key.startsWith('checkbox|')) {
-      const repeats = buf.filter(entry => entry.key === key).length;
-      if (repeats >= 3) return { kind: 'stop' };
-      if (repeats >= 2) return { kind: 'nudge' };
-    }
-    const loop = this._detectLoop(buf, key);
-    if (loop?.type === 'oscillation' && loop.a === 'find_text' && loop.b === 'find_text') {
-      return this._noteHealthyLoopCall(tabId);
-    }
-    if (!loop) {
-      return this._noteHealthyLoopCall(tabId);
-    }
-    const method = String(args?.method || 'GET').toUpperCase();
-    if (
-      loop.type === 'repeat' &&
-      URL_FAMILY_TOOLS.has(name) &&
-      method === 'GET' &&
-      this._isToolResultErroredForLoop(name, args, result)
-    ) {
-      const rangedFetch = name === 'fetch_url' && this._fetchUsesHttpByteRange(args);
-      return {
-        kind: 'stop',
-        message: rangedFetch
-          ? 'Stopped: fetch_url failed three times while probing HTTP byte ranges. Use find, offset:nextOffset, or a partial answer.'
-          : `Stopped: ${name} failed three times for the same read-only resource.`,
-      };
-    }
-    this.healthyCallsSinceLoop.delete(tabId);
-    const nudges = (this.loopNudges.get(tabId) || 0) + 1;
-    this.loopNudges.set(tabId, nudges);
-    if (nudges >= 8) {
-      return { kind: 'stop' };
-    }
-    const rangedFetch = loop.type === 'repeat'
-      && name === 'fetch_url'
-      && method === 'GET'
-      && this._fetchUsesHttpByteRange(args);
-    return {
-      kind: 'nudge',
-      warning: rangedFetch
-        ? '[LOOP DETECTED: Use fetch_url find or offset:nextOffset; do not send another Range header.]'
-        : '[LOOP DETECTED]',
-    };
-  }
-  _checkAccessibilityReadLoop(tabId, name, args, result) {
-    if (name !== 'get_accessibility_tree') {
-      this.axReadStates.delete(tabId);
-      return { kind: 'none' };
-    }
-    const previous = this.axReadStates.get(tabId) || {
-      total: 0, suspicious: 0, nextPage: null, seenPages: new Set(), warned: false,
-    };
-    const page = Number(args?.page || 1);
-    const hasRef = typeof args?.ref_id === 'string' && args.ref_id.trim() !== '';
-    const sequentialPage = !hasRef
-      && previous.total > 0
-      && Number.isFinite(previous.nextPage)
-      && page === previous.nextPage
-      && !previous.seenPages.has(page);
-    const repeatedRootOrPage = !hasRef && previous.total > 0 && !sequentialPage;
-    const content = String(result?.pageContent || '').trim();
-    const meaningfulLines = content ? content.split(/\r?\n/).filter(line => line.trim()).length : 0;
-    const suspicious = hasRef || repeatedRootOrPage || (hasRef && meaningfulLines <= 1);
-    const state = {
-      total: previous.total + 1,
-      suspicious: previous.suspicious + (suspicious ? 1 : 0),
-      nextPage: Number.isFinite(Number(result?.nextPage)) ? Number(result.nextPage) : null,
-      seenPages: new Set(previous.seenPages),
-      warned: previous.warned,
-    };
-    state.seenPages.add(page);
-    this.axReadStates.set(tabId, state);
-    if (state.suspicious >= 6 || (state.total >= 12 && (state.suspicious > 0 || !sequentialPage))) {
-      this.axReadStates.delete(tabId);
-      return { kind: 'stop' };
-    }
-    if (!state.warned && state.suspicious >= 3) {
-      state.warned = true;
-      return { kind: 'nudge' };
-    }
-    return { kind: 'none' };
-  }
-  _noProgressScrollKey(args = {}, result = {}) {
-    const direction = String(args?.direction || '').trim().toLowerCase() || 'unspecified';
-    const refId = String(args?.ref_id || '').trim();
-    if (refId) return `${direction}|ref:${refId}`;
-    const x = Number(args?.x);
-    const y = Number(args?.y);
-    if (args?.x != null && args?.y != null && Number.isFinite(x) && Number.isFinite(y)) {
-      return `${direction}|xy:${Math.round(x)},${Math.round(y)}`;
-    }
-    const origin = result?.originElement;
-    if (origin && typeof origin === 'object') {
-      const rect = origin.rect || {};
-      const text = String(origin.text || '').trim().replace(/\s+/g, ' ').slice(0, 80);
-      return `${direction}|origin:${String(result?.origin || '')}:${String(origin.tag || '')}:${String(origin.role || '')}:${Math.round(Number(rect.x) || 0)},${Math.round(Number(rect.y) || 0)},${Math.round(Number(rect.w) || 0)},${Math.round(Number(rect.h) || 0)}:${text}`;
-    }
-    return `${direction}|auto`;
-  }
-  _checkNoProgressScroll(tabId, name, args, result) {
-    if (name !== 'scroll') {
-      if (result?.pageUrlChanged === true) this.noProgressScrolls.delete(tabId);
-      return { kind: 'none' };
-    }
-    if (result?.moved !== false) {
-      this.noProgressScrolls.delete(tabId);
-      return { kind: 'none' };
-    }
-    const key = this._noProgressScrollKey(args, result);
-    const previous = this.noProgressScrolls.get(tabId);
-    const count = previous?.key === key ? previous.count + 1 : 1;
-    this.noProgressScrolls.set(tabId, { key, count });
-    if (count >= 3) {
-      this.noProgressScrolls.delete(tabId);
-      return { kind: 'stop' };
-    }
-    if (count >= 2) return { kind: 'nudge' };
-    return { kind: 'none' };
-  }
-  _detectApiShortcut(tabId, loop, buf) {
-    if (loop.type !== 'repeat') return null;
-    if (!['click', 'click_ax'].includes(loop.name)) return null;
-    const apiRequests = globalThis.__webbrainApiRequests?.get(tabId);
-    if (!apiRequests || apiRequests.length === 0) return null;
-
-    const clickTimes = buf.filter(e => e.key === loop.key).map(e => e.ts);
-    if (clickTimes.length < 2) return null;
-
-    const WINDOW_MS = 3000;
-    let candidate = null;
-    let matches = 0;
-    const usedRequestIndexes = new Set();
-    for (const clickTs of clickTimes) {
-      const hitIndex = apiRequests.findIndex((r, idx) =>
-        !usedRequestIndexes.has(idx) &&
-        r.ts >= clickTs && r.ts <= clickTs + WINDOW_MS &&
-        (!candidate || (r.url === candidate.url && String(r.method || '').toUpperCase() === candidate.method))
-      );
-      if (hitIndex < 0) continue;
-      const hit = apiRequests[hitIndex];
-      if (!hit) continue;
-      if (!candidate) {
-        candidate = {
-          url: hit.url,
-          method: String(hit.method || '').toUpperCase(),
-          replayRequestId: hit.replayRequestId,
-        };
-      }
-      usedRequestIndexes.add(hitIndex);
-      matches++;
-    }
-    if (!candidate || matches < 2) return null;
-    return {
-      url: candidate.url,
-      method: candidate.method,
-      occurrences: matches,
-      replayRequestId: candidate.replayRequestId,
-    };
-  }
-}
 
 // ────────────────────────────────────────────────────────────────────────
 // Test framework (one function, no deps)
@@ -3834,7 +3478,7 @@ test('trace recorders normalize done only from explicit loop error evidence', ()
 console.log('\nloop detection');
 
 test('no loop for distinct calls', () => {
-  const d = new LoopDetectorShim();
+  const d = new ConfiguredLoopDetector();
   const tab = 1;
   assert.equal(d._checkLoop(tab, 'read_page', {}, { ok: true }).kind, 'none');
   assert.equal(d._checkLoop(tab, 'click', { selector: '#a' }, { success: true }).kind, 'none');
@@ -3842,7 +3486,7 @@ test('no loop for distinct calls', () => {
 });
 
 test('checkbox loop detection follows unchanged semantic state across tools and arguments', () => {
-  const d = new LoopDetectorShim();
+  const d = new ConfiguredLoopDetector();
   const tab = 101;
   const unchanged = {
     success: false,
@@ -3857,7 +3501,7 @@ test('checkbox loop detection follows unchanged semantic state across tools and 
   assert.equal(d._checkLoop(tab, 'set_checked', { ref_id: 'ref_8', checked: true }, unchanged).kind, 'nudge');
   assert.equal(d._checkLoop(tab, 'click', { selector: '#firefox' }, unchanged).kind, 'stop');
 
-  const other = new LoopDetectorShim();
+  const other = new ConfiguredLoopDetector();
   assert.equal(other._checkLoop(tab, 'click_ax', { ref_id: 'ref_8' }, unchanged).kind, 'none');
   assert.equal(other._checkLoop(tab, 'set_checked', { ref_id: 'ref_9', checked: true }, {
     ...unchanged,
@@ -3866,7 +3510,7 @@ test('checkbox loop detection follows unchanged semantic state across tools and 
 });
 
 test('three identical calls trigger nudge', () => {
-  const d = new LoopDetectorShim();
+  const d = new ConfiguredLoopDetector();
   const tab = 2;
   d._checkLoop(tab, 'click', { selector: '#submit' }, { success: true });
   d._checkLoop(tab, 'click', { selector: '#submit' }, { success: true });
@@ -3876,7 +3520,7 @@ test('three identical calls trigger nudge', () => {
 
 test('find_text loop detection follows match progress in both browser agents', () => {
   const implementations = [
-    ['shim', LoopDetectorShim],
+    ['standalone', ConfiguredLoopDetector],
     ['chrome', AgentCh],
     ['firefox', AgentFx],
   ];
@@ -3979,7 +3623,7 @@ test('find_text loop detection follows match progress in both browser agents', (
 });
 
 test('failed actions nudge on attempt two and stop on attempt three', () => {
-  const d = new LoopDetectorShim();
+  const d = new ConfiguredLoopDetector();
   const tab = 3;
   assert.equal(d._checkLoop(tab, 'click', { selector: '#missing' }, { success: false }).kind, 'none');
   assert.equal(d._checkLoop(tab, 'click', { selector: '#missing' }, { success: false }).kind, 'nudge');
@@ -3988,7 +3632,7 @@ test('failed actions nudge on attempt two and stop on attempt three', () => {
 });
 
 test('three failed read-only URL calls stop instead of issuing eight nudges', () => {
-  const d = new LoopDetectorShim();
+  const d = new ConfiguredLoopDetector();
   const tab = 31;
   const args = { url: 'https://example.com/api/items' };
   d._checkLoop(tab, 'fetch_url', args, { success: false, error: 'network failed' });
@@ -3998,7 +3642,7 @@ test('three failed read-only URL calls stop instead of issuing eight nudges', ()
 });
 
 test('ranged fetch thrashing receives source-specific recovery and eventually stops', () => {
-  const d = new LoopDetectorShim();
+  const d = new ConfiguredLoopDetector();
   const tab = 35;
   let recovery = null;
   let stopped = null;
@@ -4025,7 +3669,7 @@ test('ranged fetch thrashing receives source-specific recovery and eventually st
 });
 
 test('trace ranged-fetch failure sequence stops and propagates loop_stopped status in both agents', () => {
-  const d = new LoopDetectorShim();
+  const d = new ConfiguredLoopDetector();
   const tab = 36;
   const url = 'https://raw.githubusercontent.com/o/r/main/large.js';
   for (const range of [
@@ -4069,7 +3713,7 @@ test('trace ranged-fetch failure sequence stops and propagates loop_stopped stat
 });
 
 test('failed mutating URL calls retain the ordinary nudge threshold', () => {
-  const d = new LoopDetectorShim();
+  const d = new ConfiguredLoopDetector();
   const tab = 32;
   const args = { url: 'https://example.com/api/items', method: 'POST' };
   d._checkLoop(tab, 'fetch_url', args, { success: false, status: 422 });
@@ -4079,7 +3723,7 @@ test('failed mutating URL calls retain the ordinary nudge threshold', () => {
 });
 
 test('a second equivalent non-retryable failure stops across tools and URL variants', () => {
-  const d = new LoopDetectorShim();
+  const d = new ConfiguredLoopDetector();
   const tab = 34;
   const failure = {
     success: false,
@@ -4092,7 +3736,7 @@ test('a second equivalent non-retryable failure stops across tools and URL varia
 });
 
 test('no-progress clicks nudge on attempt two and stop on attempt three', () => {
-  const d = new LoopDetectorShim();
+  const d = new ConfiguredLoopDetector();
   const tab = 33;
   assert.equal(d._checkLoop(tab, 'click', { text: 'Like' }, { success: false, noProgress: true }).kind, 'none');
   assert.equal(d._checkLoop(tab, 'click', { text: 'Like' }, { success: false, noProgress: true }).kind, 'nudge');
@@ -4101,7 +3745,7 @@ test('no-progress clicks nudge on attempt two and stop on attempt three', () => 
 });
 
 test('ambiguous click failure scope survives unrelated actions', () => {
-  const d = new LoopDetectorShim();
+  const d = new ConfiguredLoopDetector();
   const tab = 331;
   const failure = {
     success: false,
@@ -4116,7 +3760,7 @@ test('ambiguous click failure scope survives unrelated actions', () => {
 });
 
 test('verified field retries clear equivalent scoped failures', () => {
-  const d = new LoopDetectorShim();
+  const d = new ConfiguredLoopDetector();
   const tab = 332;
   const args = { ref_id: 'ref_7', text: 'query' };
   const failure = {
@@ -4141,15 +3785,15 @@ test('failed action counters reset on navigation and replacement-page evidence',
     error: 'Ambiguous text match for "Search"',
   };
 
-  const shim = new LoopDetectorShim();
-  const shimTab = 333;
-  assert.equal(shim._checkLoop(shimTab, 'click', { text: 'Search' }, failure).kind, 'none');
-  assert.equal(shim._checkLoop(shimTab, 'click', { text: 'Search' }, failure).kind, 'nudge');
-  assert.equal(shim._checkLoop(shimTab, 'navigate', { url: 'https://example.com/next' }, {
+  const standaloneDetector = new ConfiguredLoopDetector();
+  const standaloneTab = 333;
+  assert.equal(standaloneDetector._checkLoop(standaloneTab, 'click', { text: 'Search' }, failure).kind, 'none');
+  assert.equal(standaloneDetector._checkLoop(standaloneTab, 'click', { text: 'Search' }, failure).kind, 'nudge');
+  assert.equal(standaloneDetector._checkLoop(standaloneTab, 'navigate', { url: 'https://example.com/next' }, {
     success: true,
     pageUrlChanged: true,
   }).kind, 'none');
-  assert.equal(shim._checkLoop(shimTab, 'click', { text: 'Search' }, failure).kind, 'none');
+  assert.equal(standaloneDetector._checkLoop(standaloneTab, 'click', { text: 'Search' }, failure).kind, 'none');
 
   for (const [label, AgentClass] of [['chrome', AgentCh], ['firefox', AgentFx]]) {
     const agent = new AgentClass({});
@@ -4220,15 +3864,15 @@ test('revisiting a recent URL keeps loop state so navigation ping-pong is caught
     assert.equal(agent.recentCalls.get(tab)?.length, 1, `${label}: fresh-URL arrival should leave only the arriving call in the buffer`);
   }
 
-  // Shim mirror of the same arrival rule.
-  const shim = new LoopDetectorShim();
+  // Standalone production detector mirrors the same arrival rule.
+  const standaloneDetector = new ConfiguredLoopDetector();
   const tab = 338;
   const arrive = (url) => ({ success: true, pageUrlChanged: true, currentUrl: url });
-  shim._checkLoop(tab, 'click', { text: 'Next' }, arrive('https://example.com/b'));
-  shim._checkLoop(tab, 'go_back', {}, arrive('https://example.com/a'));
-  shim._checkLoop(tab, 'click', { text: 'Next' }, arrive('https://example.com/b'));
-  shim._checkLoop(tab, 'go_back', {}, arrive('https://example.com/a'));
-  assert.equal(shim._checkLoop(tab, 'click', { text: 'Next' }, arrive('https://example.com/b')).kind, 'nudge');
+  standaloneDetector._checkLoop(tab, 'click', { text: 'Next' }, arrive('https://example.com/b'));
+  standaloneDetector._checkLoop(tab, 'go_back', {}, arrive('https://example.com/a'));
+  standaloneDetector._checkLoop(tab, 'click', { text: 'Next' }, arrive('https://example.com/b'));
+  standaloneDetector._checkLoop(tab, 'go_back', {}, arrive('https://example.com/a'));
+  assert.equal(standaloneDetector._checkLoop(tab, 'click', { text: 'Next' }, arrive('https://example.com/b')).kind, 'nudge');
 });
 
 test('navigation arrival history survives intra-run resets but clears at run boundaries', () => {
@@ -4270,7 +3914,7 @@ test('navigation arrival history survives intra-run resets but clears at run bou
 
 test('errored vs successful do not collapse together', () => {
   // Two successes + one failure of the same call should NOT trigger.
-  const d = new LoopDetectorShim();
+  const d = new ConfiguredLoopDetector();
   const tab = 4;
   d._checkLoop(tab, 'click', { selector: '#x' }, { success: true });
   d._checkLoop(tab, 'click', { selector: '#x' }, { success: true });
@@ -4279,7 +3923,7 @@ test('errored vs successful do not collapse together', () => {
 });
 
 test('ABAB oscillation triggers nudge', () => {
-  const d = new LoopDetectorShim();
+  const d = new ConfiguredLoopDetector();
   const tab = 5;
   d._checkLoop(tab, 'click', { selector: '#next' }, { success: true });
   d._checkLoop(tab, 'click', { selector: '#prev' }, { success: true });
@@ -4289,7 +3933,7 @@ test('ABAB oscillation triggers nudge', () => {
 });
 
 test('eighth consecutive loop triggers stop', () => {
-  const d = new LoopDetectorShim();
+  const d = new ConfiguredLoopDetector();
   const tab = 6;
   // First nudge (calls 1-3)
   d._checkLoop(tab, 'click', { selector: '#submit' }, { success: true });
@@ -4305,7 +3949,7 @@ test('eighth consecutive loop triggers stop', () => {
 });
 
 test('nudge counter persists across one healthy call (slow loop)', () => {
-  const d = new LoopDetectorShim();
+  const d = new ConfiguredLoopDetector();
   const tab = 7;
   // Get to nudge state
   d._checkLoop(tab, 'click', { selector: '#submit' }, { success: true });
@@ -4320,7 +3964,7 @@ test('nudge counter persists across one healthy call (slow loop)', () => {
 });
 
 test('stale repeated fetch_url entries do not stop after switching tools', () => {
-  const d = new LoopDetectorShim();
+  const d = new ConfiguredLoopDetector();
   const tab = 71;
   for (let i = 0; i < 9; i++) {
     const result = d._checkLoop(
@@ -4385,7 +4029,7 @@ test('Firefox protected active-tab reads can fall back to one screenshot', async
 });
 
 test('nudge counter resets after a sustained healthy streak', () => {
-  const d = new LoopDetectorShim();
+  const d = new ConfiguredLoopDetector();
   const tab = 8;
   // Get to nudge state
   d._checkLoop(tab, 'click', { selector: '#a' }, { success: true });
@@ -4402,7 +4046,7 @@ test('nudge counter resets after a sustained healthy streak', () => {
 });
 
 test('tabs are isolated from each other', () => {
-  const d = new LoopDetectorShim();
+  const d = new ConfiguredLoopDetector();
   // Three identical calls on tab A should NOT affect tab B.
   d._checkLoop(10, 'click', { selector: '#x' }, { success: true });
   d._checkLoop(10, 'click', { selector: '#x' }, { success: true });
@@ -4683,7 +4327,7 @@ test('Enter SPA route changes reset dead-scroll state and defer queued ref reuse
 });
 
 test('accessibility-tree ref enumeration nudges at three and stops at six', () => {
-  const d = new LoopDetectorShim();
+  const d = new ConfiguredLoopDetector();
   const tab = 21;
   const root = d._checkAccessibilityReadLoop(tab, 'get_accessibility_tree', { filter: 'visible' }, {
     pageContent: 'form [ref_1]\n textbox "Subject" [ref_2]',
@@ -4700,7 +4344,7 @@ test('accessibility-tree ref enumeration nudges at three and stops at six', () =
 });
 
 test('accessibility-tree nextPage pagination past the read cap is not suspicious and other tools reset it', () => {
-  const d = new LoopDetectorShim();
+  const d = new ConfiguredLoopDetector();
   const tab = 22;
   for (let page = 1; page <= 15; page++) {
     const result = d._checkAccessibilityReadLoop(
@@ -4717,7 +4361,7 @@ test('accessibility-tree nextPage pagination past the read cap is not suspicious
 });
 
 test('accessibility-tree read cap still stops a non-sequential read after long pagination', () => {
-  const d = new LoopDetectorShim();
+  const d = new ConfiguredLoopDetector();
   const tab = 23;
   for (let page = 1; page <= 11; page++) {
     const result = d._checkAccessibilityReadLoop(
@@ -4744,12 +4388,12 @@ test('accessibility-tree read cap still stops a non-sequential read after long p
 // ────────────────────────────────────────────────────────────────────────
 
 test('coord click: first call → none', () => {
-  const d = new LoopDetectorShim();
+  const d = new ConfiguredLoopDetector();
   assert.equal(d._checkCoordClickLoop(1, 100, 200).kind, 'none');
 });
 
 test('coord click: fourth identical → none (relaxed thresholds)', () => {
-  const d = new LoopDetectorShim();
+  const d = new ConfiguredLoopDetector();
   d._checkCoordClickLoop(1, 100, 200);
   d._checkCoordClickLoop(1, 100, 200);
   d._checkCoordClickLoop(1, 100, 200);
@@ -4757,26 +4401,26 @@ test('coord click: fourth identical → none (relaxed thresholds)', () => {
 });
 
 test('coord click: fifth identical → nudge', () => {
-  const d = new LoopDetectorShim();
+  const d = new ConfiguredLoopDetector();
   for (let i = 0; i < 4; i++) d._checkCoordClickLoop(1, 100, 200);
   assert.equal(d._checkCoordClickLoop(1, 100, 200).kind, 'nudge');
 });
 
 test('coord click: eighth identical → stop', () => {
-  const d = new LoopDetectorShim();
+  const d = new ConfiguredLoopDetector();
   for (let i = 0; i < 7; i++) d._checkCoordClickLoop(1, 100, 200);
   assert.equal(d._checkCoordClickLoop(1, 100, 200).kind, 'stop');
 });
 
 test('coord click: 5px drift collapses to same bucket', () => {
-  const d = new LoopDetectorShim();
+  const d = new ConfiguredLoopDetector();
   for (let i = 0; i < 4; i++) d._checkCoordClickLoop(1, 100, 200);
   // (102, 199) rounds to (100, 200) — fifth identical bucket → nudge
   assert.equal(d._checkCoordClickLoop(1, 102, 199).kind, 'nudge');
 });
 
 test('coord click: 10px drift = different bucket', () => {
-  const d = new LoopDetectorShim();
+  const d = new ConfiguredLoopDetector();
   d._checkCoordClickLoop(1, 100, 200);
   // (115, 200) rounds to (115, 200) — different bucket
   assert.equal(d._checkCoordClickLoop(1, 115, 200).kind, 'none');
@@ -4784,7 +4428,7 @@ test('coord click: 10px drift = different bucket', () => {
 
 test('coord click: survives interleaved noise (the failure mode this fixes)', () => {
   // Coord clicks accumulate across interleaved noise. Nudge at 5, stop at 8.
-  const d = new LoopDetectorShim();
+  const d = new ConfiguredLoopDetector();
   for (let i = 0; i < 4; i++) d._checkCoordClickLoop(1, 267, 226);
   assert.equal(d._checkCoordClickLoop(1, 267, 226).kind, 'nudge'); // 5th → nudge
   // Interleaved noise doesn't reset the count
@@ -4796,7 +4440,7 @@ test('coord click: survives interleaved noise (the failure mode this fixes)', ()
 });
 
 test('coord click: tabs are isolated', () => {
-  const d = new LoopDetectorShim();
+  const d = new ConfiguredLoopDetector();
   d._checkCoordClickLoop(1, 100, 200);
   d._checkCoordClickLoop(1, 100, 200);
   // Same coords on a different tab — should still be 'none'
@@ -4804,7 +4448,7 @@ test('coord click: tabs are isolated', () => {
 });
 
 test('coord click: window of 12 — old entries roll out', () => {
-  const d = new LoopDetectorShim();
+  const d = new ConfiguredLoopDetector();
   d._checkCoordClickLoop(1, 100, 200); // first
   // 12 distinct intervening clicks
   for (let i = 0; i < 12; i++) {
@@ -4815,7 +4459,7 @@ test('coord click: window of 12 — old entries roll out', () => {
 });
 
 test('window of 6 means a loop can fall out of the window', () => {
-  const d = new LoopDetectorShim();
+  const d = new ConfiguredLoopDetector();
   const tab = 11;
   // Two #a, then 5 distinct calls — by then the buffer has rolled past #a.
   d._checkLoop(tab, 'click', { selector: '#a' }, { success: true });
@@ -4836,7 +4480,7 @@ test('window of 6 means a loop can fall out of the window', () => {
 console.log('\n_detectApiShortcut');
 
 test('_detectApiShortcut: match found returns url + method + replay id', () => {
-  const d = new LoopDetectorShim();
+  const d = new ConfiguredLoopDetector();
   const tabId = 200;
   d._recordCall(tabId, 'click', { selector: '#next' }, { success: true });
   d._recordCall(tabId, 'click', { selector: '#next' }, { success: true });
@@ -4869,7 +4513,7 @@ test('_detectApiShortcut: match found returns url + method + replay id', () => {
 });
 
 test('_detectApiShortcut: one request cannot satisfy multiple click windows', () => {
-  const d = new LoopDetectorShim();
+  const d = new ConfiguredLoopDetector();
   const tabId = 205;
   d._recordCall(tabId, 'click', { selector: '#next' }, { success: true });
   d._recordCall(tabId, 'click', { selector: '#next' }, { success: true });
@@ -4900,7 +4544,7 @@ test('_detectApiShortcut: one request cannot satisfy multiple click windows', ()
 });
 
 test('_detectApiShortcut: no API requests returns null', () => {
-  const d = new LoopDetectorShim();
+  const d = new ConfiguredLoopDetector();
   const tabId = 201;
   d._recordCall(tabId, 'click', { selector: '#next' }, { success: true });
   d._recordCall(tabId, 'click', { selector: '#next' }, { success: true });
@@ -4913,7 +4557,7 @@ test('_detectApiShortcut: no API requests returns null', () => {
 });
 
 test('_detectApiShortcut: non-click tool name returns null', () => {
-  const d = new LoopDetectorShim();
+  const d = new ConfiguredLoopDetector();
   const tabId = 202;
   d._recordCall(tabId, 'read_page', {}, { ok: true });
   d._recordCall(tabId, 'read_page', {}, { ok: true });
@@ -4934,7 +4578,7 @@ test('_detectApiShortcut: non-click tool name returns null', () => {
 });
 
 test('_detectApiShortcut: request outside 3 s window returns null', () => {
-  const d = new LoopDetectorShim();
+  const d = new ConfiguredLoopDetector();
   const tabId = 203;
   d._recordCall(tabId, 'click', { selector: '#load' }, { success: true });
   d._recordCall(tabId, 'click', { selector: '#load' }, { success: true });
@@ -4960,7 +4604,7 @@ test('_detectApiShortcut: request outside 3 s window returns null', () => {
 });
 
 test('_detectApiShortcut: write-method requests remain eligible for explicit API mode', () => {
-  const d = new LoopDetectorShim();
+  const d = new ConfiguredLoopDetector();
   const tabId = 204;
   d._recordCall(tabId, 'click', { selector: '#delete' }, { success: true });
   d._recordCall(tabId, 'click', { selector: '#delete' }, { success: true });
@@ -4987,9 +4631,16 @@ test('_detectApiShortcut: write-method requests remain eligible for explicit API
   }
 });
 
-test('_detectApiShortcut: both chrome and firefox builds define the method', () => {
-  assert.equal(typeof AgentCh.prototype._detectApiShortcut, 'function', 'chrome Agent missing _detectApiShortcut');
-  assert.equal(typeof AgentFx.prototype._detectApiShortcut, 'function', 'firefox Agent missing _detectApiShortcut');
+test('LoopDetector is production code shared by both browser agents', () => {
+  assert.equal(typeof LoopDetectorCh.prototype._detectApiShortcut, 'function');
+  assert.equal(typeof LoopDetectorFx.prototype._detectApiShortcut, 'function');
+  assert.ok(new AgentCh({}) instanceof LoopDetectorCh, 'chrome Agent must inherit LoopDetector');
+  assert.ok(new AgentFx({}) instanceof LoopDetectorFx, 'firefox Agent must inherit LoopDetector');
+  assert.equal(
+    fs.readFileSync(path.join(ROOT, 'src/chrome/src/agent/loop-detector.js'), 'utf8'),
+    fs.readFileSync(path.join(ROOT, 'src/firefox/src/agent/loop-detector.js'), 'utf8'),
+    'chrome and firefox LoopDetector copies must remain byte-identical',
+  );
 });
 
 test('_detectBulkApiMutationShortcut: detects repeated same-action clicks with different refs', () => {
@@ -6670,7 +6321,7 @@ test('LOOP DETECTOR catches URL-family thrashing (the trace bug)', () => {
   // same resource via 4 different API URLs. With the old code the loop
   // detector saw 4 distinct keys and never fired. With the bucketing
   // it sees the same key 4 times → "repeat" loop on call 3.
-  const d = new LoopDetectorShim();
+  const d = new ConfiguredLoopDetector();
   const tabId = 1;
   const variants = [
     'https://raw.githubusercontent.com/o/r/main/file.json',


### PR DESCRIPTION
## Summary

- extract loop detection from the browser-bound `Agent` into a browser-free production module
- have both Chrome and Firefox agents inherit that module without changing the existing loop API or behavior
- replace the copied `LoopDetectorShim` tests with direct tests of the production class
- enforce byte-for-byte Chrome/Firefox parity for the extracted module

## Motivation

`test/run.js` duplicated hundreds of lines from `Agent` because importing the browser-bound agent was historically difficult. That allowed the test copy and production behavior to drift independently. `TODOs.md` explicitly calls for testing the real shared logic instead of copied shims.

## Design

`LoopDetector` owns the detector state and browser-neutral behavior. `Agent` inherits it and keeps its existing page-scoped cleanup override, so bulk API replay and delivery-checkpoint state are still cleared together with loop state. The base class calls the existing `_isBrowserMutationTool` virtual method, avoiding a second tool-classification list.

The module remains mirrored under both extension roots because each unpacked extension is self-contained. A unit assertion keeps those copies byte-identical.

## Testing

- `npm test` — 1273 passed; 2 pre-existing upstream release-artifact assertions failed (`CHANGELOG.md` latest entry is 25.8.0 while `package.json` is 25.8.6, and `dist/webbrain-chrome-25.8.6.zip` is not present)
- `npm run test:fixtures` — 125 passed, 0 failed
- `npm run test:webmcp` — passed against Chrome 150.0.7871.182
- `node --check` on both agent and loop-detector modules — passed
- byte comparison of the Chrome and Firefox loop-detector modules — passed

## Compatibility and risks

There is no model-facing tool, storage, or loop-result format change. Existing method names and Agent-owned cleanup hooks remain intact. The main risk is inheritance wiring, covered by direct standalone tests, both real Agent classes, browser fixtures, and the WebMCP Agent smoke test.

## Scope

Image budget sizing, text tool-call parsing, and context trimming remain follow-up extraction candidates documented in `TODOs.md`.
