### PR TITLE
agent: add adapter for Ctrip

### DIFF
--- a/src/chrome/src/agent/adapters.js
+++ b/src/chrome/src/agent/adapters.js
@@ -16202,18 +16202,16 @@ const ADAPTERS = [
   {
     name: 'ctrip',
     category: 'general',
-    matches: (url) => /^https?:\/\/(?:(?:www|hotels|flights|trains|vacations|tickets|passport|my|secure)\.)?ctrip\.com\//.test(url),
+    matches: (url) => /^https?:\/\/(?:(?:www|hotels|flights|trains|vacations|huodong|piao|passport|my|secure)\.)?ctrip\.com\//.test(url),
     notes: `
-- Treat www.ctrip.com, hotels.ctrip.com, flights.ctrip.com, trains.ctrip.com, vacations.ctrip.com, tickets.ctrip.com, passport.ctrip.com, my.ctrip.com, and secure.ctrip.com as Ctrip's desktop booking flow as of 2026-08. Choose the intended "酒店", "机票", "火车票", "旅游", or "门票·活动" product before filling search fields because each opens a different booking flow.
-- Treat cards marked "广告" as sponsored placements. Compare the exact product, supplier, dates, included services, and final payable total instead of ranking by homepage position, crossed-out price, member price, or a displayed "起" price.
-- For hotels, set the city/property, "入住" and "离店" dates, rooms, and guests before reading availability. Select the exact "房型", bed, breakfast, occupancy, payment timing, and "退订" / cancellation rule; different rows for the same hotel are not interchangeable.
-- For flights, verify airports, local departure and arrival dates, operating carrier, stops, transfer airports, cabin, baggage "行李" allowance, change/refund rules, and whether separate tickets are involved. Do not compare only the headline fare or assume an overnight arrival is the departure date.
-- For trains, distinguish Ctrip's booking layer from the official 12306 order. Verify train, stations, date, seat class, passenger, service/insurance add-ons, and final total; if the flow hands off to 12306, re-read that page under the 12306 adapter instead of assuming Ctrip completed the ticket.
-- Stop for the user when QR "扫码", password, SMS "短信", payment verification, or real-name passenger verification appears. Do not retry around authentication, enter identity details not explicitly provided for this booking, or expose document numbers in summaries.
-- Remove optional insurance, packages, coupons, memberships, or paid add-ons unless the user requested them, and re-read the cancellation/change terms and total after any selection. A lower price can carry materially stricter restrictions.
-- Treat the review page and "提交订单" as a consequential booking action. Re-read travelers/guests, contact details, itinerary, room/fare, cancellation terms, add-ons, currency, and total, and do not submit without the user's explicit confirmation.
-- Report success only when the product-specific result shows "订单号" plus "预订成功" or, for flights/trains, the applicable "出票成功" status. A form submission, pending confirmation, payment redirect, or itinerary held for payment is not a completed booking.
-- If flights.ctrip.com becomes blank or returns HTTP 432, treat it as an anti-automation response rather than "no flights". Do not retry rapidly; return through www.ctrip.com's "机票" entry after a pause, and ask the user to handle any verification that appears.`,
+- Choose "酒店", "机票", "火车票", "旅游", or "景点门票" before filling fields. Attraction tickets may hand off to piao.ctrip.com or huodong.ctrip.com; re-read after the host changes.
+- Treat "广告" cards as sponsored. Compare the exact product, supplier, dates, inclusions, restrictions, and final total; ignore homepage rank, crossed-out/member prices, and "起" prices.
+- Hotels: set city/property, "入住" / "离店", rooms, and guests; verify "房型", bed, breakfast, occupancy, payment timing, and "退订". Rows for one hotel are not interchangeable.
+- Flights: verify airports, local dates/times, carrier, stops/transfers, cabin, "行李", change/refund terms, and separate tickets. Do not compare headline fares alone.
+- Trains: verify train, stations, date, seat, passenger, chargeable extras, and total. After a 12306 handoff, re-read the destination page; do not assume Ctrip completed the ticket.
+- Treat QR "扫码", password, SMS "短信", payment/real-name verification, a blank flights page, and HTTP 432 as blocking challenges. Do not retry or enter unprovided identity details; ask the user. For HTTP 432, pause and return through www.ctrip.com's "机票" entry.
+- On the review page, remove only unrequested chargeable extras; preserve beneficial coupons and check their restrictions. Re-read travelers, contact, itinerary, terms, currency, and total; get explicit confirmation before "提交订单".
+- Report success only with "订单号" plus "预订成功" or the applicable "出票成功" status. Pending confirmation, a payment redirect, or an itinerary held for payment is incomplete.`,
   },
   {
     name: 'google-maps',

--- a/src/chrome/src/agent/adapters.js
+++ b/src/chrome/src/agent/adapters.js
@@ -16200,6 +16200,22 @@ const ADAPTERS = [
 - Trip dashboard at /trips after a booking shows itinerary, change/cancel options. Cancellation rules vary per supplier.`,
   },
   {
+    name: 'ctrip',
+    category: 'general',
+    matches: (url) => /^https?:\/\/(?:(?:www|hotels|flights|trains|vacations|tickets|passport|my|secure)\.)?ctrip\.com\//.test(url),
+    notes: `
+- Treat www.ctrip.com, hotels.ctrip.com, flights.ctrip.com, trains.ctrip.com, vacations.ctrip.com, tickets.ctrip.com, passport.ctrip.com, my.ctrip.com, and secure.ctrip.com as Ctrip's desktop booking flow as of 2026-08. Choose the intended "酒店", "机票", "火车票", "旅游", or "门票·活动" product before filling search fields because each opens a different booking flow.
+- Treat cards marked "广告" as sponsored placements. Compare the exact product, supplier, dates, included services, and final payable total instead of ranking by homepage position, crossed-out price, member price, or a displayed "起" price.
+- For hotels, set the city/property, "入住" and "离店" dates, rooms, and guests before reading availability. Select the exact "房型", bed, breakfast, occupancy, payment timing, and "退订" / cancellation rule; different rows for the same hotel are not interchangeable.
+- For flights, verify airports, local departure and arrival dates, operating carrier, stops, transfer airports, cabin, baggage "行李" allowance, change/refund rules, and whether separate tickets are involved. Do not compare only the headline fare or assume an overnight arrival is the departure date.
+- For trains, distinguish Ctrip's booking layer from the official 12306 order. Verify train, stations, date, seat class, passenger, service/insurance add-ons, and final total; if the flow hands off to 12306, re-read that page under the 12306 adapter instead of assuming Ctrip completed the ticket.
+- Stop for the user when QR "扫码", password, SMS "短信", payment verification, or real-name passenger verification appears. Do not retry around authentication, enter identity details not explicitly provided for this booking, or expose document numbers in summaries.
+- Remove optional insurance, packages, coupons, memberships, or paid add-ons unless the user requested them, and re-read the cancellation/change terms and total after any selection. A lower price can carry materially stricter restrictions.
+- Treat the review page and "提交订单" as a consequential booking action. Re-read travelers/guests, contact details, itinerary, room/fare, cancellation terms, add-ons, currency, and total, and do not submit without the user's explicit confirmation.
+- Report success only when the product-specific result shows "订单号" plus "预订成功" or, for flights/trains, the applicable "出票成功" status. A form submission, pending confirmation, payment redirect, or itinerary held for payment is not a completed booking.
+- If flights.ctrip.com becomes blank or returns HTTP 432, treat it as an anti-automation response rather than "no flights". Do not retry rapidly; return through www.ctrip.com's "机票" entry after a pause, and ask the user to handle any verification that appears.`,
+  },
+  {
     name: 'google-maps',
     category: 'general',
     matches: (url) => /^https?:\/\/(www\.)?google\.[a-z.]+\/maps/.test(url) || /^https?:\/\/maps\.google\.[a-z.]+\//.test(url),

--- a/src/firefox/src/agent/adapters.js
+++ b/src/firefox/src/agent/adapters.js
@@ -16200,18 +16200,16 @@ const ADAPTERS = [
   {
     name: 'ctrip',
     category: 'general',
-    matches: (url) => /^https?:\/\/(?:(?:www|hotels|flights|trains|vacations|tickets|passport|my|secure)\.)?ctrip\.com\//.test(url),
+    matches: (url) => /^https?:\/\/(?:(?:www|hotels|flights|trains|vacations|huodong|piao|passport|my|secure)\.)?ctrip\.com\//.test(url),
     notes: `
-- Treat www.ctrip.com, hotels.ctrip.com, flights.ctrip.com, trains.ctrip.com, vacations.ctrip.com, tickets.ctrip.com, passport.ctrip.com, my.ctrip.com, and secure.ctrip.com as Ctrip's desktop booking flow as of 2026-08. Choose the intended "酒店", "机票", "火车票", "旅游", or "门票·活动" product before filling search fields because each opens a different booking flow.
-- Treat cards marked "广告" as sponsored placements. Compare the exact product, supplier, dates, included services, and final payable total instead of ranking by homepage position, crossed-out price, member price, or a displayed "起" price.
-- For hotels, set the city/property, "入住" and "离店" dates, rooms, and guests before reading availability. Select the exact "房型", bed, breakfast, occupancy, payment timing, and "退订" / cancellation rule; different rows for the same hotel are not interchangeable.
-- For flights, verify airports, local departure and arrival dates, operating carrier, stops, transfer airports, cabin, baggage "行李" allowance, change/refund rules, and whether separate tickets are involved. Do not compare only the headline fare or assume an overnight arrival is the departure date.
-- For trains, distinguish Ctrip's booking layer from the official 12306 order. Verify train, stations, date, seat class, passenger, service/insurance add-ons, and final total; if the flow hands off to 12306, re-read that page under the 12306 adapter instead of assuming Ctrip completed the ticket.
-- Stop for the user when QR "扫码", password, SMS "短信", payment verification, or real-name passenger verification appears. Do not retry around authentication, enter identity details not explicitly provided for this booking, or expose document numbers in summaries.
-- Remove optional insurance, packages, coupons, memberships, or paid add-ons unless the user requested them, and re-read the cancellation/change terms and total after any selection. A lower price can carry materially stricter restrictions.
-- Treat the review page and "提交订单" as a consequential booking action. Re-read travelers/guests, contact details, itinerary, room/fare, cancellation terms, add-ons, currency, and total, and do not submit without the user's explicit confirmation.
-- Report success only when the product-specific result shows "订单号" plus "预订成功" or, for flights/trains, the applicable "出票成功" status. A form submission, pending confirmation, payment redirect, or itinerary held for payment is not a completed booking.
-- If flights.ctrip.com becomes blank or returns HTTP 432, treat it as an anti-automation response rather than "no flights". Do not retry rapidly; return through www.ctrip.com's "机票" entry after a pause, and ask the user to handle any verification that appears.`,
+- Choose "酒店", "机票", "火车票", "旅游", or "景点门票" before filling fields. Attraction tickets may hand off to piao.ctrip.com or huodong.ctrip.com; re-read after the host changes.
+- Treat "广告" cards as sponsored. Compare the exact product, supplier, dates, inclusions, restrictions, and final total; ignore homepage rank, crossed-out/member prices, and "起" prices.
+- Hotels: set city/property, "入住" / "离店", rooms, and guests; verify "房型", bed, breakfast, occupancy, payment timing, and "退订". Rows for one hotel are not interchangeable.
+- Flights: verify airports, local dates/times, carrier, stops/transfers, cabin, "行李", change/refund terms, and separate tickets. Do not compare headline fares alone.
+- Trains: verify train, stations, date, seat, passenger, chargeable extras, and total. After a 12306 handoff, re-read the destination page; do not assume Ctrip completed the ticket.
+- Treat QR "扫码", password, SMS "短信", payment/real-name verification, a blank flights page, and HTTP 432 as blocking challenges. Do not retry or enter unprovided identity details; ask the user. For HTTP 432, pause and return through www.ctrip.com's "机票" entry.
+- On the review page, remove only unrequested chargeable extras; preserve beneficial coupons and check their restrictions. Re-read travelers, contact, itinerary, terms, currency, and total; get explicit confirmation before "提交订单".
+- Report success only with "订单号" plus "预订成功" or the applicable "出票成功" status. Pending confirmation, a payment redirect, or an itinerary held for payment is incomplete.`,
   },
   {
     name: 'google-maps',

--- a/src/firefox/src/agent/adapters.js
+++ b/src/firefox/src/agent/adapters.js
@@ -16198,6 +16198,22 @@ const ADAPTERS = [
 - Trip dashboard at /trips after a booking shows itinerary, change/cancel options. Cancellation rules vary per supplier.`,
   },
   {
+    name: 'ctrip',
+    category: 'general',
+    matches: (url) => /^https?:\/\/(?:(?:www|hotels|flights|trains|vacations|tickets|passport|my|secure)\.)?ctrip\.com\//.test(url),
+    notes: `
+- Treat www.ctrip.com, hotels.ctrip.com, flights.ctrip.com, trains.ctrip.com, vacations.ctrip.com, tickets.ctrip.com, passport.ctrip.com, my.ctrip.com, and secure.ctrip.com as Ctrip's desktop booking flow as of 2026-08. Choose the intended "酒店", "机票", "火车票", "旅游", or "门票·活动" product before filling search fields because each opens a different booking flow.
+- Treat cards marked "广告" as sponsored placements. Compare the exact product, supplier, dates, included services, and final payable total instead of ranking by homepage position, crossed-out price, member price, or a displayed "起" price.
+- For hotels, set the city/property, "入住" and "离店" dates, rooms, and guests before reading availability. Select the exact "房型", bed, breakfast, occupancy, payment timing, and "退订" / cancellation rule; different rows for the same hotel are not interchangeable.
+- For flights, verify airports, local departure and arrival dates, operating carrier, stops, transfer airports, cabin, baggage "行李" allowance, change/refund rules, and whether separate tickets are involved. Do not compare only the headline fare or assume an overnight arrival is the departure date.
+- For trains, distinguish Ctrip's booking layer from the official 12306 order. Verify train, stations, date, seat class, passenger, service/insurance add-ons, and final total; if the flow hands off to 12306, re-read that page under the 12306 adapter instead of assuming Ctrip completed the ticket.
+- Stop for the user when QR "扫码", password, SMS "短信", payment verification, or real-name passenger verification appears. Do not retry around authentication, enter identity details not explicitly provided for this booking, or expose document numbers in summaries.
+- Remove optional insurance, packages, coupons, memberships, or paid add-ons unless the user requested them, and re-read the cancellation/change terms and total after any selection. A lower price can carry materially stricter restrictions.
+- Treat the review page and "提交订单" as a consequential booking action. Re-read travelers/guests, contact details, itinerary, room/fare, cancellation terms, add-ons, currency, and total, and do not submit without the user's explicit confirmation.
+- Report success only when the product-specific result shows "订单号" plus "预订成功" or, for flights/trains, the applicable "出票成功" status. A form submission, pending confirmation, payment redirect, or itinerary held for payment is not a completed booking.
+- If flights.ctrip.com becomes blank or returns HTTP 432, treat it as an anti-automation response rather than "no flights". Do not retry rapidly; return through www.ctrip.com's "机票" entry after a pause, and ask the user to handle any verification that appears.`,
+  },
+  {
     name: 'google-maps',
     category: 'general',
     matches: (url) => /^https?:\/\/(www\.)?google\.[a-z.]+\/maps/.test(url) || /^https?:\/\/maps\.google\.[a-z.]+\//.test(url),

--- a/test/run.js
+++ b/test/run.js
@@ -2499,6 +2499,50 @@ test('matches Mercado Libre LATAM storefronts and includes marketplace guidance'
   assert.equal(firefoxAdapter?.notes, adapter?.notes);
 });
 
+test('matches Ctrip travel surfaces and includes Chinese booking guidance', () => {
+  const trustedUrls = [
+    'https://www.ctrip.com/',
+    'https://hotels.ctrip.com/hotels/437892.html',
+    'https://flights.ctrip.com/international/search/oneway-sha-sin',
+    'https://trains.ctrip.com/TrainBooking/SearchTrain.aspx',
+    'https://vacations.ctrip.com/',
+    'https://tickets.ctrip.com/',
+    'https://passport.ctrip.com/user/login',
+    'https://my.ctrip.com/myinfo/orders',
+    'https://secure.ctrip.com/booking',
+  ];
+  for (const url of trustedUrls) {
+    assert.equal(getActiveAdapter(url)?.name, 'ctrip');
+    assert.equal(getActiveAdapterFx(url)?.name, 'ctrip');
+  }
+
+  const rejectedUrls = [
+    'https://pages.ctrip.com/corporate/',
+    'https://ctrip.com.phishing.example/hotels',
+    'https://example.com/?next=https://hotels.ctrip.com/',
+  ];
+  for (const url of rejectedUrls) {
+    assert.notEqual(getActiveAdapter(url)?.name, 'ctrip');
+    assert.notEqual(getActiveAdapterFx(url)?.name, 'ctrip');
+  }
+
+  const adapter = getActiveAdapter('https://hotels.ctrip.com/hotels/437892.html');
+  const firefoxAdapter = getActiveAdapterFx('https://flights.ctrip.com/');
+  assert.match(adapter?.notes || '', /2026-08/);
+  assert.match(adapter?.notes || '', /酒店.*机票.*火车票/s);
+  assert.match(adapter?.notes || '', /广告/);
+  assert.match(adapter?.notes || '', /入住.*离店.*房型/s);
+  assert.match(adapter?.notes || '', /退订|取消/);
+  assert.match(adapter?.notes || '', /行李/);
+  assert.match(adapter?.notes || '', /12306/);
+  assert.match(adapter?.notes || '', /扫码|短信/);
+  assert.match(adapter?.notes || '', /flights\.ctrip\.com.*HTTP 432/s);
+  assert.match(adapter?.notes || '', /提交订单/);
+  assert.match(adapter?.notes || '', /explicit confirmation/);
+  assert.match(adapter?.notes || '', /订单号|出票成功|预订成功/);
+  assert.equal(firefoxAdapter?.notes, adapter?.notes);
+});
+
 test('matches Coupang shopping surfaces and includes Korean marketplace guidance', () => {
   const trustedUrls = [
     'https://coupang.com/',

--- a/test/run.js
+++ b/test/run.js
@@ -2506,7 +2506,8 @@ test('matches Ctrip travel surfaces and includes Chinese booking guidance', () =
     'https://flights.ctrip.com/international/search/oneway-sha-sin',
     'https://trains.ctrip.com/TrainBooking/SearchTrain.aspx',
     'https://vacations.ctrip.com/',
-    'https://tickets.ctrip.com/',
+    'https://huodong.ctrip.com/things-to-do/list',
+    'https://piao.ctrip.com/',
     'https://passport.ctrip.com/user/login',
     'https://my.ctrip.com/myinfo/orders',
     'https://secure.ctrip.com/booking',
@@ -2518,6 +2519,7 @@ test('matches Ctrip travel surfaces and includes Chinese booking guidance', () =
 
   const rejectedUrls = [
     'https://pages.ctrip.com/corporate/',
+    'https://tickets.ctrip.com/',
     'https://ctrip.com.phishing.example/hotels',
     'https://example.com/?next=https://hotels.ctrip.com/',
   ];
@@ -2528,17 +2530,20 @@ test('matches Ctrip travel surfaces and includes Chinese booking guidance', () =
 
   const adapter = getActiveAdapter('https://hotels.ctrip.com/hotels/437892.html');
   const firefoxAdapter = getActiveAdapterFx('https://flights.ctrip.com/');
-  assert.match(adapter?.notes || '', /2026-08/);
   assert.match(adapter?.notes || '', /酒店.*机票.*火车票/s);
   assert.match(adapter?.notes || '', /广告/);
   assert.match(adapter?.notes || '', /入住.*离店.*房型/s);
   assert.match(adapter?.notes || '', /退订|取消/);
   assert.match(adapter?.notes || '', /行李/);
   assert.match(adapter?.notes || '', /12306/);
+  assert.doesNotMatch(adapter?.notes || '', /12306 adapter/);
   assert.match(adapter?.notes || '', /扫码|短信/);
-  assert.match(adapter?.notes || '', /flights\.ctrip\.com.*HTTP 432/s);
+  assert.match(adapter?.notes || '', /HTTP 432/);
   assert.match(adapter?.notes || '', /提交订单/);
   assert.match(adapter?.notes || '', /explicit confirmation/);
+  assert.match(adapter?.notes || '', /preserve beneficial coupons/i);
+  const noteBullets = (adapter?.notes || '').trim().split('\n').filter((line) => line.startsWith('- '));
+  assert.equal(noteBullets.length, 8);
   assert.match(adapter?.notes || '', /订单号|出票成功|预订成功/);
   assert.equal(firefoxAdapter?.notes, adapter?.notes);
 });


### PR DESCRIPTION
## Summary

Adds a mirrored Ctrip adapter for Chrome and Firefox.

Without this adapter, the agent can compare sponsored or incomplete travel prices, confuse a Ctrip train request with an issued 12306 ticket, or report a submitted/held itinerary as a completed booking.

- Cover Ctrip hotel, flight, train, vacation, attraction, account, order, and secure-booking hosts.
- Preserve exact dates, airports/stations, room/fare conditions, passengers, add-ons, cancellation rules, and final totals.
- Require explicit confirmation before `提交订单` and verify product-specific success states.
- Handle the observed blank HTTP 432 response on `flights.ctrip.com` without rapid retry loops.
- Add host-scope, phishing-lookalike, visible-label, transaction-safety, anti-automation, and Chrome/Firefox parity tests.

## Validation

- Targeted Ctrip production and guidance assertions: passed.
- Anonymous Chrome/Playwright read-only check: home, hotel detail, and train pages returned HTTP 200 and selected `ctrip`; the flight host returned HTTP 432 but still selected `ctrip`, which is now documented as an anti-automation response.
- `node test/run.js`: 1398/1399 passed; the single failure predates this branch and is the repository's changelog/package version mismatch.
- `git diff --check`: passed.

## Compatibility and risks

The change is prompt-only and mirrored across both browser builds. No authenticated booking, passenger-data, order, or payment mutation was performed.
