### PR TITLE
fix(chrome): repair Wikipedia skill tools JSON so tools parse

### DIFF
--- a/src/chrome/skills/wikipedia.md
+++ b/src/chrome/skills/wikipedia.md
@@ -78,7 +78,7 @@ Finish with visible attribution: Powered by [Wikipedia](https://www.wikipedia.or
         "exchars": 1200,
         "inprop": "url",
         "redirects": "1"
-      }
+      },
       "resultPolicy": "untrusted",
       "responseLimits": {
         "maxTextChars": 40000


### PR DESCRIPTION
## Summary

Chrome's packaged `wikipedia.md` was missing a comma after `defaultArgs`, so `JSON.parse` failed and `parseSkillToolBlocks` silently dropped both tools. Enabling Wikipedia on Chrome exposed **zero** skill tools.

Firefox's copy was already valid. This aligns Chrome with Firefox.

## Test plan

- [x] `JSON.parse` of Chrome `webbrain-tools` block succeeds
- [x] Enable Wikipedia on Chrome → Ask mode shows `search_wikipedia` / `get_wikipedia_summary`
- [x] `node test/run.js` packaged Wikipedia opt-in test passes for Chrome