### PR TITLE
fix(firefox): implement documented global keyboard shortcuts

### DIFF
--- a/src/firefox/src/ui/sidepanel.js
+++ b/src/firefox/src/ui/sidepanel.js
@@ -9319,8 +9319,16 @@ async function handleGlobalKeydown(e) {
   const isOtherFormField = e.target !== inputEl && (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT');
 
   if (e.key === 'Escape') {
+    // IME Escape cancels a composition candidate — never abort the run for that.
+    if (e.isComposing) return;
     const slashMenuOpen = !!slashCommandMenuEl && !slashCommandMenuEl.classList.contains('hidden');
     if (slashMenuOpen) return;
+    // Provider/language pickers close on Escape in bubble/target handlers; do not
+    // abort the active run while those listboxes are open.
+    const providerPickerOpen = !!providerPickerMenu && !providerPickerMenu.classList.contains('hidden');
+    if (providerPickerOpen) return;
+    const languagePickerOpen = !!languagePickerMenu && !languagePickerMenu.classList.contains('hidden');
+    if (languagePickerOpen) return;
     if (isProcessing) {
       e.preventDefault();
       abortRun();
@@ -9330,6 +9338,9 @@ async function handleGlobalKeydown(e) {
   }
 
   if (isOtherFormField) return;
+  // AltGr (Ctrl+Alt) and Option chords type international characters — never
+  // treat them as Ctrl/Cmd shortcuts.
+  if (e.altKey || e.getModifierState?.('AltGraph')) return;
 
   const mod = e.ctrlKey || e.metaKey;
 

--- a/src/firefox/src/ui/sidepanel.js
+++ b/src/firefox/src/ui/sidepanel.js
@@ -9311,6 +9311,55 @@ async function sendToBackground(action, data = {}) {
   return response;
 }
 
+async function handleGlobalKeydown(e) {
+  if (e.defaultPrevented) return;
+
+  // Don't steal shortcuts from other input elements (e.g. schedule form fields)
+  const tag = e.target?.tagName;
+  const isOtherFormField = e.target !== inputEl && (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT');
+
+  if (e.key === 'Escape') {
+    const slashMenuOpen = !!slashCommandMenuEl && !slashCommandMenuEl.classList.contains('hidden');
+    if (slashMenuOpen) return;
+    if (isProcessing) {
+      e.preventDefault();
+      abortRun();
+      return;
+    }
+    if (isOtherFormField) return;
+  }
+
+  if (isOtherFormField) return;
+
+  const mod = e.ctrlKey || e.metaKey;
+
+  // Ctrl+/ (Cmd+/ on Mac): focus input
+  if (mod && e.key === '/') {
+    e.preventDefault();
+    inputEl.focus();
+    inputEl.setSelectionRange(inputEl.value.length, inputEl.value.length);
+    return;
+  }
+  // Ctrl+Shift+A: switch to Ask mode (blocked while agent is running)
+  if (mod && e.shiftKey && e.key === 'A' && !isProcessing) {
+    e.preventDefault();
+    setMode('ask');
+    return;
+  }
+  // Ctrl+Shift+X: switch to Act mode (blocked while agent is running)
+  if (mod && e.shiftKey && e.key === 'X' && !isProcessing) {
+    e.preventDefault();
+    await ensureActMode();
+    return;
+  }
+  // Ctrl+Shift+D: switch to Dev mode (blocked while agent is running)
+  if (mod && e.shiftKey && e.key === 'D' && !isProcessing) {
+    e.preventDefault();
+    await ensureDevMode();
+    return;
+  }
+}
+
 // --- Mode Toggle ---
 
 function positionModeHighlight(btn, { instant = false } = {}) {
@@ -9822,6 +9871,8 @@ if (attachBtn && fileAttachInput) {
 // --- Event Listeners ---
 
 sendBtn.addEventListener('click', sendMessage);
+
+document.addEventListener('keydown', handleGlobalKeydown, true);
 
 queuedMessagesEl?.addEventListener('click', (e) => {
   const btn = e.target.closest('button[data-queue-action][data-queue-id]');

--- a/test/run.js
+++ b/test/run.js
@@ -16614,6 +16614,17 @@ test('firefox sidepanel implements documented global keyboard shortcuts', () => 
   assert.match(panel, /mod && e\.shiftKey && e\.key === 'D'/, 'firefox: Dev mode shortcut missing');
   assert.match(panel, /await ensureActMode\(\)/, 'firefox: Act shortcut should call ensureActMode');
   assert.match(panel, /await ensureDevMode\(\)/, 'firefox: Dev shortcut should call ensureDevMode');
+  // Review P1s: AltGr / IME / open pickers must not steal Escape or slash entry
+  assert.match(panel, /e\.altKey \|\| e\.getModifierState\?\.\('AltGraph'\)/, 'firefox: AltGr/Option chords must not trigger Ctrl shortcuts');
+  assert.match(panel, /if \(e\.isComposing\) return;/, 'firefox: IME Escape must not abort the active run');
+  assert.match(panel, /providerPickerMenu && !providerPickerMenu\.classList\.contains\('hidden'\)/, 'firefox: open provider picker Escape must not abort');
+  assert.match(panel, /languagePickerMenu && !languagePickerMenu\.classList\.contains\('hidden'\)/, 'firefox: open language picker Escape must not abort');
+  const composingGuard = panel.indexOf('if (e.isComposing) return;', globalHandlerStart);
+  const providerPickerGuard = panel.indexOf("providerPickerMenu && !providerPickerMenu.classList.contains('hidden')", globalHandlerStart);
+  const languagePickerGuard = panel.indexOf("languagePickerMenu && !languagePickerMenu.classList.contains('hidden')", globalHandlerStart);
+  assert.equal(composingGuard !== -1 && composingGuard < abortCall, true, 'firefox: IME guard must precede abortRun');
+  assert.equal(providerPickerGuard !== -1 && providerPickerGuard < abortCall, true, 'firefox: provider picker guard must precede abortRun');
+  assert.equal(languagePickerGuard !== -1 && languagePickerGuard < abortCall, true, 'firefox: language picker guard must precede abortRun');
 
   for (const shortcut of ['Ctrl/Cmd+/', 'Ctrl/Cmd+Shift+A', 'Ctrl/Cmd+Shift+X', 'Ctrl/Cmd+Shift+D', 'Escape']) {
     assert.match(locale, new RegExp(escapeRegExpLiteral(shortcut)), `firefox: /help should mention ${shortcut}`);

--- a/test/run.js
+++ b/test/run.js
@@ -16596,6 +16596,30 @@ test('chrome sidepanel Escape abort honors slash autocomplete dismissal', () => 
   assert.equal(abortCall < recordingEscapeCall, true, 'chrome: agent-run Escape abort should take precedence over recording stop');
 });
 
+test('firefox sidepanel implements documented global keyboard shortcuts', () => {
+  const panel = fs.readFileSync(path.join(ROOT, 'src/firefox/src/ui/sidepanel.js'), 'utf8');
+  const locale = fs.readFileSync(path.join(ROOT, 'src/firefox/src/ui/locales/en.js'), 'utf8');
+
+  const globalHandlerStart = panel.indexOf('async function handleGlobalKeydown(e)');
+  const defaultPreventedGuard = panel.indexOf('if (e.defaultPrevented) return;', globalHandlerStart);
+  const abortCall = panel.indexOf('abortRun();', globalHandlerStart);
+  assert.notEqual(globalHandlerStart, -1, 'firefox: global keydown handler missing');
+  assert.notEqual(defaultPreventedGuard, -1, 'firefox: global keydown handler should honor consumed key events');
+  assert.notEqual(abortCall, -1, 'firefox: Escape abort shortcut missing');
+  assert.equal(defaultPreventedGuard < abortCall, true, 'firefox: consumed slash-menu Escape should not reach abortRun');
+  assert.match(panel, /document\.addEventListener\('keydown', handleGlobalKeydown, true\)/, 'firefox: shortcuts should run in capture phase');
+  assert.match(panel, /mod && e\.key === '\/'/, 'firefox: Ctrl/Cmd+/ focus shortcut missing');
+  assert.match(panel, /mod && e\.shiftKey && e\.key === 'A'/, 'firefox: Ask mode shortcut missing');
+  assert.match(panel, /mod && e\.shiftKey && e\.key === 'X'/, 'firefox: Act mode shortcut missing');
+  assert.match(panel, /mod && e\.shiftKey && e\.key === 'D'/, 'firefox: Dev mode shortcut missing');
+  assert.match(panel, /await ensureActMode\(\)/, 'firefox: Act shortcut should call ensureActMode');
+  assert.match(panel, /await ensureDevMode\(\)/, 'firefox: Dev shortcut should call ensureDevMode');
+
+  for (const shortcut of ['Ctrl/Cmd+/', 'Ctrl/Cmd+Shift+A', 'Ctrl/Cmd+Shift+X', 'Ctrl/Cmd+Shift+D', 'Escape']) {
+    assert.match(locale, new RegExp(escapeRegExpLiteral(shortcut)), `firefox: /help should mention ${shortcut}`);
+  }
+});
+
 test('chrome double Escape stops active recordings from sidepanel and content pages', () => {
   const panel = fs.readFileSync(path.join(ROOT, 'src/chrome/src/ui/sidepanel.js'), 'utf8');
   const content = fs.readFileSync(path.join(ROOT, 'src/chrome/src/content/content.js'), 'utf8');


### PR DESCRIPTION
## Summary

Firefox `/help` advertises keyboard shortcuts (`Ctrl/Cmd+/`, mode switches, Escape abort), but `sidepanel.js` never registered a global keydown handler — so the shortcuts did nothing.

This ports Chrome's `handleGlobalKeydown` to Firefox (without Chrome-only recording Escape handling).

## Why

Real Firefox parity gap: documented UX that was broken. Not tied to any open issue.

## Test plan

- [x] `node test/run.js`: **1350 passed, 1 failed** (existing changelog test on `main`)
- [x] Firefox sidepanel: `Ctrl/Cmd+/` focuses input
- [x] `Ctrl/Cmd+Shift+A/X/D` switch Ask/Act/Dev when idle
- [x] Escape aborts an active run; Escape with slash menu open only dismisses the menu