### PR TITLE
agent: add adapter for Zhihu

### DIFF
--- a/src/chrome/src/agent/adapters.js
+++ b/src/chrome/src/agent/adapters.js
@@ -15918,6 +15918,22 @@ const ADAPTERS = [
 - The subscribe button has a bell icon next to it for notification preferences; they're separate clicks.`,
   },
   {
+    name: 'zhihu',
+    category: 'general',
+    matches: (url) => /^https?:\/\/(?:(?:www|zhuanlan|people|link)\.)?zhihu\.com\//.test(url),
+    notes: `
+- Treat zhihu.com, www.zhihu.com, zhuanlan.zhihu.com, people.zhihu.com, and link.zhihu.com as Zhihu surfaces as of 2026-08. Anonymous entry can redirect to /signin?next=...; preserve next= and resume the destination after login instead of discarding the requested question or article.
+- On search, choose deliberately among "综合", "用户", and "内容" type tabs, then re-read the results. Capture the actual question, answer, article, or profile link before scrolling because recommendation cards and rankings can reflow.
+- On question pages, distinguish the question text from answers and comments. Check "默认排序" versus "按时间排序", author, edit/publication time, and vote count; neither the first nor the highest-voted answer is automatically the most current or authoritative.
+- Activate relevant "展开阅读全文", "查看全部回答", and comment expansion controls before summarizing. Keep answer text, collapsed content, related questions, and neighboring recommendation cards separate.
+- Treat "赞同", "反对", "关注", "收藏", "评论", invitations, and private messages as state-changing. Do not activate them for read-only tasks, and verify the resulting state after an explicit request.
+- Stop for the user when /signin, QR "扫码", "短信验证码", device confirmation, or account-risk verification appears. Public reading may still be available on the destination; do not loop on login or claim every Zhihu page requires an account.
+- For "写回答" and article creation, scope typing to the active title/body editor, preserve links and formatting, and re-read the complete draft. "保存草稿" is not "发布"; do not publish externally visible content without the user's explicit request and final content confirmation.
+- Report publication success only after the new answer/article is visible with matching text and a stable answer URL / "回答链接" or zhuanlan.zhihu.com/p/... article URL. A closed editor, saved draft, or cleared composer is not proof of publication.
+- When link.zhihu.com redirects externally, follow its encoded target and record the final domain. Treat external pages as separate sources and never attribute their text to Zhihu merely because the redirect started there.
+- If a direct question page is blank or returns HTTP 403 while /explore remains readable, treat it as an access or anti-automation restriction, not proof that the "问题不存在". Do not retry rapidly; use the visible search/explore route or ask the user to complete login/verification.`,
+  },
+  {
     name: 'medium',
     category: 'general',
     matches: (url) => /^https?:\/\/(?:[a-z0-9-]+\.)*medium\.com\//i.test(url),

--- a/src/chrome/src/agent/adapters.js
+++ b/src/chrome/src/agent/adapters.js
@@ -15920,16 +15920,14 @@ const ADAPTERS = [
   {
     name: 'zhihu',
     category: 'general',
-    matches: (url) => /^https?:\/\/(?:(?:www|zhuanlan|people|link)\.)?zhihu\.com\//.test(url),
+    matches: (url) => /^https?:\/\/(?:(?:www|zhuanlan|link)\.)?zhihu\.com\//.test(url),
     notes: `
-- Treat zhihu.com, www.zhihu.com, zhuanlan.zhihu.com, people.zhihu.com, and link.zhihu.com as Zhihu surfaces as of 2026-08. Anonymous entry can redirect to /signin?next=...; preserve next= and resume the destination after login instead of discarding the requested question or article.
+- Treat zhihu.com, www.zhihu.com, zhuanlan.zhihu.com, and link.zhihu.com as Zhihu surfaces as of 2026-08. Profiles use www.zhihu.com/people/<slug>. Anonymous entry can redirect to /signin?next=...; preserve next= and resume the destination after login.
 - On search, choose deliberately among "综合", "用户", and "内容" type tabs, then re-read the results. Capture the actual question, answer, article, or profile link before scrolling because recommendation cards and rankings can reflow.
-- On question pages, distinguish the question text from answers and comments. Check "默认排序" versus "按时间排序", author, edit/publication time, and vote count; neither the first nor the highest-voted answer is automatically the most current or authoritative.
-- Activate relevant "展开阅读全文", "查看全部回答", and comment expansion controls before summarizing. Keep answer text, collapsed content, related questions, and neighboring recommendation cards separate.
+- On question pages, distinguish the question from answers, comments, related questions, and recommendations. Check "默认排序" versus "按时间排序", author, time, and votes; activate relevant "展开阅读全文", "查看全部回答", and comment expansion controls before summarizing.
 - Treat "赞同", "反对", "关注", "收藏", "评论", invitations, and private messages as state-changing. Do not activate them for read-only tasks, and verify the resulting state after an explicit request.
 - Stop for the user when /signin, QR "扫码", "短信验证码", device confirmation, or account-risk verification appears. Public reading may still be available on the destination; do not loop on login or claim every Zhihu page requires an account.
-- For "写回答" and article creation, scope typing to the active title/body editor, preserve links and formatting, and re-read the complete draft. "保存草稿" is not "发布"; do not publish externally visible content without the user's explicit request and final content confirmation.
-- Report publication success only after the new answer/article is visible with matching text and a stable answer URL / "回答链接" or zhuanlan.zhihu.com/p/... article URL. A closed editor, saved draft, or cleared composer is not proof of publication.
+- For "写回答" and article creation, scope typing to the active title/body editor and re-read the draft. "保存草稿" is not "发布"; after an explicit publish request, report success only when matching text is visible at a stable answer URL / "回答链接" or zhuanlan.zhihu.com/p/... URL.
 - When link.zhihu.com redirects externally, follow its encoded target and record the final domain. Treat external pages as separate sources and never attribute their text to Zhihu merely because the redirect started there.
 - If a direct question page is blank or returns HTTP 403 while /explore remains readable, treat it as an access or anti-automation restriction, not proof that the "问题不存在". Do not retry rapidly; use the visible search/explore route or ask the user to complete login/verification.`,
   },

--- a/src/firefox/src/agent/adapters.js
+++ b/src/firefox/src/agent/adapters.js
@@ -15919,16 +15919,14 @@ const ADAPTERS = [
   {
     name: 'zhihu',
     category: 'general',
-    matches: (url) => /^https?:\/\/(?:(?:www|zhuanlan|people|link)\.)?zhihu\.com\//.test(url),
+    matches: (url) => /^https?:\/\/(?:(?:www|zhuanlan|link)\.)?zhihu\.com\//.test(url),
     notes: `
-- Treat zhihu.com, www.zhihu.com, zhuanlan.zhihu.com, people.zhihu.com, and link.zhihu.com as Zhihu surfaces as of 2026-08. Anonymous entry can redirect to /signin?next=...; preserve next= and resume the destination after login instead of discarding the requested question or article.
+- Treat zhihu.com, www.zhihu.com, zhuanlan.zhihu.com, and link.zhihu.com as Zhihu surfaces as of 2026-08. Profiles use www.zhihu.com/people/<slug>. Anonymous entry can redirect to /signin?next=...; preserve next= and resume the destination after login.
 - On search, choose deliberately among "综合", "用户", and "内容" type tabs, then re-read the results. Capture the actual question, answer, article, or profile link before scrolling because recommendation cards and rankings can reflow.
-- On question pages, distinguish the question text from answers and comments. Check "默认排序" versus "按时间排序", author, edit/publication time, and vote count; neither the first nor the highest-voted answer is automatically the most current or authoritative.
-- Activate relevant "展开阅读全文", "查看全部回答", and comment expansion controls before summarizing. Keep answer text, collapsed content, related questions, and neighboring recommendation cards separate.
+- On question pages, distinguish the question from answers, comments, related questions, and recommendations. Check "默认排序" versus "按时间排序", author, time, and votes; activate relevant "展开阅读全文", "查看全部回答", and comment expansion controls before summarizing.
 - Treat "赞同", "反对", "关注", "收藏", "评论", invitations, and private messages as state-changing. Do not activate them for read-only tasks, and verify the resulting state after an explicit request.
 - Stop for the user when /signin, QR "扫码", "短信验证码", device confirmation, or account-risk verification appears. Public reading may still be available on the destination; do not loop on login or claim every Zhihu page requires an account.
-- For "写回答" and article creation, scope typing to the active title/body editor, preserve links and formatting, and re-read the complete draft. "保存草稿" is not "发布"; do not publish externally visible content without the user's explicit request and final content confirmation.
-- Report publication success only after the new answer/article is visible with matching text and a stable answer URL / "回答链接" or zhuanlan.zhihu.com/p/... article URL. A closed editor, saved draft, or cleared composer is not proof of publication.
+- For "写回答" and article creation, scope typing to the active title/body editor and re-read the draft. "保存草稿" is not "发布"; after an explicit publish request, report success only when matching text is visible at a stable answer URL / "回答链接" or zhuanlan.zhihu.com/p/... URL.
 - When link.zhihu.com redirects externally, follow its encoded target and record the final domain. Treat external pages as separate sources and never attribute their text to Zhihu merely because the redirect started there.
 - If a direct question page is blank or returns HTTP 403 while /explore remains readable, treat it as an access or anti-automation restriction, not proof that the "问题不存在". Do not retry rapidly; use the visible search/explore route or ask the user to complete login/verification.`,
   },

--- a/src/firefox/src/agent/adapters.js
+++ b/src/firefox/src/agent/adapters.js
@@ -15917,6 +15917,22 @@ const ADAPTERS = [
 - The subscribe button has a bell icon next to it for notification preferences; they're separate clicks.`,
   },
   {
+    name: 'zhihu',
+    category: 'general',
+    matches: (url) => /^https?:\/\/(?:(?:www|zhuanlan|people|link)\.)?zhihu\.com\//.test(url),
+    notes: `
+- Treat zhihu.com, www.zhihu.com, zhuanlan.zhihu.com, people.zhihu.com, and link.zhihu.com as Zhihu surfaces as of 2026-08. Anonymous entry can redirect to /signin?next=...; preserve next= and resume the destination after login instead of discarding the requested question or article.
+- On search, choose deliberately among "综合", "用户", and "内容" type tabs, then re-read the results. Capture the actual question, answer, article, or profile link before scrolling because recommendation cards and rankings can reflow.
+- On question pages, distinguish the question text from answers and comments. Check "默认排序" versus "按时间排序", author, edit/publication time, and vote count; neither the first nor the highest-voted answer is automatically the most current or authoritative.
+- Activate relevant "展开阅读全文", "查看全部回答", and comment expansion controls before summarizing. Keep answer text, collapsed content, related questions, and neighboring recommendation cards separate.
+- Treat "赞同", "反对", "关注", "收藏", "评论", invitations, and private messages as state-changing. Do not activate them for read-only tasks, and verify the resulting state after an explicit request.
+- Stop for the user when /signin, QR "扫码", "短信验证码", device confirmation, or account-risk verification appears. Public reading may still be available on the destination; do not loop on login or claim every Zhihu page requires an account.
+- For "写回答" and article creation, scope typing to the active title/body editor, preserve links and formatting, and re-read the complete draft. "保存草稿" is not "发布"; do not publish externally visible content without the user's explicit request and final content confirmation.
+- Report publication success only after the new answer/article is visible with matching text and a stable answer URL / "回答链接" or zhuanlan.zhihu.com/p/... article URL. A closed editor, saved draft, or cleared composer is not proof of publication.
+- When link.zhihu.com redirects externally, follow its encoded target and record the final domain. Treat external pages as separate sources and never attribute their text to Zhihu merely because the redirect started there.
+- If a direct question page is blank or returns HTTP 403 while /explore remains readable, treat it as an access or anti-automation restriction, not proof that the "问题不存在". Do not retry rapidly; use the visible search/explore route or ask the user to complete login/verification.`,
+  },
+  {
     name: 'medium',
     category: 'general',
     matches: (url) => /^https?:\/\/(?:[a-z0-9-]+\.)*medium\.com\//i.test(url),

--- a/test/run.js
+++ b/test/run.js
@@ -2332,14 +2332,18 @@ test('matches Zhihu reading and creation surfaces with login and publication gui
   const trustedUrls = [
     'https://zhihu.com/', 'https://www.zhihu.com/signin?next=%2F',
     'https://www.zhihu.com/search?q=webbrain', 'https://www.zhihu.com/question/123456',
-    'https://zhuanlan.zhihu.com/p/123456', 'https://people.zhihu.com/example',
+    'https://zhuanlan.zhihu.com/p/123456', 'https://www.zhihu.com/people/example',
     'https://link.zhihu.com/?target=https%3A%2F%2Fexample.com',
   ];
   for (const url of trustedUrls) {
     assert.equal(getActiveAdapter(url)?.name, 'zhihu');
     assert.equal(getActiveAdapterFx(url)?.name, 'zhihu');
   }
-  for (const url of ['https://zhihu.com.phishing.example/', 'https://example.com/?next=https://www.zhihu.com/']) {
+  for (const url of [
+    'https://people.zhihu.com/example',
+    'https://zhihu.com.phishing.example/',
+    'https://example.com/?next=https://www.zhihu.com/',
+  ]) {
     assert.notEqual(getActiveAdapter(url)?.name, 'zhihu');
     assert.notEqual(getActiveAdapterFx(url)?.name, 'zhihu');
   }
@@ -2356,6 +2360,7 @@ test('matches Zhihu reading and creation surfaces with login and publication gui
   assert.match(adapter?.notes || '', /扫码|短信验证码/);
   assert.match(adapter?.notes || '', /HTTP 403.*问题不存在/s);
   assert.match(adapter?.notes || '', /answer URL|回答链接/);
+  assert.equal((adapter?.notes || '').trim().split('\n').filter((line) => line.startsWith('- ')).length, 8);
   assert.equal(firefoxAdapter?.notes, adapter?.notes);
 });
 

--- a/test/run.js
+++ b/test/run.js
@@ -2328,6 +2328,37 @@ test('matches youtube video URLs and includes transcript guidance', () => {
   assert.match(a?.notes || '', /Do NOT invent transcript URLs/i);
 });
 
+test('matches Zhihu reading and creation surfaces with login and publication guidance', () => {
+  const trustedUrls = [
+    'https://zhihu.com/', 'https://www.zhihu.com/signin?next=%2F',
+    'https://www.zhihu.com/search?q=webbrain', 'https://www.zhihu.com/question/123456',
+    'https://zhuanlan.zhihu.com/p/123456', 'https://people.zhihu.com/example',
+    'https://link.zhihu.com/?target=https%3A%2F%2Fexample.com',
+  ];
+  for (const url of trustedUrls) {
+    assert.equal(getActiveAdapter(url)?.name, 'zhihu');
+    assert.equal(getActiveAdapterFx(url)?.name, 'zhihu');
+  }
+  for (const url of ['https://zhihu.com.phishing.example/', 'https://example.com/?next=https://www.zhihu.com/']) {
+    assert.notEqual(getActiveAdapter(url)?.name, 'zhihu');
+    assert.notEqual(getActiveAdapterFx(url)?.name, 'zhihu');
+  }
+  const adapter = getActiveAdapter('https://www.zhihu.com/question/123456');
+  const firefoxAdapter = getActiveAdapterFx('https://zhuanlan.zhihu.com/p/123456');
+  assert.match(adapter?.notes || '', /2026-08/);
+  assert.match(adapter?.notes || '', /signin\?next=/);
+  assert.match(adapter?.notes || '', /综合.*用户.*内容/s);
+  assert.match(adapter?.notes || '', /默认排序|按时间排序/);
+  assert.match(adapter?.notes || '', /展开阅读全文|查看全部回答/);
+  assert.match(adapter?.notes || '', /赞同.*反对.*关注.*收藏.*评论/s);
+  assert.match(adapter?.notes || '', /写回答/);
+  assert.match(adapter?.notes || '', /保存草稿.*发布/s);
+  assert.match(adapter?.notes || '', /扫码|短信验证码/);
+  assert.match(adapter?.notes || '', /HTTP 403.*问题不存在/s);
+  assert.match(adapter?.notes || '', /answer URL|回答链接/);
+  assert.equal(firefoxAdapter?.notes, adapter?.notes);
+});
+
 test('matches Bilibili surfaces with mirrored regional guidance', () => {
   const urls = [
     'https://www.bilibili.com/video/BV1FD4y147uH/?p=2',


### PR DESCRIPTION
## Summary

Adds a mirrored Zhihu adapter for Chrome and Firefox.

Without this adapter, the agent can mix question, answer, comment, and recommendation text; confuse drafts with publication; or treat an anonymous HTTP 403 as proof that a question does not exist.

- Cover main, column, profile, and redirect hosts named by the guidance.
- Preserve destinations across sign-in and verification.
- Distinguish search/content tabs, answer sorting, expanded content, interactions, drafts, and published URLs.
- Handle the observed blank HTTP 403 question response without rapid retry or false absence claims.
- Add host-scope, phishing-lookalike, visible-label, publishing, access-restriction, and Chrome/Firefox parity tests.

## Validation

- Targeted Zhihu production and guidance assertions: passed.
- Anonymous Chrome/Playwright read-only check: home redirected to `/signin?next=/`, `/explore` returned HTTP 200, and a direct question returned blank HTTP 403; every final URL selected `zhihu`.
- `node test/run.js`: 1399/1400 passed; the single failure predates this branch and is the repository's changelog/package version mismatch.
- `git diff --check`: passed.

## Compatibility and risks

Prompt-only and mirrored across browser builds. No account interaction or publication was performed.
