### PR TITLE
web: label the feature toggle "Show more features"

### DIFF
--- a/web/ar/index.html
+++ b/web/ar/index.html
@@ -3317,10 +3317,10 @@
       type="button"
       aria-expanded="false"
       aria-controls="features-grid"
-      data-label-more="عرض كل الميزات"
+      data-label-more="عرض المزيد من الميزات"
       data-label-less="عرض أقل"
     >
-      <span id="features-more-label">عرض كل الميزات</span>
+      <span id="features-more-label">عرض المزيد من الميزات</span>
       <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
         <polyline points="6 9 12 15 18 9"/>
       </svg>

--- a/web/bn/index.html
+++ b/web/bn/index.html
@@ -3317,10 +3317,10 @@
       type="button"
       aria-expanded="false"
       aria-controls="features-grid"
-      data-label-more="সব বৈশিষ্ট্য দেখুন"
+      data-label-more="আরও বৈশিষ্ট্য দেখুন"
       data-label-less="কম দেখান"
     >
-      <span id="features-more-label">সব বৈশিষ্ট্য দেখুন</span>
+      <span id="features-more-label">আরও বৈশিষ্ট্য দেখুন</span>
       <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
         <polyline points="6 9 12 15 18 9"/>
       </svg>

--- a/web/build/locales/ar.json
+++ b/web/build/locales/ar.json
@@ -105,7 +105,7 @@
   "security.video.open_aria": "مشاهدة فيديو الأمان",
   "security.video.close_aria": "إغلاق فيديو الأمان",
   "features.label": "المزايا",
-  "features.show_all": "عرض كل الميزات",
+  "features.show_more": "عرض المزيد من الميزات",
   "features.show_less": "عرض أقل",
   "features.title": "كل ما تحتاجه في ذكاء اصطناعي للمتصفح",
   "features.subtitle": "وكيل ذكاء اصطناعي كامل المزايا يقطن لوحة المتصفح الجانبية ويفهم أي صفحة ويب.",

--- a/web/build/locales/bn.json
+++ b/web/build/locales/bn.json
@@ -105,7 +105,7 @@
   "security.video.open_aria": "নিরাপত্তা ভিডিও দেখুন",
   "security.video.close_aria": "নিরাপত্তা ভিডিও বন্ধ করুন",
   "features.label": "বৈশিষ্ট্য",
-  "features.show_all": "সব বৈশিষ্ট্য দেখুন",
+  "features.show_more": "আরও বৈশিষ্ট্য দেখুন",
   "features.show_less": "কম দেখান",
   "features.title": "একটি ব্রাউজার AI-তে আপনার যা কিছু প্রয়োজন",
   "features.subtitle": "একটি সম্পূর্ণ বৈশিষ্ট্যযুক্ত AI এজেন্ট যা আপনার ব্রাউজার সাইডবারে থাকে এবং যেকোন ওয়েব পৃষ্ঠা বোঝে।",

--- a/web/build/locales/de.json
+++ b/web/build/locales/de.json
@@ -105,7 +105,7 @@
   "security.video.open_aria": "Sicherheitsvideo ansehen",
   "security.video.close_aria": "Sicherheitsvideo schließen",
   "features.label": "Funktionen",
-  "features.show_all": "Alle Funktionen anzeigen",
+  "features.show_more": "Mehr Funktionen anzeigen",
   "features.show_less": "Weniger anzeigen",
   "features.title": "Alles, was Sie in einer Browser-KI brauchen",
   "features.subtitle": "Ein vollständiger KI-Agent, der in Ihrer Browser-Symbolleiste lebt und jede Webseite versteht.",

--- a/web/build/locales/en.json
+++ b/web/build/locales/en.json
@@ -105,7 +105,7 @@
   "security.video.open_aria": "Watch the security video",
   "security.video.close_aria": "Close the security video",
   "features.label": "Features",
-  "features.show_all": "Show all features",
+  "features.show_more": "Show more features",
   "features.show_less": "Show fewer",
   "features.title": "Everything you need in a browser AI",
   "features.subtitle": "A full-featured AI agent that lives in your browser sidebar and understands any web page.",

--- a/web/build/locales/es.json
+++ b/web/build/locales/es.json
@@ -105,7 +105,7 @@
   "security.video.open_aria": "Ver el vídeo de seguridad",
   "security.video.close_aria": "Cerrar el vídeo de seguridad",
   "features.label": "Funciones",
-  "features.show_all": "Ver todas las funciones",
+  "features.show_more": "Ver más funciones",
   "features.show_less": "Ver menos",
   "features.title": "Todo lo que necesitas en una IA de navegador",
   "features.subtitle": "Un agente de IA completo que vive en la barra lateral del navegador y entiende cualquier página web.",

--- a/web/build/locales/fa.json
+++ b/web/build/locales/fa.json
@@ -105,7 +105,7 @@
   "security.video.open_aria": "تماشای ویدیوی امنیتی",
   "security.video.close_aria": "بستن ویدیوی امنیتی",
   "features.label": "ویژگی ها",
-  "features.show_all": "نمایش همه ویژگی‌ها",
+  "features.show_more": "نمایش ویژگی‌های بیشتر",
   "features.show_less": "نمایش کمتر",
   "features.title": "هر آنچه در یک مرورگر AI نیاز دارید",
   "features.subtitle": "یک عامل هوش مصنوعی با امکانات کامل که در نوار کناری مرورگر شما زندگی می کند و هر صفحه وب را درک می کند.",

--- a/web/build/locales/fr.json
+++ b/web/build/locales/fr.json
@@ -105,7 +105,7 @@
   "security.video.open_aria": "Regarder la vidéo sur la sécurité",
   "security.video.close_aria": "Fermer la vidéo sur la sécurité",
   "features.label": "Fonctionnalités",
-  "features.show_all": "Voir toutes les fonctionnalités",
+  "features.show_more": "Voir plus de fonctionnalités",
   "features.show_less": "Voir moins",
   "features.title": "Tout ce qu'il faut pour une IA dans le navigateur",
   "features.subtitle": "Un agent IA complet qui vit dans la barre latérale du navigateur et comprend n'importe quelle page web.",

--- a/web/build/locales/he.json
+++ b/web/build/locales/he.json
@@ -105,7 +105,7 @@
   "security.video.open_aria": "צפייה בסרטון האבטחה",
   "security.video.close_aria": "סגירת סרטון האבטחה",
   "features.label": "תכונות",
-  "features.show_all": "הצג את כל התכונות",
+  "features.show_more": "הצג עוד תכונות",
   "features.show_less": "הצג פחות",
   "features.title": "כל מה שאתה צריך בדפדפן חכם",
   "features.subtitle": "סוכן בינה מלאכותית מלא תכונות שגר בסרגל הצד של הדפדפן ומבין כל דף אינטרנט.",

--- a/web/build/locales/hi.json
+++ b/web/build/locales/hi.json
@@ -105,7 +105,7 @@
   "security.video.open_aria": "सुरक्षा वीडियो देखें",
   "security.video.close_aria": "सुरक्षा वीडियो बंद करें",
   "features.label": "विशेषताएं",
-  "features.show_all": "सभी सुविधाएँ देखें",
+  "features.show_more": "और सुविधाएँ देखें",
   "features.show_less": "कम दिखाएँ",
   "features.title": "ब्राउज़र AI में आपको जो कुछ भी चाहिए वह सब कुछ",
   "features.subtitle": "एक पूर्ण विशेषताओं वाला AI एजेंट जो आपके ब्राउज़र साइडबार में रहता है और किसी भी वेब पेज को समझता है।",

--- a/web/build/locales/id.json
+++ b/web/build/locales/id.json
@@ -105,7 +105,7 @@
   "security.video.open_aria": "Tonton video keamanan",
   "security.video.close_aria": "Tutup video keamanan",
   "features.label": "Fitur",
-  "features.show_all": "Tampilkan semua fitur",
+  "features.show_more": "Tampilkan lebih banyak fitur",
   "features.show_less": "Tampilkan lebih sedikit",
   "features.title": "Semua yang Anda butuhkan dari AI peramban",
   "features.subtitle": "Agen AI berfitur lengkap yang tinggal di panel samping peramban dan memahami halaman web apa pun.",

--- a/web/build/locales/ja.json
+++ b/web/build/locales/ja.json
@@ -105,7 +105,7 @@
   "security.video.open_aria": "セキュリティ動画を見る",
   "security.video.close_aria": "セキュリティ動画を閉じる",
   "features.label": "機能",
-  "features.show_all": "すべての機能を表示",
+  "features.show_more": "さらに機能を表示",
   "features.show_less": "表示を減らす",
   "features.title": "ブラウザ AI に必要なものすべて",
   "features.subtitle": "ブラウザのサイドパネルに常駐し、あらゆる Web ページを理解する、フル機能の AI エージェント。",

--- a/web/build/locales/ko.json
+++ b/web/build/locales/ko.json
@@ -105,7 +105,7 @@
   "security.video.open_aria": "보안 동영상 보기",
   "security.video.close_aria": "보안 동영상 닫기",
   "features.label": "기능",
-  "features.show_all": "모든 기능 보기",
+  "features.show_more": "기능 더 보기",
   "features.show_less": "간략히 보기",
   "features.title": "브라우저 AI에 필요한 모든 것",
   "features.subtitle": "브라우저 사이드 패널에 자리 잡고 어떤 웹 페이지든 이해하는 완전한 기능의 AI 에이전트.",

--- a/web/build/locales/ms.json
+++ b/web/build/locales/ms.json
@@ -105,7 +105,7 @@
   "security.video.open_aria": "Tonton video keselamatan",
   "security.video.close_aria": "Tutup video keselamatan",
   "features.label": "Ciri",
-  "features.show_all": "Tunjukkan semua ciri",
+  "features.show_more": "Tunjukkan lebih banyak ciri",
   "features.show_less": "Tunjukkan kurang",
   "features.title": "Segalanya yang anda perlukan dalam AI pelayar",
   "features.subtitle": "Ejen AI berciri lengkap yang tinggal di panel sisi pelayar dan memahami mana-mana halaman web.",

--- a/web/build/locales/nl.json
+++ b/web/build/locales/nl.json
@@ -105,7 +105,7 @@
   "security.video.open_aria": "Beveiligingsvideo bekijken",
   "security.video.close_aria": "Beveiligingsvideo sluiten",
   "features.label": "Functies",
-  "features.show_all": "Alle functies tonen",
+  "features.show_more": "Meer functies tonen",
   "features.show_less": "Minder tonen",
   "features.title": "Alles wat u nodig heeft in een browser AI",
   "features.subtitle": "Een volledige AI agent die in uw browserzijbalk woont en elke webpagina begrijpt.",

--- a/web/build/locales/pt.json
+++ b/web/build/locales/pt.json
@@ -105,7 +105,7 @@
   "security.video.open_aria": "Assistir ao vídeo de segurança",
   "security.video.close_aria": "Fechar o vídeo de segurança",
   "features.label": "Recursos",
-  "features.show_all": "Ver todos os recursos",
+  "features.show_more": "Ver mais recursos",
   "features.show_less": "Ver menos",
   "features.title": "Tudo que você precisa em um navegador AI",
   "features.subtitle": "Um agente de IA completo que fica na barra lateral do seu navegador e entende qualquer página da web.",

--- a/web/build/locales/ru.json
+++ b/web/build/locales/ru.json
@@ -105,7 +105,7 @@
   "security.video.open_aria": "Посмотреть видео о безопасности",
   "security.video.close_aria": "Закрыть видео о безопасности",
   "features.label": "Возможности",
-  "features.show_all": "Показать все возможности",
+  "features.show_more": "Показать больше возможностей",
   "features.show_less": "Свернуть",
   "features.title": "Всё, что нужно от AI в браузере",
   "features.subtitle": "Полноценный AI-агент, который живёт в боковой панели браузера и понимает любую веб-страницу.",

--- a/web/build/locales/th.json
+++ b/web/build/locales/th.json
@@ -105,7 +105,7 @@
   "security.video.open_aria": "ดูวิดีโอความปลอดภัย",
   "security.video.close_aria": "ปิดวิดีโอความปลอดภัย",
   "features.label": "คุณสมบัติ",
-  "features.show_all": "แสดงคุณสมบัติทั้งหมด",
+  "features.show_more": "แสดงคุณสมบัติเพิ่มเติม",
   "features.show_less": "แสดงน้อยลง",
   "features.title": "ทุกอย่างที่ AI ในเบราว์เซอร์ควรมี",
   "features.subtitle": "AI agent เต็มรูปแบบที่อยู่ในแถบด้านข้างของเบราว์เซอร์และเข้าใจหน้าเว็บใด ๆ",

--- a/web/build/locales/tl.json
+++ b/web/build/locales/tl.json
@@ -105,7 +105,7 @@
   "security.video.open_aria": "Panoorin ang video tungkol sa seguridad",
   "security.video.close_aria": "Isara ang video tungkol sa seguridad",
   "features.label": "Mga Tampok",
-  "features.show_all": "Ipakita ang lahat ng feature",
+  "features.show_more": "Magpakita ng higit pang feature",
   "features.show_less": "Magpakita ng mas kaunti",
   "features.title": "Lahat ng kailangan mo sa isang AI sa browser",
   "features.subtitle": "Isang full-featured na AI agent na nakatira sa side panel ng iyong browser at nakakaunawa sa anumang web page.",

--- a/web/build/locales/tr.json
+++ b/web/build/locales/tr.json
@@ -105,7 +105,7 @@
   "security.video.open_aria": "Güvenlik videosunu izle",
   "security.video.close_aria": "Güvenlik videosunu kapat",
   "features.label": "Özellikler",
-  "features.show_all": "Tüm özellikleri göster",
+  "features.show_more": "Daha fazla özellik göster",
   "features.show_less": "Daha az göster",
   "features.title": "Bir tarayıcı AI'sında ihtiyacın olan her şey",
   "features.subtitle": "Tarayıcının yan panelinde yaşayan ve her web sayfasını anlayan eksiksiz bir AI ajanı.",

--- a/web/build/locales/uk.json
+++ b/web/build/locales/uk.json
@@ -105,7 +105,7 @@
   "security.video.open_aria": "Переглянути відео про безпеку",
   "security.video.close_aria": "Закрити відео про безпеку",
   "features.label": "Можливості",
-  "features.show_all": "Показати всі можливості",
+  "features.show_more": "Показати більше можливостей",
   "features.show_less": "Згорнути",
   "features.title": "Усе, що потрібно від AI у браузері",
   "features.subtitle": "Повноцінний AI-агент, який живе в бічній панелі браузера й розуміє будь-яку веб-сторінку.",

--- a/web/build/locales/vi.json
+++ b/web/build/locales/vi.json
@@ -105,7 +105,7 @@
   "security.video.open_aria": "Xem video bảo mật",
   "security.video.close_aria": "Đóng video bảo mật",
   "features.label": "Tính năng",
-  "features.show_all": "Xem tất cả tính năng",
+  "features.show_more": "Xem thêm tính năng",
   "features.show_less": "Thu gọn",
   "features.title": "Mọi thứ bạn cần trong một trình duyệt AI",
   "features.subtitle": "Một tác nhân AI đầy đủ tính năng nằm trong thanh bên trình duyệt của bạn và hiểu bất kỳ trang web nào.",

--- a/web/build/locales/zh.json
+++ b/web/build/locales/zh.json
@@ -105,7 +105,7 @@
   "security.video.open_aria": "观看安全视频",
   "security.video.close_aria": "关闭安全视频",
   "features.label": "功能",
-  "features.show_all": "显示全部功能",
+  "features.show_more": "显示更多功能",
   "features.show_less": "收起",
   "features.title": "浏览器 AI 所需的一切",
   "features.subtitle": "一个功能齐全的 AI 代理,驻扎在浏览器侧边栏,能理解任何网页。",

--- a/web/build/template.html
+++ b/web/build/template.html
@@ -3065,10 +3065,10 @@
       type="button"
       aria-expanded="false"
       aria-controls="features-grid"
-      data-label-more="{{t:features.show_all}}"
+      data-label-more="{{t:features.show_more}}"
       data-label-less="{{t:features.show_less}}"
     >
-      <span id="features-more-label">{{t:features.show_all}}</span>
+      <span id="features-more-label">{{t:features.show_more}}</span>
       <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
         <polyline points="6 9 12 15 18 9"/>
       </svg>

--- a/web/de/index.html
+++ b/web/de/index.html
@@ -3317,10 +3317,10 @@
       type="button"
       aria-expanded="false"
       aria-controls="features-grid"
-      data-label-more="Alle Funktionen anzeigen"
+      data-label-more="Mehr Funktionen anzeigen"
       data-label-less="Weniger anzeigen"
     >
-      <span id="features-more-label">Alle Funktionen anzeigen</span>
+      <span id="features-more-label">Mehr Funktionen anzeigen</span>
       <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
         <polyline points="6 9 12 15 18 9"/>
       </svg>

--- a/web/es/index.html
+++ b/web/es/index.html
@@ -3317,10 +3317,10 @@
       type="button"
       aria-expanded="false"
       aria-controls="features-grid"
-      data-label-more="Ver todas las funciones"
+      data-label-more="Ver más funciones"
       data-label-less="Ver menos"
     >
-      <span id="features-more-label">Ver todas las funciones</span>
+      <span id="features-more-label">Ver más funciones</span>
       <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
         <polyline points="6 9 12 15 18 9"/>
       </svg>

--- a/web/fa/index.html
+++ b/web/fa/index.html
@@ -3317,10 +3317,10 @@
       type="button"
       aria-expanded="false"
       aria-controls="features-grid"
-      data-label-more="نمایش همه ویژگی‌ها"
+      data-label-more="نمایش ویژگی‌های بیشتر"
       data-label-less="نمایش کمتر"
     >
-      <span id="features-more-label">نمایش همه ویژگی‌ها</span>
+      <span id="features-more-label">نمایش ویژگی‌های بیشتر</span>
       <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
         <polyline points="6 9 12 15 18 9"/>
       </svg>

--- a/web/fr/index.html
+++ b/web/fr/index.html
@@ -3317,10 +3317,10 @@
       type="button"
       aria-expanded="false"
       aria-controls="features-grid"
-      data-label-more="Voir toutes les fonctionnalités"
+      data-label-more="Voir plus de fonctionnalités"
       data-label-less="Voir moins"
     >
-      <span id="features-more-label">Voir toutes les fonctionnalités</span>
+      <span id="features-more-label">Voir plus de fonctionnalités</span>
       <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
         <polyline points="6 9 12 15 18 9"/>
       </svg>

--- a/web/he/index.html
+++ b/web/he/index.html
@@ -3317,10 +3317,10 @@
       type="button"
       aria-expanded="false"
       aria-controls="features-grid"
-      data-label-more="הצג את כל התכונות"
+      data-label-more="הצג עוד תכונות"
       data-label-less="הצג פחות"
     >
-      <span id="features-more-label">הצג את כל התכונות</span>
+      <span id="features-more-label">הצג עוד תכונות</span>
       <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
         <polyline points="6 9 12 15 18 9"/>
       </svg>

--- a/web/hi/index.html
+++ b/web/hi/index.html
@@ -3317,10 +3317,10 @@
       type="button"
       aria-expanded="false"
       aria-controls="features-grid"
-      data-label-more="सभी सुविधाएँ देखें"
+      data-label-more="और सुविधाएँ देखें"
       data-label-less="कम दिखाएँ"
     >
-      <span id="features-more-label">सभी सुविधाएँ देखें</span>
+      <span id="features-more-label">और सुविधाएँ देखें</span>
       <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
         <polyline points="6 9 12 15 18 9"/>
       </svg>

--- a/web/id/index.html
+++ b/web/id/index.html
@@ -3317,10 +3317,10 @@
       type="button"
       aria-expanded="false"
       aria-controls="features-grid"
-      data-label-more="Tampilkan semua fitur"
+      data-label-more="Tampilkan lebih banyak fitur"
       data-label-less="Tampilkan lebih sedikit"
     >
-      <span id="features-more-label">Tampilkan semua fitur</span>
+      <span id="features-more-label">Tampilkan lebih banyak fitur</span>
       <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
         <polyline points="6 9 12 15 18 9"/>
       </svg>

--- a/web/index.html
+++ b/web/index.html
@@ -3317,10 +3317,10 @@
       type="button"
       aria-expanded="false"
       aria-controls="features-grid"
-      data-label-more="Show all features"
+      data-label-more="Show more features"
       data-label-less="Show fewer"
     >
-      <span id="features-more-label">Show all features</span>
+      <span id="features-more-label">Show more features</span>
       <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
         <polyline points="6 9 12 15 18 9"/>
       </svg>

--- a/web/ja/index.html
+++ b/web/ja/index.html
@@ -3317,10 +3317,10 @@
       type="button"
       aria-expanded="false"
       aria-controls="features-grid"
-      data-label-more="すべての機能を表示"
+      data-label-more="さらに機能を表示"
       data-label-less="表示を減らす"
     >
-      <span id="features-more-label">すべての機能を表示</span>
+      <span id="features-more-label">さらに機能を表示</span>
       <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
         <polyline points="6 9 12 15 18 9"/>
       </svg>

--- a/web/ko/index.html
+++ b/web/ko/index.html
@@ -3317,10 +3317,10 @@
       type="button"
       aria-expanded="false"
       aria-controls="features-grid"
-      data-label-more="모든 기능 보기"
+      data-label-more="기능 더 보기"
       data-label-less="간략히 보기"
     >
-      <span id="features-more-label">모든 기능 보기</span>
+      <span id="features-more-label">기능 더 보기</span>
       <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
         <polyline points="6 9 12 15 18 9"/>
       </svg>

--- a/web/ms/index.html
+++ b/web/ms/index.html
@@ -3317,10 +3317,10 @@
       type="button"
       aria-expanded="false"
       aria-controls="features-grid"
-      data-label-more="Tunjukkan semua ciri"
+      data-label-more="Tunjukkan lebih banyak ciri"
       data-label-less="Tunjukkan kurang"
     >
-      <span id="features-more-label">Tunjukkan semua ciri</span>
+      <span id="features-more-label">Tunjukkan lebih banyak ciri</span>
       <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
         <polyline points="6 9 12 15 18 9"/>
       </svg>

--- a/web/nl/index.html
+++ b/web/nl/index.html
@@ -3317,10 +3317,10 @@
       type="button"
       aria-expanded="false"
       aria-controls="features-grid"
-      data-label-more="Alle functies tonen"
+      data-label-more="Meer functies tonen"
       data-label-less="Minder tonen"
     >
-      <span id="features-more-label">Alle functies tonen</span>
+      <span id="features-more-label">Meer functies tonen</span>
       <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
         <polyline points="6 9 12 15 18 9"/>
       </svg>

--- a/web/pt/index.html
+++ b/web/pt/index.html
@@ -3317,10 +3317,10 @@
       type="button"
       aria-expanded="false"
       aria-controls="features-grid"
-      data-label-more="Ver todos os recursos"
+      data-label-more="Ver mais recursos"
       data-label-less="Ver menos"
     >
-      <span id="features-more-label">Ver todos os recursos</span>
+      <span id="features-more-label">Ver mais recursos</span>
       <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
         <polyline points="6 9 12 15 18 9"/>
       </svg>

--- a/web/ru/index.html
+++ b/web/ru/index.html
@@ -3317,10 +3317,10 @@
       type="button"
       aria-expanded="false"
       aria-controls="features-grid"
-      data-label-more="Показать все возможности"
+      data-label-more="Показать больше возможностей"
       data-label-less="Свернуть"
     >
-      <span id="features-more-label">Показать все возможности</span>
+      <span id="features-more-label">Показать больше возможностей</span>
       <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
         <polyline points="6 9 12 15 18 9"/>
       </svg>

--- a/web/th/index.html
+++ b/web/th/index.html
@@ -3317,10 +3317,10 @@
       type="button"
       aria-expanded="false"
       aria-controls="features-grid"
-      data-label-more="แสดงคุณสมบัติทั้งหมด"
+      data-label-more="แสดงคุณสมบัติเพิ่มเติม"
       data-label-less="แสดงน้อยลง"
     >
-      <span id="features-more-label">แสดงคุณสมบัติทั้งหมด</span>
+      <span id="features-more-label">แสดงคุณสมบัติเพิ่มเติม</span>
       <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
         <polyline points="6 9 12 15 18 9"/>
       </svg>

--- a/web/tl/index.html
+++ b/web/tl/index.html
@@ -3317,10 +3317,10 @@
       type="button"
       aria-expanded="false"
       aria-controls="features-grid"
-      data-label-more="Ipakita ang lahat ng feature"
+      data-label-more="Magpakita ng higit pang feature"
       data-label-less="Magpakita ng mas kaunti"
     >
-      <span id="features-more-label">Ipakita ang lahat ng feature</span>
+      <span id="features-more-label">Magpakita ng higit pang feature</span>
       <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
         <polyline points="6 9 12 15 18 9"/>
       </svg>

--- a/web/tr/index.html
+++ b/web/tr/index.html
@@ -3317,10 +3317,10 @@
       type="button"
       aria-expanded="false"
       aria-controls="features-grid"
-      data-label-more="Tüm özellikleri göster"
+      data-label-more="Daha fazla özellik göster"
       data-label-less="Daha az göster"
     >
-      <span id="features-more-label">Tüm özellikleri göster</span>
+      <span id="features-more-label">Daha fazla özellik göster</span>
       <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
         <polyline points="6 9 12 15 18 9"/>
       </svg>

--- a/web/uk/index.html
+++ b/web/uk/index.html
@@ -3317,10 +3317,10 @@
       type="button"
       aria-expanded="false"
       aria-controls="features-grid"
-      data-label-more="Показати всі можливості"
+      data-label-more="Показати більше можливостей"
       data-label-less="Згорнути"
     >
-      <span id="features-more-label">Показати всі можливості</span>
+      <span id="features-more-label">Показати більше можливостей</span>
       <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
         <polyline points="6 9 12 15 18 9"/>
       </svg>

--- a/web/vi/index.html
+++ b/web/vi/index.html
@@ -3317,10 +3317,10 @@
       type="button"
       aria-expanded="false"
       aria-controls="features-grid"
-      data-label-more="Xem tất cả tính năng"
+      data-label-more="Xem thêm tính năng"
       data-label-less="Thu gọn"
     >
-      <span id="features-more-label">Xem tất cả tính năng</span>
+      <span id="features-more-label">Xem thêm tính năng</span>
       <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
         <polyline points="6 9 12 15 18 9"/>
       </svg>

--- a/web/zh/index.html
+++ b/web/zh/index.html
@@ -3317,10 +3317,10 @@
       type="button"
       aria-expanded="false"
       aria-controls="features-grid"
-      data-label-more="显示全部功能"
+      data-label-more="显示更多功能"
       data-label-less="收起"
     >
-      <span id="features-more-label">显示全部功能</span>
+      <span id="features-more-label">显示更多功能</span>
       <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
         <polyline points="6 9 12 15 18 9"/>
       </svg>


### PR DESCRIPTION
"Show all features" over-promised against a button that reveals six more cards in an already-long section. "Show more" sets the right expectation and reads better next to its "Show fewer" counterpart.

Renames the key features.show_all -> features.show_more so the identifier matches the copy, and updates all 22 locales.