### PR TITLE
agent: add adapter for Marktplaats

### DIFF
--- a/src/chrome/src/agent/adapters.js
+++ b/src/chrome/src/agent/adapters.js
@@ -16361,7 +16361,7 @@ const ADAPTERS = [
 - A bid is not a completed purchase. The seller can accept, reject, or counter it; after acceptance, eligible listings expose "Nu betalen" in Berichten and the buyer has 72 hours to pay. Do not report success until the conversation shows "Betaling geslaagd".
 - "Direct Kopen" is available only on eligible shippable listings and skips negotiation. It always adds Kopersbescherming and Verzenden via Marktplaats; review the final payable total, including buyer-protection, shipping, and service costs, before submitting payment.
 - For comparisons, distinguish the seller's asking price from a bid and from the final delivered total. Check the exact item condition, pickup/shipping option, seller profile, and "Ervaringen" rating instead of ranking on the displayed number alone.
-- Keep negotiation, payment requests, and shipping inside "Berichten". Do not move to an external payment link or share bank/address details in chat; Marktplaats collects required payment and delivery details in its own flow.
+- Keep negotiation, payment requests, and shipping inside "Berichten". Do not follow seller-supplied or otherwise untrusted external payment links or share bank/address details in chat. A bank redirect opened by Marktplaats's own "Bestel en betaal" or "Naar jouw bank" payment controls is part of its legitimate checkout flow and may be followed.
 - Shipping choices and costs depend on parcel size and carrier. Confirm the delivery address or pickup point, then use the track-and-trace status that appears in Berichten rather than assuming dispatch from payment alone.`,
   },
 

--- a/src/chrome/src/agent/adapters.js
+++ b/src/chrome/src/agent/adapters.js
@@ -16351,6 +16351,20 @@ const ADAPTERS = [
 - Smart! free delivery is conditional on an eligible offer, one seller's qualifying total, the selected delivery method, and the account's current terms. Verify the Smart! badge and cart delivery charge instead of promising free delivery from the badge alone.`,
   },
 
+  // ─── Regional — Marktplaats (Netherlands) ────────────────────────────
+  {
+    name: 'marktplaats',
+    category: 'general',
+    matches: (url) => /^https?:\/\/(www\.)?marktplaats\.nl\//.test(url),
+    notes: `
+- As of 2026-08, Marktplaats is a Dutch CLASSIFIEDS site, not a conventional cart store. A listing can offer "Bieden" (place a bid), "Bericht sturen" (message the seller), or "Direct Kopen" (buy now); use only the path the listing actually exposes.
+- A bid is not a completed purchase. The seller can accept, reject, or counter it; after acceptance, eligible listings expose "Nu betalen" in Berichten and the buyer has 72 hours to pay. Do not report success until the conversation shows "Betaling geslaagd".
+- "Direct Kopen" is available only on eligible shippable listings and skips negotiation. It always adds Kopersbescherming and Verzenden via Marktplaats; review the final payable total, including buyer-protection, shipping, and service costs, before submitting payment.
+- For comparisons, distinguish the seller's asking price from a bid and from the final delivered total. Check the exact item condition, pickup/shipping option, seller profile, and "Ervaringen" rating instead of ranking on the displayed number alone.
+- Keep negotiation, payment requests, and shipping inside "Berichten". Do not move to an external payment link or share bank/address details in chat; Marktplaats collects required payment and delivery details in its own flow.
+- Shipping choices and costs depend on parcel size and carrier. Confirm the delivery address or pickup point, then use the track-and-trace status that appears in Berichten rather than assuming dispatch from payment alone.`,
+  },
+
   // ─── Regional — Türkiye (TR) ──────────────────────────────────────────
   // Regional adapters are the project's #1 wanted contribution (CONTRIBUTING.md);
   // Türkiye is top of the priority list. Add more TR sites (trendyol,

--- a/src/firefox/src/agent/adapters.js
+++ b/src/firefox/src/agent/adapters.js
@@ -16359,7 +16359,7 @@ const ADAPTERS = [
 - A bid is not a completed purchase. The seller can accept, reject, or counter it; after acceptance, eligible listings expose "Nu betalen" in Berichten and the buyer has 72 hours to pay. Do not report success until the conversation shows "Betaling geslaagd".
 - "Direct Kopen" is available only on eligible shippable listings and skips negotiation. It always adds Kopersbescherming and Verzenden via Marktplaats; review the final payable total, including buyer-protection, shipping, and service costs, before submitting payment.
 - For comparisons, distinguish the seller's asking price from a bid and from the final delivered total. Check the exact item condition, pickup/shipping option, seller profile, and "Ervaringen" rating instead of ranking on the displayed number alone.
-- Keep negotiation, payment requests, and shipping inside "Berichten". Do not move to an external payment link or share bank/address details in chat; Marktplaats collects required payment and delivery details in its own flow.
+- Keep negotiation, payment requests, and shipping inside "Berichten". Do not follow seller-supplied or otherwise untrusted external payment links or share bank/address details in chat. A bank redirect opened by Marktplaats's own "Bestel en betaal" or "Naar jouw bank" payment controls is part of its legitimate checkout flow and may be followed.
 - Shipping choices and costs depend on parcel size and carrier. Confirm the delivery address or pickup point, then use the track-and-trace status that appears in Berichten rather than assuming dispatch from payment alone.`,
   },
 

--- a/src/firefox/src/agent/adapters.js
+++ b/src/firefox/src/agent/adapters.js
@@ -16349,6 +16349,20 @@ const ADAPTERS = [
 - Smart! free delivery is conditional on an eligible offer, one seller's qualifying total, the selected delivery method, and the account's current terms. Verify the Smart! badge and cart delivery charge instead of promising free delivery from the badge alone.`,
   },
 
+  // ─── Regional — Marktplaats (Netherlands) ────────────────────────────
+  {
+    name: 'marktplaats',
+    category: 'general',
+    matches: (url) => /^https?:\/\/(www\.)?marktplaats\.nl\//.test(url),
+    notes: `
+- As of 2026-08, Marktplaats is a Dutch CLASSIFIEDS site, not a conventional cart store. A listing can offer "Bieden" (place a bid), "Bericht sturen" (message the seller), or "Direct Kopen" (buy now); use only the path the listing actually exposes.
+- A bid is not a completed purchase. The seller can accept, reject, or counter it; after acceptance, eligible listings expose "Nu betalen" in Berichten and the buyer has 72 hours to pay. Do not report success until the conversation shows "Betaling geslaagd".
+- "Direct Kopen" is available only on eligible shippable listings and skips negotiation. It always adds Kopersbescherming and Verzenden via Marktplaats; review the final payable total, including buyer-protection, shipping, and service costs, before submitting payment.
+- For comparisons, distinguish the seller's asking price from a bid and from the final delivered total. Check the exact item condition, pickup/shipping option, seller profile, and "Ervaringen" rating instead of ranking on the displayed number alone.
+- Keep negotiation, payment requests, and shipping inside "Berichten". Do not move to an external payment link or share bank/address details in chat; Marktplaats collects required payment and delivery details in its own flow.
+- Shipping choices and costs depend on parcel size and carrier. Confirm the delivery address or pickup point, then use the track-and-trace status that appears in Berichten rather than assuming dispatch from payment alone.`,
+  },
+
   // ─── Regional — Türkiye (TR) ──────────────────────────────────────────
   // Regional adapters are the project's #1 wanted contribution (CONTRIBUTING.md);
   // Türkiye is top of the priority list. Add more TR sites (trendyol,

--- a/test/run.js
+++ b/test/run.js
@@ -2612,6 +2612,41 @@ test('matches Allegro.pl shopping surfaces and includes Polish marketplace guida
   assert.equal(firefoxAdapter?.notes, adapter?.notes);
 });
 
+test('matches Marktplaats.nl classifieds and distinguishes its transaction paths', () => {
+  const trustedUrls = [
+    'https://marktplaats.nl/',
+    'https://www.marktplaats.nl/l/fietsen-en-brommers/fietsen-heren/',
+    'https://www.marktplaats.nl/v/fietsen-en-brommers/fietsen-heren/m1234567890-example',
+    'https://www.marktplaats.nl/messages/',
+  ];
+  for (const url of trustedUrls) {
+    assert.equal(getActiveAdapter(url)?.name, 'marktplaats');
+    assert.equal(getActiveAdapterFx(url)?.name, 'marktplaats');
+  }
+
+  const rejectedUrls = [
+    'https://marktplaats.be/',
+    'https://marktplaats.nl.phishing.example/v/example',
+    'https://example.com/?next=https://www.marktplaats.nl/v/example',
+  ];
+  for (const url of rejectedUrls) {
+    assert.notEqual(getActiveAdapter(url)?.name, 'marktplaats');
+    assert.notEqual(getActiveAdapterFx(url)?.name, 'marktplaats');
+  }
+
+  const adapter = getActiveAdapter('https://www.marktplaats.nl/v/fietsen-en-brommers/fietsen-heren/m1234567890-example');
+  const firefoxAdapter = getActiveAdapterFx('https://www.marktplaats.nl/l/fietsen-en-brommers/fietsen-heren/');
+  assert.match(adapter?.notes || '', /2026-08/);
+  assert.match(adapter?.notes || '', /CLASSIFIEDS/);
+  assert.match(adapter?.notes || '', /Bieden/);
+  assert.match(adapter?.notes || '', /Berichten/);
+  assert.match(adapter?.notes || '', /Direct Kopen/);
+  assert.match(adapter?.notes || '', /Kopersbescherming/);
+  assert.match(adapter?.notes || '', /72 hours/);
+  assert.match(adapter?.notes || '', /final payable total/i);
+  assert.equal(firefoxAdapter?.notes, adapter?.notes);
+});
+
 test('matches sahibinden.com and includes anti-bot guidance', () => {
   assert.equal(getActiveAdapter('https://www.sahibinden.com/')?.name, 'sahibinden');
   assert.equal(getActiveAdapter('https://sahibinden.com/kategori/vasita')?.name, 'sahibinden');

--- a/test/run.js
+++ b/test/run.js
@@ -2644,6 +2644,10 @@ test('matches Marktplaats.nl classifieds and distinguishes its transaction paths
   assert.match(adapter?.notes || '', /Kopersbescherming/);
   assert.match(adapter?.notes || '', /72 hours/);
   assert.match(adapter?.notes || '', /final payable total/i);
+  assert.match(adapter?.notes || '', /seller-supplied or otherwise untrusted external payment links/);
+  assert.match(adapter?.notes || '', /Bestel en betaal/);
+  assert.match(adapter?.notes || '', /Naar jouw bank/);
+  assert.doesNotMatch(adapter?.notes || '', /Do not move to an external payment link/);
   assert.equal(firefoxAdapter?.notes, adapter?.notes);
 });
 


### PR DESCRIPTION
## Summary

- add a Marktplaats.nl site adapter to both browser builds
- distinguish bidding, messaging, and Direct Kopen so the agent does not treat Dutch classifieds like a conventional cart store
- cover strict hostname matching, transaction guidance, spoof rejection, and browser parity

## Motivation

Marktplaats is listed as a high-priority regional site in `CONTRIBUTING.md`. Its listing flow has three materially different paths: a bid may be accepted, rejected, or countered; an accepted eligible bid is paid from Berichten within 72 hours; and Direct Kopen skips negotiation while adding buyer-protection, shipping, and service costs. Without site guidance, an agent can mistake an asking price or accepted bid for a completed purchase and miss the final payable total.

The flow details are based on the current official Marktplaats Help pages for [bid/payment requests](https://help.marktplaats.nl/articles/nl_NL/Knowledge/hoe-verstuur-ik-een-betaalvoorstel-als-koper), [Direct Kopen](https://help.marktplaats.nl/articles/nl_NL/Knowledge/wat-is-direct-kopen-op-marktplaats), and [shipping](https://help.marktplaats.nl/articles/nl_NL/Knowledge/hoe-werkt-verzenden-via-marktplaats).

## Design

The adapter uses a strict apex/`www.marktplaats.nl` matcher and six dated prompt bullets. The notes describe stable transaction states and visible Dutch labels rather than selectors. The exact adapter is mirrored to Chrome and Firefox.

This is site-specific instead of reusing the eBay adapter because Marktplaats bidding is a seller-negotiated classifieds flow, not an auction/cart flow.

## Testing

- focused production-module contract check for trusted URLs, spoofed URLs, and Chrome/Firefox parity — passed
- `node test/security/injection-corpus.mjs` — 60/60 passed
- `node test/run.js` — the new Marktplaats test passed; the command still exits 1 on the upstream baseline's existing package/changelog mismatch (`26.0.1` versus `26.0.0`)

## Compatibility and risks

This is additive prompt guidance only: no API, config, storage, permission, or format changes. The main residual risk is future UI terminology drift, so the notes are dated `2026-08` and avoid selectors. No live extension trace was recorded in this environment.

## Scope

This PR intentionally covers only Marktplaats.nl. Other regional classifieds sites and `marktplaats.be` are deferred to separate contributions.
