### PR TITLE
agent: add adapter for 12306

### DIFF
--- a/src/chrome/src/agent/adapters.js
+++ b/src/chrome/src/agent/adapters.js
@@ -16234,6 +16234,20 @@ const ADAPTERS = [
 - Price alerts require sign-in; "Hopper" predictions on price trends are advisory, not guarantees.`,
   },
   {
+    name: 'railway-12306',
+    category: 'general',
+    matches: (url) => /^https?:\/\/(?:(?:www|kyfw|passport)\.)?12306\.cn\//.test(url),
+    notes: `
+- Treat 12306.cn, www.12306.cn, kyfw.12306.cn, and passport.12306.cn as China Railway's official desktop flow as of 2026-08. Start from the ticket form's "出发地", "到达地", and "出发日期" controls; choose the exact station when a city has multiple stations and re-read both endpoints after using the swap control.
+- Read each result row by train number and seat class. "有" means seats are currently available, a number is the remaining count, "无" means sold out, and "候补" is a waitlist action; do not treat a displayed row or estimated availability as a reservation.
+- Stop for the user when "账号登录", "扫码登录", "人证核验", or "手机验证" appears. Do not retry around QR, app, SMS, or identity checks, and do not add or edit a passenger's real-name identity data unless the user explicitly asks.
+- Use "预订" only for an available train and confirm the exact date, train, departure/arrival stations and times, seat class, passenger, and ticket type on the passenger-confirmation page. Similar station names and overnight arrival dates are not interchangeable.
+- Treat "候补" as a paid waitlist, not a booked ticket. Read every requested train/seat combination, whether "接受新增列车" or "接受无座" is enabled, and the "截止兑现时间" before continuing; the "预付款" can use the highest requested fare and successful fulfillment can create a paid order automatically.
+- Do not click "提交订单", the subsequent confirmation control, or any payment control without the user's explicit confirmation. These actions can enter the queue, reserve inventory, create a pending order, or fund a waitlist even though travel is not yet confirmed.
+- Report success only from "我的12306" / "订单" and the final "订单状态": a normal ticket must show a successful paid booking, while a waitlist must distinguish "待兑现", "已兑现", "已退单", and "兑现失败". A queue dialog, payment redirect, or submitted form is not proof of a ticket.
+- Keep payment and order management on the official 12306 domains. Do not follow unsolicited third-party ticket, refund, or payment links, and never expose passenger document numbers in summaries.`,
+  },
+  {
     name: 'opentable',
     category: 'general',
     matches: (url) => /^https?:\/\/(www\.)?opentable\.[a-z.]+\//.test(url),

--- a/src/chrome/src/agent/adapters.js
+++ b/src/chrome/src/agent/adapters.js
@@ -16236,16 +16236,17 @@ const ADAPTERS = [
   {
     name: 'railway-12306',
     category: 'general',
-    matches: (url) => /^https?:\/\/(?:(?:www|kyfw|passport)\.)?12306\.cn\//.test(url),
+    matches: (url) => /^https?:\/\/(?:(?:www|kyfw|passport|epay|mobile|cx|dynamic|travel)\.)?12306\.cn\//.test(url),
     notes: `
-- Treat 12306.cn, www.12306.cn, kyfw.12306.cn, and passport.12306.cn as China Railway's official desktop flow as of 2026-08. Start from the ticket form's "出发地", "到达地", and "出发日期" controls; choose the exact station when a city has multiple stations and re-read both endpoints after using the swap control.
+- Treat 12306.cn and its www, kyfw, passport, epay, mobile, cx, dynamic, and travel hosts as China Railway's official flow as of 2026-08. A step can hand off between them (for example kyfw to epay); that is still official, while any host outside 12306.cn is not. Start from the ticket form's "出发地", "到达地", and "出发日期" controls; choose the exact station when a city has multiple stations and re-read both endpoints after using the swap control.
 - Read each result row by train number and seat class. "有" means seats are currently available, a number is the remaining count, "无" means sold out, and "候补" is a waitlist action; do not treat a displayed row or estimated availability as a reservation.
+- If a verification or anti-bot interstitial is served instead of the requested page, STOP and ask the user to complete it manually; do not retry the URL, attempt to solve it, or report data you did not read.
 - Stop for the user when "账号登录", "扫码登录", "人证核验", or "手机验证" appears. Do not retry around QR, app, SMS, or identity checks, and do not add or edit a passenger's real-name identity data unless the user explicitly asks.
 - Use "预订" only for an available train and confirm the exact date, train, departure/arrival stations and times, seat class, passenger, and ticket type on the passenger-confirmation page. Similar station names and overnight arrival dates are not interchangeable.
 - Treat "候补" as a paid waitlist, not a booked ticket. Read every requested train/seat combination, whether "接受新增列车" or "接受无座" is enabled, and the "截止兑现时间" before continuing; the "预付款" can use the highest requested fare and successful fulfillment can create a paid order automatically.
 - Do not click "提交订单", the subsequent confirmation control, or any payment control without the user's explicit confirmation. These actions can enter the queue, reserve inventory, create a pending order, or fund a waitlist even though travel is not yet confirmed.
 - Report success only from "我的12306" / "订单" and the final "订单状态": a normal ticket must show a successful paid booking, while a waitlist must distinguish "待兑现", "已兑现", "已退单", and "兑现失败". A queue dialog, payment redirect, or submitted form is not proof of a ticket.
-- Keep payment and order management on the official 12306 domains. Do not follow unsolicited third-party ticket, refund, or payment links, and never expose passenger document numbers in summaries.`,
+- Keep payment and order management on 12306.cn hosts. Do not follow unsolicited third-party ticket, refund, or payment links, and never expose passenger document numbers in summaries.`,
   },
   {
     name: 'opentable',

--- a/src/firefox/src/agent/adapters.js
+++ b/src/firefox/src/agent/adapters.js
@@ -16234,16 +16234,17 @@ const ADAPTERS = [
   {
     name: 'railway-12306',
     category: 'general',
-    matches: (url) => /^https?:\/\/(?:(?:www|kyfw|passport)\.)?12306\.cn\//.test(url),
+    matches: (url) => /^https?:\/\/(?:(?:www|kyfw|passport|epay|mobile|cx|dynamic|travel)\.)?12306\.cn\//.test(url),
     notes: `
-- Treat 12306.cn, www.12306.cn, kyfw.12306.cn, and passport.12306.cn as China Railway's official desktop flow as of 2026-08. Start from the ticket form's "出发地", "到达地", and "出发日期" controls; choose the exact station when a city has multiple stations and re-read both endpoints after using the swap control.
+- Treat 12306.cn and its www, kyfw, passport, epay, mobile, cx, dynamic, and travel hosts as China Railway's official flow as of 2026-08. A step can hand off between them (for example kyfw to epay); that is still official, while any host outside 12306.cn is not. Start from the ticket form's "出发地", "到达地", and "出发日期" controls; choose the exact station when a city has multiple stations and re-read both endpoints after using the swap control.
 - Read each result row by train number and seat class. "有" means seats are currently available, a number is the remaining count, "无" means sold out, and "候补" is a waitlist action; do not treat a displayed row or estimated availability as a reservation.
+- If a verification or anti-bot interstitial is served instead of the requested page, STOP and ask the user to complete it manually; do not retry the URL, attempt to solve it, or report data you did not read.
 - Stop for the user when "账号登录", "扫码登录", "人证核验", or "手机验证" appears. Do not retry around QR, app, SMS, or identity checks, and do not add or edit a passenger's real-name identity data unless the user explicitly asks.
 - Use "预订" only for an available train and confirm the exact date, train, departure/arrival stations and times, seat class, passenger, and ticket type on the passenger-confirmation page. Similar station names and overnight arrival dates are not interchangeable.
 - Treat "候补" as a paid waitlist, not a booked ticket. Read every requested train/seat combination, whether "接受新增列车" or "接受无座" is enabled, and the "截止兑现时间" before continuing; the "预付款" can use the highest requested fare and successful fulfillment can create a paid order automatically.
 - Do not click "提交订单", the subsequent confirmation control, or any payment control without the user's explicit confirmation. These actions can enter the queue, reserve inventory, create a pending order, or fund a waitlist even though travel is not yet confirmed.
 - Report success only from "我的12306" / "订单" and the final "订单状态": a normal ticket must show a successful paid booking, while a waitlist must distinguish "待兑现", "已兑现", "已退单", and "兑现失败". A queue dialog, payment redirect, or submitted form is not proof of a ticket.
-- Keep payment and order management on the official 12306 domains. Do not follow unsolicited third-party ticket, refund, or payment links, and never expose passenger document numbers in summaries.`,
+- Keep payment and order management on 12306.cn hosts. Do not follow unsolicited third-party ticket, refund, or payment links, and never expose passenger document numbers in summaries.`,
   },
   {
     name: 'opentable',

--- a/src/firefox/src/agent/adapters.js
+++ b/src/firefox/src/agent/adapters.js
@@ -16232,6 +16232,20 @@ const ADAPTERS = [
 - Price alerts require sign-in; "Hopper" predictions on price trends are advisory, not guarantees.`,
   },
   {
+    name: 'railway-12306',
+    category: 'general',
+    matches: (url) => /^https?:\/\/(?:(?:www|kyfw|passport)\.)?12306\.cn\//.test(url),
+    notes: `
+- Treat 12306.cn, www.12306.cn, kyfw.12306.cn, and passport.12306.cn as China Railway's official desktop flow as of 2026-08. Start from the ticket form's "出发地", "到达地", and "出发日期" controls; choose the exact station when a city has multiple stations and re-read both endpoints after using the swap control.
+- Read each result row by train number and seat class. "有" means seats are currently available, a number is the remaining count, "无" means sold out, and "候补" is a waitlist action; do not treat a displayed row or estimated availability as a reservation.
+- Stop for the user when "账号登录", "扫码登录", "人证核验", or "手机验证" appears. Do not retry around QR, app, SMS, or identity checks, and do not add or edit a passenger's real-name identity data unless the user explicitly asks.
+- Use "预订" only for an available train and confirm the exact date, train, departure/arrival stations and times, seat class, passenger, and ticket type on the passenger-confirmation page. Similar station names and overnight arrival dates are not interchangeable.
+- Treat "候补" as a paid waitlist, not a booked ticket. Read every requested train/seat combination, whether "接受新增列车" or "接受无座" is enabled, and the "截止兑现时间" before continuing; the "预付款" can use the highest requested fare and successful fulfillment can create a paid order automatically.
+- Do not click "提交订单", the subsequent confirmation control, or any payment control without the user's explicit confirmation. These actions can enter the queue, reserve inventory, create a pending order, or fund a waitlist even though travel is not yet confirmed.
+- Report success only from "我的12306" / "订单" and the final "订单状态": a normal ticket must show a successful paid booking, while a waitlist must distinguish "待兑现", "已兑现", "已退单", and "兑现失败". A queue dialog, payment redirect, or submitted form is not proof of a ticket.
+- Keep payment and order management on the official 12306 domains. Do not follow unsolicited third-party ticket, refund, or payment links, and never expose passenger document numbers in summaries.`,
+  },
+  {
     name: 'opentable',
     category: 'general',
     matches: (url) => /^https?:\/\/(www\.)?opentable\.[a-z.]+\//.test(url),

--- a/test/run.js
+++ b/test/run.js
@@ -2464,6 +2464,11 @@ test('matches China Railway 12306 surfaces and includes ticket and waitlist guid
     'https://kyfw.12306.cn/otn/queryOrder/initNoComplete',
     'https://kyfw.12306.cn/otn/view/lineUp_toPay.html',
     'https://passport.12306.cn/passport/web/login',
+    'https://epay.12306.cn/',
+    'https://mobile.12306.cn/',
+    'https://cx.12306.cn/',
+    'https://dynamic.12306.cn/',
+    'https://travel.12306.cn/',
   ];
   for (const url of trustedUrls) {
     assert.equal(getActiveAdapter(url)?.name, 'railway-12306');
@@ -2473,6 +2478,9 @@ test('matches China Railway 12306 surfaces and includes ticket and waitlist guid
   const rejectedUrls = [
     'https://www.95306.cn/',
     'https://12306.cn.phishing.example/otn/leftTicket/init',
+    'https://kyfw.12306.cn@phishing.example/otn/leftTicket/init',
+    'https://epay.12306.cn.phishing.example/',
+    'https://x12306.cn/',
     'https://example.com/?next=https://kyfw.12306.cn/otn/leftTicket/init',
   ];
   for (const url of rejectedUrls) {
@@ -2484,15 +2492,20 @@ test('matches China Railway 12306 surfaces and includes ticket and waitlist guid
   const firefoxAdapter = getActiveAdapterFx('https://www.12306.cn/index/');
   assert.match(adapter?.notes || '', /2026-08/);
   assert.match(adapter?.notes || '', /出发地.*到达地.*出发日期/s);
-  assert.match(adapter?.notes || '', /有.*无.*候补/s);
+  assert.match(adapter?.notes || '', /"有" means seats are currently available/);
+  assert.match(adapter?.notes || '', /"无" means sold out/);
   assert.match(adapter?.notes || '', /账号登录.*扫码登录/s);
   assert.match(adapter?.notes || '', /人证核验|手机验证/);
-  assert.match(adapter?.notes || '', /预订/);
-  assert.match(adapter?.notes || '', /候补/);
-  assert.match(adapter?.notes || '', /预付款/);
-  assert.match(adapter?.notes || '', /提交订单/);
+  assert.match(adapter?.notes || '', /verification or anti-bot interstitial/);
+  assert.match(adapter?.notes || '', /epay/);
+  assert.match(adapter?.notes || '', /Use "预订" only for an available train/);
+  assert.match(adapter?.notes || '', /Treat "候补" as a paid waitlist, not a booked ticket/);
+  assert.match(adapter?.notes || '', /"预付款" can use the highest requested fare/);
+  assert.match(adapter?.notes || '', /Do not click "提交订单"/);
   assert.match(adapter?.notes || '', /explicit confirmation/);
-  assert.match(adapter?.notes || '', /订单.*状态/s);
+  assert.match(adapter?.notes || '', /"订单状态"/);
+  assert.match(adapter?.notes || '', /待兑现.*已兑现.*已退单.*兑现失败/s);
+  assert.match(adapter?.notes || '', /never expose passenger document numbers/);
   assert.equal(firefoxAdapter?.notes, adapter?.notes);
 });
 

--- a/test/run.js
+++ b/test/run.js
@@ -2455,6 +2455,47 @@ test('matches apple store pages', () => {
   assert.equal(getActiveAdapter('https://secure.store.apple.com/shop/checkout')?.name, 'apple');
 });
 
+test('matches China Railway 12306 surfaces and includes ticket and waitlist guidance', () => {
+  const trustedUrls = [
+    'https://12306.cn/',
+    'https://www.12306.cn/index/',
+    'https://kyfw.12306.cn/otn/leftTicket/init',
+    'https://kyfw.12306.cn/otn/confirmPassenger/initDc',
+    'https://kyfw.12306.cn/otn/queryOrder/initNoComplete',
+    'https://kyfw.12306.cn/otn/view/lineUp_toPay.html',
+    'https://passport.12306.cn/passport/web/login',
+  ];
+  for (const url of trustedUrls) {
+    assert.equal(getActiveAdapter(url)?.name, 'railway-12306');
+    assert.equal(getActiveAdapterFx(url)?.name, 'railway-12306');
+  }
+
+  const rejectedUrls = [
+    'https://www.95306.cn/',
+    'https://12306.cn.phishing.example/otn/leftTicket/init',
+    'https://example.com/?next=https://kyfw.12306.cn/otn/leftTicket/init',
+  ];
+  for (const url of rejectedUrls) {
+    assert.notEqual(getActiveAdapter(url)?.name, 'railway-12306');
+    assert.notEqual(getActiveAdapterFx(url)?.name, 'railway-12306');
+  }
+
+  const adapter = getActiveAdapter('https://kyfw.12306.cn/otn/leftTicket/init');
+  const firefoxAdapter = getActiveAdapterFx('https://www.12306.cn/index/');
+  assert.match(adapter?.notes || '', /2026-08/);
+  assert.match(adapter?.notes || '', /出发地.*到达地.*出发日期/s);
+  assert.match(adapter?.notes || '', /有.*无.*候补/s);
+  assert.match(adapter?.notes || '', /账号登录.*扫码登录/s);
+  assert.match(adapter?.notes || '', /人证核验|手机验证/);
+  assert.match(adapter?.notes || '', /预订/);
+  assert.match(adapter?.notes || '', /候补/);
+  assert.match(adapter?.notes || '', /预付款/);
+  assert.match(adapter?.notes || '', /提交订单/);
+  assert.match(adapter?.notes || '', /explicit confirmation/);
+  assert.match(adapter?.notes || '', /订单.*状态/s);
+  assert.equal(firefoxAdapter?.notes, adapter?.notes);
+});
+
 test('matches Mercado Libre LATAM storefronts and includes marketplace guidance', () => {
   const trustedUrls = [
     'https://mercadolibre.com.ar/',


### PR DESCRIPTION
## Summary

Adds a mirrored China Railway 12306 adapter for Chrome and Firefox.

Without this adapter, the agent can confuse live availability, a paid waitlist, a queued order, and a successfully booked ticket, or retry around identity verification.

- Scope matching to the official 12306 home, ticketing, order, waitlist, and passport hosts.
- Preserve exact stations, dates, trains, seat classes, passengers, and ticket types through the booking flow.
- Distinguish `有`, numeric inventory, `无`, `预订`, and `候补` states.
- Stop for QR/app/SMS/identity checks and require explicit confirmation before order, waitlist, or payment actions.
- Verify success from the final `订单状态`, including distinct waitlist outcomes.
- Add positive, negative, phishing-lookalike, label, transaction-safety, and Chrome/Firefox parity assertions.

## Validation

- Targeted 12306 production and guidance assertions: passed.
- Anonymous Chrome/Playwright read-only check: official home, ticket-search, and waitlist-help pages returned HTTP 200 and every final URL selected the `railway-12306` adapter.
- `node test/run.js`: 1397/1398 passed; the single failure predates this branch and is the repository's changelog/package version mismatch.
- `git diff --check`: passed.

## Compatibility and risks

The change is prompt-only and mirrored across both browser builds. No booking, passenger, identity, waitlist, or payment mutation was performed; those authenticated steps are grounded in the official 12306 flow and explicitly fail closed for user confirmation.
