### PR TITLE
agent: add adapter for Rakuten Ichiba

### DIFF
--- a/src/chrome/src/agent/adapters.js
+++ b/src/chrome/src/agent/adapters.js
@@ -16294,6 +16294,20 @@ const ADAPTERS = [
 - Search hosts (listado.mercadolibre.com.ar, listado.mercadolibre.com.mx, lista.mercadolivre.com.br) can redirect automation to /gz/account-verification. If that wall appears, STOP and ask the user to complete it manually — do not retry, bypass, or claim results were read.`,
   },
 
+  // ─── Regional — Rakuten Ichiba (Japan) ────────────────────────────────
+  {
+    name: 'rakuten-ichiba',
+    category: 'general',
+    matches: (url) => /^https?:\/\/(?:(?:www|search|item)\.rakuten\.co\.jp|basket\.step\.rakuten\.co\.jp)\//.test(url),
+    notes: `
+- As of 2026-07, Rakuten Ichiba is a MARKETPLACE of independently operated "ショップ" (shops). Stable labels: "買い物かごに入れる" = add to cart, "買い物かご" = cart, and "ご購入手続き" = proceed to checkout.
+- Search results marked "[PR]" are sponsored. For a price comparison, use "同じ商品を安い順で見る" when available, then compare the exact variant's "価格+送料" and per-unit price; do not rank the first result or a bare "〜" price range as cheapest.
+- Select every size, color, pack count, delivery timing, and other required option before comparing or adding. "定期購入" is a recurring purchase with a different price — keep normal purchase selected unless the user explicitly asks for a subscription.
+- The cart is divided into boxes by shop. On desktop, items from different shops cannot share one checkout; mobile "おまとめ購入" may batch the steps, but each shop still creates a separate order and shipment. Read each box and click its own "ご購入手続き".
+- Shipping is shop- and destination-specific. A 39 Shop's 3,980円 free-shipping line applies within the same eligible shop and order, not across shops; "特定送料", remote regions, chilled delivery, and large items can remain chargeable. Verify every shop's cart total.
+- "ポイント", SPU, and スーパーDEAL are conditional rewards, not an immediate cash-price reduction; campaigns may require entry, membership, payment methods, or have caps, and shipping/tax do not earn ordinary points. Report the payable total separately from expected points.`,
+  },
+
   // ─── Regional — Türkiye (TR) ──────────────────────────────────────────
   // Regional adapters are the project's #1 wanted contribution (CONTRIBUTING.md);
   // Türkiye is top of the priority list. Add more TR sites (trendyol,

--- a/src/firefox/src/agent/adapters.js
+++ b/src/firefox/src/agent/adapters.js
@@ -16292,6 +16292,20 @@ const ADAPTERS = [
 - Search hosts (listado.mercadolibre.com.ar, listado.mercadolibre.com.mx, lista.mercadolivre.com.br) can redirect automation to /gz/account-verification. If that wall appears, STOP and ask the user to complete it manually — do not retry, bypass, or claim results were read.`,
   },
 
+  // ─── Regional — Rakuten Ichiba (Japan) ────────────────────────────────
+  {
+    name: 'rakuten-ichiba',
+    category: 'general',
+    matches: (url) => /^https?:\/\/(?:(?:www|search|item)\.rakuten\.co\.jp|basket\.step\.rakuten\.co\.jp)\//.test(url),
+    notes: `
+- As of 2026-07, Rakuten Ichiba is a MARKETPLACE of independently operated "ショップ" (shops). Stable labels: "買い物かごに入れる" = add to cart, "買い物かご" = cart, and "ご購入手続き" = proceed to checkout.
+- Search results marked "[PR]" are sponsored. For a price comparison, use "同じ商品を安い順で見る" when available, then compare the exact variant's "価格+送料" and per-unit price; do not rank the first result or a bare "〜" price range as cheapest.
+- Select every size, color, pack count, delivery timing, and other required option before comparing or adding. "定期購入" is a recurring purchase with a different price — keep normal purchase selected unless the user explicitly asks for a subscription.
+- The cart is divided into boxes by shop. On desktop, items from different shops cannot share one checkout; mobile "おまとめ購入" may batch the steps, but each shop still creates a separate order and shipment. Read each box and click its own "ご購入手続き".
+- Shipping is shop- and destination-specific. A 39 Shop's 3,980円 free-shipping line applies within the same eligible shop and order, not across shops; "特定送料", remote regions, chilled delivery, and large items can remain chargeable. Verify every shop's cart total.
+- "ポイント", SPU, and スーパーDEAL are conditional rewards, not an immediate cash-price reduction; campaigns may require entry, membership, payment methods, or have caps, and shipping/tax do not earn ordinary points. Report the payable total separately from expected points.`,
+  },
+
   // ─── Regional — Türkiye (TR) ──────────────────────────────────────────
   // Regional adapters are the project's #1 wanted contribution (CONTRIBUTING.md);
   // Türkiye is top of the priority list. Add more TR sites (trendyol,

--- a/test/run.js
+++ b/test/run.js
@@ -2453,6 +2453,44 @@ test('matches Mercado Libre LATAM storefronts and includes marketplace guidance'
   assert.equal(firefoxAdapter?.notes, adapter?.notes);
 });
 
+test('matches Rakuten Ichiba shopping surfaces and includes marketplace guidance', () => {
+  const trustedUrls = [
+    'https://www.rakuten.co.jp/',
+    'https://search.rakuten.co.jp/search/mall/%E6%B0%B4/',
+    'https://item.rakuten.co.jp/example-shop/example-item/',
+    'https://basket.step.rakuten.co.jp/rms/mall/bs/cart/',
+  ];
+  for (const url of trustedUrls) {
+    assert.equal(getActiveAdapter(url)?.name, 'rakuten-ichiba');
+    assert.equal(getActiveAdapterFx(url)?.name, 'rakuten-ichiba');
+  }
+
+  const rejectedUrls = [
+    'https://travel.rakuten.co.jp/',
+    'https://books.rakuten.co.jp/',
+    'https://order.step.rakuten.co.jp/',
+    'https://www.rakuten.co.jp.phishing.example/',
+    'https://example.com/item.rakuten.co.jp/example-shop/example-item/',
+  ];
+  for (const url of rejectedUrls) {
+    assert.notEqual(getActiveAdapter(url)?.name, 'rakuten-ichiba');
+    assert.notEqual(getActiveAdapterFx(url)?.name, 'rakuten-ichiba');
+  }
+
+  const adapter = getActiveAdapter('https://search.rakuten.co.jp/search/mall/%E6%B0%B4/');
+  const firefoxAdapter = getActiveAdapterFx('https://item.rakuten.co.jp/example-shop/example-item/');
+  assert.match(adapter?.notes || '', /2026-07/);
+  assert.match(adapter?.notes || '', /\[PR\]/);
+  assert.match(adapter?.notes || '', /同じ商品を安い順で見る/);
+  assert.match(adapter?.notes || '', /定期購入/);
+  assert.match(adapter?.notes || '', /different shops/i);
+  assert.match(adapter?.notes || '', /ご購入手続き/);
+  assert.match(adapter?.notes || '', /3,980円/);
+  assert.match(adapter?.notes || '', /特定送料/);
+  assert.match(adapter?.notes || '', /ポイント/);
+  assert.equal(firefoxAdapter?.notes, adapter?.notes);
+});
+
 test('matches sahibinden.com and includes anti-bot guidance', () => {
   assert.equal(getActiveAdapter('https://www.sahibinden.com/')?.name, 'sahibinden');
   assert.equal(getActiveAdapter('https://sahibinden.com/kategori/vasita')?.name, 'sahibinden');


### PR DESCRIPTION
## Summary

- add a Rakuten Ichiba adapter for the researched Japanese marketplace search, item, shop, and cart surfaces
- guide the agent around sponsored results, variant and subscription prices, shop-separated carts, shipping exceptions, and conditional points
- mirror the adapter in Chrome and Firefox with routing, spoofing-boundary, behavior, and parity tests

## Motivation

`CONTRIBUTING.md` lists `rakuten.co.jp` as a high-priority East Asia adapter, but WebBrain currently uses only generic commerce behavior there. Current official [search results](https://search.rakuten.co.jp/search/mall/%E6%B0%B4/) and Rakuten help for [multi-shop shipping](https://ichiba.faq.rakuten.net/detail/000006502), [shop-grouped carts](https://ichiba.faq.rakuten.net/detail/000006440), and [39 Shop shipping exceptions](https://ichiba.faq.rakuten.net/detail/000013788) expose several non-obvious traps:

- `[PR]` results are sponsored, while `〜` prices and variants make the first displayed price non-comparable
- `定期購入` is a recurring purchase with a different price from the normal option
- different shops have independent carts, orders, shipments, and shipping policies
- the 3,980円 free-shipping line is evaluated within an eligible shop/order and does not override `特定送料` or destination/delivery exceptions
- points and Super DEAL rewards are conditional and are not an immediate reduction of the payable price

Without site guidance, these behaviors can lead to incorrect cheapest-price claims, unintended subscriptions, combined-shipping promises, or overstated savings.

## Design

The adapter explicitly matches only the researched Rakuten Ichiba surfaces:

- `www.rakuten.co.jp`
- `search.rakuten.co.jp`
- `item.rakuten.co.jp`
- `basket.step.rakuten.co.jp`

It deliberately excludes Rakuten Travel, Books, unresearched order/checkout hosts, other group services, and suffix/path lookalikes.

Six dated, imperative notes tell the agent to:

- distinguish add-to-cart and checkout labels
- ignore sponsored position and compare the same exact variant by price plus shipping
- select required options and avoid recurring purchase unless requested
- handle desktop/mobile shop-separated cart behavior accurately
- verify 39 Shop thresholds and shipping exceptions per shop
- report payable totals separately from conditional points

This follows the existing regional-adapter shape without adding APIs, permissions, dependencies, or network calls.

## Testing

- production-module focused assertions for trusted/rejected URLs and Chrome/Firefox note parity — passed
- `node --check src/chrome/src/agent/adapters.js` — passed
- `node --check src/firefox/src/agent/adapters.js` — passed
- exact Chrome/Firefox Rakuten-block diff — passed
- `npm run test:security` — passed, 60/60 checks
- `npm run test:webmcp` — passed with real Chrome
- `node test/run.js` — 1,354 passed; one unchanged baseline failure remains because `package.json` is `26.0.1` while the newest `CHANGELOG.md` entry is `26.0.0`

## Compatibility and risks

This is additive prompt metadata with no public API or configuration changes. The main residual risk is UI drift; the notes are dated `2026-07`, use stable marketplace labels and documented policies rather than selectors, and keep host matching conservative.

## Scope

Rakuten Travel, Books, other group services, unresearched checkout hosts, and mobile-app-only flows are intentionally deferred.
