### PR TITLE
fix(captcha): consume response token state

### DIFF
--- a/src/chrome/src/agent/agent.js
+++ b/src/chrome/src/agent/agent.js
@@ -123,6 +123,95 @@ function normalizeDoneOutcome(value) {
   return DONE_OUTCOMES.has(outcome) ? outcome : null;
 }
 
+function captchaCandidateFramePath(candidate) {
+  if (Array.isArray(candidate?.framePathIndexes)) {
+    return candidate.framePathIndexes.map(Number);
+  }
+  return Array.isArray(candidate?.framePath)
+    ? candidate.framePath.map(segment => Number(segment?.index))
+    : [];
+}
+
+function captchaGateCandidateIdentity(candidate) {
+  if (!candidate || typeof candidate !== 'object') return null;
+  return {
+    frameId: Number.isInteger(candidate.frameId) ? candidate.frameId : null,
+    framePathIndexes: captchaCandidateFramePath(candidate),
+    type: String(candidate.type || ''),
+    websiteKey: candidate.websiteKey || null,
+    isEnterprise: candidate.isEnterprise === true,
+    responseFieldId: candidate.responseFieldId || null,
+    responseFieldIndex: Number.isInteger(candidate.responseFieldIndex)
+      ? candidate.responseFieldIndex
+      : null,
+    alsoResponseFieldId: candidate.alsoResponseFieldId || null,
+    alsoResponseFieldIndex: Number.isInteger(candidate.alsoResponseFieldIndex)
+      ? candidate.alsoResponseFieldIndex
+      : null,
+  };
+}
+
+function captchaCandidateMatchesGate(candidate, identity) {
+  if (!candidate || !identity) return false;
+  if (Number.isInteger(identity.frameId) && candidate.frameId !== identity.frameId) return false;
+  if (
+    identity.type
+    && !captchaTypesMatch(
+      identity.type,
+      candidate.type,
+      identity.isEnterprise,
+      candidate.isEnterprise,
+    )
+  ) return false;
+  if (identity.websiteKey && candidate.websiteKey !== identity.websiteKey) return false;
+  const expectedPath = Array.isArray(identity.framePathIndexes)
+    ? identity.framePathIndexes
+    : [];
+  const candidatePath = captchaCandidateFramePath(candidate);
+  if (
+    expectedPath.length !== candidatePath.length
+    || expectedPath.some((value, index) => value !== candidatePath[index])
+  ) return false;
+
+  const expectedFieldIds = [identity.responseFieldId, identity.alsoResponseFieldId]
+    .filter(Boolean);
+  const candidateFieldIds = new Set([
+    candidate.responseFieldId,
+    candidate.alsoResponseFieldId,
+  ].filter(Boolean));
+  if (expectedFieldIds.length) {
+    return expectedFieldIds.some(fieldId => candidateFieldIds.has(fieldId));
+  }
+
+  const expectedIndexes = [
+    ['responseFieldIndex', identity.responseFieldIndex],
+    ['alsoResponseFieldIndex', identity.alsoResponseFieldIndex],
+  ].filter(([, value]) => Number.isInteger(value));
+  // Token-backed clearance requires an exact response-field identity. When
+  // the page exposes no stable id or index, retain the existing read-based
+  // verification path instead of borrowing another widget's token state.
+  return expectedIndexes.length > 0
+    && expectedIndexes.some(([field, value]) => candidate[field] === value);
+}
+
+function captchaPostSolveTokenState(detection, identity) {
+  const candidates = Array.isArray(detection?.candidates) ? detection.candidates : [];
+  const candidate = candidates.find(entry => captchaCandidateMatchesGate(entry, identity)) || null;
+  const visibleActiveChallenge = candidates.some(entry =>
+    entry?.activeChallengeFrame === true
+    && entry?.activeChallengeFrameVisible === true
+    && entry?.visible === true
+    && entry?.frameVisible !== false
+  ) || (detection?.diagnostics?.frames || []).some(frame =>
+    frame?.activeChallengeFrame === true && frame?.visible === true
+  );
+  return {
+    candidate,
+    responseTokenPresent: candidate?.responseTokenPresent === true,
+    visibleActiveChallenge,
+  };
+}
+
 function isBrowserNewTabUrl(url) {
   const value = String(url || '').toLowerCase();
   return BROWSER_NEW_TAB_URL_PREFIXES.some(prefix => value.startsWith(prefix));
@@ -2864,6 +2953,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
       || isNetworkMutation(toolName, toolArgs);
     if (
       !gate
+      || gate.status === 'cleared'
       || !gatedAction
       || abandonmentNavigation
       || (gatedCompletion && gate.status === 'manual_required')
@@ -3050,7 +3140,11 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
       || isNetworkMutation(toolName, toolArgs);
     if (!gatedAction || toolName === 'solve_captcha' || Agent.NAV_TOOLS.has(toolName)) return null;
     const activeGate = this._captchaGateStates.get(tabId);
-    if (activeGate && !this._shouldRetryCaptchaManualGate(activeGate)) return null;
+    if (
+      activeGate
+      && activeGate.status !== 'cleared'
+      && !this._shouldRetryCaptchaManualGate(activeGate)
+    ) return null;
     const challenge = await this._detectChallengeDialogBeforeMutation(tabId);
     if (!challenge?.label) return null;
     let pageUrl = '';
@@ -3226,12 +3320,45 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
         return { gate: guardedGate, loopCheck: { kind: 'none' } };
       }
     }
+    let postSolveTokenState = null;
+    if (
+      ['verification_pending', 'cleared'].includes(activeGate?.status)
+      && activeGate.captchaCandidateIdentity
+    ) {
+      await inspectCaptchaFrames();
+      if (!detectionFailed && detection && typeof detection === 'object') {
+        postSolveTokenState = captchaPostSolveTokenState(
+          detection,
+          activeGate.captchaCandidateIdentity,
+        );
+      }
+    }
     const loopCheck = challenge || authoritativeRootRead
       ? this._checkVerificationChallengeLoop(tabId, {
           pageUrl,
           dialogLabel: challenge?.normalizedLabel || '',
         })
       : { kind: 'none' };
+    if (
+      postSolveTokenState?.responseTokenPresent === true
+      && postSolveTokenState.visibleActiveChallenge === false
+    ) {
+      const alreadyCleared = activeGate.status === 'cleared';
+      const clearedGate = {
+        ...activeGate.publicGate,
+        status: 'cleared',
+        responseTokenPresent: true,
+        clearedByResponseToken: true,
+      };
+      this._captchaGateStates.set(tabId, {
+        ...activeGate,
+        status: 'cleared',
+        publicGate: clearedGate,
+      });
+      if (alreadyCleared) return { gate: null, loopCheck };
+      toolResult.captchaGate = clearedGate;
+      return { gate: clearedGate, loopCheck };
+    }
     if (!challenge) {
       if (activeGate && authoritativeRootRead) {
         const clearedGate = {
@@ -3242,6 +3369,9 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
         this._captchaGateStates.delete(tabId);
         toolResult.captchaGate = clearedGate;
         return { gate: clearedGate, loopCheck };
+      }
+      if (activeGate?.status === 'cleared') {
+        return { gate: null, loopCheck };
       }
       if (activeGate) {
         toolResult.captchaGate = activeGate.publicGate;
@@ -3323,7 +3453,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
       toolResult.captchaGate = manualGate;
       return { gate: manualGate, loopCheck };
     }
-    if (existing?.key === key && !retryManualDetection) {
+    if (existing?.key === key && existing.status !== 'cleared' && !retryManualDetection) {
       toolResult.captchaGate = existing.publicGate;
       return { gate: existing.publicGate, loopCheck };
     }
@@ -3369,10 +3499,12 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
       ...(detection?.selected && !selectedCorrelated ? { candidateNotCorrelated: true } : {}),
       ...(languageNeutralFrameTrigger ? { languageNeutralFrameTrigger: true } : {}),
     };
+    const captchaCandidateIdentity = captchaGateCandidateIdentity(detection?.selected);
     this._captchaGateStates.set(tabId, {
       key,
       status: publicGate.status,
       publicGate,
+      ...(captchaCandidateIdentity ? { captchaCandidateIdentity } : {}),
       ...(Number.isInteger(observedChallengeFrameId)
         ? {
             challengeFrameId: observedChallengeFrameId,
@@ -4450,8 +4582,13 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
         resultContent += '\n[TRUSTED CAPTCHA GATE: A verification challenge is active, but no safely selectable supported widget was detected. Stop automation and ask the user to complete it manually. Do not dismiss, close, or resubmit the challenge.]';
         onUpdate('warning', { message: 'Verification challenge requires manual completion.' });
       } else if (captchaGateDecision?.status === 'cleared') {
-        resultContent += '\n[TRUSTED CAPTCHA GATE: A read-only root check confirmed that the verification dialog is gone. The CAPTCHA gate is cleared. Choose any continuation or submit action only on a fresh model turn.]';
-        onUpdate('warning', { message: 'Read-only verification confirmed the CAPTCHA dialog cleared.' });
+        if (captchaGateDecision.clearedByResponseToken === true) {
+          resultContent += '\n[TRUSTED CAPTCHA GATE: The gated widget now exposes a response token and no active challenge frame remains. The CAPTCHA gate is cleared. Choose any continuation or submit action only on a fresh model turn; the mutation preflight will re-arm the gate if the site rejects the token and shows the challenge again.]';
+          onUpdate('warning', { message: 'Response-token verification confirmed the CAPTCHA widget cleared.' });
+        } else {
+          resultContent += '\n[TRUSTED CAPTCHA GATE: A read-only root check confirmed that the verification dialog is gone. The CAPTCHA gate is cleared. Choose any continuation or submit action only on a fresh model turn.]';
+          onUpdate('warning', { message: 'Read-only verification confirmed the CAPTCHA dialog cleared.' });
+        }
       } else if (captchaGateDecision?.status === 'verification_pending') {
         resultContent += captchaGateDecision.verificationRetryRequired
           ? '\n[TRUSTED CAPTCHA GATE: The verification dialog was still present on the first complete post-solve check. Wait briefly, then make one final complete root accessibility-tree read with filter "visible". Do not submit, dismiss, or call solve_captcha again.]'
@@ -6567,7 +6704,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
           captchaGateState
           && typeof captchaGateState === 'object'
           && typeof captchaGateState.key === 'string'
-          && ['solve_required', 'verification_pending', 'manual_required'].includes(
+          && ['solve_required', 'verification_pending', 'manual_required', 'cleared'].includes(
             captchaGateState.status
           )
           && captchaGateState.publicGate

--- a/src/chrome/src/agent/agent.js
+++ b/src/chrome/src/agent/agent.js
@@ -3145,7 +3145,12 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
       && activeGate.status !== 'cleared'
       && !this._shouldRetryCaptchaManualGate(activeGate)
     ) return null;
-    const challenge = await this._detectChallengeDialogBeforeMutation(tabId);
+    const detectedChallenge = await this._detectChallengeDialogBeforeMutation(tabId);
+    const challenge = detectedChallenge?.label
+      ? detectedChallenge
+      : activeGate?.status === 'cleared'
+        ? activeGate.publicGate?.challengeDialog
+        : null;
     if (!challenge?.label) return null;
     let pageUrl = '';
     try { pageUrl = await this._currentUrl(tabId); } catch {}

--- a/src/firefox/src/agent/agent.js
+++ b/src/firefox/src/agent/agent.js
@@ -2769,7 +2769,12 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
       && activeGate.status !== 'cleared'
       && !this._shouldRetryCaptchaManualGate(activeGate)
     ) return null;
-    const challenge = await this._detectChallengeDialogBeforeMutation(tabId);
+    const detectedChallenge = await this._detectChallengeDialogBeforeMutation(tabId);
+    const challenge = detectedChallenge?.label
+      ? detectedChallenge
+      : activeGate?.status === 'cleared'
+        ? activeGate.publicGate?.challengeDialog
+        : null;
     if (!challenge?.label) return null;
     let pageUrl = '';
     try { pageUrl = await this._currentUrl(tabId); } catch {}

--- a/src/firefox/src/agent/agent.js
+++ b/src/firefox/src/agent/agent.js
@@ -123,6 +123,95 @@ function normalizeDoneOutcome(value) {
   return DONE_OUTCOMES.has(outcome) ? outcome : null;
 }
 
+function captchaCandidateFramePath(candidate) {
+  if (Array.isArray(candidate?.framePathIndexes)) {
+    return candidate.framePathIndexes.map(Number);
+  }
+  return Array.isArray(candidate?.framePath)
+    ? candidate.framePath.map(segment => Number(segment?.index))
+    : [];
+}
+
+function captchaGateCandidateIdentity(candidate) {
+  if (!candidate || typeof candidate !== 'object') return null;
+  return {
+    frameId: Number.isInteger(candidate.frameId) ? candidate.frameId : null,
+    framePathIndexes: captchaCandidateFramePath(candidate),
+    type: String(candidate.type || ''),
+    websiteKey: candidate.websiteKey || null,
+    isEnterprise: candidate.isEnterprise === true,
+    responseFieldId: candidate.responseFieldId || null,
+    responseFieldIndex: Number.isInteger(candidate.responseFieldIndex)
+      ? candidate.responseFieldIndex
+      : null,
+    alsoResponseFieldId: candidate.alsoResponseFieldId || null,
+    alsoResponseFieldIndex: Number.isInteger(candidate.alsoResponseFieldIndex)
+      ? candidate.alsoResponseFieldIndex
+      : null,
+  };
+}
+
+function captchaCandidateMatchesGate(candidate, identity) {
+  if (!candidate || !identity) return false;
+  if (Number.isInteger(identity.frameId) && candidate.frameId !== identity.frameId) return false;
+  if (
+    identity.type
+    && !captchaTypesMatch(
+      identity.type,
+      candidate.type,
+      identity.isEnterprise,
+      candidate.isEnterprise,
+    )
+  ) return false;
+  if (identity.websiteKey && candidate.websiteKey !== identity.websiteKey) return false;
+  const expectedPath = Array.isArray(identity.framePathIndexes)
+    ? identity.framePathIndexes
+    : [];
+  const candidatePath = captchaCandidateFramePath(candidate);
+  if (
+    expectedPath.length !== candidatePath.length
+    || expectedPath.some((value, index) => value !== candidatePath[index])
+  ) return false;
+
+  const expectedFieldIds = [identity.responseFieldId, identity.alsoResponseFieldId]
+    .filter(Boolean);
+  const candidateFieldIds = new Set([
+    candidate.responseFieldId,
+    candidate.alsoResponseFieldId,
+  ].filter(Boolean));
+  if (expectedFieldIds.length) {
+    return expectedFieldIds.some(fieldId => candidateFieldIds.has(fieldId));
+  }
+
+  const expectedIndexes = [
+    ['responseFieldIndex', identity.responseFieldIndex],
+    ['alsoResponseFieldIndex', identity.alsoResponseFieldIndex],
+  ].filter(([, value]) => Number.isInteger(value));
+  // Token-backed clearance requires an exact response-field identity. When
+  // the page exposes no stable id or index, retain the existing read-based
+  // verification path instead of borrowing another widget's token state.
+  return expectedIndexes.length > 0
+    && expectedIndexes.some(([field, value]) => candidate[field] === value);
+}
+
+function captchaPostSolveTokenState(detection, identity) {
+  const candidates = Array.isArray(detection?.candidates) ? detection.candidates : [];
+  const candidate = candidates.find(entry => captchaCandidateMatchesGate(entry, identity)) || null;
+  const visibleActiveChallenge = candidates.some(entry =>
+    entry?.activeChallengeFrame === true
+    && entry?.activeChallengeFrameVisible === true
+    && entry?.visible === true
+    && entry?.frameVisible !== false
+  ) || (detection?.diagnostics?.frames || []).some(frame =>
+    frame?.activeChallengeFrame === true && frame?.visible === true
+  );
+  return {
+    candidate,
+    responseTokenPresent: candidate?.responseTokenPresent === true,
+    visibleActiveChallenge,
+  };
+}
+
 // Only read a 3-digit number as a status code where it actually reads like
 // one — prefixed by a status word, leading the message, or parenthesized.
 // A bare scan would turn "max_tokens 512" into a 5xx and recommend a retry
@@ -751,7 +840,7 @@ export class Agent extends LoopDetector {
           captchaGateState
           && typeof captchaGateState === 'object'
           && typeof captchaGateState.key === 'string'
-          && ['solve_required', 'verification_pending', 'manual_required'].includes(
+          && ['solve_required', 'verification_pending', 'manual_required', 'cleared'].includes(
             captchaGateState.status
           )
           && captchaGateState.publicGate
@@ -2497,6 +2586,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
       || isNetworkMutation(toolName, toolArgs);
     if (
       !gate
+      || gate.status === 'cleared'
       || !gatedAction
       || abandonmentNavigation
       || (gatedCompletion && gate.status === 'manual_required')
@@ -2674,7 +2764,11 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
       || isNetworkMutation(toolName, toolArgs);
     if (!gatedAction || toolName === 'solve_captcha' || Agent.NAV_TOOLS.has(toolName)) return null;
     const activeGate = this._captchaGateStates.get(tabId);
-    if (activeGate && !this._shouldRetryCaptchaManualGate(activeGate)) return null;
+    if (
+      activeGate
+      && activeGate.status !== 'cleared'
+      && !this._shouldRetryCaptchaManualGate(activeGate)
+    ) return null;
     const challenge = await this._detectChallengeDialogBeforeMutation(tabId);
     if (!challenge?.label) return null;
     let pageUrl = '';
@@ -2850,12 +2944,45 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
         return { gate: guardedGate, loopCheck: { kind: 'none' } };
       }
     }
+    let postSolveTokenState = null;
+    if (
+      ['verification_pending', 'cleared'].includes(activeGate?.status)
+      && activeGate.captchaCandidateIdentity
+    ) {
+      await inspectCaptchaFrames();
+      if (!detectionFailed && detection && typeof detection === 'object') {
+        postSolveTokenState = captchaPostSolveTokenState(
+          detection,
+          activeGate.captchaCandidateIdentity,
+        );
+      }
+    }
     const loopCheck = challenge || authoritativeRootRead
       ? this._checkVerificationChallengeLoop(tabId, {
           pageUrl,
           dialogLabel: challenge?.normalizedLabel || '',
         })
       : { kind: 'none' };
+    if (
+      postSolveTokenState?.responseTokenPresent === true
+      && postSolveTokenState.visibleActiveChallenge === false
+    ) {
+      const alreadyCleared = activeGate.status === 'cleared';
+      const clearedGate = {
+        ...activeGate.publicGate,
+        status: 'cleared',
+        responseTokenPresent: true,
+        clearedByResponseToken: true,
+      };
+      this._captchaGateStates.set(tabId, {
+        ...activeGate,
+        status: 'cleared',
+        publicGate: clearedGate,
+      });
+      if (alreadyCleared) return { gate: null, loopCheck };
+      toolResult.captchaGate = clearedGate;
+      return { gate: clearedGate, loopCheck };
+    }
     if (!challenge) {
       if (activeGate && authoritativeRootRead) {
         const clearedGate = {
@@ -2866,6 +2993,9 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
         this._captchaGateStates.delete(tabId);
         toolResult.captchaGate = clearedGate;
         return { gate: clearedGate, loopCheck };
+      }
+      if (activeGate?.status === 'cleared') {
+        return { gate: null, loopCheck };
       }
       if (activeGate) {
         toolResult.captchaGate = activeGate.publicGate;
@@ -2947,7 +3077,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
       toolResult.captchaGate = manualGate;
       return { gate: manualGate, loopCheck };
     }
-    if (existing?.key === key && !retryManualDetection) {
+    if (existing?.key === key && existing.status !== 'cleared' && !retryManualDetection) {
       toolResult.captchaGate = existing.publicGate;
       return { gate: existing.publicGate, loopCheck };
     }
@@ -2993,10 +3123,12 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
       ...(detection?.selected && !selectedCorrelated ? { candidateNotCorrelated: true } : {}),
       ...(languageNeutralFrameTrigger ? { languageNeutralFrameTrigger: true } : {}),
     };
+    const captchaCandidateIdentity = captchaGateCandidateIdentity(detection?.selected);
     this._captchaGateStates.set(tabId, {
       key,
       status: publicGate.status,
       publicGate,
+      ...(captchaCandidateIdentity ? { captchaCandidateIdentity } : {}),
       ...(Number.isInteger(observedChallengeFrameId)
         ? {
             challengeFrameId: observedChallengeFrameId,
@@ -3998,8 +4130,13 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
         resultContent += '\n[TRUSTED CAPTCHA GATE: A verification challenge is active, but no safely selectable supported widget was detected. Stop automation and ask the user to complete it manually. Do not dismiss, close, or resubmit the challenge.]';
         onUpdate('warning', { message: 'Verification challenge requires manual completion.' });
       } else if (captchaGateDecision?.status === 'cleared') {
-        resultContent += '\n[TRUSTED CAPTCHA GATE: A read-only root check confirmed that the verification dialog is gone. The CAPTCHA gate is cleared. Choose any continuation or submit action only on a fresh model turn.]';
-        onUpdate('warning', { message: 'Read-only verification confirmed the CAPTCHA dialog cleared.' });
+        if (captchaGateDecision.clearedByResponseToken === true) {
+          resultContent += '\n[TRUSTED CAPTCHA GATE: The gated widget now exposes a response token and no active challenge frame remains. The CAPTCHA gate is cleared. Choose any continuation or submit action only on a fresh model turn; the mutation preflight will re-arm the gate if the site rejects the token and shows the challenge again.]';
+          onUpdate('warning', { message: 'Response-token verification confirmed the CAPTCHA widget cleared.' });
+        } else {
+          resultContent += '\n[TRUSTED CAPTCHA GATE: A read-only root check confirmed that the verification dialog is gone. The CAPTCHA gate is cleared. Choose any continuation or submit action only on a fresh model turn.]';
+          onUpdate('warning', { message: 'Read-only verification confirmed the CAPTCHA dialog cleared.' });
+        }
       } else if (captchaGateDecision?.status === 'verification_pending') {
         resultContent += captchaGateDecision.verificationRetryRequired
           ? '\n[TRUSTED CAPTCHA GATE: The verification dialog was still present on the first complete post-solve check. Wait briefly, then make one final complete root accessibility-tree read with filter "visible". Do not submit, dismiss, or call solve_captcha again.]'

--- a/test/run.js
+++ b/test/run.js
@@ -6587,7 +6587,7 @@ test('CAPTCHA gate survives user continuations and only a complete dialog-capabl
   }
 });
 
-test('unresolved CAPTCHA gates hydrate after a background worker restart', async () => {
+test('pending and token-cleared CAPTCHA gates hydrate after a background worker restart', async () => {
   for (const [label, AgentClass, apiName] of [
     ['chrome', AgentCh, 'chrome'],
     ['firefox', AgentFx, 'browser'],
@@ -6595,6 +6595,9 @@ test('unresolved CAPTCHA gates hydrate after a background worker restart', async
     const tabId = label === 'chrome' ? 8825 : 8826;
     const agent = new AgentClass({});
     const key = agent._convKey(tabId);
+    const clearedTabId = tabId + 10;
+    const clearedAgent = new AgentClass({});
+    const clearedKey = clearedAgent._convKey(clearedTabId);
     const captchaGateState = {
       key: 'https://example.test/signup\nsecurity verification',
       status: 'verification_pending',
@@ -6603,6 +6606,22 @@ test('unresolved CAPTCHA gates hydrate after a background worker restart', async
         status: 'verification_pending',
         challengeDialog: { label: 'Security verification' },
         diagnostics: { vendors: ['recaptcha'], frames: [] },
+      },
+    };
+    const clearedCaptchaGateState = {
+      key: 'https://example.test/signup\nsecurity verification',
+      status: 'cleared',
+      captchaCandidateIdentity: {
+        frameId: 0,
+        framePathIndexes: [],
+        type: 'recaptcha_v2',
+        websiteKey: 'PERSISTED_GATE_KEY',
+        responseFieldId: 'g-recaptcha-response-persisted',
+      },
+      publicGate: {
+        status: 'cleared',
+        responseTokenPresent: true,
+        clearedByResponseToken: true,
       },
     };
     const previousApi = globalThis[apiName];
@@ -6617,6 +6636,11 @@ test('unresolved CAPTCHA gates hydrate after a background worker restart', async
               mode: 'act',
               captchaGateState,
             },
+            [clearedKey]: {
+              messages: [{ role: 'system', content: 'test' }],
+              mode: 'act',
+              captchaGateState: clearedCaptchaGateState,
+            },
           }),
         },
       },
@@ -6624,6 +6648,12 @@ test('unresolved CAPTCHA gates hydrate after a background worker restart', async
     try {
       await agent._hydrate(tabId);
       assert.deepEqual(agent._captchaGateStates.get(tabId), captchaGateState, `${label}: worker restart lost the unresolved CAPTCHA gate`);
+      await clearedAgent._hydrate(clearedTabId);
+      assert.deepEqual(
+        clearedAgent._captchaGateStates.get(clearedTabId),
+        clearedCaptchaGateState,
+        `${label}: worker restart lost the token-clearance recheck marker`,
+      );
     } finally {
       globalThis[apiName] = previousApi;
     }
@@ -57158,6 +57188,228 @@ test('language-neutral CAPTCHA challenge frames arm the gate without matching di
         observed.gate?.candidateNotCorrelated,
         true,
         `${build}: hidden active frame was correlated without effective visibility`,
+      );
+    });
+  }
+});
+
+test('post-solve CAPTCHA gates consume only the correlated response token and re-arm on rejection', async () => {
+  for (const [build, AgentClass] of [['chrome', AgentCh], ['firefox', AgentFx]]) {
+    const responseField = captchaEl('textarea', {
+      id: 'g-recaptcha-response-gated',
+      name: 'g-recaptcha-response',
+    });
+    const activeFrame = captchaEl('iframe', {
+      src: 'https://www.google.com/recaptcha/api2/bframe?k=TOKEN_GATE_KEY',
+    });
+    const nodes = [
+      captchaEl('div', { role: 'dialog', innerText: 'Security verification' }, [
+        captchaEl('h2', { textContent: 'Security verification' }),
+        captchaEl('div', { class: 'g-recaptcha', 'data-sitekey': 'TOKEN_GATE_KEY' }, [
+          responseField,
+          activeFrame,
+        ]),
+      ]),
+    ];
+
+    await withCaptchaFakePage(build, nodes, async () => {
+      const agent = new AgentClass({});
+      agent.captchaSolverEnabled = true;
+      agent._currentUrl = async () => 'https://example.test/signup';
+      const initial = await agent._observeCaptchaChallenge(
+        1,
+        'get_accessibility_tree',
+        { pageContent: 'dialog "Security verification" [ref_1]' },
+        { filter: 'visible' },
+      );
+      assert.equal(initial.gate?.status, 'solve_required', `${build}: active challenge did not arm`);
+      const armed = agent._captchaGateStates.get(1);
+      assert.equal(
+        armed?.captchaCandidateIdentity?.responseFieldId,
+        'g-recaptcha-response-gated',
+        `${build}: gate did not retain its exact response field`,
+      );
+      agent._captchaGateStates.set(1, {
+        ...armed,
+        status: 'verification_pending',
+        publicGate: {
+          ...armed.publicGate,
+          status: 'verification_pending',
+          solveAttempted: true,
+        },
+      });
+
+      responseField.value = 'token-produced-by-widget';
+      const stillActive = await agent._observeCaptchaChallenge(
+        1,
+        'get_accessibility_tree',
+        { pageContent: 'dialog "Security verification" [ref_1]' },
+        { filter: 'interactive' },
+      );
+      assert.equal(
+        stillActive.gate?.status,
+        'verification_pending',
+        `${build}: token cleared the gate while its active frame remained visible`,
+      );
+      assert.equal(
+        stillActive.gate?.clearedByResponseToken,
+        undefined,
+        `${build}: visible challenge was reported token-cleared`,
+      );
+
+      activeFrame.hidden = true;
+      const tokenCleared = await agent._observeCaptchaChallenge(
+        1,
+        'get_accessibility_tree',
+        { pageContent: 'dialog "Security verification" [ref_1]' },
+        { filter: 'interactive' },
+      );
+      assert.equal(tokenCleared.gate?.status, 'cleared', `${build}: correlated token did not clear gate`);
+      assert.equal(
+        tokenCleared.gate?.clearedByResponseToken,
+        true,
+        `${build}: token clearance reason missing`,
+      );
+      assert.equal(
+        agent._captchaGateStates.get(1)?.status,
+        'cleared',
+        `${build}: token clearance did not retain a preflight recheck marker`,
+      );
+      assert.equal(
+        agent._captchaGateBlockResult(1, 'click_ax'),
+        null,
+        `${build}: token-cleared recheck marker blocked continuation`,
+      );
+
+      const stillCleared = await agent._captchaMutationPreflight(1, 'click_ax');
+      assert.equal(
+        stillCleared,
+        null,
+        `${build}: stale dialog text interrupted a token-cleared continuation`,
+      );
+      assert.equal(
+        agent._captchaGateStates.get(1)?.status,
+        'cleared',
+        `${build}: preflight discarded the token-clearance recheck marker`,
+      );
+
+      activeFrame.hidden = false;
+      const rearmed = await agent._captchaMutationPreflight(1, 'click_ax');
+      assert.equal(
+        rearmed?.status,
+        'solve_required',
+        `${build}: reappearing challenge frame did not re-arm after token rejection`,
+      );
+      assert.equal(agent._captchaGateStates.has(1), true, `${build}: re-armed gate was not persisted`);
+    });
+
+    const firstField = captchaEl('textarea', {
+      id: 'g-recaptcha-response-first',
+      name: 'g-recaptcha-response',
+    });
+    const secondField = captchaEl('textarea', {
+      id: 'g-recaptcha-response-second',
+      name: 'g-recaptcha-response',
+      value: 'unrelated-widget-token',
+    });
+    await withCaptchaFakePage(build, [
+      captchaEl('div', { role: 'dialog', innerText: 'Security verification' }, [
+        captchaEl('div', { class: 'g-recaptcha', 'data-sitekey': 'SHARED_SITE_KEY' }, [firstField]),
+        captchaEl('div', { class: 'g-recaptcha', 'data-sitekey': 'SHARED_SITE_KEY' }, [secondField]),
+      ]),
+    ], async () => {
+      const agent = new AgentClass({});
+      agent._currentUrl = async () => 'https://example.test/signup';
+      agent._captchaGateStates.set(2, {
+        key: 'https://example.test/signup\nsecurity verification',
+        status: 'verification_pending',
+        captchaCandidateIdentity: {
+          frameId: 0,
+          framePathIndexes: [],
+          type: 'recaptcha_v2',
+          websiteKey: 'SHARED_SITE_KEY',
+          isEnterprise: false,
+          responseFieldId: 'g-recaptcha-response-first',
+          responseFieldIndex: 0,
+          alsoResponseFieldId: null,
+          alsoResponseFieldIndex: null,
+        },
+        publicGate: {
+          status: 'verification_pending',
+          solveAttempted: true,
+          challengeDialog: { label: 'Security verification' },
+        },
+      });
+      const unrelatedToken = await agent._observeCaptchaChallenge(
+        2,
+        'get_accessibility_tree',
+        { pageContent: 'dialog "Security verification" [ref_2]' },
+        { filter: 'interactive' },
+      );
+      assert.equal(
+        unrelatedToken.gate?.status,
+        'verification_pending',
+        `${build}: a sibling widget token cleared the gated widget`,
+      );
+      firstField.value = 'gated-widget-token';
+      const exactToken = await agent._observeCaptchaChallenge(
+        2,
+        'get_accessibility_tree',
+        { pageContent: 'dialog "Security verification" [ref_2]' },
+        { filter: 'interactive' },
+      );
+      assert.equal(exactToken.gate?.clearedByResponseToken, true, `${build}: exact widget token did not clear`);
+    });
+
+    const hcaptchaField = captchaEl('textarea', {
+      id: 'h-captcha-response-gated',
+      name: 'h-captcha-response',
+    });
+    const hcaptchaCompatibilityField = captchaEl('textarea', {
+      id: 'g-recaptcha-response-hcaptcha',
+      name: 'g-recaptcha-response',
+      value: 'hcaptcha-compatibility-token',
+    });
+    await withCaptchaFakePage(build, [
+      captchaEl('div', { role: 'dialog', innerText: 'Security verification' }, [
+        captchaEl('div', { class: 'h-captcha', 'data-sitekey': 'HCAPTCHA_GATE_KEY' }, [
+          hcaptchaField,
+          hcaptchaCompatibilityField,
+        ]),
+      ]),
+    ], async () => {
+      const agent = new AgentClass({});
+      agent._currentUrl = async () => 'https://example.test/signup';
+      agent._captchaGateStates.set(3, {
+        key: 'https://example.test/signup\nsecurity verification',
+        status: 'verification_pending',
+        captchaCandidateIdentity: {
+          frameId: 0,
+          framePathIndexes: [],
+          type: 'hcaptcha',
+          websiteKey: 'HCAPTCHA_GATE_KEY',
+          isEnterprise: false,
+          responseFieldId: 'h-captcha-response-gated',
+          responseFieldIndex: 0,
+          alsoResponseFieldId: 'g-recaptcha-response-hcaptcha',
+          alsoResponseFieldIndex: 0,
+        },
+        publicGate: {
+          status: 'verification_pending',
+          solveAttempted: true,
+          challengeDialog: { label: 'Security verification' },
+        },
+      });
+      const compatibilityToken = await agent._observeCaptchaChallenge(
+        3,
+        'get_accessibility_tree',
+        { pageContent: 'dialog "Security verification" [ref_3]' },
+        { filter: 'interactive' },
+      );
+      assert.equal(
+        compatibilityToken.gate?.clearedByResponseToken,
+        true,
+        `${build}: hCaptcha compatibility token did not clear its exact gate`,
       );
     });
   }


### PR DESCRIPTION
## Summary

- retain the exact CAPTCHA candidate and response-field identity when a gate arms
- consume the matched candidate's boolean `responseTokenPresent` state after a solve
- clear only when that exact widget has a token and no active challenge frame remains
- keep a non-blocking, persisted recheck marker so stale dialog copy does not immediately re-arm the solved widget
- re-arm before mutation if the token disappears or an active challenge frame returns
- keep Chrome and Firefox behavior aligned

## Motivation

#505 identified that the gate inferred solve state from dialog wording and disappearance even after #512 made the widget response-token state available. #2615 added language-neutral active-frame signals, but the gate still did not consume the token boolean.

This change connects those two primitives without treating a widget token as proof that the site's server accepted it.

## Safety and behavior

The token is reduced to a boolean by the existing detector; no raw token is retained or serialized. Token-backed clearance requires the original frame, frame path, type, site key, and exact response-field id or index to match. A sibling widget's token cannot clear the gate.

A visible active challenge frame always wins over token presence. After clearance, every mutation still runs the read-only preflight. If the server rejects the token and re-renders the challenge, the gate is restored before the mutation dispatches.

## Testing

- `node test/run.js` — 1,396 passed; 1 inherited failure because `package.json` is `26.0.3` while the newest `CHANGELOG.md` entry is `26.0.0`
- `npm run test:security` — 60/60 passed
- `npm run test:fixtures` — 125/125 passed
- `npm run test:ci` — passed
- `node --check` for both agent builds and `test/run.js` — passed
- `git diff --check` — passed

Regression coverage includes exact multi-widget correlation, hCaptcha's compatibility response field, visible-frame fail-closed behavior, token clearance, worker restart persistence, stale dialog text, and challenge re-arming.

## Scope

This PR does not remove the legacy verification retry/read ladder, consolidate English regexes, or add full-page Cloudflare interstitial detection. Those remain separate unchecked items in #505.

Advances #505.
