### PR TITLE
fix(captcha): report response token state

### DIFF
--- a/src/chrome/src/agent/captcha-frame-runtime.js
+++ b/src/chrome/src/agent/captcha-frame-runtime.js
@@ -300,6 +300,7 @@ function candidateSummary(candidate) {
     recaptchaDataSValue: candidate?.recaptchaDataSValue || null,
     explicitWebsiteKey: candidate?.explicitWebsiteKey === true,
     callbackName: candidate?.callbackName || null,
+    responseTokenPresent: candidate?.responseTokenPresent === true,
     responseFieldId: candidate?.responseFieldId || null,
     responseFieldIndex: Number.isInteger(candidate?.responseFieldIndex)
       ? candidate.responseFieldIndex
@@ -407,6 +408,8 @@ export function selectCaptchaCandidate(candidates, constraints = {}) {
         challengeFrame: previous.challengeFrame === true || candidate.challengeFrame === true,
         dialogAssociated: previous.dialogAssociated === true || candidate.dialogAssociated === true,
         responseField: previous.responseField === true || candidate.responseField === true,
+        responseTokenPresent: previous.responseTokenPresent === true
+          || candidate.responseTokenPresent === true,
       };
       for (const field of taskParameterFields) {
         const previousValue = previous[field];
@@ -686,6 +689,7 @@ export function detectCaptchaCandidatesInPage(scope = null) {
     const {
       responseFieldDialogAssociated,
       alsoResponseFieldDialogAssociated,
+      alsoResponseTokenPresent,
       ...serializableCandidate
     } = candidate;
     candidates.push({
@@ -693,6 +697,8 @@ export function detectCaptchaCandidatesInPage(scope = null) {
       frameUrl,
       challengeFrame,
       responseField,
+      responseTokenPresent: candidate.responseTokenPresent === true
+        || alsoResponseTokenPresent === true,
       documentTimeOrigin,
       dialogAssociated: candidate.dialogAssociated === true
         || responseFieldDialogAssociated === true
@@ -728,9 +734,12 @@ export function detectCaptchaCandidatesInPage(scope = null) {
     const responseFieldIndex = fields.indexOf(field);
     let responseFieldId = '';
     try { responseFieldId = String(field.id || field.getAttribute?.('id') || ''); } catch (_) {}
+    let responseTokenPresent = false;
+    try { responseTokenPresent = String(field.value || '').trim().length > 0; } catch (_) {}
     return {
       ...(responseFieldId ? { responseFieldId } : {}),
       ...(responseFieldIndex >= 0 ? { responseFieldIndex } : {}),
+      responseTokenPresent,
       ...(elementInChallengeDialog(field) ? { responseFieldDialogAssociated: true } : {}),
     };
   };
@@ -741,6 +750,7 @@ export function detectCaptchaCandidatesInPage(scope = null) {
       ...(Number.isInteger(identity.responseFieldIndex)
         ? { alsoResponseFieldIndex: identity.responseFieldIndex }
         : {}),
+      alsoResponseTokenPresent: identity.responseTokenPresent === true,
       ...(identity.responseFieldDialogAssociated
         ? { alsoResponseFieldDialogAssociated: true }
         : {}),

--- a/src/firefox/src/agent/captcha-frame-runtime.js
+++ b/src/firefox/src/agent/captcha-frame-runtime.js
@@ -300,6 +300,7 @@ function candidateSummary(candidate) {
     recaptchaDataSValue: candidate?.recaptchaDataSValue || null,
     explicitWebsiteKey: candidate?.explicitWebsiteKey === true,
     callbackName: candidate?.callbackName || null,
+    responseTokenPresent: candidate?.responseTokenPresent === true,
     responseFieldId: candidate?.responseFieldId || null,
     responseFieldIndex: Number.isInteger(candidate?.responseFieldIndex)
       ? candidate.responseFieldIndex
@@ -407,6 +408,8 @@ export function selectCaptchaCandidate(candidates, constraints = {}) {
         challengeFrame: previous.challengeFrame === true || candidate.challengeFrame === true,
         dialogAssociated: previous.dialogAssociated === true || candidate.dialogAssociated === true,
         responseField: previous.responseField === true || candidate.responseField === true,
+        responseTokenPresent: previous.responseTokenPresent === true
+          || candidate.responseTokenPresent === true,
       };
       for (const field of taskParameterFields) {
         const previousValue = previous[field];
@@ -686,6 +689,7 @@ export function detectCaptchaCandidatesInPage(scope = null) {
     const {
       responseFieldDialogAssociated,
       alsoResponseFieldDialogAssociated,
+      alsoResponseTokenPresent,
       ...serializableCandidate
     } = candidate;
     candidates.push({
@@ -693,6 +697,8 @@ export function detectCaptchaCandidatesInPage(scope = null) {
       frameUrl,
       challengeFrame,
       responseField,
+      responseTokenPresent: candidate.responseTokenPresent === true
+        || alsoResponseTokenPresent === true,
       documentTimeOrigin,
       dialogAssociated: candidate.dialogAssociated === true
         || responseFieldDialogAssociated === true
@@ -728,9 +734,12 @@ export function detectCaptchaCandidatesInPage(scope = null) {
     const responseFieldIndex = fields.indexOf(field);
     let responseFieldId = '';
     try { responseFieldId = String(field.id || field.getAttribute?.('id') || ''); } catch (_) {}
+    let responseTokenPresent = false;
+    try { responseTokenPresent = String(field.value || '').trim().length > 0; } catch (_) {}
     return {
       ...(responseFieldId ? { responseFieldId } : {}),
       ...(responseFieldIndex >= 0 ? { responseFieldIndex } : {}),
+      responseTokenPresent,
       ...(elementInChallengeDialog(field) ? { responseFieldDialogAssociated: true } : {}),
     };
   };
@@ -741,6 +750,7 @@ export function detectCaptchaCandidatesInPage(scope = null) {
       ...(Number.isInteger(identity.responseFieldIndex)
         ? { alsoResponseFieldIndex: identity.responseFieldIndex }
         : {}),
+      alsoResponseTokenPresent: identity.responseTokenPresent === true,
       ...(identity.responseFieldDialogAssociated
         ? { alsoResponseFieldDialogAssociated: true }
         : {}),

--- a/test/run.js
+++ b/test/run.js
@@ -52554,6 +52554,7 @@ function captchaEl(tag, attrs = {}, children = []) {
     src: attrs.src,
     innerText: attrs.innerText || '',
     textContent: attrs.textContent || attrs.innerText || '',
+    value: attrs.value || '',
     hidden: attrs.hidden === true,
     style: {},
     classList: { contains: (c) => String(attrs.class || '').split(/\s+/).includes(c) },
@@ -52682,6 +52683,13 @@ async function detectCaptchaOnFakePage(build, nodes) {
   return withCaptchaFakePage(build, nodes, async () => {
     const mod = await import(pathToFileURL(path.join(ROOT, `src/${build}/src/agent/captcha-solver.js`)).href);
     return (await mod.detectCaptcha(1)).selected;
+  });
+}
+
+async function detectCaptchaDetailsOnFakePage(build, nodes) {
+  return withCaptchaFakePage(build, nodes, async () => {
+    const mod = await import(pathToFileURL(path.join(ROOT, `src/${build}/src/agent/captcha-solver.js`)).href);
+    return mod.detectCaptcha(1);
   });
 }
 
@@ -53136,11 +53144,16 @@ test('challenge dialog with no enabled supported solver stops the batch for manu
   }
 });
 
-test('CAPTCHA gate helper stays byte-identical and cloud traces retain gate diagnostics outside update rollover', () => {
+test('CAPTCHA helpers stay byte-identical and cloud traces retain gate diagnostics outside update rollover', () => {
   assert.equal(
     fs.readFileSync(path.join(ROOT, 'src/chrome/src/agent/captcha-gate.js'), 'utf8'),
     fs.readFileSync(path.join(ROOT, 'src/firefox/src/agent/captcha-gate.js'), 'utf8'),
     'chrome and firefox CAPTCHA gate helpers must remain byte-identical',
+  );
+  assert.equal(
+    fs.readFileSync(path.join(ROOT, 'src/chrome/src/agent/captcha-frame-runtime.js'), 'utf8'),
+    fs.readFileSync(path.join(ROOT, 'src/firefox/src/agent/captcha-frame-runtime.js'), 'utf8'),
+    'chrome and firefox CAPTCHA frame runtimes must remain byte-identical',
   );
   const cloudSource = fs.readFileSync(path.join(ROOT, 'src/chrome/src/cloud-runs.js'), 'utf8');
   assert.match(cloudSource, /if \(type === 'captcha_gate'\)[\s\S]*?run\.captchaDiagnostics = \{ \.\.\.scrubbedData, observedAt: run\.updatedAt \};/);
@@ -53398,6 +53411,110 @@ test('captcha detection binds the selected widget to its own response field', as
       `${build}: hCaptcha compatibility field identity missing`,
     );
     assert.equal(hcaptcha.alsoResponseFieldIndex, 0, `${build}: hCaptcha compatibility field index missing`);
+  }
+});
+
+test('captcha detection reports exact response token state without exposing token values', async () => {
+  const token = 'RAW_CAPTCHA_TOKEN_MUST_NOT_ESCAPE_7fc2';
+  for (const build of ['chrome', 'firefox']) {
+    const solvedField = captchaEl('textarea', {
+      id: 'g-recaptcha-response-solved',
+      name: 'g-recaptcha-response',
+      value: token,
+    });
+    const pendingField = captchaEl('textarea', {
+      id: 'g-recaptcha-response-pending',
+      name: 'g-recaptcha-response',
+    });
+    const solvedHost = captchaEl('div', {
+      class: 'g-recaptcha',
+      'data-sitekey': 'KEY_SOLVED_WIDGET',
+      hidden: true,
+    }, [solvedField]);
+    const pendingHost = captchaEl('div', {
+      class: 'g-recaptcha',
+      'data-sitekey': 'KEY_PENDING_WIDGET',
+    }, [pendingField]);
+
+    const pendingDetection = await detectCaptchaDetailsOnFakePage(build, [
+      solvedHost,
+      pendingHost,
+      captchaEl('script', { src: 'https://www.google.com/recaptcha/api.js' }),
+    ]);
+    assert.equal(
+      pendingDetection.selected.responseTokenPresent,
+      false,
+      `${build}: a solved sibling widget contaminated the selected pending widget`,
+    );
+    assert.equal(
+      pendingDetection.candidates.find(candidate =>
+        candidate.websiteKey === 'KEY_SOLVED_WIDGET'
+      )?.responseTokenPresent,
+      true,
+      `${build}: non-empty exact response field was not reported as solved`,
+    );
+    assert.doesNotMatch(
+      JSON.stringify(pendingDetection),
+      new RegExp(token),
+      `${build}: raw response token escaped through detection`,
+    );
+
+    pendingField.value = token;
+    const solvedDetection = await detectCaptchaDetailsOnFakePage(build, [
+      solvedHost,
+      pendingHost,
+      captchaEl('script', { src: 'https://www.google.com/recaptcha/api.js' }),
+    ]);
+    assert.equal(
+      solvedDetection.selected.responseTokenPresent,
+      true,
+      `${build}: selected non-empty response field was not reported as solved`,
+    );
+    assert.doesNotMatch(
+      JSON.stringify(solvedDetection),
+      new RegExp(token),
+      `${build}: selected raw response token escaped through detection`,
+    );
+
+    const primaryField = captchaEl('textarea', {
+      id: 'h-captcha-response-primary',
+      name: 'h-captcha-response',
+    });
+    const compatibilityField = captchaEl('textarea', {
+      id: 'g-recaptcha-response-compatibility',
+      name: 'g-recaptcha-response',
+      value: token,
+    });
+    const hcaptcha = await detectCaptchaOnFakePage(build, [
+      captchaEl('div', {
+        class: 'h-captcha',
+        'data-sitekey': 'HKEY_SOLVED_COMPATIBILITY',
+      }, [primaryField, compatibilityField]),
+    ]);
+    assert.equal(
+      hcaptcha.responseTokenPresent,
+      true,
+      `${build}: solved hCaptcha compatibility field was ignored`,
+    );
+    assert.doesNotMatch(
+      JSON.stringify(hcaptcha),
+      new RegExp(token),
+      `${build}: hCaptcha compatibility token escaped through detection`,
+    );
+
+    Object.defineProperty(pendingField, 'value', {
+      configurable: true,
+      get() { throw new Error('hostile response field getter'); },
+    });
+    const unreadable = await detectCaptchaOnFakePage(build, [
+      pendingHost,
+      captchaEl('script', { src: 'https://www.google.com/recaptcha/api.js' }),
+    ]);
+    assert.equal(
+      unreadable.responseTokenPresent,
+      false,
+      `${build}: unreadable response field did not fail closed`,
+    );
   }
 });
 


### PR DESCRIPTION
## Summary

- report `responseTokenPresent` for each detected CAPTCHA candidate after resolving its exact response field
- combine the canonical and compatibility fields for hCaptcha while keeping sibling widgets isolated
- expose only a boolean and never retain or serialize the response token value

## Motivation

Issue #505 notes that CAPTCHA verification currently infers solve state from dialog wording and disappearance even though the widget response field provides a language-neutral signal. This lands the issue's suggested Step 2 as a standalone detection primitive.

## Design

The page-side detector reads `field.value` only after `responseFieldIdentity` has bound a candidate to its exact field. It immediately reduces that value to a boolean. Empty or unreadable values fail closed as `false`; the raw value is never placed on a candidate, summary, diagnostic, or trace-facing object.

hCaptcha treats either its canonical `h-captcha-response` field or its compatibility `g-recaptcha-response` field as token-present. Duplicate observations preserve a positive boolean without changing candidate ranking.

Chrome and Firefox keep byte-identical frame runtimes, now enforced by a regression assertion.

## Testing

- `node test/run.js` — 1,329 passed; 1 inherited baseline failure (`package.json` is 25.9.7 while the newest changelog entry is 25.9.0)
- `npm run test:security` — 60/60 passed
- `npm run test:fixtures` — 125/125 passed
- `npm run test:webmcp` — passed against Chrome 150
- `npm run test:ci` — passed
- `node --check src/{chrome,firefox}/src/agent/captcha-frame-runtime.js` — passed

## Compatibility and risks

This is an additive detection field. It does not change tool arguments, candidate ranking, token injection, paid solving, or the CAPTCHA gate state machine. A response token means the widget produced a token; it does not claim that the site accepted it.

## Scope

This intentionally defers the remaining #505 work: classifying vendor challenge frames, consuming the boolean in gate transitions, and demoting English dialog regexes.

Refs #505
