### PR TITLE
agent: add adapter for Amap

### DIFF
--- a/src/chrome/src/agent/adapters.js
+++ b/src/chrome/src/agent/adapters.js
@@ -16306,6 +16306,20 @@ const ADAPTERS = [
 - Sharing a place produces a /maps/place/... URL with a CID — that's the stable link. The current viewport URL with @lat,lng,zoom is not a place link.`,
   },
   {
+    name: 'amap',
+    category: 'general',
+    matches: (url) => /^https?:\/\/(?:(?:www|m|uri)\.)?amap\.com\//.test(url),
+    notes: `
+- Treat amap.com, www.amap.com, m.amap.com, and uri.amap.com as Amap / 高德地图 consumer surfaces as of 2026-08. Exclude lbs.amap.com because it is the developer platform, not the map task UI.
+- Enter places in "搜索位置、公交站、地铁站" and read results from the side panel. The map itself is canvas / 画布 rendered, so do not infer names, coordinates, routes, or traffic from pixels when the selected result and sidebar text are available.
+- Confirm the current city and the exact POI name, category, district, and street address before selecting a result. A /search URL can carry its city= "城市" value from geolocation or a previous search; same-named places in different cities are not interchangeable.
+- For directions, set and re-read both start and destination, then choose deliberately among "驾车", "公交", "步行", and "骑行". If the start is blank, the site may use current location; do not assume that location is correct or grant location permission without the user's intent.
+- Compare route duration, distance, transfers, walking, tolls, and arrival estimates from the route side panel. Traffic-sensitive times and "推荐" ranking can change; report the observation time and do not promise an arrival from a single estimate.
+- Treat "卫星", "路况", "测距", and "地铁" as map layers/tools, not search results. Toggling them changes presentation and can obscure the active side panel; re-read the selected POI or route after changing a layer.
+- Public place search and route planning do not require sign-in. If "短信登录" or "二维码登录" appears, close or defer it for read-only work; ask the user to authenticate only for an explicitly requested account feature such as favorites or synchronized history.
+- Follow actual share/navigation links on m.amap.com or uri.amap.com and preserve their provided coordinates, POI IDs, names, and route mode. Do not synthesize a destination from rounded visible coordinates, and record the final place/route after the handoff.`,
+  },
+  {
     name: 'google-flights',
     category: 'general',
     matches: (url) => /^https?:\/\/(www\.)?google\.[a-z.]+\/(travel\/)?flights/.test(url),

--- a/src/firefox/src/agent/adapters.js
+++ b/src/firefox/src/agent/adapters.js
@@ -16304,6 +16304,20 @@ const ADAPTERS = [
 - Sharing a place produces a /maps/place/... URL with a CID — that's the stable link. The current viewport URL with @lat,lng,zoom is not a place link.`,
   },
   {
+    name: 'amap',
+    category: 'general',
+    matches: (url) => /^https?:\/\/(?:(?:www|m|uri)\.)?amap\.com\//.test(url),
+    notes: `
+- Treat amap.com, www.amap.com, m.amap.com, and uri.amap.com as Amap / 高德地图 consumer surfaces as of 2026-08. Exclude lbs.amap.com because it is the developer platform, not the map task UI.
+- Enter places in "搜索位置、公交站、地铁站" and read results from the side panel. The map itself is canvas / 画布 rendered, so do not infer names, coordinates, routes, or traffic from pixels when the selected result and sidebar text are available.
+- Confirm the current city and the exact POI name, category, district, and street address before selecting a result. A /search URL can carry its city= "城市" value from geolocation or a previous search; same-named places in different cities are not interchangeable.
+- For directions, set and re-read both start and destination, then choose deliberately among "驾车", "公交", "步行", and "骑行". If the start is blank, the site may use current location; do not assume that location is correct or grant location permission without the user's intent.
+- Compare route duration, distance, transfers, walking, tolls, and arrival estimates from the route side panel. Traffic-sensitive times and "推荐" ranking can change; report the observation time and do not promise an arrival from a single estimate.
+- Treat "卫星", "路况", "测距", and "地铁" as map layers/tools, not search results. Toggling them changes presentation and can obscure the active side panel; re-read the selected POI or route after changing a layer.
+- Public place search and route planning do not require sign-in. If "短信登录" or "二维码登录" appears, close or defer it for read-only work; ask the user to authenticate only for an explicitly requested account feature such as favorites or synchronized history.
+- Follow actual share/navigation links on m.amap.com or uri.amap.com and preserve their provided coordinates, POI IDs, names, and route mode. Do not synthesize a destination from rounded visible coordinates, and record the final place/route after the handoff.`,
+  },
+  {
     name: 'google-flights',
     category: 'general',
     matches: (url) => /^https?:\/\/(www\.)?google\.[a-z.]+\/(travel\/)?flights/.test(url),

--- a/test/run.js
+++ b/test/run.js
@@ -2576,6 +2576,37 @@ test('matches apple store pages', () => {
   assert.equal(getActiveAdapter('https://secure.store.apple.com/shop/checkout')?.name, 'apple');
 });
 
+test('matches Amap consumer map surfaces without hijacking the developer platform', () => {
+  const trustedUrls = [
+    'https://amap.com/',
+    'https://www.amap.com/',
+    'https://www.amap.com/search?query=%E8%99%B9%E6%A1%A5%E7%81%AB%E8%BD%A6%E7%AB%99&city=310000',
+    'https://www.amap.com/dir?from%5Bname%5D=%E4%BA%BA%E6%B0%91%E5%B9%BF%E5%9C%BA',
+    'https://m.amap.com/navi/?dest=121.3,31.2',
+    'https://uri.amap.com/marker?position=121.3,31.2',
+  ];
+  for (const url of trustedUrls) {
+    assert.equal(getActiveAdapter(url)?.name, 'amap');
+    assert.equal(getActiveAdapterFx(url)?.name, 'amap');
+  }
+  for (const url of ['https://lbs.amap.com/', 'https://amap.com.phishing.example/', 'https://example.com/?next=https://www.amap.com/']) {
+    assert.notEqual(getActiveAdapter(url)?.name, 'amap');
+    assert.notEqual(getActiveAdapterFx(url)?.name, 'amap');
+  }
+  const adapter = getActiveAdapter('https://www.amap.com/search?query=x');
+  const firefoxAdapter = getActiveAdapterFx('https://m.amap.com/navi/');
+  assert.match(adapter?.notes || '', /2026-08/);
+  assert.match(adapter?.notes || '', /搜索位置、公交站、地铁站/);
+  assert.match(adapter?.notes || '', /canvas|画布/i);
+  assert.match(adapter?.notes || '', /city=.*城市/s);
+  assert.match(adapter?.notes || '', /驾车.*公交.*步行.*骑行/s);
+  assert.match(adapter?.notes || '', /卫星.*路况.*测距.*地铁/s);
+  assert.match(adapter?.notes || '', /短信登录.*二维码登录/s);
+  assert.match(adapter?.notes || '', /do not require sign-in/i);
+  assert.match(adapter?.notes || '', /m\.amap\.com.*uri\.amap\.com/s);
+  assert.equal(firefoxAdapter?.notes, adapter?.notes);
+});
+
 test('matches China Railway 12306 surfaces and includes ticket and waitlist guidance', () => {
   const trustedUrls = [
     'https://12306.cn/',


### PR DESCRIPTION
## Summary

Adds a mirrored Amap / 高德地图 adapter for Chrome and Firefox.

Without this adapter, the agent can try to read a canvas map as DOM text, silently use the wrong geolocated city/start point, or confuse map layers with place and route results.

- Cover Amap desktop, mobile, and URI consumer surfaces while excluding the `lbs.amap.com` developer platform.
- Read place and route facts from the side panel instead of map pixels.
- Verify city, POI, endpoints, travel mode, traffic-sensitive timing, route constraints, and shared-link coordinates.
- Keep public search/routing usable without forcing account login.
- Add host-scope, phishing-lookalike, visible-label, canvas, geolocation, route-mode, login, and Chrome/Firefox parity tests.

## Validation

- Targeted Amap production and guidance assertions: passed.
- Anonymous Chrome/Playwright read-only check: home returned HTTP 200; filling `搜索位置、公交站、地铁站` produced `/search?query=...&city=...`; visible controls included `卫星`, `路况`, `测距`, `地铁`, `短信登录`, and `二维码登录`.
- `node test/run.js`: 1404/1405 passed; the single failure predates this branch (`package.json` 26.0.4 versus `CHANGELOG.md` 26.0.0).
- `node test/security/injection-corpus.mjs`: 60/60 passed.
- `git diff --check`: passed.

## Compatibility and risks

Prompt-only and mirrored across browser builds. No location permission, sign-in, favorite, or external navigation action was performed.
