### PR TITLE
feat: add ATIF trace converter

### DIFF
--- a/docs/export-and-workflow-formats.md
+++ b/docs/export-and-workflow-formats.md
@@ -59,6 +59,32 @@ Screenshot events can include `screenshot_base64` or `screenshot_dataUrl`.
 Consumers should check `schema`, tolerate additional fields, and avoid relying
 on undocumented event internals.
 
+### Convert a trace to ATIF v1.7
+
+The dependency-free converter turns one Traces-page JSON export into the
+[Agent Trajectory Interchange Format (ATIF)](https://github.com/harbor-framework/harbor/blob/main/rfcs/0001-trajectory-format.md):
+
+```bash
+node scripts/trace-to-atif.mjs webbrain-trace-model-run.json
+```
+
+By default this writes `webbrain-trace-model-run.atif.json` next to the source
+file. Pass a second path to choose another destination, or `-` to write the
+trajectory to standard output:
+
+```bash
+node scripts/trace-to-atif.mjs trace.json trajectory.json
+node scripts/trace-to-atif.mjs trace.json -
+```
+
+The converter maps user and agent messages, tool calls and observations, token
+metrics, errors, model metadata, and final content. It does not upload data.
+Screenshots and verbose diagnostic event kinds are counted in
+`extra.omitted_event_counts` but are not copied: ATIF represents images as
+files referenced alongside the trajectory, while a WebBrain JSON export embeds
+them as data URLs or base64. The converted trajectory remains sensitive because
+it still contains prompts, tool arguments, URLs, and results.
+
 ## Settings snapshots: `webbrain-config/1`
 
 `/export --config` creates a versioned Settings snapshot:

--- a/scripts/trace-to-atif.mjs
+++ b/scripts/trace-to-atif.mjs
@@ -1,0 +1,354 @@
+#!/usr/bin/env node
+
+/**
+ * Convert a Traces-page `webbrain-trace/1` JSON export to ATIF v1.7.
+ *
+ * This deliberately stays offline and dependency-free. Screenshots and verbose
+ * diagnostic events are counted but not copied because ATIF represents images
+ * as files referenced alongside the trajectory, not embedded data URLs.
+ */
+
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import process from 'node:process';
+import { fileURLToPath } from 'node:url';
+
+const SOURCE_SCHEMA = 'webbrain-trace/1';
+const ATIF_SCHEMA_VERSION = 'ATIF-v1.7';
+
+function isObject(value) {
+  return !!value && typeof value === 'object' && !Array.isArray(value);
+}
+
+function finiteNumber(value) {
+  return typeof value === 'number' && Number.isFinite(value) ? value : undefined;
+}
+
+function timestamp(value) {
+  if (value == null || value === '') return undefined;
+  const date = new Date(value);
+  return Number.isNaN(date.getTime()) ? undefined : date.toISOString();
+}
+
+function jsonSafe(value, fallback) {
+  try {
+    const serialized = JSON.stringify(value);
+    return serialized === undefined ? fallback : JSON.parse(serialized);
+  } catch {
+    return fallback;
+  }
+}
+
+function compactObject(value) {
+  return Object.fromEntries(
+    Object.entries(value).filter(([, item]) => item !== undefined),
+  );
+}
+
+function parseArguments(value) {
+  if (isObject(value)) return { arguments: jsonSafe(value, {}) };
+  if (typeof value === 'string') {
+    try {
+      const parsed = JSON.parse(value);
+      if (isObject(parsed)) return { arguments: parsed };
+    } catch {}
+    return {
+      arguments: {},
+      extra: { raw_arguments: value },
+    };
+  }
+  if (value == null) return { arguments: {} };
+  return {
+    arguments: {},
+    extra: { raw_arguments: String(value) },
+  };
+}
+
+function resultContent(value) {
+  if (value === undefined) return '(missing tool result)';
+  if (typeof value === 'string') return value;
+  try {
+    const serialized = JSON.stringify(value);
+    return serialized === undefined ? String(value) : serialized;
+  } catch {
+    return String(value);
+  }
+}
+
+function usageMetrics(usage) {
+  if (!isObject(usage)) return undefined;
+  const extra = {};
+  // WebBrain records provider-native cost. Some providers report USD, while
+  // others do not guarantee a currency, so never mislabel it as ATIF cost_usd.
+  const reportedCost = finiteNumber(usage.cost);
+  if (reportedCost !== undefined) extra.webbrain_reported_cost = reportedCost;
+  const metrics = compactObject({
+    prompt_tokens: finiteNumber(usage.prompt_tokens),
+    completion_tokens: finiteNumber(usage.completion_tokens),
+    cached_tokens: finiteNumber(
+      usage.cached_tokens ?? usage.prompt_tokens_details?.cached_tokens,
+    ),
+    extra: Object.keys(extra).length ? extra : undefined,
+  });
+  return Object.keys(metrics).length ? metrics : undefined;
+}
+
+function eventOrder(left, right) {
+  const leftSeq = finiteNumber(left?.seq) ?? Number.MAX_SAFE_INTEGER;
+  const rightSeq = finiteNumber(right?.seq) ?? Number.MAX_SAFE_INTEGER;
+  if (leftSeq !== rightSeq) return leftSeq - rightSeq;
+  return (finiteNumber(left?.ts) ?? 0) - (finiteNumber(right?.ts) ?? 0);
+}
+
+function sameToolName(left, right) {
+  return String(left || '') === String(right || '');
+}
+
+export function webbrainTraceToAtif(input) {
+  if (!isObject(input)) throw new TypeError('WebBrain trace export must be an object.');
+  if (input.schema !== SOURCE_SCHEMA) {
+    throw new TypeError(`Expected schema "${SOURCE_SCHEMA}".`);
+  }
+  if (!isObject(input.run)) throw new TypeError('WebBrain trace run must be an object.');
+  if (!Array.isArray(input.events)) throw new TypeError('WebBrain trace events must be an array.');
+  if (typeof input.run.runId !== 'string' || !input.run.runId.trim()) {
+    throw new TypeError('WebBrain trace run.runId must be a non-empty string.');
+  }
+
+  const run = input.run;
+  const runId = String(run.runId).trim();
+  const version = String(
+    run.webbrainVersion || input.exportedByWebBrainVersion || 'unknown',
+  );
+  const steps = [];
+  const omittedEventCounts = {};
+  let lastAgentMessage = '';
+  let pendingAgent = null;
+  const allocatedToolCallIds = new Set();
+
+  function appendStep(step) {
+    const complete = { step_id: steps.length + 1, ...compactObject(step) };
+    steps.push(complete);
+    return complete;
+  }
+
+  appendStep({
+    timestamp: timestamp(run.startedAt),
+    source: 'user',
+    message: String(run.userMessage || ''),
+  });
+
+  for (const event of [...input.events].sort(eventOrder)) {
+    if (!isObject(event)) continue;
+    if (event.runId != null && String(event.runId) !== runId) {
+      throw new TypeError(`Trace event runId "${event.runId}" does not match run.runId "${runId}".`);
+    }
+    const data = isObject(event.data) ? event.data : {};
+    const eventSeq = finiteNumber(event.seq);
+
+    if (event.kind === 'llm_response') {
+      const toolCalls = Array.isArray(data.toolCalls)
+        ? data.toolCalls.map((call, index) => {
+          const parsed = parseArguments(call?.args);
+          const recordedId = String(call?.id || '').trim();
+          const fallbackId = `webbrain-${runId}-${eventSeq ?? 'unknown'}-${index + 1}`;
+          const toolCallId = recordedId && !allocatedToolCallIds.has(recordedId)
+            ? recordedId
+            : fallbackId;
+          allocatedToolCallIds.add(toolCallId);
+          return compactObject({
+            tool_call_id: toolCallId,
+            function_name: String(call?.name || 'unknown_tool'),
+            arguments: parsed.arguments,
+            extra: parsed.extra,
+          });
+        })
+        : [];
+      const message = String(data.content || '');
+      const extra = compactObject({
+        webbrain_seq: eventSeq,
+        webbrain_step: finiteNumber(data.step),
+        phase: data.phase ? String(data.phase) : undefined,
+        latency_ms: finiteNumber(data.latencyMs),
+      });
+      const step = appendStep({
+        timestamp: timestamp(event.ts),
+        source: 'agent',
+        model_name: data.model ? String(data.model) : undefined,
+        message,
+        tool_calls: toolCalls.length ? toolCalls : undefined,
+        metrics: usageMetrics(data.usage),
+        llm_call_count: 1,
+        extra: Object.keys(extra).length ? extra : undefined,
+      });
+      pendingAgent = {
+        step,
+        webbrainStep: finiteNumber(data.step),
+        usedCallIds: new Set(),
+      };
+      if (message.trim()) lastAgentMessage = message.trim();
+      continue;
+    }
+
+    if (event.kind === 'tool') {
+      const toolName = String(data.name || 'unknown_tool');
+      const pendingCall = pendingAgent?.step.tool_calls?.find((call) => (
+        !pendingAgent.usedCallIds.has(call.tool_call_id)
+        && sameToolName(call.function_name, toolName)
+        && (
+          pendingAgent.webbrainStep === undefined
+          || finiteNumber(data.step) === undefined
+          || pendingAgent.webbrainStep === finiteNumber(data.step)
+        )
+      ));
+      const observationExtra = compactObject({
+        latency_ms: finiteNumber(data.latencyMs),
+        webbrain_seq: eventSeq,
+      });
+      if (pendingCall) {
+        pendingAgent.usedCallIds.add(pendingCall.tool_call_id);
+        if (!pendingAgent.step.observation) pendingAgent.step.observation = { results: [] };
+        pendingAgent.step.observation.results.push({
+          source_call_id: pendingCall.tool_call_id,
+          content: resultContent(data.result),
+          ...(Object.keys(observationExtra).length ? { extra: observationExtra } : {}),
+        });
+        continue;
+      }
+
+      const parsed = parseArguments(data.args);
+      let toolCallId = `webbrain-${runId}-${eventSeq ?? steps.length + 1}-1`;
+      let suffix = 2;
+      while (allocatedToolCallIds.has(toolCallId)) {
+        toolCallId = `webbrain-${runId}-${eventSeq ?? steps.length + 1}-${suffix}`;
+        suffix += 1;
+      }
+      allocatedToolCallIds.add(toolCallId);
+      const stepExtra = compactObject({
+        webbrain_seq: eventSeq,
+        webbrain_step: finiteNumber(data.step),
+      });
+      appendStep({
+        timestamp: timestamp(event.ts),
+        source: 'agent',
+        message: '',
+        tool_calls: [compactObject({
+          tool_call_id: toolCallId,
+          function_name: toolName,
+          arguments: parsed.arguments,
+          extra: parsed.extra,
+        })],
+        observation: {
+          results: [{
+            source_call_id: toolCallId,
+            content: resultContent(data.result),
+            ...(Object.keys(observationExtra).length ? { extra: observationExtra } : {}),
+          }],
+        },
+        llm_call_count: 0,
+        extra: Object.keys(stepExtra).length ? stepExtra : undefined,
+      });
+      pendingAgent = null;
+      continue;
+    }
+
+    if (event.kind === 'error') {
+      const errorExtra = compactObject({
+        webbrain_seq: eventSeq,
+        webbrain_step: finiteNumber(data.step),
+        phase: data.phase ? String(data.phase) : undefined,
+      });
+      appendStep({
+        timestamp: timestamp(event.ts),
+        source: 'system',
+        message: 'WebBrain runtime error',
+        observation: {
+          results: [{ content: String(data.message || 'Unknown error') }],
+        },
+        extra: Object.keys(errorExtra).length ? errorExtra : undefined,
+      });
+      pendingAgent = null;
+      continue;
+    }
+
+    const kind = String(event.kind || 'unknown');
+    omittedEventCounts[kind] = (omittedEventCounts[kind] || 0) + 1;
+  }
+
+  const finalContent = String(run.finalContent || '').trim();
+  if (finalContent && finalContent !== lastAgentMessage) {
+    appendStep({
+      timestamp: timestamp(run.endedAt),
+      source: 'agent',
+      message: finalContent,
+      extra: { webbrain_final_content: true },
+    });
+  }
+
+  const agentExtra = compactObject({
+    provider_id: run.providerId ? String(run.providerId) : undefined,
+    provider_class: run.providerClass ? String(run.providerClass) : undefined,
+    mode: run.mode ? String(run.mode) : undefined,
+  });
+  const rootExtra = compactObject({
+    source_schema: SOURCE_SCHEMA,
+    source_exported_at: timestamp(input.exportedAt),
+    source_exported_by_webbrain_version: input.exportedByWebBrainVersion
+      ? String(input.exportedByWebBrainVersion)
+      : undefined,
+    status: run.status ? String(run.status) : undefined,
+    tab_url: run.tabUrl ? String(run.tabUrl) : undefined,
+    tab_title: run.tabTitle ? String(run.tabTitle) : undefined,
+    omitted_event_counts: Object.keys(omittedEventCounts).length
+      ? omittedEventCounts
+      : undefined,
+  });
+  const finalMetrics = compactObject({
+    total_prompt_tokens: finiteNumber(run.totalInputTokens),
+    total_completion_tokens: finiteNumber(run.totalOutputTokens),
+    total_steps: steps.length,
+  });
+
+  return {
+    schema_version: ATIF_SCHEMA_VERSION,
+    session_id: runId,
+    trajectory_id: runId,
+    agent: compactObject({
+      name: 'webbrain',
+      version,
+      model_name: run.model ? String(run.model) : undefined,
+      extra: Object.keys(agentExtra).length ? agentExtra : undefined,
+    }),
+    steps,
+    final_metrics: finalMetrics,
+    extra: rootExtra,
+  };
+}
+
+async function main(argv) {
+  const [inputPath, outputPath] = argv;
+  if (!inputPath || argv.length > 2) {
+    throw new Error('Usage: node scripts/trace-to-atif.mjs <trace.json> [trajectory.json|-]');
+  }
+  const raw = await fs.readFile(inputPath, 'utf8');
+  const trajectory = webbrainTraceToAtif(JSON.parse(raw));
+  const serialized = `${JSON.stringify(trajectory, null, 2)}\n`;
+  if (outputPath === '-') {
+    process.stdout.write(serialized);
+    return;
+  }
+  const destination = outputPath || path.join(
+    path.dirname(inputPath),
+    `${path.basename(inputPath, path.extname(inputPath))}.atif.json`,
+  );
+  await fs.writeFile(destination, serialized, 'utf8');
+  process.stderr.write(`Wrote ${destination}\n`);
+}
+
+const invokedPath = process.argv[1] ? path.resolve(process.argv[1]) : '';
+if (invokedPath === fileURLToPath(import.meta.url)) {
+  main(process.argv.slice(2)).catch((error) => {
+    process.stderr.write(`${error?.message || error}\n`);
+    process.exitCode = 1;
+  });
+}

--- a/test/run.js
+++ b/test/run.js
@@ -8,8 +8,10 @@
  */
 
 import { strict as assert } from 'node:assert';
+import { spawnSync } from 'node:child_process';
 import fs from 'node:fs';
 import { fileURLToPath, pathToFileURL } from 'node:url';
+import os from 'node:os';
 import path from 'node:path';
 import vm from 'node:vm';
 
@@ -216,6 +218,9 @@ const { tracesToMarkdown } = await import(
 );
 const { tracesToMarkdown: tracesToMarkdownFx } = await import(
   'file://' + path.join(ROOT, 'src/firefox/src/agent/trace-export.js').replace(/\\/g, '/')
+);
+const { webbrainTraceToAtif } = await import(
+  'file://' + path.join(ROOT, 'scripts/trace-to-atif.mjs').replace(/\\/g, '/')
 );
 const SavedWorkflowsCh = await import(
   'file://' + path.join(ROOT, 'src/chrome/src/agent/workflows.js').replace(/\\/g, '/')
@@ -2715,6 +2720,253 @@ const TRACE_RUNS = [
     ],
   },
 ];
+
+test('ATIF export: maps a WebBrain run, LLM calls, tools, metrics, and final response', () => {
+  const input = {
+    schema: 'webbrain-trace/1',
+    exportedAt: 1_770_000_100_000,
+    exportedByWebBrainVersion: '23.4.0',
+    run: {
+      runId: 'atif-run-1',
+      conversationId: 'conversation-7',
+      startedAt: 1_770_000_000_000,
+      endedAt: 1_770_000_010_000,
+      userMessage: 'Find the current title',
+      model: 'test-model',
+      providerId: 'local-test',
+      providerClass: 'openai-compatible',
+      mode: 'act',
+      status: 'done',
+      webbrainVersion: '23.3.1',
+      totalInputTokens: 12,
+      totalOutputTokens: 7,
+      finalContent: 'The title is Example.',
+    },
+    events: [
+      {
+        runId: 'atif-run-1',
+        seq: 1,
+        ts: 1_770_000_001_000,
+        kind: 'llm_response',
+        data: {
+          step: 1,
+          content: '',
+          model: 'test-model-v2',
+          latencyMs: 120,
+          toolCalls: [{
+            id: 'call-1',
+            name: 'read_page',
+            args: '{"include":"title"}',
+          }],
+          usage: {
+            prompt_tokens: 12,
+            completion_tokens: 3,
+            prompt_tokens_details: { cached_tokens: 2 },
+            cost: 0.001,
+          },
+        },
+      },
+      {
+        runId: 'atif-run-1',
+        seq: 2,
+        ts: 1_770_000_002_000,
+        kind: 'tool',
+        data: {
+          step: 1,
+          name: 'read_page',
+          args: { include: 'title' },
+          result: { title: 'Example' },
+          latencyMs: 80,
+        },
+      },
+      {
+        runId: 'atif-run-1',
+        seq: 3,
+        ts: 1_770_000_003_000,
+        kind: 'llm_response',
+        data: {
+          step: 2,
+          content: 'The title is Example.',
+          usage: { prompt_tokens: 0, completion_tokens: 4 },
+        },
+      },
+      {
+        runId: 'atif-run-1',
+        seq: 4,
+        ts: 1_770_000_004_000,
+        kind: 'screenshot',
+        data: { caption: 'viewport', screenshot_base64: 'sensitive-bytes' },
+      },
+    ],
+  };
+
+  const atif = webbrainTraceToAtif(input);
+  assert.equal(atif.schema_version, 'ATIF-v1.7');
+  assert.equal(atif.session_id, 'atif-run-1');
+  assert.equal(atif.trajectory_id, 'atif-run-1');
+  assert.deepEqual(atif.agent, {
+    name: 'webbrain',
+    version: '23.3.1',
+    model_name: 'test-model',
+    extra: {
+      provider_id: 'local-test',
+      provider_class: 'openai-compatible',
+      mode: 'act',
+    },
+  });
+  assert.equal(atif.steps.length, 3);
+  assert.deepEqual(atif.steps[0], {
+    step_id: 1,
+    timestamp: '2026-02-02T02:40:00.000Z',
+    source: 'user',
+    message: 'Find the current title',
+  });
+  assert.equal(atif.steps[1].source, 'agent');
+  assert.equal(atif.steps[1].model_name, 'test-model-v2');
+  assert.deepEqual(atif.steps[1].tool_calls, [{
+    tool_call_id: 'call-1',
+    function_name: 'read_page',
+    arguments: { include: 'title' },
+  }]);
+  assert.deepEqual(atif.steps[1].observation.results, [{
+    source_call_id: 'call-1',
+    content: '{"title":"Example"}',
+    extra: { latency_ms: 80, webbrain_seq: 2 },
+  }]);
+  assert.deepEqual(atif.steps[1].metrics, {
+    prompt_tokens: 12,
+    completion_tokens: 3,
+    cached_tokens: 2,
+    extra: { webbrain_reported_cost: 0.001 },
+  });
+  assert.equal(atif.steps[2].message, 'The title is Example.');
+  assert.deepEqual(atif.final_metrics, {
+    total_prompt_tokens: 12,
+    total_completion_tokens: 7,
+    total_steps: 3,
+  });
+  assert.deepEqual(atif.extra.omitted_event_counts, { screenshot: 1 });
+  assert.ok(!JSON.stringify(atif).includes('sensitive-bytes'));
+});
+
+test('ATIF export: synthesizes deterministic tool calls and preserves malformed arguments safely', () => {
+  const input = {
+    schema: 'webbrain-trace/1',
+    exportedByWebBrainVersion: '23.4.0',
+    run: {
+      runId: 'standalone-tool',
+      userMessage: '',
+      model: '',
+      finalContent: 'Finished.',
+    },
+    events: [
+      {
+        seq: 7,
+        ts: 1_770_000_007_000,
+        kind: 'tool',
+        data: {
+          step: 1,
+          name: 'custom_tool',
+          args: '{not valid json',
+          result: undefined,
+        },
+      },
+    ],
+  };
+  const atif = webbrainTraceToAtif(input);
+  assert.equal(atif.agent.version, '23.4.0');
+  assert.equal(atif.steps[1].llm_call_count, 0);
+  assert.deepEqual(atif.steps[1].tool_calls, [{
+    tool_call_id: 'webbrain-standalone-tool-7-1',
+    function_name: 'custom_tool',
+    arguments: {},
+    extra: { raw_arguments: '{not valid json' },
+  }]);
+  assert.deepEqual(atif.steps[1].observation.results, [{
+    source_call_id: 'webbrain-standalone-tool-7-1',
+    content: '(missing tool result)',
+    extra: { webbrain_seq: 7 },
+  }]);
+  assert.equal(atif.steps[2].message, 'Finished.');
+});
+
+test('ATIF export: replaces repeated provider tool-call IDs deterministically', () => {
+  const atif = webbrainTraceToAtif({
+    schema: 'webbrain-trace/1',
+    run: { runId: 'duplicate-calls', userMessage: 'Run both tools' },
+    events: [
+      {
+        seq: 1,
+        kind: 'llm_response',
+        data: {
+          step: 1,
+          toolCalls: [
+            { id: 'duplicate', name: 'first', args: '{}' },
+            { id: 'duplicate', name: 'second', args: '{}' },
+          ],
+        },
+      },
+    ],
+  });
+  assert.deepEqual(
+    atif.steps[1].tool_calls.map((call) => call.tool_call_id),
+    ['duplicate', 'webbrain-duplicate-calls-1-2'],
+  );
+});
+
+test('ATIF export: rejects unsupported or malformed WebBrain exports', () => {
+  assert.throws(
+    () => webbrainTraceToAtif({ schema: 'other/1', run: {}, events: [] }),
+    /Expected schema "webbrain-trace\/1"/,
+  );
+  assert.throws(
+    () => webbrainTraceToAtif({ schema: 'webbrain-trace/1', run: {}, events: 'nope' }),
+    /events must be an array/,
+  );
+  assert.throws(
+    () => webbrainTraceToAtif({ schema: 'webbrain-trace/1', run: {}, events: [] }),
+    /run\.runId must be a non-empty string/,
+  );
+  assert.throws(
+    () => webbrainTraceToAtif({ schema: 'webbrain-trace/1', run: { runId: 7 }, events: [] }),
+    /run\.runId must be a non-empty string/,
+  );
+  assert.throws(
+    () => webbrainTraceToAtif({
+      schema: 'webbrain-trace/1',
+      run: { runId: 'expected' },
+      events: [{ runId: 'foreign', kind: 'tool', data: {} }],
+    }),
+    /event runId "foreign" does not match/,
+  );
+});
+
+test('ATIF export: CLI writes a sibling .atif.json file', () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'webbrain-atif-'));
+  try {
+    const sourcePath = path.join(tempDir, 'trace.json');
+    fs.writeFileSync(sourcePath, JSON.stringify({
+      schema: 'webbrain-trace/1',
+      exportedByWebBrainVersion: '23.4.0',
+      run: { runId: 'cli-run', userMessage: 'Hello' },
+      events: [],
+    }));
+    const result = spawnSync(
+      process.execPath,
+      [path.join(ROOT, 'scripts/trace-to-atif.mjs'), sourcePath],
+      { encoding: 'utf8' },
+    );
+    assert.equal(result.status, 0, result.stderr);
+    assert.match(result.stderr, /trace\.atif\.json/);
+    const output = JSON.parse(
+      fs.readFileSync(path.join(tempDir, 'trace.atif.json'), 'utf8'),
+    );
+    assert.equal(output.schema_version, 'ATIF-v1.7');
+    assert.equal(output.session_id, 'cli-run');
+  } finally {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
+});
 
 test('trace export: renders the full tool chain from trace events, in order', () => {
   const { markdown, turnCount, toolCount } = tracesToMarkdown(TRACE_RUNS);


### PR DESCRIPTION
## Summary
- add a dependency-free CLI that converts one `webbrain-trace/1` JSON export to ATIF v1.7
- map messages, LLM metrics, tool calls/observations, errors, model metadata, and final content
- omit embedded screenshots and count unsupported diagnostic event kinds without uploading any data
- document CLI usage, output handling, compatibility, and sensitivity

## Safety and compatibility
- leaves the browser extension runtime and existing trace schema unchanged
- rejects malformed schemas, missing/mismatched run IDs, and rewrites duplicate tool-call IDs deterministically
- keeps provider-native cost in `extra.webbrain_reported_cost` instead of incorrectly labeling unknown currency as USD

## Testing
- `node test/run.js`: 1333 passed; one unrelated upstream baseline failure remains because package.json is 25.9.7 while the newest changelog entry is 25.9.0
- `node test/security/injection-corpus.mjs`: 60/60 passed
- generated trajectory validated with Harbor current ATIF v1.7 `Trajectory.model_validate`
- `node --check scripts/trace-to-atif.mjs`
- `git diff --check`