### PR TITLE
refactor(agent): extract text tool-call parser

### DIFF
--- a/src/chrome/src/agent/agent.js
+++ b/src/chrome/src/agent/agent.js
@@ -1,6 +1,7 @@
 import { AGENT_TOOLS, AGENT_TOOL_NAMES, RESERVED_AGENT_TOOL_NAMES, getToolsForMode, SYSTEM_PROMPT_ASK, SYSTEM_PROMPT_ACT, SYSTEM_PROMPT_ACT_COMPACT, SYSTEM_PROMPT_ACT_MID, SYSTEM_PROMPT_DEV_APPENDIX, SYSTEM_PROMPT_WEBMCP_ASK, SYSTEM_PROMPT_WEBMCP_ACT } from './tools.js';
 import { handleDoneJson } from './cloud-output.js';
 import { LoopDetector } from './loop-detector.js';
+import { parseToolCallsFromText } from './tool-call-parser.js';
 import { BROWSER_MUTATION_TOOLS, STATE_CHANGE_TOOLS as SHARED_STATE_CHANGE_TOOLS } from './mutation-tools.js';
 import { isCredentialField, CREDENTIAL_NOTE_STRICT, STRICT_SECRET_SYSTEM_NOTE } from './credential-fields.js';
 import { detectProgressAction, formatLedgerRow, formatLedgerSummary, isBlockedLedgerDowngrade, isTerminalLedgerStatus, isValidLedgerStatus, ledgerDoneBlock, ledgerRowKey, normalizeLedgerStatus, progressCounts, selectLedgerRows, unresolvedLedgerRows, upsertLedgerItems } from './progress-ledger.js';
@@ -18715,136 +18716,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
    *   smaller set (e.g. COMPACT_TOOL_NAMES) to restrict in compact mode.
    */
   _tryParseToolCallsFromText(text, allowedNames = AGENT_TOOL_NAMES) {
-    if (!text || text.length > 10000) return [];
-
-    const results = [];
-    const parseXmlParamValue = (value) => {
-      const cleaned = String(value || '')
-        .replace(/<[^>]+>/g, '')
-        .trim();
-      if (!cleaned) return '';
-      try {
-        if (/^(?:"|'.*'|\{|\[|-?\d|true\b|false\b|null\b)/i.test(cleaned)) {
-          return JSON.parse(cleaned.replace(/^'([\s\S]*)'$/, '"$1"'));
-        }
-      } catch { /* fall through to string cleanup */ }
-      return cleaned.replace(/^["']+|["']+$/g, '');
-    };
-
-    // Collect candidate JSON strings from known wrapper patterns.
-    const patterns = [
-      // <tool_call>JSON</tool_call>
-      /<tool_call>\s*([\s\S]*?)\s*<\/tool_call>/gi,
-      // <|tool_call|>JSON<|/tool_call|>  or  <|tool_call>JSON<tool_call|>
-      /<\|tool_call\|?>\s*([\s\S]*?)\s*<\|?\/?tool_call\|?>/gi,
-      // <functioncall>JSON</functioncall>
-      /<functioncall>\s*([\s\S]*?)\s*<\/functioncall>/gi,
-    ];
-
-    for (const re of patterns) {
-      let m;
-      while ((m = re.exec(text)) !== null) {
-        const inner = m[1].trim();
-        // Try JSON first (most common).
-        try {
-          const obj = JSON.parse(inner);
-          if (obj && obj.name && allowedNames.has(obj.name)) {
-            results.push(obj);
-            continue;
-          }
-        } catch { /* not JSON — try call:name{} format below */ }
-
-        // call:toolName{key:<|"|>value<|"|>, ...} format.
-        // Some local models use <|"|> as quote tokens and call:name as the
-        // invocation syntax.  Normalize to JSON and parse.
-        const callMatch = /^call:(\w+)\s*\{([\s\S]*)\}$/.exec(inner);
-        if (callMatch && allowedNames.has(callMatch[1])) {
-          const toolName = callMatch[1];
-          let argsBody = callMatch[2]
-            .replace(/<\|"\|>/g, '"')  // replace quote tokens with real quotes
-            .replace(/<\|'\\?\|>/g, "'");  // handle single-quote tokens if any
-          // argsBody is now like: url:"https://example.com",text:"hello"
-          // Wrap unquoted keys to make valid JSON: key:"val" → "key":"val"
-          argsBody = argsBody.replace(/(?<=^|,)\s*(\w+)\s*:/g, '"$1":');
-          try {
-            const args = JSON.parse(`{${argsBody}}`);
-            results.push({ name: toolName, arguments: args });
-          } catch {
-            // If JSON parse still fails, try treating entire body as single
-            // string argument for zero-arg or simple calls.
-            results.push({ name: toolName, arguments: {} });
-          }
-          continue;
-        }
-      }
-    }
-
-    // XML-ish tool-call format used by some local/chat-template models:
-    // <tool_call><function=click_ax><parameter=ref_id>ref_6</parameter>...
-    const xmlToolRe = /<tool_call>\s*<function(?:\s*=\s*["']?([A-Za-z_]\w*)["']?|\s+name\s*=\s*["']?([A-Za-z_]\w*)["']?)\s*>\s*([\s\S]*?)\s*<\/function>\s*<\/tool_call>/gi;
-    let xmlMatch;
-    while ((xmlMatch = xmlToolRe.exec(text)) !== null) {
-      const toolName = xmlMatch[1] || xmlMatch[2];
-      if (!allowedNames.has(toolName)) continue;
-      const body = xmlMatch[3] || '';
-      const args = {};
-      const paramRe = /<parameter(?:\s*=\s*["']?([A-Za-z_]\w*)["']?|\s+name\s*=\s*["']?([A-Za-z_]\w*)["']?)\s*>\s*([\s\S]*?)\s*<\/parameter>/gi;
-      let paramMatch;
-      while ((paramMatch = paramRe.exec(body)) !== null) {
-        const key = paramMatch[1] || paramMatch[2];
-        if (!key) continue;
-        args[key] = parseXmlParamValue(paramMatch[3]);
-      }
-      results.push({ name: toolName, arguments: args });
-    }
-
-    // Fallback: scan for bare JSON objects containing a "name" key with a
-    // known tool name. Only look for top-level objects (starts with {).
-    if (results.length === 0) {
-      const bareRe = /\{[^{}]*"name"\s*:\s*"(\w+)"[^{}]*\}/g;
-      let m;
-      while ((m = bareRe.exec(text)) !== null) {
-        if (!allowedNames.has(m[1])) continue;
-        try {
-          const obj = JSON.parse(m[0]);
-          if (obj && obj.name && allowedNames.has(obj.name)) {
-            results.push(obj);
-          }
-        } catch { /* skip */ }
-      }
-    }
-
-    // Last resort: call:toolName{...} outside of any wrapper tags.
-    if (results.length === 0) {
-      const callRe = /call:(\w+)\s*\{([\s\S]*?)\}/g;
-      let m;
-      while ((m = callRe.exec(text)) !== null) {
-        if (!allowedNames.has(m[1])) continue;
-        const toolName = m[1];
-        let argsBody = m[2]
-          .replace(/<\|"\|>/g, '"')
-          .replace(/<\|'\\?\|>/g, "'");
-        argsBody = argsBody.replace(/(?<=^|,)\s*(\w+)\s*:/g, '"$1":');
-        try {
-          const args = JSON.parse(`{${argsBody}}`);
-          results.push({ name: toolName, arguments: args });
-        } catch {
-          results.push({ name: toolName, arguments: {} });
-        }
-      }
-    }
-
-    // Convert to OpenAI tool_calls format.
-    return results.map((obj, i) => ({
-      id: `fallback_call_${Date.now()}_${i}`,
-      type: 'function',
-      function: {
-        name: obj.name,
-        arguments: typeof obj.arguments === 'string'
-          ? obj.arguments
-          : JSON.stringify(obj.arguments || obj.parameters || {}),
-      },
-    }));
+    return parseToolCallsFromText(text, allowedNames);
   }
   // ─────────────────────────────────────────────────────────────────────
 

--- a/src/chrome/src/agent/tool-call-parser.js
+++ b/src/chrome/src/agent/tool-call-parser.js
@@ -1,0 +1,123 @@
+// Browser-free fallback parser for local models that emit tool calls as text
+// instead of using the provider's structured tool_calls field. This file is
+// mirrored in the Firefox tree; keep both copies byte-identical.
+
+/**
+ * Parse common text tool-call formats into OpenAI-style tool call objects.
+ * Only names in allowedNames are accepted.
+ */
+export function parseToolCallsFromText(text, allowedNames) {
+  if (!text || text.length > 10000) return [];
+
+  const results = [];
+  const parseXmlParamValue = (value) => {
+    const cleaned = String(value || '')
+      .replace(/<[^>]+>/g, '')
+      .trim();
+    if (!cleaned) return '';
+    try {
+      if (/^(?:"|'.*'|\{|\[|-?\d|true\b|false\b|null\b)/i.test(cleaned)) {
+        return JSON.parse(cleaned.replace(/^'([\s\S]*)'$/, '"$1"'));
+      }
+    } catch { /* fall through to string cleanup */ }
+    return cleaned.replace(/^["']+|["']+$/g, '');
+  };
+
+  const patterns = [
+    /<tool_call>\s*([\s\S]*?)\s*<\/tool_call>/gi,
+    /<\|tool_call\|?>\s*([\s\S]*?)\s*<\|?\/?tool_call\|?>/gi,
+    /<functioncall>\s*([\s\S]*?)\s*<\/functioncall>/gi,
+  ];
+
+  for (const re of patterns) {
+    let match;
+    while ((match = re.exec(text)) !== null) {
+      const inner = match[1].trim();
+      try {
+        const obj = JSON.parse(inner);
+        if (obj && obj.name && allowedNames.has(obj.name)) {
+          results.push(obj);
+          continue;
+        }
+      } catch { /* not JSON — try call:name{} format below */ }
+
+      const callMatch = /^call:(\w+)\s*\{([\s\S]*)\}$/.exec(inner);
+      if (callMatch && allowedNames.has(callMatch[1])) {
+        const toolName = callMatch[1];
+        let argsBody = callMatch[2]
+          .replace(/<\|"\|>/g, '"')
+          .replace(/<\|'\\?\|>/g, "'");
+        argsBody = argsBody.replace(/(?<=^|,)\s*(\w+)\s*:/g, '"$1":');
+        try {
+          const args = JSON.parse(`{${argsBody}}`);
+          results.push({ name: toolName, arguments: args });
+        } catch {
+          results.push({ name: toolName, arguments: {} });
+        }
+      }
+    }
+  }
+
+  // XML-ish tool-call format used by some local/chat-template models:
+  // <tool_call><function=click_ax><parameter=ref_id>ref_6</parameter>...
+  const xmlToolRe = /<tool_call>\s*<function(?:\s*=\s*["']?([A-Za-z_]\w*)["']?|\s+name\s*=\s*["']?([A-Za-z_]\w*)["']?)\s*>\s*([\s\S]*?)\s*<\/function>\s*<\/tool_call>/gi;
+  let xmlMatch;
+  while ((xmlMatch = xmlToolRe.exec(text)) !== null) {
+    const toolName = xmlMatch[1] || xmlMatch[2];
+    if (!allowedNames.has(toolName)) continue;
+    const body = xmlMatch[3] || '';
+    const args = {};
+    const paramRe = /<parameter(?:\s*=\s*["']?([A-Za-z_]\w*)["']?|\s+name\s*=\s*["']?([A-Za-z_]\w*)["']?)\s*>\s*([\s\S]*?)\s*<\/parameter>/gi;
+    let paramMatch;
+    while ((paramMatch = paramRe.exec(body)) !== null) {
+      const key = paramMatch[1] || paramMatch[2];
+      if (!key) continue;
+      args[key] = parseXmlParamValue(paramMatch[3]);
+    }
+    results.push({ name: toolName, arguments: args });
+  }
+
+  if (results.length === 0) {
+    const bareRe = /\{[^{}]*"name"\s*:\s*"(\w+)"[^{}]*\}/g;
+    let match;
+    while ((match = bareRe.exec(text)) !== null) {
+      if (!allowedNames.has(match[1])) continue;
+      try {
+        const obj = JSON.parse(match[0]);
+        if (obj && obj.name && allowedNames.has(obj.name)) {
+          results.push(obj);
+        }
+      } catch { /* skip */ }
+    }
+  }
+
+  if (results.length === 0) {
+    const callRe = /call:(\w+)\s*\{([\s\S]*?)\}/g;
+    let match;
+    while ((match = callRe.exec(text)) !== null) {
+      if (!allowedNames.has(match[1])) continue;
+      const toolName = match[1];
+      let argsBody = match[2]
+        .replace(/<\|"\|>/g, '"')
+        .replace(/<\|'\\?\|>/g, "'");
+      argsBody = argsBody.replace(/(?<=^|,)\s*(\w+)\s*:/g, '"$1":');
+      try {
+        const args = JSON.parse(`{${argsBody}}`);
+        results.push({ name: toolName, arguments: args });
+      } catch {
+        results.push({ name: toolName, arguments: {} });
+      }
+    }
+  }
+
+  return results.map((obj, index) => ({
+    id: `fallback_call_${Date.now()}_${index}`,
+    type: 'function',
+    function: {
+      name: obj.name,
+      arguments: typeof obj.arguments === 'string'
+        ? obj.arguments
+        : JSON.stringify(obj.arguments || obj.parameters || {}),
+    },
+  }));
+}

--- a/src/firefox/src/agent/agent.js
+++ b/src/firefox/src/agent/agent.js
@@ -1,6 +1,7 @@
 import { AGENT_TOOLS, AGENT_TOOL_NAMES, RESERVED_AGENT_TOOL_NAMES, getToolsForMode, SYSTEM_PROMPT_ASK, SYSTEM_PROMPT_ACT, SYSTEM_PROMPT_ACT_COMPACT, SYSTEM_PROMPT_ACT_MID, SYSTEM_PROMPT_DEV_APPENDIX } from './tools.js';
 import { handleDoneJson } from './cloud-output.js';
 import { LoopDetector } from './loop-detector.js';
+import { parseToolCallsFromText } from './tool-call-parser.js';
 import { BROWSER_MUTATION_TOOLS, STATE_CHANGE_TOOLS as SHARED_STATE_CHANGE_TOOLS } from './mutation-tools.js';
 import { isCredentialField, CREDENTIAL_NOTE_STRICT, STRICT_SECRET_SYSTEM_NOTE } from './credential-fields.js';
 import { detectProgressAction, formatLedgerRow, formatLedgerSummary, isBlockedLedgerDowngrade, isTerminalLedgerStatus, isValidLedgerStatus, ledgerDoneBlock, ledgerRowKey, normalizeLedgerStatus, progressCounts, selectLedgerRows, unresolvedLedgerRows, upsertLedgerItems } from './progress-ledger.js';
@@ -14013,124 +14014,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
    * was found. Only tool names present in the allowed-name set are accepted.
    */
   _tryParseToolCallsFromText(text, allowedNames = AGENT_TOOL_NAMES) {
-    if (!text || text.length > 10000) return [];
-
-    const results = [];
-    const parseXmlParamValue = (value) => {
-      const cleaned = String(value || '')
-        .replace(/<[^>]+>/g, '')
-        .trim();
-      if (!cleaned) return '';
-      try {
-        if (/^(?:"|'.*'|\{|\[|-?\d|true\b|false\b|null\b)/i.test(cleaned)) {
-          return JSON.parse(cleaned.replace(/^'([\s\S]*)'$/, '"$1"'));
-        }
-      } catch { /* fall through to string cleanup */ }
-      return cleaned.replace(/^["']+|["']+$/g, '');
-    };
-
-    const patterns = [
-      /<tool_call>\s*([\s\S]*?)\s*<\/tool_call>/gi,
-      /<\|tool_call\|?>\s*([\s\S]*?)\s*<\|?\/?tool_call\|?>/gi,
-      /<functioncall>\s*([\s\S]*?)\s*<\/functioncall>/gi,
-    ];
-
-    for (const re of patterns) {
-      let m;
-      while ((m = re.exec(text)) !== null) {
-        const inner = m[1].trim();
-        // Try JSON first (most common).
-        try {
-          const obj = JSON.parse(inner);
-          if (obj && obj.name && allowedNames.has(obj.name)) {
-            results.push(obj);
-            continue;
-          }
-        } catch { /* not JSON — try call:name{} format below */ }
-
-        // call:toolName{key:<|"|>value<|"|>, ...} format.
-        const callMatch = /^call:(\w+)\s*\{([\s\S]*)\}$/.exec(inner);
-        if (callMatch && allowedNames.has(callMatch[1])) {
-          const toolName = callMatch[1];
-          let argsBody = callMatch[2]
-            .replace(/<\|"\|>/g, '"')
-            .replace(/<\|'\\?\|>/g, "'");
-          argsBody = argsBody.replace(/(?<=^|,)\s*(\w+)\s*:/g, '"$1":');
-          try {
-            const args = JSON.parse(`{${argsBody}}`);
-            results.push({ name: toolName, arguments: args });
-          } catch {
-            results.push({ name: toolName, arguments: {} });
-          }
-          continue;
-        }
-      }
-    }
-
-    // XML-ish tool-call format used by some local/chat-template models:
-    // <tool_call><function=click_ax><parameter=ref_id>ref_6</parameter>...
-    const xmlToolRe = /<tool_call>\s*<function(?:\s*=\s*["']?([A-Za-z_]\w*)["']?|\s+name\s*=\s*["']?([A-Za-z_]\w*)["']?)\s*>\s*([\s\S]*?)\s*<\/function>\s*<\/tool_call>/gi;
-    let xmlMatch;
-    while ((xmlMatch = xmlToolRe.exec(text)) !== null) {
-      const toolName = xmlMatch[1] || xmlMatch[2];
-      if (!allowedNames.has(toolName)) continue;
-      const body = xmlMatch[3] || '';
-      const args = {};
-      const paramRe = /<parameter(?:\s*=\s*["']?([A-Za-z_]\w*)["']?|\s+name\s*=\s*["']?([A-Za-z_]\w*)["']?)\s*>\s*([\s\S]*?)\s*<\/parameter>/gi;
-      let paramMatch;
-      while ((paramMatch = paramRe.exec(body)) !== null) {
-        const key = paramMatch[1] || paramMatch[2];
-        if (!key) continue;
-        args[key] = parseXmlParamValue(paramMatch[3]);
-      }
-      results.push({ name: toolName, arguments: args });
-    }
-
-    // Fallback: scan for bare JSON objects containing a "name" key.
-    if (results.length === 0) {
-      const bareRe = /\{[^{}]*"name"\s*:\s*"(\w+)"[^{}]*\}/g;
-      let m;
-      while ((m = bareRe.exec(text)) !== null) {
-        if (!allowedNames.has(m[1])) continue;
-        try {
-          const obj = JSON.parse(m[0]);
-          if (obj && obj.name && allowedNames.has(obj.name)) {
-            results.push(obj);
-          }
-        } catch { /* skip */ }
-      }
-    }
-
-    // Last resort: call:toolName{...} outside of any wrapper tags.
-    if (results.length === 0) {
-      const callRe = /call:(\w+)\s*\{([\s\S]*?)\}/g;
-      let m;
-      while ((m = callRe.exec(text)) !== null) {
-        if (!allowedNames.has(m[1])) continue;
-        const toolName = m[1];
-        let argsBody = m[2]
-          .replace(/<\|"\|>/g, '"')
-          .replace(/<\|'\\?\|>/g, "'");
-        argsBody = argsBody.replace(/(?<=^|,)\s*(\w+)\s*:/g, '"$1":');
-        try {
-          const args = JSON.parse(`{${argsBody}}`);
-          results.push({ name: toolName, arguments: args });
-        } catch {
-          results.push({ name: toolName, arguments: {} });
-        }
-      }
-    }
-
-    return results.map((obj, i) => ({
-      id: `fallback_call_${Date.now()}_${i}`,
-      type: 'function',
-      function: {
-        name: obj.name,
-        arguments: typeof obj.arguments === 'string'
-          ? obj.arguments
-          : JSON.stringify(obj.arguments || obj.parameters || {}),
-      },
-    }));
+    return parseToolCallsFromText(text, allowedNames);
   }
   // ─────────────────────────────────────────────────────────────────────
 

--- a/src/firefox/src/agent/tool-call-parser.js
+++ b/src/firefox/src/agent/tool-call-parser.js
@@ -1,0 +1,123 @@
+// Browser-free fallback parser for local models that emit tool calls as text
+// instead of using the provider's structured tool_calls field. This file is
+// mirrored in the Firefox tree; keep both copies byte-identical.
+
+/**
+ * Parse common text tool-call formats into OpenAI-style tool call objects.
+ * Only names in allowedNames are accepted.
+ */
+export function parseToolCallsFromText(text, allowedNames) {
+  if (!text || text.length > 10000) return [];
+
+  const results = [];
+  const parseXmlParamValue = (value) => {
+    const cleaned = String(value || '')
+      .replace(/<[^>]+>/g, '')
+      .trim();
+    if (!cleaned) return '';
+    try {
+      if (/^(?:"|'.*'|\{|\[|-?\d|true\b|false\b|null\b)/i.test(cleaned)) {
+        return JSON.parse(cleaned.replace(/^'([\s\S]*)'$/, '"$1"'));
+      }
+    } catch { /* fall through to string cleanup */ }
+    return cleaned.replace(/^["']+|["']+$/g, '');
+  };
+
+  const patterns = [
+    /<tool_call>\s*([\s\S]*?)\s*<\/tool_call>/gi,
+    /<\|tool_call\|?>\s*([\s\S]*?)\s*<\|?\/?tool_call\|?>/gi,
+    /<functioncall>\s*([\s\S]*?)\s*<\/functioncall>/gi,
+  ];
+
+  for (const re of patterns) {
+    let match;
+    while ((match = re.exec(text)) !== null) {
+      const inner = match[1].trim();
+      try {
+        const obj = JSON.parse(inner);
+        if (obj && obj.name && allowedNames.has(obj.name)) {
+          results.push(obj);
+          continue;
+        }
+      } catch { /* not JSON — try call:name{} format below */ }
+
+      const callMatch = /^call:(\w+)\s*\{([\s\S]*)\}$/.exec(inner);
+      if (callMatch && allowedNames.has(callMatch[1])) {
+        const toolName = callMatch[1];
+        let argsBody = callMatch[2]
+          .replace(/<\|"\|>/g, '"')
+          .replace(/<\|'\\?\|>/g, "'");
+        argsBody = argsBody.replace(/(?<=^|,)\s*(\w+)\s*:/g, '"$1":');
+        try {
+          const args = JSON.parse(`{${argsBody}}`);
+          results.push({ name: toolName, arguments: args });
+        } catch {
+          results.push({ name: toolName, arguments: {} });
+        }
+      }
+    }
+  }
+
+  // XML-ish tool-call format used by some local/chat-template models:
+  // <tool_call><function=click_ax><parameter=ref_id>ref_6</parameter>...
+  const xmlToolRe = /<tool_call>\s*<function(?:\s*=\s*["']?([A-Za-z_]\w*)["']?|\s+name\s*=\s*["']?([A-Za-z_]\w*)["']?)\s*>\s*([\s\S]*?)\s*<\/function>\s*<\/tool_call>/gi;
+  let xmlMatch;
+  while ((xmlMatch = xmlToolRe.exec(text)) !== null) {
+    const toolName = xmlMatch[1] || xmlMatch[2];
+    if (!allowedNames.has(toolName)) continue;
+    const body = xmlMatch[3] || '';
+    const args = {};
+    const paramRe = /<parameter(?:\s*=\s*["']?([A-Za-z_]\w*)["']?|\s+name\s*=\s*["']?([A-Za-z_]\w*)["']?)\s*>\s*([\s\S]*?)\s*<\/parameter>/gi;
+    let paramMatch;
+    while ((paramMatch = paramRe.exec(body)) !== null) {
+      const key = paramMatch[1] || paramMatch[2];
+      if (!key) continue;
+      args[key] = parseXmlParamValue(paramMatch[3]);
+    }
+    results.push({ name: toolName, arguments: args });
+  }
+
+  if (results.length === 0) {
+    const bareRe = /\{[^{}]*"name"\s*:\s*"(\w+)"[^{}]*\}/g;
+    let match;
+    while ((match = bareRe.exec(text)) !== null) {
+      if (!allowedNames.has(match[1])) continue;
+      try {
+        const obj = JSON.parse(match[0]);
+        if (obj && obj.name && allowedNames.has(obj.name)) {
+          results.push(obj);
+        }
+      } catch { /* skip */ }
+    }
+  }
+
+  if (results.length === 0) {
+    const callRe = /call:(\w+)\s*\{([\s\S]*?)\}/g;
+    let match;
+    while ((match = callRe.exec(text)) !== null) {
+      if (!allowedNames.has(match[1])) continue;
+      const toolName = match[1];
+      let argsBody = match[2]
+        .replace(/<\|"\|>/g, '"')
+        .replace(/<\|'\\?\|>/g, "'");
+      argsBody = argsBody.replace(/(?<=^|,)\s*(\w+)\s*:/g, '"$1":');
+      try {
+        const args = JSON.parse(`{${argsBody}}`);
+        results.push({ name: toolName, arguments: args });
+      } catch {
+        results.push({ name: toolName, arguments: {} });
+      }
+    }
+  }
+
+  return results.map((obj, index) => ({
+    id: `fallback_call_${Date.now()}_${index}`,
+    type: 'function',
+    function: {
+      name: obj.name,
+      arguments: typeof obj.arguments === 'string'
+        ? obj.arguments
+        : JSON.stringify(obj.arguments || obj.parameters || {}),
+    },
+  }));
+}

--- a/test/run.js
+++ b/test/run.js
@@ -442,6 +442,12 @@ const CaptchaGateCh = await import(
 const CaptchaGateFx = await import(
   'file://' + path.join(ROOT, 'src/firefox/src/agent/captcha-gate.js').replace(/\\/g, '/')
 );
+const ToolCallParserCh = await import(
+  'file://' + path.join(ROOT, 'src/chrome/src/agent/tool-call-parser.js').replace(/\\/g, '/')
+);
+const ToolCallParserFx = await import(
+  'file://' + path.join(ROOT, 'src/firefox/src/agent/tool-call-parser.js').replace(/\\/g, '/')
+);
 // The mutating-tool surface differs per build, so it lives outside the
 // byte-identical loop-detector module. Import the real sets rather than
 // restating them here — a hand-copied list is exactly the drift this suite
@@ -43799,6 +43805,103 @@ test('streamed plain final answers cannot bypass unresolved progress rows', asyn
     assert.ok(progressBlock, `${AgentClass.name}: streamed plain final progress block nudge missing`);
     const blockedDone = agent.conversations.get(tabId).find(msg => msg.role === 'tool' && /"blockedDone":true/.test(msg.content || ''));
     assert.ok(blockedDone, `${AgentClass.name}: streamed done after plain-final nudge was not blocked`);
+  }
+});
+
+test('text tool-call parser is production code with format and allowlist coverage', () => {
+  assert.equal(
+    fs.readFileSync(path.join(ROOT, 'src/chrome/src/agent/tool-call-parser.js'), 'utf8'),
+    fs.readFileSync(path.join(ROOT, 'src/firefox/src/agent/tool-call-parser.js'), 'utf8'),
+    'chrome and firefox tool-call parsers must remain byte-identical',
+  );
+  const allowed = new Set(['click', 'click_ax', 'navigate', 'read_page']);
+  const cases = [
+    {
+      label: 'tool_call JSON with nested arguments',
+      raw: '<tool_call>{"name":"click","arguments":{"text":"Save","meta":{"source":"dialog"}}}</tool_call>',
+      expected: [{ name: 'click', args: { text: 'Save', meta: { source: 'dialog' } } }],
+    },
+    {
+      label: 'token wrapper',
+      raw: '<|tool_call|>{"name":"read_page","arguments":{}}<|/tool_call|>',
+      expected: [{ name: 'read_page', args: {} }],
+    },
+    {
+      label: 'functioncall wrapper',
+      raw: '<functioncall>{"name":"navigate","arguments":{"url":"https://example.test/path"}}</functioncall>',
+      expected: [{ name: 'navigate', args: { url: 'https://example.test/path' } }],
+    },
+    {
+      label: 'custom quote tokens',
+      raw: 'call:click{text:<|"|>Save<|"|>}',
+      expected: [{ name: 'click', args: { text: 'Save' } }],
+    },
+    {
+      label: 'bare JSON with string arguments',
+      raw: '{"name":"read_page","arguments":"[]"}',
+      expected: [{ name: 'read_page', args: [] }],
+    },
+    {
+      label: 'XML typed parameters',
+      raw: [
+        '<tool_call><function=click>',
+        '<parameter=name>"Save"</parameter>',
+        '<parameter=index>2</parameter>',
+        '<parameter=force>true</parameter>',
+        '<parameter=coordinates>[10,20]</parameter>',
+        '</function></tool_call>',
+      ].join(''),
+      expected: [{
+        name: 'click',
+        args: { name: 'Save', index: 2, force: true, coordinates: [10, 20] },
+      }],
+    },
+    {
+      label: 'multiple wrappers preserve order',
+      raw: [
+        '<tool_call>{"name":"read_page","arguments":{}}</tool_call>',
+        '<tool_call>{"name":"click_ax","arguments":{"ref_id":"ref_7"}}</tool_call>',
+      ].join('\n'),
+      expected: [
+        { name: 'read_page', args: {} },
+        { name: 'click_ax', args: { ref_id: 'ref_7' } },
+      ],
+    },
+  ];
+
+  for (const parser of [ToolCallParserCh, ToolCallParserFx]) {
+    for (const scenario of cases) {
+      const calls = parser.parseToolCallsFromText(scenario.raw, allowed);
+      assert.deepEqual(
+        calls.map(call => ({
+          name: call.function.name,
+          args: JSON.parse(call.function.arguments),
+        })),
+        scenario.expected,
+        scenario.label,
+      );
+      assert.equal(
+        calls.every((call, index) =>
+          new RegExp(`^fallback_call_\\d+_${index}$`).test(call.id)
+        ),
+        true,
+        `${scenario.label}: fallback IDs were not stable OpenAI-style call IDs`,
+      );
+    }
+
+    assert.deepEqual(
+      parser.parseToolCallsFromText(
+        '<tool_call>{"name":"execute_js","arguments":{"code":"alert(1)"}}</tool_call>',
+        allowed,
+      ),
+      [],
+      'disallowed tool name bypassed the allowlist',
+    );
+    assert.deepEqual(
+      parser.parseToolCallsFromText('x'.repeat(10001), allowed),
+      [],
+      'oversized model text was parsed',
+    );
   }
 });
 


### PR DESCRIPTION
## Summary

- extract the raw-text tool-call parser from both browser `Agent` classes into byte-identical, browser-free modules
- keep the existing Agent method as a compatibility wrapper with the current default and mode-specific allowlists
- exercise every currently supported text format directly against production parser code in both builds

## Motivation

Local/chat-template models can return tool calls as raw text rather than through a provider's structured `tool_calls` field. That fallback parser had grown inside both large Agent classes, while most formats were not directly regression-tested. Isolating it makes the security boundary and future parser changes easier to review without changing current behavior.

## Design

- preserve the existing 10,000-character cap, allowlist checks, parsing order, output shape, and fallback IDs
- keep browser-specific tool-name sets at the Agent call sites
- mirror the small module in each independently packaged extension tree and enforce byte parity in tests
- leave parser behavior improvements and broader context-trimming work for separate changes

## Testing

- `node test/run.js`: 1329 passed, 1 inherited failure (`package.json` is `25.9.7` while the newest `CHANGELOG.md` entry is `25.9.0`)
- `npm run test:security`: 60/60
- `npm run test:fixtures`: 125/125
- `npm run test:webmcp`: passed with Chrome 150
- `npm run test:ci`: passed
- `node --check` on both parser modules and both Agent modules
- `git diff --check`

## Compatibility

No public API, tool schema, accepted format, or browser packaging behavior changes.
