### PR TITLE
docs: fix site adapter matcher API name

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,7 +57,7 @@ The shape is:
 {
   name: 'sahibinden',
   category: 'general',
-  match: (url) => /^https?:\/\/(www\.)?sahibinden\.com\//.test(url),
+  matches: (url) => /^https?:\/\/(www\.)?sahibinden\.com\//.test(url),
   notes: `
 - (one short bullet per non-obvious fact about the site, written in the
    imperative voice for an LLM that has never seen this page before.)
@@ -69,7 +69,7 @@ Each adapter needs four things:
 
 1. **`name`** — short identifier, lowercase, no spaces. Used in logs and the settings UI.
 2. **`category`** — usually `'general'`. Reserved for future filtering.
-3. **`match(url)`** — regex against the current tab URL. Match the broadest
+3. **`matches(url)`** — regex against the current tab URL. Match the broadest
    form of the domain (`.com`, `.co.uk`, `.com.tr` country variants if applicable),
    but don't match unrelated subdomains.
 4. **`notes`** — the body the agent will see prepended to its first message

--- a/docs/fr/site-adapters.md
+++ b/docs/fr/site-adapters.md
@@ -12,14 +12,14 @@ Les adaptateurs de site sont la **contribution la plus recherchée n°1** (voir 
 
 ### Correspondance
 
-`getActiveAdapter(url)` parcourt le tableau `ADAPTERS` et retourne le **premier** adaptateur dont `match(url)` retourne `true` :
+`getActiveAdapter(url)` parcourt le tableau `ADAPTERS` et retourne le **premier** adaptateur dont `matches(url)` retourne `true` :
 
 ```js
 export function getActiveAdapter(url) {
   if (!url) return null;
   for (const a of ADAPTERS) {
     try {
-      if (a.match(url)) return a;
+      if (a.matches(url)) return a;
     } catch (e) { /* ignorer les matchers mal formés */ }
   }
   return null;
@@ -52,7 +52,7 @@ d'injecter les conseils Mastodon plus largement.
 {
   name: 'my-site',          // identifiant court unique
   category: 'general',       // 'general' | 'finance'
-  match: (url) => /^https?:\/\/(www\.)?example\.com\//.test(url),
+  matches: (url) => /^https?:\/\/(www\.)?example\.com\//.test(url),
   notes: `
 - Point 1 : le conseil actionnable.
 - Point 2 : un autre conseil.
@@ -67,7 +67,7 @@ d'injecter les conseils Mastodon plus largement.
 |---|---|---|
 | `name` | string | Identifiant unique pour l'adaptateur. Utilisé dans les en-têtes d'invite système. |
 | `category` | `'general'` ou `'finance'` | `'finance'` ajoute une bannière `[FINANCE / ENJEUX ÉLEVÉS]` à l'en-tête et déclenche des consignes de sécurité supplémentaires dans l'invite système. |
-| `match` | `(url) => boolean` | Retourne `true` quand l'adaptateur doit se déclencher pour cette URL. L'expression régulière est préférée — gardez-la assez spécifique pour éviter les faux positifs. |
+| `matches` | `(url) => boolean` | Retourne `true` quand l'adaptateur doit se déclencher pour cette URL. L'expression régulière est préférée — gardez-la assez spécifique pour éviter les faux positifs. |
 | `notes` | string | Conseils sous forme de puces injectés dans le premier message utilisateur. **Maximum 4 à 8 lignes.** Voir les consignes de style ci-dessous. |
 
 ### Ordre
@@ -108,7 +108,7 @@ Les adaptateurs sont ordonnés par catégorie/site dans le tableau `ADAPTERS`. *
 {
   name: 'twitter',
   category: 'general',
-  match: (url) => /^https?:\/\/(www\.)?(twitter\.com|x\.com)\//.test(url),
+  matches: (url) => /^https?:\/\/(www\.)?(twitter\.com|x\.com)\//.test(url),
   notes: `
 - Le composeur est un contenteditable, pas un textarea. Le nombre de caractères est appliqué côté client.
 - La timeline est virtualisée — les tweets disparaissent du DOM. Utilisez la recherche, pas le défilement, pour trouver un tweet.
@@ -124,7 +124,7 @@ Les adaptateurs sont ordonnés par catégorie/site dans le tableau `ADAPTERS`. *
 {
   name: 'stripe',
   category: 'finance',
-  match: (url) => /^https?:\/\/(dashboard\.)?stripe\.com\//.test(url),
+  matches: (url) => /^https?:\/\/(dashboard\.)?stripe\.com\//.test(url),
   notes: `
 - Bascule LIVE vs TEST en haut à droite. Toujours confirmer le mode.
 - Les remboursements sont partiels par défaut — vérifier le montant attentivement.
@@ -161,7 +161,7 @@ Ouvrez chaque site adapté et vérifiez :
 
 - [ ] Ajouter l'objet adaptateur au tableau `ADAPTERS` dans `src/chrome/src/agent/adapters.js`
 - [ ] Refléter exactement la même modification dans `src/firefox/src/agent/adapters.js`
-- [ ] S'assurer que la regex `match()` est spécifique et ne masque pas les adaptateurs voisins
+- [ ] S'assurer que la regex `matches()` est spécifique et ne masque pas les adaptateurs voisins
 - [ ] Si `category: 'finance'`, le placer AVANT `finance-generic` dans le tableau
 - [ ] Vérifier que les notes sont concises (4 à 8 puces)
 - [ ] Tester la correspondance avec `getActiveAdapter(url)`

--- a/docs/site-adapters.md
+++ b/docs/site-adapters.md
@@ -12,14 +12,14 @@ Site adapters are the **#1 most-wanted contribution** (see CONTRIBUTING.md). The
 
 ### Matching
 
-`getActiveAdapter(url)` iterates the `ADAPTERS` array and returns the **first** adapter whose `match(url)` returns `true`:
+`getActiveAdapter(url)` iterates the `ADAPTERS` array and returns the **first** adapter whose `matches(url)` returns `true`:
 
 ```js
 export function getActiveAdapter(url) {
   if (!url) return null;
   for (const a of ADAPTERS) {
     try {
-      if (a.match(url)) return a;
+      if (a.matches(url)) return a;
     } catch (e) { /* skip malformed matchers */ }
   }
   return null;
@@ -52,7 +52,7 @@ injecting Mastodon guidance more broadly.
 {
   name: 'my-site',          // unique short identifier
   category: 'general',       // 'general' | 'finance'
-  match: (url) => /^https?:\/\/(www\.)?example\.com\//.test(url),
+  matches: (url) => /^https?:\/\/(www\.)?example\.com\//.test(url),
   notes: `
 - Bullet 1: the actionable tip.
 - Bullet 2: another tip.
@@ -67,7 +67,7 @@ injecting Mastodon guidance more broadly.
 |---|---|---|
 | `name` | string | Unique identifier for the adapter. Used in system-prompt headings. |
 | `category` | `'general'` or `'finance'` | `'finance'` adds a `[FINANCE / HIGH-STAKES]` banner to the heading and triggers extra safety guidance in the system prompt. |
-| `match` | `(url) => boolean` | Returns `true` when the adapter should fire for this URL. Regex is preferred — keep it specific enough to avoid false matches. |
+| `matches` | `(url) => boolean` | Returns `true` when the adapter should fire for this URL. Regex is preferred — keep it specific enough to avoid false matches. |
 | `notes` | string | Bulleted guidance injected into the first user message. **Keep 4–8 lines max.** See style guidance below. |
 
 ### Ordering
@@ -108,7 +108,7 @@ Adapters are ordered by category/site in the `ADAPTERS` array. **Finance adapter
 {
   name: 'twitter',
   category: 'general',
-  match: (url) => /^https?:\/\/(www\.)?(twitter\.com|x\.com)\//.test(url),
+  matches: (url) => /^https?:\/\/(www\.)?(twitter\.com|x\.com)\//.test(url),
   notes: `
 - The composer is a contenteditable, not a textarea. Character count is enforced client-side.
 - The timeline is virtualized — tweets scroll out of the DOM. Use search, not scroll, to find a tweet.
@@ -124,7 +124,7 @@ Adapters are ordered by category/site in the `ADAPTERS` array. **Finance adapter
 {
   name: 'stripe',
   category: 'finance',
-  match: (url) => /^https?:\/\/(dashboard\.)?stripe\.com\//.test(url),
+  matches: (url) => /^https?:\/\/(dashboard\.)?stripe\.com\//.test(url),
   notes: `
 - LIVE vs TEST mode toggle in the top-right. Always confirm which mode.
 - Refunds are partial-by-default — check the amount carefully.
@@ -161,7 +161,7 @@ Open each adapted site and verify:
 
 - [ ] Add the adapter object to the `ADAPTERS` array in `src/chrome/src/agent/adapters.js`
 - [ ] Mirror the exact same change to `src/firefox/src/agent/adapters.js`
-- [ ] Ensure the `match()` regex is specific and doesn't shadow neighboring adapters
+- [ ] Ensure the `matches()` regex is specific and doesn't shadow neighboring adapters
 - [ ] If `category: 'finance'`, place it BEFORE `finance-generic` in the array
 - [ ] Verify the notes are 4–8 concise bullets
 - [ ] Test matching with `getActiveAdapter(url)`

--- a/docs/zh-CN/site-adapters.md
+++ b/docs/zh-CN/site-adapters.md
@@ -12,14 +12,14 @@
 
 ### 匹配
 
-`getActiveAdapter(url)` 遍历 `ADAPTERS` 数组，返回第一个 `match(url)` 返回 `true` 的适配器：
+`getActiveAdapter(url)` 遍历 `ADAPTERS` 数组，返回第一个 `matches(url)` 返回 `true` 的适配器：
 
 ```js
 export function getActiveAdapter(url) {
   if (!url) return null;
   for (const a of ADAPTERS) {
     try {
-      if (a.match(url)) return a;
+      if (a.matches(url)) return a;
     } catch (e) { /* 跳过格式错误的匹配器 */ }
   }
   return null;
@@ -51,7 +51,7 @@ export function getActiveAdapter(url) {
 {
   name: 'my-site',          // 唯一短标识符
   category: 'general',       // 'general' | 'finance'
-  match: (url) => /^https?:\/\/(www\.)?example\.com\//.test(url),
+  matches: (url) => /^https?:\/\/(www\.)?example\.com\//.test(url),
   notes: `
 - 要点 1：可操作的建议。
 - 要点 2：另一个建议。
@@ -66,7 +66,7 @@ export function getActiveAdapter(url) {
 |---|---|---|
 | `name` | string | 适配器的唯一标识符。用于系统提示的标题。 |
 | `category` | `'general'` 或 `'finance'` | `'finance'` 会在标题中添加 `[FINANCE / HIGH-STAKES]` 横幅，并在系统提示中触发额外的安全指导。 |
-| `match` | `(url) => boolean` | 当适配器应为该 URL 触发时返回 `true`。推荐使用正则表达式——保持足够具体以避免错误匹配。 |
+| `matches` | `(url) => boolean` | 当适配器应为该 URL 触发时返回 `true`。推荐使用正则表达式——保持足够具体以避免错误匹配。 |
 | `notes` | string | 注入到第一条用户消息中的要点式指导。**最多保持 4–8 行。** 参见下面的风格指南。 |
 
 ### 排序
@@ -107,7 +107,7 @@ export function getActiveAdapter(url) {
 {
   name: 'twitter',
   category: 'general',
-  match: (url) => /^https?:\/\/(www\.)?(twitter\.com|x\.com)\//.test(url),
+  matches: (url) => /^https?:\/\/(www\.)?(twitter\.com|x\.com)\//.test(url),
   notes: `
 - 编辑器是一个 contenteditable，而不是 textarea。字符数由客户端强制限制。
 - 时间线是虚拟化的——推文会滚动出 DOM。使用搜索而不是滚动来查找推文。
@@ -123,7 +123,7 @@ export function getActiveAdapter(url) {
 {
   name: 'stripe',
   category: 'finance',
-  match: (url) => /^https?:\/\/(dashboard\.)?stripe\.com\//.test(url),
+  matches: (url) => /^https?:\/\/(dashboard\.)?stripe\.com\//.test(url),
   notes: `
 - LIVE 与 TEST 模式切换在右上角。始终确认当前模式。
 - 退款默认为部分退款——请仔细检查金额。
@@ -160,7 +160,7 @@ export function getActiveAdapter(url) {
 
 - [ ] 将适配器对象添加到 `src/chrome/src/agent/adapters.js` 的 `ADAPTERS` 数组中
 - [ ] 将完全相同的更改同步到 `src/firefox/src/agent/adapters.js`
-- [ ] 确保 `match()` 正则表达式具体且不会遮蔽相邻的适配器
+- [ ] 确保 `matches()` 正则表达式具体且不会遮蔽相邻的适配器
 - [ ] 如果 `category: 'finance'`，将其放在数组中 `finance-generic` 之前
 - [ ] 验证 notes 是 4–8 条简洁的要点
 - [ ] 使用 `getActiveAdapter(url)` 测试匹配


### PR DESCRIPTION
## Summary

- update site-adapter examples from `match` to the implemented `matches` property
- align `getActiveAdapter()` snippets with the production call to `a.matches(url)`
- keep the English, Chinese, and French adapter guides consistent

## Why

The current implementation calls `a.matches(url)`. Copying the documented `match` examples creates an adapter that never activates.

## Testing

- `git diff --check`
- verified the four updated guides contain no stale `match: (url)` or `a.match(url)` examples
- `npm test`: 1352 passed, 2 unrelated existing failures (`CHANGELOG.md` version lags `package.json`; promotion recommendation locale expectation)