### PR TITLE
agent: add adapter for Allegro

### DIFF
--- a/src/chrome/src/agent/adapters.js
+++ b/src/chrome/src/agent/adapters.js
@@ -16337,6 +16337,20 @@ const ADAPTERS = [
 - "ポイント", SPU, and スーパーDEAL are conditional rewards, not an immediate cash-price reduction; campaigns may require entry, membership, payment methods, or have caps, and shipping/tax do not earn ordinary points. Report the payable total separately from expected points.`,
   },
 
+  // ─── Regional — Allegro (Poland) ─────────────────────────────────────
+  {
+    name: 'allegro',
+    category: 'general',
+    matches: (url) => /^https?:\/\/(www\.)?allegro\.pl\//.test(url),
+    notes: `
+- As of 2026-07, Allegro.pl is a Polish MARKETPLACE. Stable labels: "dodaj do koszyka" = add to cart, "dostawa i płatność" = delivery and payment, and "kup i zapłać" = buy and pay.
+- Search placements marked "Sponsorowane" or "Promowane" are paid placements. For price comparisons choose "cena z dostawą: od najniższej" and compare the delivered total, not the default relevance order or bare item price.
+- Product cards can group variants and sellers: "dostępne warianty" means variants are available, while "zobacz N ofert" opens the other offers for that product. Select the exact variant and compare seller, delivery date, and delivered price before choosing.
+- The cart can contain products from multiple sellers and groups them by seller. All added products are selected by default, adding does not reserve stock, and delivery is still calculated per seller; re-check the selected rows and totals before continuing.
+- "kup i zapłać" is the quick-purchase path and skips the delivery/payment form by reusing saved choices. Do not click it for collection or comparison tasks; use the cart and "dostawa i płatność" when the user wants to review details first.
+- Smart! free delivery is conditional on an eligible offer, one seller's qualifying total, the selected delivery method, and the account's current terms. Verify the Smart! badge and cart delivery charge instead of promising free delivery from the badge alone.`,
+  },
+
   // ─── Regional — Türkiye (TR) ──────────────────────────────────────────
   // Regional adapters are the project's #1 wanted contribution (CONTRIBUTING.md);
   // Türkiye is top of the priority list. Add more TR sites (trendyol,

--- a/src/firefox/src/agent/adapters.js
+++ b/src/firefox/src/agent/adapters.js
@@ -16335,6 +16335,20 @@ const ADAPTERS = [
 - "ポイント", SPU, and スーパーDEAL are conditional rewards, not an immediate cash-price reduction; campaigns may require entry, membership, payment methods, or have caps, and shipping/tax do not earn ordinary points. Report the payable total separately from expected points.`,
   },
 
+  // ─── Regional — Allegro (Poland) ─────────────────────────────────────
+  {
+    name: 'allegro',
+    category: 'general',
+    matches: (url) => /^https?:\/\/(www\.)?allegro\.pl\//.test(url),
+    notes: `
+- As of 2026-07, Allegro.pl is a Polish MARKETPLACE. Stable labels: "dodaj do koszyka" = add to cart, "dostawa i płatność" = delivery and payment, and "kup i zapłać" = buy and pay.
+- Search placements marked "Sponsorowane" or "Promowane" are paid placements. For price comparisons choose "cena z dostawą: od najniższej" and compare the delivered total, not the default relevance order or bare item price.
+- Product cards can group variants and sellers: "dostępne warianty" means variants are available, while "zobacz N ofert" opens the other offers for that product. Select the exact variant and compare seller, delivery date, and delivered price before choosing.
+- The cart can contain products from multiple sellers and groups them by seller. All added products are selected by default, adding does not reserve stock, and delivery is still calculated per seller; re-check the selected rows and totals before continuing.
+- "kup i zapłać" is the quick-purchase path and skips the delivery/payment form by reusing saved choices. Do not click it for collection or comparison tasks; use the cart and "dostawa i płatność" when the user wants to review details first.
+- Smart! free delivery is conditional on an eligible offer, one seller's qualifying total, the selected delivery method, and the account's current terms. Verify the Smart! badge and cart delivery charge instead of promising free delivery from the badge alone.`,
+  },
+
   // ─── Regional — Türkiye (TR) ──────────────────────────────────────────
   // Regional adapters are the project's #1 wanted contribution (CONTRIBUTING.md);
   // Türkiye is top of the priority list. Add more TR sites (trendyol,

--- a/test/run.js
+++ b/test/run.js
@@ -2575,6 +2575,43 @@ test('matches Rakuten Ichiba shopping surfaces and includes marketplace guidance
   assert.equal(firefoxAdapter?.notes, adapter?.notes);
 });
 
+test('matches Allegro.pl shopping surfaces and includes Polish marketplace guidance', () => {
+  const trustedUrls = [
+    'https://allegro.pl/',
+    'https://www.allegro.pl/listing?string=sluchawki',
+    'https://allegro.pl/oferta/example-product-123456789',
+    'https://allegro.pl/koszyk',
+  ];
+  for (const url of trustedUrls) {
+    assert.equal(getActiveAdapter(url)?.name, 'allegro');
+    assert.equal(getActiveAdapterFx(url)?.name, 'allegro');
+  }
+
+  const rejectedUrls = [
+    'https://allegrolokalnie.pl/oferta/example',
+    'https://allegro.cz/listing?string=sluchawki',
+    'https://allegro.pl.phishing.example/oferta/example',
+    'https://example.com/allegro.pl/oferta/example',
+  ];
+  for (const url of rejectedUrls) {
+    assert.notEqual(getActiveAdapter(url)?.name, 'allegro');
+    assert.notEqual(getActiveAdapterFx(url)?.name, 'allegro');
+  }
+
+  const adapter = getActiveAdapter('https://allegro.pl/listing?string=sluchawki');
+  const firefoxAdapter = getActiveAdapterFx('https://allegro.pl/oferta/example-product-123456789');
+  assert.match(adapter?.notes || '', /2026-07/);
+  assert.match(adapter?.notes || '', /MARKETPLACE/);
+  assert.match(adapter?.notes || '', /Sponsorowane/);
+  assert.match(adapter?.notes || '', /Promowane/);
+  assert.match(adapter?.notes || '', /cena z dostawą: od najniższej/);
+  assert.match(adapter?.notes || '', /zobacz N ofert/);
+  assert.match(adapter?.notes || '', /kup i zapłać/);
+  assert.match(adapter?.notes || '', /dostawa i płatność/);
+  assert.match(adapter?.notes || '', /Smart!/);
+  assert.equal(firefoxAdapter?.notes, adapter?.notes);
+});
+
 test('matches sahibinden.com and includes anti-bot guidance', () => {
   assert.equal(getActiveAdapter('https://www.sahibinden.com/')?.name, 'sahibinden');
   assert.equal(getActiveAdapter('https://sahibinden.com/kategori/vasita')?.name, 'sahibinden');


### PR DESCRIPTION
## Summary

- add a focused Allegro.pl site adapter for Chrome and Firefox
- guide the agent through sponsored placements, grouped variants and sellers, cart review, quick purchase, and conditional Smart! delivery
- cover trusted storefront URLs, lookalike hosts, other Allegro country sites, and Chrome/Firefox parity

## Motivation

Allegro.pl is listed as a high-priority regional site in `CONTRIBUTING.md`, but it had no adapter. The current search UI mixes `Sponsorowane`/`Promowane` placements with ordinary results, exposes a delivered-price sort, and can group multiple offers behind one product card. Without site guidance, an agent can mistake a paid/default result for the cheapest offer or enter the `kup i zapłać` quick-purchase path before the user reviews delivery and payment details.

The guidance was checked against the [current search surface](https://allegro.pl/listing?string=sluchawki), Allegro's [cart documentation](https://allegro.pl/pomoc/dla-kupujacych/podstawy-kupowania/czym-jest-i-jak-dziala-koszyk-4GDdXb8KBSD), and its [buyer flow documentation](https://allegro.pl/pomoc/dla-kupujacych/podstawy-kupowania/jak-kupowac-na-allegro-5VZxXd3mDUX).

## Design

- match only `allegro.pl` and `www.allegro.pl`
- deliberately exclude Allegro Lokalnie, lookalike hosts, and other country storefronts that need separate localization research
- keep the six guidance bullets byte-identical across Chrome and Firefox
- avoid hard-coding a Smart! threshold because eligibility depends on the seller, delivery method, and the account's current terms

## Testing

- `node --check src/chrome/src/agent/adapters.js` — passed
- `node --check src/firefox/src/agent/adapters.js` — passed
- `git diff --check` — passed
- `node test/security/injection-corpus.mjs` — 60/60 passed
- `node test/run.js` — new Allegro coverage passed; 1387 passed overall, with the existing unrelated version/CHANGELOG mismatch still failing (`26.0.1` vs `26.0.0`)

## Compatibility and risks

This only adds a new exact-host adapter and does not change behavior on existing sites. The UI guidance is dated 2026-07 so future label drift is visible to maintainers.

## Scope

Allegro Lokalnie and the Czech, Slovak, and Hungarian Allegro storefronts are intentionally deferred until their localized flows are researched independently.
