### PR TITLE
fix(captcha): detect active challenge frames

### DIFF
--- a/src/chrome/src/agent/agent.js
+++ b/src/chrome/src/agent/agent.js
@@ -3027,6 +3027,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
     if (!challenge && hasDialogSurface) {
       await inspectCaptchaFrames();
       const selectedActiveFrame = detection?.selected?.activeChallengeFrame === true
+        && detection?.selected?.activeChallengeFrameVisible === true
         && detection?.selected?.visible === true
         && detection?.selected?.frameVisible !== false;
       const diagnosticActiveFrame = (detection?.diagnostics?.frames || []).find(frame =>
@@ -3220,10 +3221,15 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
         && frame?.visible === true
       ))
       .map(frame => frame.vendor))];
-    const selectedCorrelated = (
-      detection?.selected?.dialogAssociated === true
-      || detection?.selected?.activeChallengeFrame === true
-    ) && detection?.selected?.frameVisible !== false;
+    const selectedCorrelated = detection?.selected?.frameVisible !== false
+      && (
+        detection?.selected?.dialogAssociated === true
+        || (
+          detection?.selected?.activeChallengeFrame === true
+          && detection?.selected?.activeChallengeFrameVisible === true
+          && detection?.selected?.visible === true
+        )
+      );
     const supported = this.captchaSolverEnabled
       && !detectionFailed
       && !detection?.error

--- a/src/chrome/src/agent/agent.js
+++ b/src/chrome/src/agent/agent.js
@@ -3007,6 +3007,55 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
     if (!pageUrl) {
       try { pageUrl = await this._currentUrl(tabId); } catch {}
     }
+    let detection = null;
+    let detectionFailed = false;
+    let failedDiagnostics = null;
+    let detectionAttempted = false;
+    const inspectCaptchaFrames = async () => {
+      if (detectionAttempted) return;
+      detectionAttempted = true;
+      try {
+        detection = await detectCaptcha(tabId);
+      } catch (error) {
+        detectionFailed = true;
+        failedDiagnostics = error?.captchaDiagnostics || null;
+      }
+    };
+    let languageNeutralFrameTrigger = false;
+    const hasDialogSurface = toolResult.pageGate?.surface === 'dialog'
+      || /^\s*(?:dialog|alertdialog)(?=\s|$)/im.test(toolResult.pageContent);
+    if (!challenge && hasDialogSurface) {
+      await inspectCaptchaFrames();
+      const selectedActiveFrame = detection?.selected?.activeChallengeFrame === true
+        && detection?.selected?.visible === true
+        && detection?.selected?.frameVisible !== false;
+      const diagnosticActiveFrame = (detection?.diagnostics?.frames || []).find(frame =>
+        frame?.activeChallengeFrame === true && frame?.visible === true
+      );
+      if (selectedActiveFrame || diagnosticActiveFrame) {
+        const vendor = diagnosticActiveFrame?.vendor
+          || (String(detection?.selected?.type || '').startsWith('recaptcha')
+            ? 'recaptcha'
+            : detection?.selected?.type || 'captcha');
+        const vendorLabel = vendor === 'recaptcha'
+          ? 'reCAPTCHA'
+          : vendor === 'hcaptcha'
+            ? 'hCaptcha'
+            : vendor === 'arkose'
+              ? 'Arkose'
+              : 'CAPTCHA';
+        challenge = detectChallengeDialog(`dialog ${JSON.stringify(`Visible ${vendorLabel} CAPTCHA challenge`)}`);
+        languageNeutralFrameTrigger = !!challenge;
+        if (selectedActiveFrame) {
+          observedChallengeFrameId = Number.isInteger(detection.selected.frameId)
+            ? detection.selected.frameId
+            : observedChallengeFrameId;
+          observedChallengeFrameUrl = String(
+            detection.selected.frameUrl || observedChallengeFrameUrl
+          );
+        }
+      }
+    }
     const requestedPage = toolArgs?.page;
     const requestedMaxDepth = toolArgs?.maxDepth;
     const parsedMaxDepth = Number(requestedMaxDepth);
@@ -3157,17 +3206,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
       return { gate: existing.publicGate, loopCheck };
     }
 
-    let detection = null;
-    let detectionFailed = false;
-    let failedDiagnostics = null;
-    if (this.captchaSolverEnabled) {
-      try {
-        detection = await detectCaptcha(tabId);
-      } catch (error) {
-        detectionFailed = true;
-        failedDiagnostics = error?.captchaDiagnostics || null;
-      }
-    }
+    await inspectCaptchaFrames();
     const diagnostics = detection?.diagnostics || failedDiagnostics || {
       vendors: [],
       candidateTypes: [],
@@ -3181,8 +3220,10 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
         && frame?.visible === true
       ))
       .map(frame => frame.vendor))];
-    const selectedCorrelated = detection?.selected?.dialogAssociated === true
-      && detection?.selected?.frameVisible !== false;
+    const selectedCorrelated = (
+      detection?.selected?.dialogAssociated === true
+      || detection?.selected?.activeChallengeFrame === true
+    ) && detection?.selected?.frameVisible !== false;
     const supported = this.captchaSolverEnabled
       && !detectionFailed
       && !detection?.error
@@ -3199,6 +3240,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
       ...(!this.captchaSolverEnabled ? { solverDisabled: true } : {}),
       ...(detection?.error ? { selectionFailed: true } : {}),
       ...(detection?.selected && !selectedCorrelated ? { candidateNotCorrelated: true } : {}),
+      ...(languageNeutralFrameTrigger ? { languageNeutralFrameTrigger: true } : {}),
     };
     this._captchaGateStates.set(tabId, {
       key,

--- a/src/chrome/src/agent/captcha-frame-runtime.js
+++ b/src/chrome/src/agent/captcha-frame-runtime.js
@@ -291,6 +291,7 @@ function candidateSummary(candidate) {
     visible: candidate?.visible === true,
     normalCheckbox: candidate?.normalCheckbox === true,
     challengeFrame: candidate?.challengeFrame === true,
+    activeChallengeFrame: candidate?.activeChallengeFrame === true,
     dialogAssociated: candidate?.dialogAssociated === true,
     frameVisible: candidate?.frameVisible !== false,
     isInvisible: candidate?.isInvisible === true,
@@ -326,7 +327,7 @@ function candidateScore(candidate) {
   // Priority is tiered so no combination of secondary signals can make a
   // generic visible/background integration outrank an active challenge
   // frame or visible checkbox.
-  const activeChallengeFrame = candidate?.challengeFrame
+  const activeChallengeFrame = candidate?.activeChallengeFrame
     && candidate?.visible === true
     && candidate?.frameVisible !== false;
   const primary = (candidate?.normalCheckbox && candidate?.visible) || activeChallengeFrame;
@@ -406,6 +407,8 @@ export function selectCaptchaCandidate(candidates, constraints = {}) {
         visible: previous.visible === true || candidate.visible === true,
         normalCheckbox: previous.normalCheckbox === true || candidate.normalCheckbox === true,
         challengeFrame: previous.challengeFrame === true || candidate.challengeFrame === true,
+        activeChallengeFrame: previous.activeChallengeFrame === true
+          || candidate.activeChallengeFrame === true,
         dialogAssociated: previous.dialogAssociated === true || candidate.dialogAssociated === true,
         responseField: previous.responseField === true || candidate.responseField === true,
         responseTokenPresent: previous.responseTokenPresent === true
@@ -580,7 +583,7 @@ function selectedReason(candidate, constraints) {
   if (constraints.frameUrl) return 'exact frameUrl match';
   if (constraints.websiteKey) return 'exact websiteKey match';
   if (candidate.normalCheckbox && candidate.visible) return 'visible checkbox challenge';
-  if (candidate.visible && candidate.challengeFrame && candidate.frameVisible !== false) return 'visible challenge frame';
+  if (candidate.visible && candidate.activeChallengeFrame && candidate.frameVisible !== false) return 'visible challenge frame';
   if (candidate.visible) return 'visible CAPTCHA widget';
   if (candidate.challengeFrame && candidate.frameVisible !== false) return 'challenge frame candidate';
   return 'only detected CAPTCHA candidate';
@@ -627,6 +630,29 @@ export function detectCaptchaCandidatesInPage(scope = null) {
       return null;
     }
   };
+  // Page-serialized counterpart of captchaActiveChallengeFrameVendor in
+  // captcha-gate.js. Only challenge routes, never checkbox routes, may arm it.
+  const activeChallengeFrameVendor = (urlStr) => {
+    try {
+      const parsed = new URL(String(urlStr || ''), frameUrl || 'https://dummy.host');
+      const host = parsed.hostname.toLowerCase();
+      const path = parsed.pathname.toLowerCase();
+      if (
+        (/(^|\.)google\.com$/.test(host) || /(^|\.)recaptcha\.net$/.test(host))
+        && /\/recaptcha\/(?:api2|enterprise)\/bframe(?:\/|$)/.test(path)
+      ) return 'recaptcha';
+      if (/(^|\.)hcaptcha\.com$/.test(host)) {
+        const frame = new URLSearchParams(String(parsed.hash || '').replace(/^#/, '')).get('frame');
+        if (frame === 'challenge') return 'hcaptcha';
+      }
+      if (
+        /(^|\.)(?:arkoselabs|funcaptcha)\.com$/.test(host)
+        && /\/fc\/gc(?:\/|$)/.test(path)
+      ) return 'arkose';
+    } catch (_) {}
+    return '';
+  };
+  const documentChallengeVendor = activeChallengeFrameVendor(frameUrl);
   const visibleElement = (element) => {
     if (!element) return false;
     try {
@@ -714,7 +740,9 @@ export function detectCaptchaCandidatesInPage(scope = null) {
     candidates.push({
       ...serializableCandidate,
       frameUrl,
-      challengeFrame,
+      challengeFrame: candidate.challengeFrame === true || challengeFrame,
+      activeChallengeFrame: candidate.activeChallengeFrame === true
+        || !!documentChallengeVendor,
       responseField,
       responseTokenPresent: candidate.responseTokenPresent === true
         || alsoResponseTokenPresent === true,
@@ -873,16 +901,21 @@ export function detectCaptchaCandidatesInPage(scope = null) {
   const recaptchaFrames = iframeUrls.filter(({ url }) =>
     /recaptcha\/(api2|enterprise)\/anchor/i.test(url)
   );
+  const recaptchaChallengeFrames = iframeUrls.filter(({ url }) =>
+    activeChallengeFrameVendor(url) === 'recaptcha'
+  );
 
   for (const { element, url } of iframeUrls) {
     if (/hcaptcha\.com/i.test(url)) {
       const websiteKey = urlParam(url, 'sitekey');
       if (websiteKey) {
+        const activeChallengeFrame = activeChallengeFrameVendor(url) === 'hcaptcha';
         add({
           type: 'hcaptcha',
           websiteKey,
           visible: visibleElement(element),
-          normalCheckbox: visibleElement(element),
+          normalCheckbox: visibleElement(element) && !activeChallengeFrame,
+          activeChallengeFrame,
           ...responseFieldIdentity(
             element,
             'h-captcha-response',
@@ -919,10 +952,31 @@ export function detectCaptchaCandidatesInPage(scope = null) {
       }
       continue;
     }
-    if (!/recaptcha\/(api2|enterprise)\/anchor/i.test(url)) continue;
+    const recaptchaChallengeFrame = activeChallengeFrameVendor(url) === 'recaptcha';
+    if (!recaptchaChallengeFrame && !/recaptcha\/(api2|enterprise)\/anchor/i.test(url)) continue;
     const websiteKey = urlParam(url, 'k');
     if (!websiteKey) continue;
     const isEnterprise = /recaptcha\/enterprise/i.test(url);
+    if (recaptchaChallengeFrame) {
+      const challengeIndex = recaptchaChallengeFrames.findIndex(frame => frame.element === element);
+      add({
+        type: isEnterprise ? 'recaptcha_v2_enterprise' : 'recaptcha_v2',
+        websiteKey,
+        isInvisible: false,
+        isEnterprise,
+        visible: visibleElement(element),
+        normalCheckbox: false,
+        activeChallengeFrame: true,
+        ...responseFieldIdentity(
+          element,
+          'g-recaptcha-response',
+          challengeIndex,
+          recaptchaChallengeFrames.length,
+        ),
+        detectedVia: 'url',
+      }, element);
+      continue;
+    }
     const isInvisible = urlParam(url, 'size') === 'invisible';
     const matchingV3Script = scriptUrls.find(scriptUrl => urlParam(scriptUrl, 'render') === websiteKey) || null;
     const isV3 = !!matchingV3Script;
@@ -994,6 +1048,7 @@ export function detectCaptchaCandidatesInPage(scope = null) {
     try { url = String(element.src || ''); } catch (_) {}
     try { loadedUrl = String(element.contentWindow?.location?.href || ''); } catch (_) {}
     try { name = String(element.name || element.getAttribute?.('name') || ''); } catch (_) {}
+    const activeChallengeFrame = !!activeChallengeFrameVendor(loadedUrl || url);
     return {
       index,
       url,
@@ -1001,6 +1056,7 @@ export function detectCaptchaCandidatesInPage(scope = null) {
       name,
       visible: visibleElement(element),
       dialogAssociated: elementInChallengeDialog(element),
+      activeChallengeFrame,
     };
   });
   let frameName = '';

--- a/src/chrome/src/agent/captcha-frame-runtime.js
+++ b/src/chrome/src/agent/captcha-frame-runtime.js
@@ -263,16 +263,26 @@ export function applyCaptchaFrameVisibility(candidates, frameContexts, navigatio
     const candidate = reconcileAncestorLoader(rawCandidate);
     const frameVisible = frameIsVisible(candidate?.frameId)
       && candidate?.frameVisibleWithinAnchor !== false;
+    const visible = candidate?.visible === true && frameVisible;
     return {
       ...candidate,
       frameVisible,
       websiteURL: nearestHttpUrl(candidate),
       dialogAssociated: candidate?.dialogAssociated === true
         || frameIsDialogAssociated(candidate?.frameId),
-      visible: candidate?.visible === true && frameVisible,
+      visible,
       normalCheckbox: candidate?.normalCheckbox === true && candidate?.visible === true && frameVisible,
+      activeChallengeFrameVisible: candidate?.activeChallengeFrame === true && visible,
     };
   });
+}
+
+function isVisibleActiveChallengeFrame(candidate) {
+  if (candidate?.activeChallengeFrameVisible === true) return true;
+  if (candidate?.activeChallengeFrameVisible === false) return false;
+  return candidate?.activeChallengeFrame === true
+    && candidate?.visible === true
+    && candidate?.frameVisible !== false;
 }
 
 function candidateSummary(candidate) {
@@ -292,6 +302,7 @@ function candidateSummary(candidate) {
     normalCheckbox: candidate?.normalCheckbox === true,
     challengeFrame: candidate?.challengeFrame === true,
     activeChallengeFrame: candidate?.activeChallengeFrame === true,
+    activeChallengeFrameVisible: isVisibleActiveChallengeFrame(candidate),
     dialogAssociated: candidate?.dialogAssociated === true,
     frameVisible: candidate?.frameVisible !== false,
     isInvisible: candidate?.isInvisible === true,
@@ -327,9 +338,7 @@ function candidateScore(candidate) {
   // Priority is tiered so no combination of secondary signals can make a
   // generic visible/background integration outrank an active challenge
   // frame or visible checkbox.
-  const activeChallengeFrame = candidate?.activeChallengeFrame
-    && candidate?.visible === true
-    && candidate?.frameVisible !== false;
+  const activeChallengeFrame = isVisibleActiveChallengeFrame(candidate);
   const primary = (candidate?.normalCheckbox && candidate?.visible) || activeChallengeFrame;
   const tier = primary ? 3 : (candidate?.visible ? 2 : 1);
   let score = tier * 1000;
@@ -409,6 +418,8 @@ export function selectCaptchaCandidate(candidates, constraints = {}) {
         challengeFrame: previous.challengeFrame === true || candidate.challengeFrame === true,
         activeChallengeFrame: previous.activeChallengeFrame === true
           || candidate.activeChallengeFrame === true,
+        activeChallengeFrameVisible: isVisibleActiveChallengeFrame(previous)
+          || isVisibleActiveChallengeFrame(candidate),
         dialogAssociated: previous.dialogAssociated === true || candidate.dialogAssociated === true,
         responseField: previous.responseField === true || candidate.responseField === true,
         responseTokenPresent: previous.responseTokenPresent === true
@@ -583,7 +594,7 @@ function selectedReason(candidate, constraints) {
   if (constraints.frameUrl) return 'exact frameUrl match';
   if (constraints.websiteKey) return 'exact websiteKey match';
   if (candidate.normalCheckbox && candidate.visible) return 'visible checkbox challenge';
-  if (candidate.visible && candidate.activeChallengeFrame && candidate.frameVisible !== false) return 'visible challenge frame';
+  if (isVisibleActiveChallengeFrame(candidate)) return 'visible challenge frame';
   if (candidate.visible) return 'visible CAPTCHA widget';
   if (candidate.challengeFrame && candidate.frameVisible !== false) return 'challenge frame candidate';
   return 'only detected CAPTCHA candidate';

--- a/src/chrome/src/agent/captcha-gate.js
+++ b/src/chrome/src/agent/captcha-gate.js
@@ -1,3 +1,5 @@
+import { applyCaptchaFrameVisibility } from './captcha-frame-runtime.js';
+
 const CHALLENGE_DIALOG_RE = /\b(?:(?:re|h|fun)?captcha|security verification|human verification|verify (?:that )?you(?:'|\u2019)re (?:a )?human|verify (?:that )?you are (?:a )?human|are you (?:a )?human|robot check|challenge verification)\b/i;
 const CHALLENGE_FAILURE_RE = /\b(?:verification (?:failed|error|unsuccessful|expired|timed out)|could not verify|unable to verify)\b/i;
 const CHALLENGE_CONTEXT_RE = /\b(?:(?:re|h|fun)?captcha|human|robot|challenge)\b/i;
@@ -374,6 +376,7 @@ export function buildCaptchaDiagnostics({
       source: 'navigation',
     });
   }
+  const embeddedFrames = [];
   for (const context of frameContexts || []) {
     addFrame({
       frameId: context?.frameId,
@@ -381,13 +384,27 @@ export function buildCaptchaDiagnostics({
       source: 'document',
     });
     for (const child of context?.childFrames || []) {
-      addFrame({
+      embeddedFrames.push({
+        frameId: context?.frameId,
         frameUrl: child?.loadedUrl || child?.url,
-        source: 'embedded',
         visible: child?.visible,
         activeChallengeFrame: child?.activeChallengeFrame === true,
       });
     }
+  }
+  const visibleEmbeddedFrames = applyCaptchaFrameVisibility(
+    embeddedFrames,
+    frameContexts,
+    navigationFrames,
+  );
+  for (const frame of visibleEmbeddedFrames) {
+    addFrame({
+      frameId: frame?.frameId,
+      frameUrl: frame?.frameUrl,
+      source: 'embedded',
+      visible: frame?.visible,
+      activeChallengeFrame: frame?.activeChallengeFrame === true,
+    });
   }
   for (const candidate of candidates || []) {
     addFrame({

--- a/src/chrome/src/agent/captcha-gate.js
+++ b/src/chrome/src/agent/captcha-gate.js
@@ -134,17 +134,42 @@ export function detectChallengeDialogInPage(options = null) {
       return false;
     }
   };
+  // This detector is serialized into the page, so it cannot call the exported
+  // classifier below. Keep the vendor-specific routes aligned with it.
+  const activeFrameVendor = (value) => {
+    try {
+      const parsed = new URL(String(value || ''));
+      const host = parsed.hostname.toLowerCase();
+      const path = parsed.pathname.toLowerCase();
+      if (
+        (/(^|\.)google\.com$/.test(host) || /(^|\.)recaptcha\.net$/.test(host))
+        && /\/recaptcha\/(?:api2|enterprise)\/bframe(?:\/|$)/.test(path)
+      ) return 'recaptcha';
+      if (/(^|\.)hcaptcha\.com$/.test(host)) {
+        const frame = new URLSearchParams(String(parsed.hash || '').replace(/^#/, '')).get('frame');
+        if (frame === 'challenge') return 'hcaptcha';
+      }
+      if (
+        /(^|\.)(?:arkoselabs|funcaptcha)\.com$/.test(host)
+        && /\/fc\/gc(?:\/|$)/.test(path)
+      ) return 'arkose';
+    } catch {}
+    return '';
+  };
   const childFrames = Array.from(document.querySelectorAll('iframe')).map((element, index) => {
     let loadedUrl = '';
     try {
       loadedUrl = String(element.contentWindow?.location?.href || '');
     } catch {}
+    const url = String(element.getAttribute?.('src') || element.src || '');
+    const activeChallengeVendor = activeFrameVendor(loadedUrl || url);
     return {
       index,
-      url: String(element.getAttribute?.('src') || element.src || ''),
+      url,
       loadedUrl,
       name: String(element.getAttribute?.('name') || element.name || ''),
       visible: visible(element),
+      ...(activeChallengeVendor ? { activeChallengeVendor } : {}),
     };
   });
   // A challenge dialog that exists in the DOM but is hidden or off-viewport
@@ -250,6 +275,20 @@ export function detectChallengeDialogInPage(options = null) {
       if (label) return finish({ label });
     }
   }
+  const activeChallengeFrame = childFrames.find(frame =>
+    frame.visible === true && frame.activeChallengeVendor
+  );
+  if (activeChallengeFrame) {
+    const vendorLabel = activeChallengeFrame.activeChallengeVendor === 'recaptcha'
+      ? 'reCAPTCHA'
+      : activeChallengeFrame.activeChallengeVendor === 'hcaptcha'
+        ? 'hCaptcha'
+        : 'Arkose';
+    return finish({
+      label: `Visible ${vendorLabel} challenge frame`,
+      languageNeutralFrame: true,
+    });
+  }
   return finish(null);
 }
 
@@ -302,7 +341,14 @@ export function buildCaptchaDiagnostics({
 } = {}) {
   const rows = [];
   const seen = new Set();
-  const addFrame = ({ frameId = null, parentFrameId = null, frameUrl = '', source, visible = null }) => {
+  const addFrame = ({
+    frameId = null,
+    parentFrameId = null,
+    frameUrl = '',
+    source,
+    visible = null,
+    activeChallengeFrame = false,
+  }) => {
     const sanitizedUrl = sanitizeCaptchaFrameUrl(frameUrl);
     if (!sanitizedUrl) return;
     const vendor = captchaVendorFromUrl(frameUrl);
@@ -315,6 +361,7 @@ export function buildCaptchaDiagnostics({
       frameUrl: sanitizedUrl,
       vendor,
       source,
+      ...(activeChallengeFrame ? { activeChallengeFrame: true } : {}),
       ...(typeof visible === 'boolean' ? { visible } : {}),
     });
   };
@@ -338,6 +385,7 @@ export function buildCaptchaDiagnostics({
         frameUrl: child?.loadedUrl || child?.url,
         source: 'embedded',
         visible: child?.visible,
+        activeChallengeFrame: child?.activeChallengeFrame === true,
       });
     }
   }
@@ -347,6 +395,7 @@ export function buildCaptchaDiagnostics({
       frameUrl: candidate?.frameUrl,
       source: 'candidate',
       visible: candidate?.visible,
+      activeChallengeFrame: candidate?.activeChallengeFrame === true,
     });
   }
 

--- a/src/firefox/src/agent/agent.js
+++ b/src/firefox/src/agent/agent.js
@@ -2632,6 +2632,55 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
     if (!pageUrl) {
       try { pageUrl = await this._currentUrl(tabId); } catch {}
     }
+    let detection = null;
+    let detectionFailed = false;
+    let failedDiagnostics = null;
+    let detectionAttempted = false;
+    const inspectCaptchaFrames = async () => {
+      if (detectionAttempted) return;
+      detectionAttempted = true;
+      try {
+        detection = await detectCaptcha(tabId);
+      } catch (error) {
+        detectionFailed = true;
+        failedDiagnostics = error?.captchaDiagnostics || null;
+      }
+    };
+    let languageNeutralFrameTrigger = false;
+    const hasDialogSurface = toolResult.pageGate?.surface === 'dialog'
+      || /^\s*(?:dialog|alertdialog)(?=\s|$)/im.test(toolResult.pageContent);
+    if (!challenge && hasDialogSurface) {
+      await inspectCaptchaFrames();
+      const selectedActiveFrame = detection?.selected?.activeChallengeFrame === true
+        && detection?.selected?.visible === true
+        && detection?.selected?.frameVisible !== false;
+      const diagnosticActiveFrame = (detection?.diagnostics?.frames || []).find(frame =>
+        frame?.activeChallengeFrame === true && frame?.visible === true
+      );
+      if (selectedActiveFrame || diagnosticActiveFrame) {
+        const vendor = diagnosticActiveFrame?.vendor
+          || (String(detection?.selected?.type || '').startsWith('recaptcha')
+            ? 'recaptcha'
+            : detection?.selected?.type || 'captcha');
+        const vendorLabel = vendor === 'recaptcha'
+          ? 'reCAPTCHA'
+          : vendor === 'hcaptcha'
+            ? 'hCaptcha'
+            : vendor === 'arkose'
+              ? 'Arkose'
+              : 'CAPTCHA';
+        challenge = detectChallengeDialog(`dialog ${JSON.stringify(`Visible ${vendorLabel} CAPTCHA challenge`)}`);
+        languageNeutralFrameTrigger = !!challenge;
+        if (selectedActiveFrame) {
+          observedChallengeFrameId = Number.isInteger(detection.selected.frameId)
+            ? detection.selected.frameId
+            : observedChallengeFrameId;
+          observedChallengeFrameUrl = String(
+            detection.selected.frameUrl || observedChallengeFrameUrl
+          );
+        }
+      }
+    }
     const requestedPage = toolArgs?.page;
     const requestedMaxDepth = toolArgs?.maxDepth;
     const parsedMaxDepth = Number(requestedMaxDepth);
@@ -2782,17 +2831,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
       return { gate: existing.publicGate, loopCheck };
     }
 
-    let detection = null;
-    let detectionFailed = false;
-    let failedDiagnostics = null;
-    if (this.captchaSolverEnabled) {
-      try {
-        detection = await detectCaptcha(tabId);
-      } catch (error) {
-        detectionFailed = true;
-        failedDiagnostics = error?.captchaDiagnostics || null;
-      }
-    }
+    await inspectCaptchaFrames();
     const diagnostics = detection?.diagnostics || failedDiagnostics || {
       vendors: [],
       candidateTypes: [],
@@ -2806,8 +2845,10 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
         && frame?.visible === true
       ))
       .map(frame => frame.vendor))];
-    const selectedCorrelated = detection?.selected?.dialogAssociated === true
-      && detection?.selected?.frameVisible !== false;
+    const selectedCorrelated = (
+      detection?.selected?.dialogAssociated === true
+      || detection?.selected?.activeChallengeFrame === true
+    ) && detection?.selected?.frameVisible !== false;
     const supported = this.captchaSolverEnabled
       && !detectionFailed
       && !detection?.error
@@ -2824,6 +2865,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
       ...(!this.captchaSolverEnabled ? { solverDisabled: true } : {}),
       ...(detection?.error ? { selectionFailed: true } : {}),
       ...(detection?.selected && !selectedCorrelated ? { candidateNotCorrelated: true } : {}),
+      ...(languageNeutralFrameTrigger ? { languageNeutralFrameTrigger: true } : {}),
     };
     this._captchaGateStates.set(tabId, {
       key,

--- a/src/firefox/src/agent/agent.js
+++ b/src/firefox/src/agent/agent.js
@@ -2652,6 +2652,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
     if (!challenge && hasDialogSurface) {
       await inspectCaptchaFrames();
       const selectedActiveFrame = detection?.selected?.activeChallengeFrame === true
+        && detection?.selected?.activeChallengeFrameVisible === true
         && detection?.selected?.visible === true
         && detection?.selected?.frameVisible !== false;
       const diagnosticActiveFrame = (detection?.diagnostics?.frames || []).find(frame =>
@@ -2845,10 +2846,15 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
         && frame?.visible === true
       ))
       .map(frame => frame.vendor))];
-    const selectedCorrelated = (
-      detection?.selected?.dialogAssociated === true
-      || detection?.selected?.activeChallengeFrame === true
-    ) && detection?.selected?.frameVisible !== false;
+    const selectedCorrelated = detection?.selected?.frameVisible !== false
+      && (
+        detection?.selected?.dialogAssociated === true
+        || (
+          detection?.selected?.activeChallengeFrame === true
+          && detection?.selected?.activeChallengeFrameVisible === true
+          && detection?.selected?.visible === true
+        )
+      );
     const supported = this.captchaSolverEnabled
       && !detectionFailed
       && !detection?.error

--- a/src/firefox/src/agent/captcha-frame-runtime.js
+++ b/src/firefox/src/agent/captcha-frame-runtime.js
@@ -291,6 +291,7 @@ function candidateSummary(candidate) {
     visible: candidate?.visible === true,
     normalCheckbox: candidate?.normalCheckbox === true,
     challengeFrame: candidate?.challengeFrame === true,
+    activeChallengeFrame: candidate?.activeChallengeFrame === true,
     dialogAssociated: candidate?.dialogAssociated === true,
     frameVisible: candidate?.frameVisible !== false,
     isInvisible: candidate?.isInvisible === true,
@@ -326,7 +327,7 @@ function candidateScore(candidate) {
   // Priority is tiered so no combination of secondary signals can make a
   // generic visible/background integration outrank an active challenge
   // frame or visible checkbox.
-  const activeChallengeFrame = candidate?.challengeFrame
+  const activeChallengeFrame = candidate?.activeChallengeFrame
     && candidate?.visible === true
     && candidate?.frameVisible !== false;
   const primary = (candidate?.normalCheckbox && candidate?.visible) || activeChallengeFrame;
@@ -406,6 +407,8 @@ export function selectCaptchaCandidate(candidates, constraints = {}) {
         visible: previous.visible === true || candidate.visible === true,
         normalCheckbox: previous.normalCheckbox === true || candidate.normalCheckbox === true,
         challengeFrame: previous.challengeFrame === true || candidate.challengeFrame === true,
+        activeChallengeFrame: previous.activeChallengeFrame === true
+          || candidate.activeChallengeFrame === true,
         dialogAssociated: previous.dialogAssociated === true || candidate.dialogAssociated === true,
         responseField: previous.responseField === true || candidate.responseField === true,
         responseTokenPresent: previous.responseTokenPresent === true
@@ -580,7 +583,7 @@ function selectedReason(candidate, constraints) {
   if (constraints.frameUrl) return 'exact frameUrl match';
   if (constraints.websiteKey) return 'exact websiteKey match';
   if (candidate.normalCheckbox && candidate.visible) return 'visible checkbox challenge';
-  if (candidate.visible && candidate.challengeFrame && candidate.frameVisible !== false) return 'visible challenge frame';
+  if (candidate.visible && candidate.activeChallengeFrame && candidate.frameVisible !== false) return 'visible challenge frame';
   if (candidate.visible) return 'visible CAPTCHA widget';
   if (candidate.challengeFrame && candidate.frameVisible !== false) return 'challenge frame candidate';
   return 'only detected CAPTCHA candidate';
@@ -627,6 +630,29 @@ export function detectCaptchaCandidatesInPage(scope = null) {
       return null;
     }
   };
+  // Page-serialized counterpart of captchaActiveChallengeFrameVendor in
+  // captcha-gate.js. Only challenge routes, never checkbox routes, may arm it.
+  const activeChallengeFrameVendor = (urlStr) => {
+    try {
+      const parsed = new URL(String(urlStr || ''), frameUrl || 'https://dummy.host');
+      const host = parsed.hostname.toLowerCase();
+      const path = parsed.pathname.toLowerCase();
+      if (
+        (/(^|\.)google\.com$/.test(host) || /(^|\.)recaptcha\.net$/.test(host))
+        && /\/recaptcha\/(?:api2|enterprise)\/bframe(?:\/|$)/.test(path)
+      ) return 'recaptcha';
+      if (/(^|\.)hcaptcha\.com$/.test(host)) {
+        const frame = new URLSearchParams(String(parsed.hash || '').replace(/^#/, '')).get('frame');
+        if (frame === 'challenge') return 'hcaptcha';
+      }
+      if (
+        /(^|\.)(?:arkoselabs|funcaptcha)\.com$/.test(host)
+        && /\/fc\/gc(?:\/|$)/.test(path)
+      ) return 'arkose';
+    } catch (_) {}
+    return '';
+  };
+  const documentChallengeVendor = activeChallengeFrameVendor(frameUrl);
   const visibleElement = (element) => {
     if (!element) return false;
     try {
@@ -714,7 +740,9 @@ export function detectCaptchaCandidatesInPage(scope = null) {
     candidates.push({
       ...serializableCandidate,
       frameUrl,
-      challengeFrame,
+      challengeFrame: candidate.challengeFrame === true || challengeFrame,
+      activeChallengeFrame: candidate.activeChallengeFrame === true
+        || !!documentChallengeVendor,
       responseField,
       responseTokenPresent: candidate.responseTokenPresent === true
         || alsoResponseTokenPresent === true,
@@ -873,16 +901,21 @@ export function detectCaptchaCandidatesInPage(scope = null) {
   const recaptchaFrames = iframeUrls.filter(({ url }) =>
     /recaptcha\/(api2|enterprise)\/anchor/i.test(url)
   );
+  const recaptchaChallengeFrames = iframeUrls.filter(({ url }) =>
+    activeChallengeFrameVendor(url) === 'recaptcha'
+  );
 
   for (const { element, url } of iframeUrls) {
     if (/hcaptcha\.com/i.test(url)) {
       const websiteKey = urlParam(url, 'sitekey');
       if (websiteKey) {
+        const activeChallengeFrame = activeChallengeFrameVendor(url) === 'hcaptcha';
         add({
           type: 'hcaptcha',
           websiteKey,
           visible: visibleElement(element),
-          normalCheckbox: visibleElement(element),
+          normalCheckbox: visibleElement(element) && !activeChallengeFrame,
+          activeChallengeFrame,
           ...responseFieldIdentity(
             element,
             'h-captcha-response',
@@ -919,10 +952,31 @@ export function detectCaptchaCandidatesInPage(scope = null) {
       }
       continue;
     }
-    if (!/recaptcha\/(api2|enterprise)\/anchor/i.test(url)) continue;
+    const recaptchaChallengeFrame = activeChallengeFrameVendor(url) === 'recaptcha';
+    if (!recaptchaChallengeFrame && !/recaptcha\/(api2|enterprise)\/anchor/i.test(url)) continue;
     const websiteKey = urlParam(url, 'k');
     if (!websiteKey) continue;
     const isEnterprise = /recaptcha\/enterprise/i.test(url);
+    if (recaptchaChallengeFrame) {
+      const challengeIndex = recaptchaChallengeFrames.findIndex(frame => frame.element === element);
+      add({
+        type: isEnterprise ? 'recaptcha_v2_enterprise' : 'recaptcha_v2',
+        websiteKey,
+        isInvisible: false,
+        isEnterprise,
+        visible: visibleElement(element),
+        normalCheckbox: false,
+        activeChallengeFrame: true,
+        ...responseFieldIdentity(
+          element,
+          'g-recaptcha-response',
+          challengeIndex,
+          recaptchaChallengeFrames.length,
+        ),
+        detectedVia: 'url',
+      }, element);
+      continue;
+    }
     const isInvisible = urlParam(url, 'size') === 'invisible';
     const matchingV3Script = scriptUrls.find(scriptUrl => urlParam(scriptUrl, 'render') === websiteKey) || null;
     const isV3 = !!matchingV3Script;
@@ -994,6 +1048,7 @@ export function detectCaptchaCandidatesInPage(scope = null) {
     try { url = String(element.src || ''); } catch (_) {}
     try { loadedUrl = String(element.contentWindow?.location?.href || ''); } catch (_) {}
     try { name = String(element.name || element.getAttribute?.('name') || ''); } catch (_) {}
+    const activeChallengeFrame = !!activeChallengeFrameVendor(loadedUrl || url);
     return {
       index,
       url,
@@ -1001,6 +1056,7 @@ export function detectCaptchaCandidatesInPage(scope = null) {
       name,
       visible: visibleElement(element),
       dialogAssociated: elementInChallengeDialog(element),
+      activeChallengeFrame,
     };
   });
   let frameName = '';

--- a/src/firefox/src/agent/captcha-frame-runtime.js
+++ b/src/firefox/src/agent/captcha-frame-runtime.js
@@ -263,16 +263,26 @@ export function applyCaptchaFrameVisibility(candidates, frameContexts, navigatio
     const candidate = reconcileAncestorLoader(rawCandidate);
     const frameVisible = frameIsVisible(candidate?.frameId)
       && candidate?.frameVisibleWithinAnchor !== false;
+    const visible = candidate?.visible === true && frameVisible;
     return {
       ...candidate,
       frameVisible,
       websiteURL: nearestHttpUrl(candidate),
       dialogAssociated: candidate?.dialogAssociated === true
         || frameIsDialogAssociated(candidate?.frameId),
-      visible: candidate?.visible === true && frameVisible,
+      visible,
       normalCheckbox: candidate?.normalCheckbox === true && candidate?.visible === true && frameVisible,
+      activeChallengeFrameVisible: candidate?.activeChallengeFrame === true && visible,
     };
   });
+}
+
+function isVisibleActiveChallengeFrame(candidate) {
+  if (candidate?.activeChallengeFrameVisible === true) return true;
+  if (candidate?.activeChallengeFrameVisible === false) return false;
+  return candidate?.activeChallengeFrame === true
+    && candidate?.visible === true
+    && candidate?.frameVisible !== false;
 }
 
 function candidateSummary(candidate) {
@@ -292,6 +302,7 @@ function candidateSummary(candidate) {
     normalCheckbox: candidate?.normalCheckbox === true,
     challengeFrame: candidate?.challengeFrame === true,
     activeChallengeFrame: candidate?.activeChallengeFrame === true,
+    activeChallengeFrameVisible: isVisibleActiveChallengeFrame(candidate),
     dialogAssociated: candidate?.dialogAssociated === true,
     frameVisible: candidate?.frameVisible !== false,
     isInvisible: candidate?.isInvisible === true,
@@ -327,9 +338,7 @@ function candidateScore(candidate) {
   // Priority is tiered so no combination of secondary signals can make a
   // generic visible/background integration outrank an active challenge
   // frame or visible checkbox.
-  const activeChallengeFrame = candidate?.activeChallengeFrame
-    && candidate?.visible === true
-    && candidate?.frameVisible !== false;
+  const activeChallengeFrame = isVisibleActiveChallengeFrame(candidate);
   const primary = (candidate?.normalCheckbox && candidate?.visible) || activeChallengeFrame;
   const tier = primary ? 3 : (candidate?.visible ? 2 : 1);
   let score = tier * 1000;
@@ -409,6 +418,8 @@ export function selectCaptchaCandidate(candidates, constraints = {}) {
         challengeFrame: previous.challengeFrame === true || candidate.challengeFrame === true,
         activeChallengeFrame: previous.activeChallengeFrame === true
           || candidate.activeChallengeFrame === true,
+        activeChallengeFrameVisible: isVisibleActiveChallengeFrame(previous)
+          || isVisibleActiveChallengeFrame(candidate),
         dialogAssociated: previous.dialogAssociated === true || candidate.dialogAssociated === true,
         responseField: previous.responseField === true || candidate.responseField === true,
         responseTokenPresent: previous.responseTokenPresent === true
@@ -583,7 +594,7 @@ function selectedReason(candidate, constraints) {
   if (constraints.frameUrl) return 'exact frameUrl match';
   if (constraints.websiteKey) return 'exact websiteKey match';
   if (candidate.normalCheckbox && candidate.visible) return 'visible checkbox challenge';
-  if (candidate.visible && candidate.activeChallengeFrame && candidate.frameVisible !== false) return 'visible challenge frame';
+  if (isVisibleActiveChallengeFrame(candidate)) return 'visible challenge frame';
   if (candidate.visible) return 'visible CAPTCHA widget';
   if (candidate.challengeFrame && candidate.frameVisible !== false) return 'challenge frame candidate';
   return 'only detected CAPTCHA candidate';

--- a/src/firefox/src/agent/captcha-gate.js
+++ b/src/firefox/src/agent/captcha-gate.js
@@ -1,3 +1,5 @@
+import { applyCaptchaFrameVisibility } from './captcha-frame-runtime.js';
+
 const CHALLENGE_DIALOG_RE = /\b(?:(?:re|h|fun)?captcha|security verification|human verification|verify (?:that )?you(?:'|\u2019)re (?:a )?human|verify (?:that )?you are (?:a )?human|are you (?:a )?human|robot check|challenge verification)\b/i;
 const CHALLENGE_FAILURE_RE = /\b(?:verification (?:failed|error|unsuccessful|expired|timed out)|could not verify|unable to verify)\b/i;
 const CHALLENGE_CONTEXT_RE = /\b(?:(?:re|h|fun)?captcha|human|robot|challenge)\b/i;
@@ -374,6 +376,7 @@ export function buildCaptchaDiagnostics({
       source: 'navigation',
     });
   }
+  const embeddedFrames = [];
   for (const context of frameContexts || []) {
     addFrame({
       frameId: context?.frameId,
@@ -381,13 +384,27 @@ export function buildCaptchaDiagnostics({
       source: 'document',
     });
     for (const child of context?.childFrames || []) {
-      addFrame({
+      embeddedFrames.push({
+        frameId: context?.frameId,
         frameUrl: child?.loadedUrl || child?.url,
-        source: 'embedded',
         visible: child?.visible,
         activeChallengeFrame: child?.activeChallengeFrame === true,
       });
     }
+  }
+  const visibleEmbeddedFrames = applyCaptchaFrameVisibility(
+    embeddedFrames,
+    frameContexts,
+    navigationFrames,
+  );
+  for (const frame of visibleEmbeddedFrames) {
+    addFrame({
+      frameId: frame?.frameId,
+      frameUrl: frame?.frameUrl,
+      source: 'embedded',
+      visible: frame?.visible,
+      activeChallengeFrame: frame?.activeChallengeFrame === true,
+    });
   }
   for (const candidate of candidates || []) {
     addFrame({

--- a/src/firefox/src/agent/captcha-gate.js
+++ b/src/firefox/src/agent/captcha-gate.js
@@ -134,17 +134,42 @@ export function detectChallengeDialogInPage(options = null) {
       return false;
     }
   };
+  // This detector is serialized into the page, so it cannot call the exported
+  // classifier below. Keep the vendor-specific routes aligned with it.
+  const activeFrameVendor = (value) => {
+    try {
+      const parsed = new URL(String(value || ''));
+      const host = parsed.hostname.toLowerCase();
+      const path = parsed.pathname.toLowerCase();
+      if (
+        (/(^|\.)google\.com$/.test(host) || /(^|\.)recaptcha\.net$/.test(host))
+        && /\/recaptcha\/(?:api2|enterprise)\/bframe(?:\/|$)/.test(path)
+      ) return 'recaptcha';
+      if (/(^|\.)hcaptcha\.com$/.test(host)) {
+        const frame = new URLSearchParams(String(parsed.hash || '').replace(/^#/, '')).get('frame');
+        if (frame === 'challenge') return 'hcaptcha';
+      }
+      if (
+        /(^|\.)(?:arkoselabs|funcaptcha)\.com$/.test(host)
+        && /\/fc\/gc(?:\/|$)/.test(path)
+      ) return 'arkose';
+    } catch {}
+    return '';
+  };
   const childFrames = Array.from(document.querySelectorAll('iframe')).map((element, index) => {
     let loadedUrl = '';
     try {
       loadedUrl = String(element.contentWindow?.location?.href || '');
     } catch {}
+    const url = String(element.getAttribute?.('src') || element.src || '');
+    const activeChallengeVendor = activeFrameVendor(loadedUrl || url);
     return {
       index,
-      url: String(element.getAttribute?.('src') || element.src || ''),
+      url,
       loadedUrl,
       name: String(element.getAttribute?.('name') || element.name || ''),
       visible: visible(element),
+      ...(activeChallengeVendor ? { activeChallengeVendor } : {}),
     };
   });
   // A challenge dialog that exists in the DOM but is hidden or off-viewport
@@ -250,6 +275,20 @@ export function detectChallengeDialogInPage(options = null) {
       if (label) return finish({ label });
     }
   }
+  const activeChallengeFrame = childFrames.find(frame =>
+    frame.visible === true && frame.activeChallengeVendor
+  );
+  if (activeChallengeFrame) {
+    const vendorLabel = activeChallengeFrame.activeChallengeVendor === 'recaptcha'
+      ? 'reCAPTCHA'
+      : activeChallengeFrame.activeChallengeVendor === 'hcaptcha'
+        ? 'hCaptcha'
+        : 'Arkose';
+    return finish({
+      label: `Visible ${vendorLabel} challenge frame`,
+      languageNeutralFrame: true,
+    });
+  }
   return finish(null);
 }
 
@@ -302,7 +341,14 @@ export function buildCaptchaDiagnostics({
 } = {}) {
   const rows = [];
   const seen = new Set();
-  const addFrame = ({ frameId = null, parentFrameId = null, frameUrl = '', source, visible = null }) => {
+  const addFrame = ({
+    frameId = null,
+    parentFrameId = null,
+    frameUrl = '',
+    source,
+    visible = null,
+    activeChallengeFrame = false,
+  }) => {
     const sanitizedUrl = sanitizeCaptchaFrameUrl(frameUrl);
     if (!sanitizedUrl) return;
     const vendor = captchaVendorFromUrl(frameUrl);
@@ -315,6 +361,7 @@ export function buildCaptchaDiagnostics({
       frameUrl: sanitizedUrl,
       vendor,
       source,
+      ...(activeChallengeFrame ? { activeChallengeFrame: true } : {}),
       ...(typeof visible === 'boolean' ? { visible } : {}),
     });
   };
@@ -338,6 +385,7 @@ export function buildCaptchaDiagnostics({
         frameUrl: child?.loadedUrl || child?.url,
         source: 'embedded',
         visible: child?.visible,
+        activeChallengeFrame: child?.activeChallengeFrame === true,
       });
     }
   }
@@ -347,6 +395,7 @@ export function buildCaptchaDiagnostics({
       frameUrl: candidate?.frameUrl,
       source: 'candidate',
       visible: candidate?.visible,
+      activeChallengeFrame: candidate?.activeChallengeFrame === true,
     });
   }
 

--- a/test/run.js
+++ b/test/run.js
@@ -54560,6 +54560,22 @@ test('language-neutral CAPTCHA challenge frames arm the gate without matching di
         }),
       },
       {
+        label: 'visible anchor paired with a hidden reCAPTCHA challenge frame',
+        node: captchaEl('div', {}, [
+          captchaEl('textarea', {
+            id: 'g-recaptcha-response-shared',
+            name: 'g-recaptcha-response',
+          }),
+          captchaEl('iframe', {
+            src: 'https://www.google.com/recaptcha/api2/anchor?k=SHARED_RECAPTCHA_KEY',
+          }),
+          captchaEl('iframe', {
+            src: 'https://www.google.com/recaptcha/api2/bframe?k=SHARED_RECAPTCHA_KEY',
+            hidden: true,
+          }),
+        ]),
+      },
+      {
         label: 'generic application CAPTCHA route',
         node: captchaEl('iframe', {
           src: 'https://example.test/checkpoint/captcha/challenge',
@@ -54595,6 +54611,40 @@ test('language-neutral CAPTCHA challenge frames arm the gate without matching di
         );
       });
     }
+
+    await withCaptchaFakePage(build, [
+      captchaEl('div', { role: 'dialog', innerText: 'Security verification' }, [
+        captchaEl('h2', { textContent: 'Security verification' }),
+      ]),
+      captchaEl('textarea', {
+        id: 'g-recaptcha-response-hidden',
+        name: 'g-recaptcha-response',
+      }),
+      captchaEl('iframe', {
+        src: 'https://www.google.com/recaptcha/api2/bframe?k=HIDDEN_DIALOG_KEY',
+        hidden: true,
+      }),
+    ], async () => {
+      const agent = new AgentClass({});
+      agent.captchaSolverEnabled = true;
+      agent._currentUrl = async () => 'https://example.test/signup';
+      const observed = await agent._observeCaptchaChallenge(
+        5,
+        'get_accessibility_tree',
+        { pageContent: 'dialog "Security verification" [ref_320]' },
+        { filter: 'visible' },
+      );
+      assert.equal(
+        observed.gate?.status,
+        'manual_required',
+        `${build}: hidden active frame was treated as a solvable dialog challenge`,
+      );
+      assert.equal(
+        observed.gate?.candidateNotCorrelated,
+        true,
+        `${build}: hidden active frame was correlated without effective visibility`,
+      );
+    });
   }
 });
 
@@ -55656,6 +55706,7 @@ test('Firefox detects and injects an inherited-origin srcdoc CAPTCHA through its
 test('captcha frame visibility propagation demotes descendants of hidden embedding frames', async () => {
   for (const build of ['chrome', 'firefox']) {
     const runtime = await import(pathToFileURL(path.join(ROOT, `src/${build}/src/agent/captcha-frame-runtime.js`)).href);
+    const gate = await import(pathToFileURL(path.join(ROOT, `src/${build}/src/agent/captcha-gate.js`)).href);
     const visibleCandidate = {
       frameId: 0,
       frameUrl: 'https://example.test/form',
@@ -55702,6 +55753,7 @@ test('captcha frame visibility propagation demotes descendants of hidden embeddi
           loadedUrl: nestedCandidate.frameUrl,
           name: 'captcha-internal',
           visible: true,
+          activeChallengeFrame: true,
         }],
       },
       {
@@ -55725,6 +55777,20 @@ test('captcha frame visibility propagation demotes descendants of hidden embeddi
       'KEY_VISIBLE',
       `${build}: hidden nested CAPTCHA outranked the visible candidate`,
     );
+    const hiddenDiagnostics = gate.buildCaptchaDiagnostics({
+      candidates: hiddenAdjusted,
+      frameContexts,
+      navigationFrames,
+    });
+    assert.equal(
+      hiddenDiagnostics.frames.some(frame =>
+        frame.source === 'embedded'
+        && frame.activeChallengeFrame === true
+        && frame.visible === true
+      ),
+      false,
+      `${build}: hidden ancestor remained visible in embedded-frame diagnostics`,
+    );
 
     frameContexts[0].childFrames[0].visible = true;
     const visibleAdjusted = runtime.applyCaptchaFrameVisibility(
@@ -55737,6 +55803,20 @@ test('captcha frame visibility propagation demotes descendants of hidden embeddi
       runtime.selectCaptchaCandidate(visibleAdjusted).selected.websiteKey,
       'KEY_HIDDEN_NESTED',
       `${build}: visible nested challenge was not restored`,
+    );
+    const visibleDiagnostics = gate.buildCaptchaDiagnostics({
+      candidates: visibleAdjusted,
+      frameContexts,
+      navigationFrames,
+    });
+    assert.equal(
+      visibleDiagnostics.frames.some(frame =>
+        frame.source === 'embedded'
+        && frame.activeChallengeFrame === true
+        && frame.visible === true
+      ),
+      true,
+      `${build}: visible ancestor chain did not restore embedded-frame diagnostics`,
     );
     frameContexts[0].childFrames[0].dialogAssociated = true;
     const dialogAdjusted = runtime.applyCaptchaFrameVisibility(
@@ -56011,6 +56091,56 @@ test('captcha candidate ranking fails closed on ties and honors exact targeting'
       activeChallenge.selected.websiteKey,
       'KEY_ACTIVE',
       `${build}: generic visible widget outranked the active challenge frame`,
+    );
+
+    const sharedWidgetObservations = runtime.applyCaptchaFrameVisibility([
+      {
+        frameId: 0,
+        frameUrl: 'https://example.test/form',
+        type: 'recaptcha_v2',
+        websiteKey: 'KEY_SHARED_VISIBILITY',
+        responseFieldId: 'g-recaptcha-response-shared',
+        visible: true,
+        normalCheckbox: true,
+        activeChallengeFrame: false,
+        detectedVia: 'url',
+      },
+      {
+        frameId: 0,
+        frameUrl: 'https://example.test/form',
+        type: 'recaptcha_v2',
+        websiteKey: 'KEY_SHARED_VISIBILITY',
+        responseFieldId: 'g-recaptcha-response-shared',
+        visible: false,
+        normalCheckbox: false,
+        activeChallengeFrame: true,
+        detectedVia: 'url',
+      },
+    ], [{
+      frameId: 0,
+      frameUrl: 'https://example.test/form',
+      childFrames: [],
+    }], [{
+      frameId: 0,
+      parentFrameId: -1,
+      url: 'https://example.test/form',
+    }]);
+    const sharedWidget = runtime.selectCaptchaCandidate(sharedWidgetObservations).selected;
+    assert.equal(sharedWidget.visible, true, `${build}: visible anchor was lost during candidate merge`);
+    assert.equal(
+      sharedWidget.activeChallengeFrame,
+      true,
+      `${build}: hidden active-frame observation was lost during candidate merge`,
+    );
+    assert.equal(
+      sharedWidget.activeChallengeFrameVisible,
+      false,
+      `${build}: visible anchor was combined with a hidden active frame`,
+    );
+    assert.equal(
+      sharedWidget.selectionReason,
+      'visible checkbox challenge',
+      `${build}: hidden active frame changed the merged candidate's ranking reason`,
     );
   }
 });

--- a/test/run.js
+++ b/test/run.js
@@ -54419,6 +54419,185 @@ test('challenge-dialog routing detects supported widgets and diagnoses unsupport
   }
 });
 
+test('language-neutral CAPTCHA challenge frames arm the gate without matching dialog copy', async () => {
+  for (const [build, AgentClass] of [['chrome', AgentCh], ['firefox', AgentFx]]) {
+    const supportedCases = [
+      {
+        label: 'reCAPTCHA bframe',
+        status: 'solve_required',
+        selectedType: 'recaptcha_v2',
+        nodes: [
+          captchaEl('div', { role: 'dialog', innerText: 'Sicherheitsüberprüfung' }, [
+            captchaEl('h2', { textContent: 'Sicherheitsüberprüfung' }),
+            captchaEl('textarea', {
+              id: 'g-recaptcha-response-localized',
+              name: 'g-recaptcha-response',
+            }),
+            captchaEl('iframe', {
+              src: 'https://www.google.com/recaptcha/api2/bframe?k=LOCALIZED_RECAPTCHA_KEY',
+            }),
+          ]),
+        ],
+      },
+      {
+        label: 'hCaptcha challenge frame',
+        status: 'solve_required',
+        selectedType: 'hcaptcha',
+        nodes: [
+          captchaEl('div', { role: 'dialog', innerText: 'Güvenlik doğrulaması' }, [
+            captchaEl('h2', { textContent: 'Güvenlik doğrulaması' }),
+            captchaEl('textarea', {
+              id: 'h-captcha-response-localized',
+              name: 'h-captcha-response',
+            }),
+            captchaEl('iframe', {
+              src: 'https://newassets.hcaptcha.com/captcha/v1/hcaptcha.html#frame=challenge&sitekey=LOCALIZED_HCAPTCHA_KEY',
+            }),
+          ]),
+        ],
+      },
+      {
+        label: 'Arkose enforcement frame',
+        status: 'manual_required',
+        nodes: [
+          captchaEl('div', { role: 'dialog', innerText: 'Vérification de sécurité' }, [
+            captchaEl('h2', { textContent: 'Vérification de sécurité' }),
+            captchaEl('iframe', {
+              src: 'https://client-api.arkoselabs.com/fc/gc/?token=LOCALIZED_ARKOSE_TOKEN',
+            }),
+          ]),
+        ],
+      },
+    ];
+
+    for (const example of supportedCases) {
+      await withCaptchaFakePage(build, example.nodes, async () => {
+        const agent = new AgentClass({});
+        agent.captchaSolverEnabled = true;
+        agent._currentUrl = async () => 'https://example.test/signup';
+        const observed = await agent._observeCaptchaChallenge(
+          1,
+          'get_accessibility_tree',
+          {
+            pageContent: 'dialog "Sicherheitsüberprüfung" [ref_300]\n button "Weiter" [ref_301]',
+          },
+          { filter: 'visible' },
+        );
+        assert.equal(
+          observed.gate?.status,
+          example.status,
+          `${build}: ${example.label} did not arm the localized challenge gate`,
+        );
+        if (example.selectedType) {
+          assert.equal(
+            observed.gate?.selectedType,
+            example.selectedType,
+            `${build}: ${example.label} selected the wrong solver type`,
+          );
+        } else {
+          assert.equal(
+            observed.gate?.unsupportedVendors?.includes('arkose'),
+            true,
+            `${build}: ${example.label} did not report the unsupported vendor`,
+          );
+        }
+        assert.equal(
+          observed.gate?.languageNeutralFrameTrigger,
+          true,
+          `${build}: ${example.label} did not report the language-neutral trigger`,
+        );
+
+        const disabledAgent = new AgentClass({});
+        disabledAgent.captchaSolverEnabled = false;
+        disabledAgent._currentUrl = async () => 'https://example.test/signup';
+        const disabled = await disabledAgent._observeCaptchaChallenge(
+          4,
+          'get_accessibility_tree',
+          { pageContent: 'dialog "Sicherheitsüberprüfung" [ref_302]' },
+          { filter: 'visible' },
+        );
+        assert.equal(
+          disabled.gate?.status,
+          'manual_required',
+          `${build}: ${example.label} bypassed the gate when the solver was disabled`,
+        );
+        assert.equal(
+          disabled.gate?.solverDisabled,
+          true,
+          `${build}: ${example.label} did not explain manual routing`,
+        );
+
+        const preflightAgent = new AgentClass({});
+        preflightAgent.captchaSolverEnabled = true;
+        preflightAgent._currentUrl = async () => 'https://example.test/signup';
+        const preflight = await preflightAgent._captchaMutationPreflight(2, 'click_ax');
+        assert.equal(
+          preflight?.status,
+          example.status,
+          `${build}: ${example.label} did not block the first mutation`,
+        );
+      });
+    }
+
+    const inactiveCases = [
+      {
+        label: 'ordinary reCAPTCHA anchor',
+        node: captchaEl('iframe', {
+          src: 'https://www.google.com/recaptcha/api2/anchor?k=IDLE_RECAPTCHA_KEY',
+        }),
+      },
+      {
+        label: 'hCaptcha checkbox frame',
+        node: captchaEl('iframe', {
+          src: 'https://newassets.hcaptcha.com/captcha/v1/hcaptcha.html#frame=checkbox&sitekey=IDLE_HCAPTCHA_KEY',
+        }),
+      },
+      {
+        label: 'hidden reCAPTCHA challenge frame',
+        node: captchaEl('iframe', {
+          src: 'https://www.google.com/recaptcha/api2/bframe?k=HIDDEN_RECAPTCHA_KEY',
+          hidden: true,
+        }),
+      },
+      {
+        label: 'generic application CAPTCHA route',
+        node: captchaEl('iframe', {
+          src: 'https://example.test/checkpoint/captcha/challenge',
+        }),
+      },
+      {
+        label: 'spoofed reCAPTCHA vendor host',
+        node: captchaEl('iframe', {
+          src: 'https://google.com.example.test/recaptcha/api2/bframe?k=SPOOFED_KEY',
+        }),
+      },
+    ];
+    for (const example of inactiveCases) {
+      await withCaptchaFakePage(build, [
+        captchaEl('div', { role: 'dialog', innerText: 'Sicherheitsüberprüfung' }, [
+          captchaEl('h2', { textContent: 'Sicherheitsüberprüfung' }),
+          example.node,
+        ]),
+      ], async () => {
+        const agent = new AgentClass({});
+        agent.captchaSolverEnabled = true;
+        agent._currentUrl = async () => 'https://example.test/signup';
+        const observed = await agent._observeCaptchaChallenge(
+          3,
+          'get_accessibility_tree',
+          { pageContent: 'dialog "Sicherheitsüberprüfung" [ref_310]' },
+          { filter: 'visible' },
+        );
+        assert.equal(
+          observed.gate,
+          null,
+          `${build}: ${example.label} armed a language-neutral challenge gate`,
+        );
+      });
+    }
+  }
+});
+
 test('enabled CAPTCHA gate performs a read-only dialog preflight before the first mutation', async () => {
   for (const [build, AgentClass] of [['chrome', AgentCh], ['firefox', AgentFx]]) {
     const challengeLabel = 'Complete "Security verification" now';
@@ -55494,6 +55673,7 @@ test('captcha frame visibility propagation demotes descendants of hidden embeddi
       visible: true,
       normalCheckbox: true,
       challengeFrame: true,
+      activeChallengeFrame: true,
       detectedVia: 'host',
     };
     const navigationFrames = [
@@ -55793,6 +55973,7 @@ test('captcha candidate ranking fails closed on ties and honors exact targeting'
       websiteKey: 'KEY_HIDDEN',
       visible: false,
       challengeFrame: true,
+      activeChallengeFrame: true,
       responseField: true,
       detectedVia: 'script',
     };


### PR DESCRIPTION
## Summary

- distinguish active CAPTCHA challenge frames from ordinary checkbox/anchor frames
- arm the CAPTCHA gate from visible reCAPTCHA, hCaptcha, and Arkose challenge routes without relying on English dialog copy
- keep Chrome and Firefox routing, diagnostics, and regression coverage aligned

## Motivation

The gate currently starts from English phrases such as "Security verification".
Localized challenge dialogs therefore remain unguarded even when the page exposes
a language-neutral vendor challenge frame. This advances #505 after the response
token-state work from #512.

## Design

The detector now records a separate `activeChallengeFrame` signal for exact
vendor routes:

- reCAPTCHA `/recaptcha/{api2,enterprise}/bframe`
- hCaptcha `#frame=challenge`
- Arkose `/fc/gc/`

That signal is deliberately narrower than the existing generic
`challengeFrame` heuristic. Visible reCAPTCHA anchors, hCaptcha checkbox
frames, hidden frames, generic application CAPTCHA paths, and spoofed vendor
hostnames cannot arm it.

For an accessibility-tree result, local CAPTCHA detection runs early only when
the tree already exposes a dialog surface. Before the first mutation, the
existing read-only page preflight also recognizes a visible active challenge
frame. Supported visible frames route to `solve_required`; Arkose and
solver-disabled cases continue to fail closed as `manual_required`.

## Testing

- `node test/run.js` — 1354 passed; 1 inherited failure because
  `package.json` is `26.0.1` while the newest `CHANGELOG.md` entry is `26.0.0`
- `node test/security/injection-corpus.mjs` — 60/60 passed
- `node --check` for both `agent.js`, `captcha-gate.js`, and
  `captcha-frame-runtime.js` copies — passed
- Chrome/Firefox byte-parity checks for the mirrored CAPTCHA helper modules —
  passed
- `git diff --check` — passed

## Compatibility and risks

No public API, permission, network, or storage behavior changes. The remaining
risk is vendor URL drift; exact route matching intentionally prefers a missed
new route over a false-positive gate.

## Scope

This PR does not add localized phrase tables, rewrite verification-state
cleanup, or detect full-page Cloudflare interstitials. Those remain separate
steps in #505.

Advances #505.
