### PR TITLE
agent: add adapter for JD

### DIFF
--- a/src/chrome/src/agent/adapters.js
+++ b/src/chrome/src/agent/adapters.js
@@ -16337,6 +16337,21 @@ const ADAPTERS = [
 - "ポイント", SPU, and スーパーDEAL are conditional rewards, not an immediate cash-price reduction; campaigns may require entry, membership, payment methods, or have caps, and shipping/tax do not earn ordinary points. Report the payable total separately from expected points.`,
   },
 
+  // ─── Regional — JD.com (China) ───────────────────────────────────────
+  {
+    name: 'jd',
+    category: 'general',
+    matches: (url) => /^https?:\/\/(?:(?:www|search|item|cart|trade|order|passport)\.)?jd\.com\//.test(url),
+    notes: `
+- Treat www.jd.com, search.jd.com, item.jd.com, cart.jd.com, trade.jd.com, order.jd.com, and passport.jd.com as JD's desktop shopping flow as of 2026-08. Expect anonymous visits to search or product pages to redirect to passport.jd.com/new/login.aspx with czLogin=1.
+- When that login redirect appears, STOP and ask the user to complete QR code, password, or SMS login manually. Do not loop back to the product/search URL or claim it is unavailable. After login, continue the encoded ReturnUrl and re-read the destination page.
+- On product pages, "搜全站" searches all of JD while "搜本店" restricts results to the current store. Use "搜全站" unless the user explicitly wants more products from that store.
+- Read the store/seller name and the "自营" badge for the selected offer because JD includes both self-operated and third-party marketplace offers; do not infer that JD is the seller merely from the jd.com URL.
+- Select the exact color, capacity, edition, bundle, or service option and set "配送至" before quoting price, stock, or arrival. "京东价", promotions, national subsidies, coupons, and 京豆 can be conditional; treat the selected cart/checkout total as authoritative.
+- "加入购物车" does not place an order. "立即购买" skips the cart, so do not use it for research or comparison tasks; add the exact variant to the cart and verify the selected row and quantity instead.
+- Treat "去结算" as order review; only "提交订单" creates the order. Before submitting, re-read the items, quantities, seller, address, delivery, invoice, discounts, and final total. Do not click "提交订单" without the user's explicit confirmation. Report success only after the confirmation shows an "订单编号" (also visible in "我的订单").`,
+  },
+
   // ─── Regional — Allegro (Poland) ─────────────────────────────────────
   {
     name: 'allegro',

--- a/src/chrome/src/agent/adapters.js
+++ b/src/chrome/src/agent/adapters.js
@@ -16341,13 +16341,13 @@ const ADAPTERS = [
   {
     name: 'jd',
     category: 'general',
-    matches: (url) => /^https?:\/\/(?:(?:www|search|item|cart|trade|order|passport)\.)?jd\.com\//.test(url),
+    matches: (url) => /^https?:\/\/(?:(?:www|search|so|list|item|mall|cart|trade|order|passport)\.)?(?:m\.)?jd\.com\//.test(url),
     notes: `
-- Treat www.jd.com, search.jd.com, item.jd.com, cart.jd.com, trade.jd.com, order.jd.com, and passport.jd.com as JD's desktop shopping flow as of 2026-08. Expect anonymous visits to search or product pages to redirect to passport.jd.com/new/login.aspx with czLogin=1.
-- When that login redirect appears, STOP and ask the user to complete QR code, password, or SMS login manually. Do not loop back to the product/search URL or claim it is unavailable. After login, continue the encoded ReturnUrl and re-read the destination page.
-- On product pages, "搜全站" searches all of JD while "搜本店" restricts results to the current store. Use "搜全站" unless the user explicitly wants more products from that store.
+- Treat www.jd.com, search.jd.com, list.jd.com, item.jd.com, mall.jd.com, cart.jd.com, trade.jd.com, order.jd.com, passport.jd.com, and their m.jd.com mobile equivalents as JD's shopping flow as of 2026-08. Anonymous visits to search or product pages may redirect to passport.jd.com/new/login.aspx with czLogin=1.
+- When that login redirect appears, STOP and ask the user to complete QR code, password, or SMS login manually. Do not loop back to the product/search URL or claim it is unavailable. JD returns to the encoded ReturnUrl after login, so re-read the destination page instead of re-navigating.
+- search.jd.com and list.jd.com are keyword and category browsing; mall.jd.com is one store. On product and store pages "搜全站" searches all of JD while "搜本店" restricts results to the current store. Use "搜全站" unless the user explicitly wants more products from that store.
 - Read the store/seller name and the "自营" badge for the selected offer because JD includes both self-operated and third-party marketplace offers; do not infer that JD is the seller merely from the jd.com URL.
-- Select the exact color, capacity, edition, bundle, or service option and set "配送至" before quoting price, stock, or arrival. "京东价", promotions, national subsidies, coupons, and 京豆 can be conditional; treat the selected cart/checkout total as authoritative.
+- Select the exact color, capacity, edition, bundle, or service option and set "配送至" before quoting price, stock, or arrival. "京东价", "APP专享价", promotions, national subsidies, coupons, and 京豆 are conditional and may not apply on this surface; treat the selected cart/checkout total as authoritative.
 - "加入购物车" does not place an order. "立即购买" skips the cart, so do not use it for research or comparison tasks; add the exact variant to the cart and verify the selected row and quantity instead.
 - Treat "去结算" as order review; only "提交订单" creates the order. Before submitting, re-read the items, quantities, seller, address, delivery, invoice, discounts, and final total. Do not click "提交订单" without the user's explicit confirmation. Report success only after the confirmation shows an "订单编号" (also visible in "我的订单").`,
   },

--- a/src/firefox/src/agent/adapters.js
+++ b/src/firefox/src/agent/adapters.js
@@ -16339,13 +16339,13 @@ const ADAPTERS = [
   {
     name: 'jd',
     category: 'general',
-    matches: (url) => /^https?:\/\/(?:(?:www|search|item|cart|trade|order|passport)\.)?jd\.com\//.test(url),
+    matches: (url) => /^https?:\/\/(?:(?:www|search|so|list|item|mall|cart|trade|order|passport)\.)?(?:m\.)?jd\.com\//.test(url),
     notes: `
-- Treat www.jd.com, search.jd.com, item.jd.com, cart.jd.com, trade.jd.com, order.jd.com, and passport.jd.com as JD's desktop shopping flow as of 2026-08. Expect anonymous visits to search or product pages to redirect to passport.jd.com/new/login.aspx with czLogin=1.
-- When that login redirect appears, STOP and ask the user to complete QR code, password, or SMS login manually. Do not loop back to the product/search URL or claim it is unavailable. After login, continue the encoded ReturnUrl and re-read the destination page.
-- On product pages, "搜全站" searches all of JD while "搜本店" restricts results to the current store. Use "搜全站" unless the user explicitly wants more products from that store.
+- Treat www.jd.com, search.jd.com, list.jd.com, item.jd.com, mall.jd.com, cart.jd.com, trade.jd.com, order.jd.com, passport.jd.com, and their m.jd.com mobile equivalents as JD's shopping flow as of 2026-08. Anonymous visits to search or product pages may redirect to passport.jd.com/new/login.aspx with czLogin=1.
+- When that login redirect appears, STOP and ask the user to complete QR code, password, or SMS login manually. Do not loop back to the product/search URL or claim it is unavailable. JD returns to the encoded ReturnUrl after login, so re-read the destination page instead of re-navigating.
+- search.jd.com and list.jd.com are keyword and category browsing; mall.jd.com is one store. On product and store pages "搜全站" searches all of JD while "搜本店" restricts results to the current store. Use "搜全站" unless the user explicitly wants more products from that store.
 - Read the store/seller name and the "自营" badge for the selected offer because JD includes both self-operated and third-party marketplace offers; do not infer that JD is the seller merely from the jd.com URL.
-- Select the exact color, capacity, edition, bundle, or service option and set "配送至" before quoting price, stock, or arrival. "京东价", promotions, national subsidies, coupons, and 京豆 can be conditional; treat the selected cart/checkout total as authoritative.
+- Select the exact color, capacity, edition, bundle, or service option and set "配送至" before quoting price, stock, or arrival. "京东价", "APP专享价", promotions, national subsidies, coupons, and 京豆 are conditional and may not apply on this surface; treat the selected cart/checkout total as authoritative.
 - "加入购物车" does not place an order. "立即购买" skips the cart, so do not use it for research or comparison tasks; add the exact variant to the cart and verify the selected row and quantity instead.
 - Treat "去结算" as order review; only "提交订单" creates the order. Before submitting, re-read the items, quantities, seller, address, delivery, invoice, discounts, and final total. Do not click "提交订单" without the user's explicit confirmation. Report success only after the confirmation shows an "订单编号" (also visible in "我的订单").`,
   },

--- a/src/firefox/src/agent/adapters.js
+++ b/src/firefox/src/agent/adapters.js
@@ -16335,6 +16335,21 @@ const ADAPTERS = [
 - "ポイント", SPU, and スーパーDEAL are conditional rewards, not an immediate cash-price reduction; campaigns may require entry, membership, payment methods, or have caps, and shipping/tax do not earn ordinary points. Report the payable total separately from expected points.`,
   },
 
+  // ─── Regional — JD.com (China) ───────────────────────────────────────
+  {
+    name: 'jd',
+    category: 'general',
+    matches: (url) => /^https?:\/\/(?:(?:www|search|item|cart|trade|order|passport)\.)?jd\.com\//.test(url),
+    notes: `
+- Treat www.jd.com, search.jd.com, item.jd.com, cart.jd.com, trade.jd.com, order.jd.com, and passport.jd.com as JD's desktop shopping flow as of 2026-08. Expect anonymous visits to search or product pages to redirect to passport.jd.com/new/login.aspx with czLogin=1.
+- When that login redirect appears, STOP and ask the user to complete QR code, password, or SMS login manually. Do not loop back to the product/search URL or claim it is unavailable. After login, continue the encoded ReturnUrl and re-read the destination page.
+- On product pages, "搜全站" searches all of JD while "搜本店" restricts results to the current store. Use "搜全站" unless the user explicitly wants more products from that store.
+- Read the store/seller name and the "自营" badge for the selected offer because JD includes both self-operated and third-party marketplace offers; do not infer that JD is the seller merely from the jd.com URL.
+- Select the exact color, capacity, edition, bundle, or service option and set "配送至" before quoting price, stock, or arrival. "京东价", promotions, national subsidies, coupons, and 京豆 can be conditional; treat the selected cart/checkout total as authoritative.
+- "加入购物车" does not place an order. "立即购买" skips the cart, so do not use it for research or comparison tasks; add the exact variant to the cart and verify the selected row and quantity instead.
+- Treat "去结算" as order review; only "提交订单" creates the order. Before submitting, re-read the items, quantities, seller, address, delivery, invoice, discounts, and final total. Do not click "提交订单" without the user's explicit confirmation. Report success only after the confirmation shows an "订单编号" (also visible in "我的订单").`,
+  },
+
   // ─── Regional — Allegro (Poland) ─────────────────────────────────────
   {
     name: 'allegro',

--- a/test/run.js
+++ b/test/run.js
@@ -2579,7 +2579,11 @@ test('matches JD shopping surfaces and includes Chinese login and checkout guida
   const trustedUrls = [
     'https://www.jd.com/',
     'https://search.jd.com/Search?keyword=%E6%89%8B%E6%9C%BA',
+    'https://list.jd.com/list.html?cat=9987%2C653%2C655',
     'https://item.jd.com/100134399065.html',
+    'https://mall.jd.com/index-1000004123.html',
+    'https://m.jd.com/',
+    'https://item.m.jd.com/product/100134399065.html',
     'https://cart.jd.com/cart_index',
     'https://trade.jd.com/shopping/order/getOrderInfo.action',
     'https://order.jd.com/center/list.action',
@@ -2594,6 +2598,7 @@ test('matches JD shopping surfaces and includes Chinese login and checkout guida
     'https://corporate.jd.com/home',
     'https://help.jd.com/user/guide.html',
     'https://item.jd.com.phishing.example/100134399065.html',
+    'https://item.jd.com@phishing.example/100134399065.html',
     'https://example.com/?next=https://item.jd.com/100134399065.html',
   ];
   for (const url of rejectedUrls) {
@@ -2607,9 +2612,12 @@ test('matches JD shopping surfaces and includes Chinese login and checkout guida
   assert.match(adapter?.notes || '', /passport\.jd\.com.*czLogin=1/s);
   assert.match(adapter?.notes || '', /QR code.*password.*SMS/i);
   assert.match(adapter?.notes || '', /ReturnUrl/);
+  assert.match(adapter?.notes || '', /list\.jd\.com/);
+  assert.match(adapter?.notes || '', /mall\.jd\.com/);
   assert.match(adapter?.notes || '', /搜全站.*搜本店/s);
   assert.match(adapter?.notes || '', /自营/);
   assert.match(adapter?.notes || '', /配送至/);
+  assert.match(adapter?.notes || '', /APP专享价/);
   assert.match(adapter?.notes || '', /加入购物车/);
   assert.match(adapter?.notes || '', /立即购买/);
   assert.match(adapter?.notes || '', /去结算/);

--- a/test/run.js
+++ b/test/run.js
@@ -2575,6 +2575,50 @@ test('matches Rakuten Ichiba shopping surfaces and includes marketplace guidance
   assert.equal(firefoxAdapter?.notes, adapter?.notes);
 });
 
+test('matches JD shopping surfaces and includes Chinese login and checkout guidance', () => {
+  const trustedUrls = [
+    'https://www.jd.com/',
+    'https://search.jd.com/Search?keyword=%E6%89%8B%E6%9C%BA',
+    'https://item.jd.com/100134399065.html',
+    'https://cart.jd.com/cart_index',
+    'https://trade.jd.com/shopping/order/getOrderInfo.action',
+    'https://order.jd.com/center/list.action',
+    'https://passport.jd.com/new/login.aspx?ReturnUrl=https%3A%2F%2Fitem.jd.com%2F100134399065.html&czLogin=1',
+  ];
+  for (const url of trustedUrls) {
+    assert.equal(getActiveAdapter(url)?.name, 'jd');
+    assert.equal(getActiveAdapterFx(url)?.name, 'jd');
+  }
+
+  const rejectedUrls = [
+    'https://corporate.jd.com/home',
+    'https://help.jd.com/user/guide.html',
+    'https://item.jd.com.phishing.example/100134399065.html',
+    'https://example.com/?next=https://item.jd.com/100134399065.html',
+  ];
+  for (const url of rejectedUrls) {
+    assert.notEqual(getActiveAdapter(url)?.name, 'jd');
+    assert.notEqual(getActiveAdapterFx(url)?.name, 'jd');
+  }
+
+  const adapter = getActiveAdapter('https://item.jd.com/100134399065.html');
+  const firefoxAdapter = getActiveAdapterFx('https://cart.jd.com/cart_index');
+  assert.match(adapter?.notes || '', /2026-08/);
+  assert.match(adapter?.notes || '', /passport\.jd\.com.*czLogin=1/s);
+  assert.match(adapter?.notes || '', /QR code.*password.*SMS/i);
+  assert.match(adapter?.notes || '', /ReturnUrl/);
+  assert.match(adapter?.notes || '', /搜全站.*搜本店/s);
+  assert.match(adapter?.notes || '', /自营/);
+  assert.match(adapter?.notes || '', /配送至/);
+  assert.match(adapter?.notes || '', /加入购物车/);
+  assert.match(adapter?.notes || '', /立即购买/);
+  assert.match(adapter?.notes || '', /去结算/);
+  assert.match(adapter?.notes || '', /提交订单/);
+  assert.match(adapter?.notes || '', /Do not click "提交订单" without the user's explicit confirmation/);
+  assert.match(adapter?.notes || '', /订单编号/);
+  assert.equal(firefoxAdapter?.notes, adapter?.notes);
+});
+
 test('matches Allegro.pl shopping surfaces and includes Polish marketplace guidance', () => {
   const trustedUrls = [
     'https://allegro.pl/',


### PR DESCRIPTION
## Summary

Adds a mirrored JD.com adapter for Chrome and Firefox.

Without this adapter, anonymous JD product navigation can land on JD's passport login flow without recovery guidance, and shopping actions can blur the distinction between adding to cart, reviewing checkout, and creating an order.

- Scope matching to JD's consumer shopping, checkout, order, and login hosts.
- Handle `passport.jd.com/new/login.aspx` redirects without navigation loops.
- Distinguish self-operated and third-party offers, variant and delivery-dependent totals, cart review, checkout review, and final order submission.
- Require explicit user confirmation before `提交订单` and verify `订单编号` before reporting success.
- Add positive, negative, phishing-lookalike, guidance, and Chrome/Firefox parity assertions.

## Validation

- Targeted JD production assertions: passed.
- `node test/run.js`: 1396/1397 passed; the single failure predates this branch and is the repository's `CHANGELOG.md` latest version (`26.0.0`) not matching `package.json` (`26.0.3`).
- `node test/security/injection-corpus.mjs`: 60/60 passed.
- Anonymous Chrome/Playwright read-only check: JD search, product/login redirect, and cart final URLs all selected the `jd` adapter; the product URL redirected to JD's `passport.jd.com` login with `czLogin=1`.
- `git diff --check`: passed.
