### PR TITLE
agent: add adapter for Weibo

### DIFF
--- a/src/chrome/src/agent/adapters.js
+++ b/src/chrome/src/agent/adapters.js
@@ -15863,6 +15863,20 @@ const ADAPTERS = [
 - Quote tweets vs reposts: the retweet icon opens a menu with both options.`,
   },
   {
+    name: 'weibo',
+    category: 'general',
+    matches: (url) => /^https?:\/\/(?:(?:www|s|passport|m)\.)?weibo\.(?:com|cn)\//.test(url),
+    notes: `
+- Treat weibo.com, www.weibo.com, s.weibo.com, passport.weibo.com, m.weibo.cn, and weibo.cn as Weibo surfaces as of 2026-08. Anonymous desktop navigation may redirect to passport.weibo.com/visitor/visitor or /sso/signin; preserve the encoded url= destination and resume it after authentication instead of looping on the original page.
+- Search on s.weibo.com and choose deliberately among "综合", "实时", "热门", and "视频". Re-read results after changing the tab or time filter, and capture each post's actual dynamic link before paging because ranking and card positions change.
+- Distinguish a "转发微博" card's added commentary from the embedded "原微博" author and text. Expand every relevant "展开" / long-post control and follow the original post link before attributing a claim or counting engagement.
+- Treat feeds, profiles, comments, and m.weibo.cn lists as incrementally loaded. Record author, timestamp, text, and permalink for visible posts before scrolling; pinned, recommended, and hot-comment sections are not chronological evidence.
+- Treat "关注", "转发", "评论", "赞", favorites, and private messages as state-changing actions. Do not activate them during read-only tasks, and verify the resulting state after an explicit user request rather than trusting a click result.
+- Stop for the user when QR "扫码", SMS "短信", image "验证码", device confirmation, or account-risk verification appears. Do not bypass, repeatedly reload, or claim public content is unavailable merely because the current session requires verification.
+- Before "发布" or confirming a repost/comment, re-read the target account, complete text, mentions, hashtags, media, audience, and any location setting. These actions are externally visible; perform them only for the user's explicit request.
+- Report publication success only after the new post appears on the intended profile/feed with matching text and a stable status URL / "动态链接". A closed composer, cleared textbox, or successful click is not proof of publication.`,
+  },
+  {
     name: 'linkedin',
     category: 'general',
     matches: (url) => /^https?:\/\/(www\.)?linkedin\.com\//.test(url),

--- a/src/firefox/src/agent/adapters.js
+++ b/src/firefox/src/agent/adapters.js
@@ -15862,6 +15862,20 @@ const ADAPTERS = [
 - Quote tweets vs reposts: the retweet icon opens a menu with both options.`,
   },
   {
+    name: 'weibo',
+    category: 'general',
+    matches: (url) => /^https?:\/\/(?:(?:www|s|passport|m)\.)?weibo\.(?:com|cn)\//.test(url),
+    notes: `
+- Treat weibo.com, www.weibo.com, s.weibo.com, passport.weibo.com, m.weibo.cn, and weibo.cn as Weibo surfaces as of 2026-08. Anonymous desktop navigation may redirect to passport.weibo.com/visitor/visitor or /sso/signin; preserve the encoded url= destination and resume it after authentication instead of looping on the original page.
+- Search on s.weibo.com and choose deliberately among "综合", "实时", "热门", and "视频". Re-read results after changing the tab or time filter, and capture each post's actual dynamic link before paging because ranking and card positions change.
+- Distinguish a "转发微博" card's added commentary from the embedded "原微博" author and text. Expand every relevant "展开" / long-post control and follow the original post link before attributing a claim or counting engagement.
+- Treat feeds, profiles, comments, and m.weibo.cn lists as incrementally loaded. Record author, timestamp, text, and permalink for visible posts before scrolling; pinned, recommended, and hot-comment sections are not chronological evidence.
+- Treat "关注", "转发", "评论", "赞", favorites, and private messages as state-changing actions. Do not activate them during read-only tasks, and verify the resulting state after an explicit user request rather than trusting a click result.
+- Stop for the user when QR "扫码", SMS "短信", image "验证码", device confirmation, or account-risk verification appears. Do not bypass, repeatedly reload, or claim public content is unavailable merely because the current session requires verification.
+- Before "发布" or confirming a repost/comment, re-read the target account, complete text, mentions, hashtags, media, audience, and any location setting. These actions are externally visible; perform them only for the user's explicit request.
+- Report publication success only after the new post appears on the intended profile/feed with matching text and a stable status URL / "动态链接". A closed composer, cleared textbox, or successful click is not proof of publication.`,
+  },
+  {
     name: 'linkedin',
     category: 'general',
     matches: (url) => /^https?:\/\/(www\.)?linkedin\.com\//.test(url),

--- a/test/run.js
+++ b/test/run.js
@@ -2284,6 +2284,37 @@ test('matches twitter.com and x.com', () => {
   }
 });
 
+test('matches Weibo desktop and mobile surfaces and includes login and posting guidance', () => {
+  const trustedUrls = [
+    'https://weibo.com/',
+    'https://www.weibo.com/u/123456',
+    'https://s.weibo.com/weibo?q=webbrain',
+    'https://passport.weibo.com/visitor/visitor?url=https%3A%2F%2Fweibo.com%2F',
+    'https://m.weibo.cn/',
+    'https://weibo.cn/pub/',
+  ];
+  for (const url of trustedUrls) {
+    assert.equal(getActiveAdapter(url)?.name, 'weibo');
+    assert.equal(getActiveAdapterFx(url)?.name, 'weibo');
+  }
+  for (const url of ['https://weibo.com.phishing.example/', 'https://example.com/?next=https://weibo.com/']) {
+    assert.notEqual(getActiveAdapter(url)?.name, 'weibo');
+    assert.notEqual(getActiveAdapterFx(url)?.name, 'weibo');
+  }
+  const adapter = getActiveAdapter('https://s.weibo.com/weibo?q=webbrain');
+  const firefoxAdapter = getActiveAdapterFx('https://m.weibo.cn/');
+  assert.match(adapter?.notes || '', /2026-08/);
+  assert.match(adapter?.notes || '', /passport\.weibo\.com.*url=/s);
+  assert.match(adapter?.notes || '', /综合.*实时.*热门.*视频/s);
+  assert.match(adapter?.notes || '', /转发微博.*原微博/s);
+  assert.match(adapter?.notes || '', /展开/);
+  assert.match(adapter?.notes || '', /关注.*转发.*评论.*赞/s);
+  assert.match(adapter?.notes || '', /发布/);
+  assert.match(adapter?.notes || '', /扫码|短信|验证码/);
+  assert.match(adapter?.notes || '', /status URL|动态链接/);
+  assert.equal(firefoxAdapter?.notes, adapter?.notes);
+});
+
 test('matches youtube video URLs and includes transcript guidance', () => {
   const a = getActiveAdapter('https://www.youtube.com/watch?v=dQw4w9WgXcQ');
   assert.equal(a?.name, 'youtube');


### PR DESCRIPTION
## Summary

Adds a mirrored Weibo adapter for Chrome and Firefox.

Without this adapter, anonymous navigation can bounce through Weibo's visitor/sign-in hosts, and the agent can conflate repost commentary with the original post or report an unverified publication.

- Cover desktop search/profile, visitor/login, mobile, and legacy mobile hosts.
- Preserve the encoded destination across authentication and verification.
- Distinguish search tabs, repost/original content, incremental feeds, hot comments, and state-changing interactions.
- Require explicit posting intent and verify publication from the matching post and stable link.
- Add host-scope, phishing-lookalike, Chinese-label, login, posting, and Chrome/Firefox parity tests.

## Validation

- Targeted Weibo production and post-rebase assertions: passed.
- Anonymous Chrome/Playwright read-only check: desktop home redirected to `passport.weibo.com/visitor/visitor`, search redirected to `/sso/signin`, and `m.weibo.cn` / `weibo.cn` remained readable; all are covered.
- `node test/run.js`: 1399/1400 passed; the single failure predates this branch and is the repository's changelog/package version mismatch.
- `git diff --check`: passed.

## Compatibility and risks

Prompt-only, mirrored across browser builds, and aligned with the new contribution rule that every host named in notes is selected by the matcher. No account or posting mutation was performed.
