### PR TITLE
feat(traces): add offline OTLP converter

### DIFF
--- a/docs/export-and-workflow-formats.md
+++ b/docs/export-and-workflow-formats.md
@@ -59,6 +59,53 @@ Screenshot events can include `screenshot_base64` or `screenshot_dataUrl`.
 Consumers should check `schema`, tolerate additional fields, and avoid relying
 on undocumented event internals.
 
+### Convert a trace to OpenTelemetry OTLP JSON
+
+The repository includes an offline converter for sending an exported
+`webbrain-trace/1` run through an OpenTelemetry-compatible observability
+pipeline:
+
+```sh
+npm run trace:otlp -- webbrain-trace-example.json \
+  --output webbrain-trace-example.otlp.json
+```
+
+The output is an
+[OTLP/HTTP JSON](https://opentelemetry.io/docs/specs/otlp/#json-protobuf-encoding)
+`ExportTraceServiceRequest`. It contains one `invoke_agent WebBrain` root span,
+child model-call and `execute_tool` spans, and lightweight lifecycle events.
+The mappings follow the current
+[OpenTelemetry GenAI semantic conventions](https://github.com/open-telemetry/semantic-conventions-genai/blob/main/docs/gen-ai/gen-ai-agent-spans.md),
+which are still marked development and may change.
+
+The converter does not upload anything. To send the result to a collector, use
+that collector's OTLP/HTTP traces endpoint; for example, for a trusted local
+collector:
+
+```sh
+curl -H 'Content-Type: application/json' \
+  --data-binary @webbrain-trace-example.otlp.json \
+  http://127.0.0.1:4318/v1/traces
+```
+
+Content capture is off by default. User messages, assistant text, error
+messages, tool arguments, and tool results are omitted, while operational
+metadata such as model, provider, timings, token counts, tool names, and run
+identifiers remains. Screenshots are never embedded in the OTLP output. Add
+`--include-content` only when the destination is trusted and the trace has been
+reviewed:
+
+```sh
+npm run trace:otlp -- webbrain-trace-example.json \
+  --output webbrain-trace-example.otlp.json \
+  --include-content
+```
+
+This is a post-run conversion, not live OpenTelemetry instrumentation. Child
+span start times are reconstructed from the recorder's completion timestamp and
+reported latency, so they should be used for diagnostics rather than
+distributed context propagation.
+
 ## Settings snapshots: `webbrain-config/1`
 
 `/export --config` creates a versioned Settings snapshot:

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "build:web:landing": "node web/build/build.mjs",
     "build:web": "npm run build:web:landing && npm run build:blog && npm run build:docs",
     "build:zip": "node scripts/build-zip.mjs",
+    "trace:otlp": "node scripts/trace-to-otlp.mjs",
     "sync:logo": "python3 scripts/sync-logo-assets.py && python3 scripts/gen-store-promos.py && node assets/webstore-explainer-2026/render.mjs",
     "bump": "node scripts/bump-version.mjs",
     "release": "node scripts/bump-version.mjs --release"

--- a/scripts/trace-to-otlp.mjs
+++ b/scripts/trace-to-otlp.mjs
@@ -1,0 +1,316 @@
+#!/usr/bin/env node
+import { createHash } from 'node:crypto';
+import { readFileSync, writeFileSync } from 'node:fs';
+import { pathToFileURL } from 'node:url';
+
+const WEBBRAIN_TRACE_SCHEMA = 'webbrain-trace/1';
+const CONTENT_LIMIT = 20_000;
+const SPAN_KIND_INTERNAL = 1;
+const SPAN_KIND_CLIENT = 3;
+const STATUS_CODE_ERROR = 2;
+
+function finiteNumber(value, fallback = 0) {
+  const number = Number(value);
+  return Number.isFinite(number) ? number : fallback;
+}
+
+function unixNano(milliseconds) {
+  const micros = BigInt(Math.max(0, Math.round(finiteNumber(milliseconds) * 1000)));
+  return String(micros * 1000n);
+}
+
+function stableHex(seed, length) {
+  const value = createHash('sha256').update(String(seed)).digest('hex').slice(0, length);
+  return /^0+$/.test(value) ? `${'0'.repeat(length - 1)}1` : value;
+}
+
+function safeJson(value) {
+  try {
+    const serialized = JSON.stringify(value);
+    return serialized === undefined ? '' : serialized;
+  } catch {
+    try {
+      return String(value);
+    } catch {
+      return '(unserializable)';
+    }
+  }
+}
+
+function boundedContent(value) {
+  if (value == null) return '';
+  const text = typeof value === 'string' ? value : safeJson(value);
+  if (text.length <= CONTENT_LIMIT) return text;
+  return `${text.slice(0, CONTENT_LIMIT)}…`;
+}
+
+function anyValue(value) {
+  if (typeof value === 'boolean') return { boolValue: value };
+  if (typeof value === 'number') {
+    if (!Number.isFinite(value)) return null;
+    return Number.isInteger(value)
+      ? { intValue: String(value) }
+      : { doubleValue: value };
+  }
+  if (value == null || value === '') return null;
+  return { stringValue: String(value) };
+}
+
+function attributes(entries) {
+  return entries.flatMap(([key, value]) => {
+    const encoded = anyValue(value);
+    return encoded ? [{ key, value: encoded }] : [];
+  });
+}
+
+function eventTime(event, fallback) {
+  const value = finiteNumber(event?.ts, fallback);
+  return value > 0 ? value : fallback;
+}
+
+function spanBounds(event, runStart) {
+  const end = eventTime(event, runStart);
+  const latency = Math.max(0, finiteNumber(event?.data?.latencyMs));
+  return {
+    startTimeUnixNano: unixNano(Math.max(runStart, end - latency)),
+    endTimeUnixNano: unixNano(Math.max(runStart, end)),
+  };
+}
+
+function failedToolResult(result) {
+  if (result == null) return true;
+  return typeof result === 'object' && (result.success === false || Boolean(result.error));
+}
+
+function contentAttributes(run, includeContent) {
+  if (!includeContent) return [];
+  return [
+    ['webbrain.user.message', boundedContent(run.userMessage)],
+    ['webbrain.final.response', boundedContent(run.finalContent)],
+  ];
+}
+
+function rootEvents(events, includeContent, runStart) {
+  return events.flatMap((event) => {
+    const data = event?.data || {};
+    const base = [
+      ['webbrain.event.sequence', finiteNumber(event?.seq)],
+      ['webbrain.step', finiteNumber(data.step)],
+    ];
+    if (event?.kind === 'error') {
+      return [{
+        timeUnixNano: unixNano(eventTime(event, runStart)),
+        name: 'exception',
+        attributes: attributes([
+          ...base,
+          ['exception.type', data.phase ? `webbrain.${data.phase}` : 'webbrain.error'],
+          ...(includeContent ? [['exception.message', boundedContent(data.message)]] : []),
+        ]),
+      }];
+    }
+    if (event?.kind === 'streaming' || event?.kind === 'note' || event?.kind === 'screenshot') {
+      return [{
+        timeUnixNano: unixNano(eventTime(event, runStart)),
+        name: `webbrain.${event.kind}`,
+        attributes: attributes([
+          ...base,
+          ['webbrain.event.status', data.status],
+          ['webbrain.event.reason', data.reason],
+          ...(includeContent && event.kind === 'note'
+            ? [['webbrain.note', boundedContent(data.note)]]
+            : []),
+        ]),
+      }];
+    }
+    return [];
+  });
+}
+
+function inferenceSpan(event, context, includeContent) {
+  const data = event.data || {};
+  const model = String(data.model || context.run.model || 'unknown');
+  const usage = data.usage || {};
+  return {
+    traceId: context.traceId,
+    spanId: stableHex(`${context.run.runId}:llm_response:${event.seq}`, 16),
+    parentSpanId: context.rootSpanId,
+    name: `chat ${model}`,
+    kind: SPAN_KIND_CLIENT,
+    ...spanBounds(event, context.runStart),
+    attributes: attributes([
+      ['gen_ai.operation.name', 'chat'],
+      ['gen_ai.provider.name', context.run.providerId],
+      ['gen_ai.request.model', model],
+      ['gen_ai.usage.input_tokens', usage.prompt_tokens],
+      ['gen_ai.usage.output_tokens', usage.completion_tokens],
+      ['webbrain.event.sequence', finiteNumber(event.seq)],
+      ['webbrain.step', finiteNumber(data.step)],
+      ...(includeContent
+        ? [['webbrain.llm.response.content', boundedContent(data.content)]]
+        : []),
+    ]),
+  };
+}
+
+function toolSpan(event, context, includeContent) {
+  const data = event.data || {};
+  const name = String(data.name || 'unknown');
+  const failed = failedToolResult(data.result);
+  return {
+    traceId: context.traceId,
+    spanId: stableHex(`${context.run.runId}:tool:${event.seq}`, 16),
+    parentSpanId: context.rootSpanId,
+    name: `execute_tool ${name}`,
+    kind: SPAN_KIND_INTERNAL,
+    ...spanBounds(event, context.runStart),
+    attributes: attributes([
+      ['gen_ai.operation.name', 'execute_tool'],
+      ['gen_ai.tool.name', name],
+      ['gen_ai.agent.name', 'WebBrain'],
+      ...(failed ? [['error.type', 'tool_error']] : []),
+      ['webbrain.event.sequence', finiteNumber(event.seq)],
+      ['webbrain.step', finiteNumber(data.step)],
+      ...(includeContent
+        ? [
+            ['gen_ai.tool.call.arguments', boundedContent(data.args)],
+            ['gen_ai.tool.call.result', boundedContent(data.result)],
+          ]
+        : []),
+    ]),
+    ...(failed ? { status: { code: STATUS_CODE_ERROR } } : {}),
+  };
+}
+
+export function traceExportToOtlp(input, { includeContent = false } = {}) {
+  if (!input || input.schema !== WEBBRAIN_TRACE_SCHEMA) {
+    throw new Error(`Expected a ${WEBBRAIN_TRACE_SCHEMA} export.`);
+  }
+  if (!input.run || typeof input.run !== 'object' || Array.isArray(input.run)) {
+    throw new Error('Trace export must contain a run object.');
+  }
+  if (!Array.isArray(input.events)) {
+    throw new Error('Trace export must contain an events array.');
+  }
+
+  const run = input.run;
+  const events = [...input.events]
+    .filter((event) => event && typeof event === 'object')
+    .sort((a, b) => finiteNumber(a.seq) - finiteNumber(b.seq));
+  const eventTimes = events.map((event) => finiteNumber(event.ts)).filter((time) => time > 0);
+  const fallbackStarts = [...eventTimes, finiteNumber(input.exportedAt)].filter((time) => time > 0);
+  const initialStart = finiteNumber(
+    run.startedAt,
+    fallbackStarts.length ? Math.min(...fallbackStarts) : 0,
+  );
+  const childStarts = events.map((event) => (
+    eventTime(event, initialStart) - Math.max(0, finiteNumber(event?.data?.latencyMs))
+  ));
+  const runStart = Math.max(0, Math.min(initialStart, ...childStarts));
+  const runEnd = Math.max(
+    runStart,
+    finiteNumber(run.endedAt),
+    runStart + Math.max(0, finiteNumber(run.durationMs)),
+    ...eventTimes,
+  );
+  const traceId = stableHex(`webbrain:${run.runId || runStart}`, 32);
+  const rootSpanId = stableHex(`webbrain:${run.runId || runStart}:root`, 16);
+  const context = { run, runStart, traceId, rootSpanId };
+  const hasError = ['error', 'failed', 'loop_stopped'].includes(String(run.status || '').toLowerCase())
+    || events.some((event) => event.kind === 'error');
+
+  const root = {
+    traceId,
+    spanId: rootSpanId,
+    name: 'invoke_agent WebBrain',
+    kind: SPAN_KIND_INTERNAL,
+    startTimeUnixNano: unixNano(runStart),
+    endTimeUnixNano: unixNano(runEnd),
+    attributes: attributes([
+      ['gen_ai.operation.name', 'invoke_agent'],
+      ['gen_ai.agent.name', 'WebBrain'],
+      ['gen_ai.agent.version', run.webbrainVersion || input.exportedByWebBrainVersion],
+      ['gen_ai.provider.name', run.providerId],
+      ['gen_ai.request.model', run.model],
+      ['gen_ai.conversation.id', run.conversationId],
+      ['gen_ai.usage.input_tokens', run.totalInputTokens],
+      ['gen_ai.usage.output_tokens', run.totalOutputTokens],
+      ['webbrain.run.id', run.runId],
+      ['webbrain.run.status', run.status],
+      ...contentAttributes(run, includeContent),
+    ]),
+    events: rootEvents(events, includeContent, runStart),
+    ...(hasError ? { status: { code: STATUS_CODE_ERROR } } : {}),
+  };
+  const childSpans = events.flatMap((event) => {
+    if (event.kind === 'llm_response') return [inferenceSpan(event, context, includeContent)];
+    if (event.kind === 'tool') return [toolSpan(event, context, includeContent)];
+    return [];
+  });
+
+  return {
+    resourceSpans: [{
+      resource: {
+        attributes: attributes([
+          ['service.name', 'webbrain'],
+          ['service.version', run.webbrainVersion || input.exportedByWebBrainVersion],
+        ]),
+      },
+      scopeSpans: [{
+        scope: {
+          name: 'webbrain.trace-export',
+          ...(input.exportedByWebBrainVersion
+            ? { version: String(input.exportedByWebBrainVersion) }
+            : {}),
+        },
+        spans: [root, ...childSpans],
+      }],
+    }],
+  };
+}
+
+export function parseTraceToOtlpArgs(argv) {
+  const parsed = { input: '', output: '', includeContent: false };
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === '--include-content') {
+      parsed.includeContent = true;
+    } else if (arg === '--output') {
+      const value = argv[index + 1];
+      if (!value || value.startsWith('--')) throw new Error('Missing value for --output.');
+      parsed.output = value;
+      index += 1;
+    } else if (arg.startsWith('--')) {
+      throw new Error(`Unknown option: ${arg}`);
+    } else if (!parsed.input) {
+      parsed.input = arg;
+    } else {
+      throw new Error(`Unexpected argument: ${arg}`);
+    }
+  }
+  if (!parsed.input) throw new Error('Missing input trace JSON path.');
+  return parsed;
+}
+
+function runCli() {
+  try {
+    const args = parseTraceToOtlpArgs(process.argv.slice(2));
+    const input = JSON.parse(readFileSync(args.input, 'utf8'));
+    const output = `${JSON.stringify(
+      traceExportToOtlp(input, { includeContent: args.includeContent }),
+      null,
+      2,
+    )}\n`;
+    if (args.output) {
+      writeFileSync(args.output, output);
+    } else {
+      process.stdout.write(output);
+    }
+  } catch (error) {
+    console.error(`trace-to-otlp: ${error.message}`);
+    process.exitCode = 1;
+  }
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  runCli();
+}

--- a/test/run.js
+++ b/test/run.js
@@ -554,6 +554,9 @@ const {
 } = await import(
   'file://' + path.join(ROOT, 'scripts/build-zip.mjs').replace(/\\/g, '/')
 );
+const { traceExportToOtlp, parseTraceToOtlpArgs } = await import(
+  'file://' + path.join(ROOT, 'scripts/trace-to-otlp.mjs').replace(/\\/g, '/')
+);
 
 // providers/manager.js — pure ESM at module load (chrome.* only inside
 // methods). We import the class so we can exercise the static categoryFor()
@@ -2940,6 +2943,189 @@ test('trace export: renders Ask streaming decisions and aggregate lifecycle metr
     assert.match(markdown, /Ask stream completed · chat_completions · terminal_event_received · 7 text deltas · 128 chars · first delta 42 ms · 310 ms total · 0 tool calls/, `${label}: completion metrics missing`);
     assert.match(markdown, /Ask stream fallback · responses · missing_terminal_event · code missing_response_completed · 2 text deltas/, `${label}: fallback reason missing`);
   }
+});
+
+const OTLP_TRACE_FIXTURE = {
+  schema: 'webbrain-trace/1',
+  exportedAt: 1_784_937_600_000,
+  exportedByWebBrainVersion: '25.9.7',
+  run: {
+    runId: 'run_otlp_fixture',
+    conversationId: 'conversation_fixture',
+    startedAt: 1_784_937_600_000,
+    endedAt: 1_784_937_601_500,
+    durationMs: 1500,
+    status: 'loop_stopped',
+    model: 'test-model',
+    providerId: 'test-provider',
+    webbrainVersion: '25.9.6',
+    userMessage: 'Private user request',
+    finalContent: 'Private final answer',
+  },
+  events: [
+    {
+      runId: 'run_otlp_fixture',
+      seq: 1,
+      ts: 1_784_937_600_500,
+      kind: 'llm_response',
+      data: {
+        step: 1,
+        model: 'response-model',
+        latencyMs: 200,
+        usage: { prompt_tokens: 31, completion_tokens: 12 },
+        content: 'Private model response',
+      },
+    },
+    {
+      runId: 'run_otlp_fixture',
+      seq: 2,
+      ts: 1_784_937_600_900,
+      kind: 'tool',
+      data: {
+        step: 1,
+        name: 'fetch_url',
+        latencyMs: 75,
+        args: { url: 'https://private.example/account' },
+        result: { success: false, error: 'Private tool failure' },
+      },
+    },
+    {
+      runId: 'run_otlp_fixture',
+      seq: 3,
+      ts: 1_784_937_601_000,
+      kind: 'error',
+      data: { step: 1, phase: 'loop', message: 'Stopped after repeated failures.' },
+    },
+    {
+      runId: 'run_otlp_fixture',
+      seq: 4,
+      ts: 1_784_937_601_100,
+      kind: 'screenshot',
+      data: { step: 1, screenshot_base64: 'data:image/png;base64,PRIVATE_SCREENSHOT' },
+    },
+  ],
+};
+
+function otlpAttributes(items = []) {
+  return Object.fromEntries(items.map(({ key, value }) => {
+    const entry = value || {};
+    const field = Object.keys(entry)[0];
+    return [key, entry[field]];
+  }));
+}
+
+test('OTLP trace converter emits valid ID, hierarchy, timing, and GenAI span shapes', () => {
+  const payload = traceExportToOtlp(OTLP_TRACE_FIXTURE);
+  assert.equal(payload.resourceSpans.length, 1);
+  const [{ resource, scopeSpans }] = payload.resourceSpans;
+  assert.equal(otlpAttributes(resource.attributes)['service.name'], 'webbrain');
+  assert.equal(scopeSpans.length, 1);
+  assert.equal(scopeSpans[0].scope.name, 'webbrain.trace-export');
+
+  const spans = scopeSpans[0].spans;
+  assert.equal(spans.length, 3);
+  const [root, inference, tool] = spans;
+  assert.match(root.traceId, /^[0-9a-f]{32}$/);
+  assert.match(root.spanId, /^[0-9a-f]{16}$/);
+  assert.equal(root.parentSpanId, undefined);
+  assert.equal(root.name, 'invoke_agent WebBrain');
+  assert.equal(root.kind, 1);
+  assert.equal(root.startTimeUnixNano, '1784937600000000000');
+  assert.equal(root.endTimeUnixNano, '1784937601500000000');
+  assert.equal(root.status.code, 2);
+
+  for (const child of [inference, tool]) {
+    assert.equal(child.traceId, root.traceId);
+    assert.equal(child.parentSpanId, root.spanId);
+    assert.match(child.spanId, /^[0-9a-f]{16}$/);
+  }
+  assert.equal(inference.name, 'chat response-model');
+  assert.equal(inference.kind, 3);
+  assert.equal(inference.startTimeUnixNano, '1784937600300000000');
+  assert.equal(inference.endTimeUnixNano, '1784937600500000000');
+  assert.deepEqual(otlpAttributes(inference.attributes), {
+    'gen_ai.operation.name': 'chat',
+    'gen_ai.provider.name': 'test-provider',
+    'gen_ai.request.model': 'response-model',
+    'gen_ai.usage.input_tokens': '31',
+    'gen_ai.usage.output_tokens': '12',
+    'webbrain.event.sequence': '1',
+    'webbrain.step': '1',
+  });
+
+  assert.equal(tool.name, 'execute_tool fetch_url');
+  assert.equal(tool.kind, 1);
+  assert.equal(tool.status.code, 2);
+  assert.equal(otlpAttributes(tool.attributes)['error.type'], 'tool_error');
+  assert.equal(otlpAttributes(tool.attributes)['gen_ai.tool.name'], 'fetch_url');
+});
+
+test('OTLP trace converter is deterministic and private-by-default', () => {
+  const first = traceExportToOtlp(OTLP_TRACE_FIXTURE);
+  const second = traceExportToOtlp(OTLP_TRACE_FIXTURE);
+  assert.deepEqual(second, first);
+  const serialized = JSON.stringify(first);
+  assert.doesNotMatch(serialized, /Private user request|Private final answer|Private model response/);
+  assert.doesNotMatch(serialized, /private\.example|Private tool failure/);
+  assert.doesNotMatch(serialized, /gen_ai\.tool\.call\.(?:arguments|result)/);
+
+  const withContent = traceExportToOtlp(OTLP_TRACE_FIXTURE, { includeContent: true });
+  const contentText = JSON.stringify(withContent);
+  assert.match(contentText, /Private user request/);
+  assert.match(contentText, /Private final answer/);
+  assert.match(contentText, /Private model response/);
+  assert.match(contentText, /gen_ai\.tool\.call\.arguments/);
+  assert.match(contentText, /gen_ai\.tool\.call\.result/);
+  assert.doesNotMatch(contentText, /PRIVATE_SCREENSHOT/);
+});
+
+test('OTLP trace converter rejects other schemas and malformed records', () => {
+  assert.throws(
+    () => traceExportToOtlp({ ...OTLP_TRACE_FIXTURE, schema: 'webbrain-trace/2' }),
+    /webbrain-trace\/1/,
+  );
+  assert.throws(
+    () => traceExportToOtlp({ ...OTLP_TRACE_FIXTURE, run: null }),
+    /run object/,
+  );
+  assert.throws(
+    () => traceExportToOtlp({ ...OTLP_TRACE_FIXTURE, events: {} }),
+    /events array/,
+  );
+  const legacy = traceExportToOtlp({
+    schema: 'webbrain-trace/1',
+    run: { runId: 'legacy-run' },
+    events: [{
+      seq: 1,
+      ts: 1234,
+      kind: 'tool',
+      data: { name: 'read_page' },
+    }],
+  }, { includeContent: true });
+  const [root, tool] = legacy.resourceSpans[0].scopeSpans[0].spans;
+  assert.equal(root.startTimeUnixNano, '1234000000');
+  assert.equal(tool.startTimeUnixNano, '1234000000');
+  assert.doesNotMatch(JSON.stringify(legacy), /stringValue\":\"(?:undefined|null)\"/);
+});
+
+test('OTLP trace converter CLI parsing keeps content opt-in and output explicit', () => {
+  assert.deepEqual(parseTraceToOtlpArgs(['trace.json']), {
+    input: 'trace.json',
+    output: '',
+    includeContent: false,
+  });
+  assert.deepEqual(parseTraceToOtlpArgs([
+    'trace.json',
+    '--output',
+    'trace.otlp.json',
+    '--include-content',
+  ]), {
+    input: 'trace.json',
+    output: 'trace.otlp.json',
+    includeContent: true,
+  });
+  assert.throws(() => parseTraceToOtlpArgs([]), /input trace JSON/);
+  assert.throws(() => parseTraceToOtlpArgs(['a.json', '--upload']), /Unknown option/);
 });
 
 test('/export --traces is wired in both side panels and backgrounds', () => {


### PR DESCRIPTION
## Summary

- add a dependency-free CLI that converts a Traces-page `webbrain-trace/1` export into an OTLP/HTTP JSON `ExportTraceServiceRequest`
- map each run to an OpenTelemetry GenAI `invoke_agent` root span with child inference and `execute_tool` spans
- keep content capture opt-in and document the offline workflow, privacy boundary, and timing limitations

## Motivation

WebBrain already records detailed local traces, but its diagnostic JSON cannot be sent through standard observability pipelines without a custom adapter. An offline converter lets users inspect WebBrain runs with OpenTelemetry-compatible collectors and backends while keeping the extension free of telemetry endpoints, uploads, and additional permissions.

## Design

`npm run trace:otlp -- <trace.json> [--output <file>]` validates the `webbrain-trace/1` envelope and emits OTLP JSON using deterministic 16-byte trace IDs, 8-byte span IDs, integer enum values, and decimal-string nanosecond timestamps.

The mapping follows the current development OpenTelemetry GenAI conventions:

- one internal `invoke_agent WebBrain` root span per run
- one client `chat <model>` span per recorded LLM response
- one internal `execute_tool <name>` span per tool result
- errors and lightweight non-content lifecycle markers remain root-span events

Prompts, assistant text, error messages, tool arguments, and tool results are omitted by default. `--include-content` enables those text fields explicitly, with a 20,000-character bound. Screenshots are never embedded. The converter reads and writes local files only and contains no upload code.

## Testing

- `node test/run.js` — 1332 passed; the one failure is the existing repository release-history mismatch (`package.json` 25.9.7 vs. latest `CHANGELOG.md` entry 25.9.0)
- `node test/security/injection-corpus.mjs` — 60/60 checks passed
- `node --check scripts/trace-to-otlp.mjs` — passed
- generated output parsed successfully as the official `opentelemetry-proto` `ExportTraceServiceRequest` (1 resource, 3 spans)
- `git diff --check` — passed

## Compatibility and risks

This adds one npm script and does not change browser runtime code, dependencies, network behavior, permissions, or the existing trace schema. OpenTelemetry GenAI semantic conventions are still marked development, so attribute guidance may evolve. Span start times are reconstructed from recorded completion timestamps and latencies; this is post-run diagnostic conversion, not distributed tracing context propagation.

## Scope

This PR does not add live telemetry, automatic uploads, collector configuration, trace-context propagation, or screenshot export. Those would require separate privacy and runtime designs.
