### PR TITLE
docs: require adapter host coverage to match what the notes describe

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -72,6 +72,27 @@ Each adapter needs four things:
 3. **`matches(url)`** — regex against the current tab URL. Match the broadest
    form of the domain (`.com`, `.co.uk`, `.com.tr` country variants if applicable),
    but don't match unrelated subdomains.
+
+   **Every surface your notes mention must be a surface the regex selects on.**
+   The most common defect in adapter PRs is a note describing a page the adapter
+   never activates on. Before submitting, walk your own bullets and check each
+   named page against the regex. In particular:
+
+   - **Store/seller pages** are usually a different host or host pattern than
+     product pages (`mall.jd.com`, `shop<id>.taobao.com`). If a bullet mentions
+     in-shop search, shop ratings, or seller pages, the regex needs them.
+   - **Mobile hosts** (`m.`, `h5.m.`) are separate origins on most sites, and
+     the agent lands on them from search results and shared links.
+   - **Sibling brands sharing one flow** — if a bullet tells the model to
+     distinguish two storefronts, both must match, or the guidance dead-ends on
+     the one that doesn't (Taobao/Tmall share a login, cart, and checkout across
+     two registrable domains).
+   - **Category and listing hosts** (`list.`, `search.`, `s.`) when the site
+     splits browsing away from the home page.
+
+   Enumerated host alternations are fine — preferred, even, since they keep
+   `corporate.`, `help.`, and `rule.` subdomains out — but enumerate
+   completely.
 4. **`notes`** — the body the agent will see prepended to its first message
    on this site. **This is the actual contribution.** See below.
 


### PR DESCRIPTION
## Summary

The last two adapter PRs both shipped notes referencing pages the matcher did not select on:

- **#2638 (JD)** — the `搜本店` bullet described in-shop search, but `mall.jd.com` was not matched.
- **#2639 (Taobao)** — the in-shop search bullet needed `shop<id>.taobao.com`, and the 天猫店/淘宝店 bullet needed `detail.tmall.com`. Neither matched.

Both were caught in review and fixed on the branch, but it is the same defect twice from the same shape of matcher, so it belongs in the guide rather than in review comments.

Adds the check to the `matches(url)` section of `CONTRIBUTING.md`, naming the four host families that have actually been missed: store/seller pages, mobile hosts, sibling brands sharing one checkout, and category/listing hosts. Also states that enumerated host alternations are the preferred style — they keep `corporate.`/`help.`/`rule.` subdomains out — as long as they are complete.

## Validation

- `node test/run.js`: 1397/1398 passed. The single failure is the pre-existing `CHANGELOG.md` (`26.0.0`) vs `package.json` (`26.0.3`) version check, which also fails on `main` and is unrelated to this change.
- `git diff --check`: passed. Added lines wrap at the surrounding prose width.

Docs-only; no runtime or prompt content changes.