### PR TITLE
agent: add adapter for BOSS Zhipin

### DIFF
--- a/src/chrome/src/agent/adapters.js
+++ b/src/chrome/src/agent/adapters.js
@@ -16768,6 +16768,22 @@ const ADAPTERS = [
 
   // ─── Job Portals ──────────────────────────────────────────────────────
   {
+    name: 'boss-zhipin',
+    category: 'general',
+    matches: (url) => /^https?:\/\/(?:(?:www|m)\.)?zhipin\.com\//.test(url),
+    notes: `
+- Observed 2026-08 on the BOSS直聘 desktop site; the same guidance covers public m.zhipin.com job listings. The main search field is labeled "搜索职位、公司".
+- Search results use /web/geek/jobs?query=...&city=...&industry=&position=. Verify the visible 城市 before comparing results: the numeric city= value may come from a default or geolocation and can silently be wrong.
+- Read each card's job title, K-denominated salary range, suffix such as "·15薪", district, experience, education, company, financing, and company size. "·15薪" means 15 salary months, not the monthly amount; do not rank on the headline salary alone.
+- Open the job detail and verify the full description, location, company, and recruiter/BOSS identity and active-time indicators. Check for duplicate or agency listings and any mismatch with the result card before recommending it.
+- "立即沟通" / "开聊" starts a direct conversation; it is not an application or an offer. Treat starting the chat and sending its first message as an external social action, and require the user's explicit request and reviewed message.
+- Sending or attaching a resume, choosing "交换联系方式", and accepting an 面试邀请 are separate consequential actions that can expose the registered phone number or 微信. Ask for explicit confirmation immediately before each action; permission to find jobs does not authorize any of them.
+- Resume visibility controls are under "通知与隐私设置" and include "对BOSS隐藏简历" and "屏蔽公司". Report these options when relevant, but never change privacy or blocking settings without the user's request.
+- Login may require SMS, QR-code scanning, or the "安全验证" route at /web/passport/zp/verify.html. Pause for the user. A search route can also end at about:blank or show no content after an initial HTTP 200; treat that as an access/anti-automation restriction, not "no jobs", avoid rapid retries, and use a public /zhaopin/... listing or request user verification.
+- Verify completion from the resulting state: a sent chat must be visible in the message thread, a resume must show a sent/delivered status if one was requested, and an interview invitation must show its explicit status. Opening a card or clicking into a conversation is not proof of application, delivery, or an offer.
+    `,
+  },
+  {
     name: 'greenhouse',
     category: 'general',
     // Greenhouse hosts ATS for many employers under boards.greenhouse.io

--- a/src/firefox/src/agent/adapters.js
+++ b/src/firefox/src/agent/adapters.js
@@ -16766,6 +16766,22 @@ const ADAPTERS = [
 
   // ─── Job Portals ──────────────────────────────────────────────────────
   {
+    name: 'boss-zhipin',
+    category: 'general',
+    matches: (url) => /^https?:\/\/(?:(?:www|m)\.)?zhipin\.com\//.test(url),
+    notes: `
+- Observed 2026-08 on the BOSS直聘 desktop site; the same guidance covers public m.zhipin.com job listings. The main search field is labeled "搜索职位、公司".
+- Search results use /web/geek/jobs?query=...&city=...&industry=&position=. Verify the visible 城市 before comparing results: the numeric city= value may come from a default or geolocation and can silently be wrong.
+- Read each card's job title, K-denominated salary range, suffix such as "·15薪", district, experience, education, company, financing, and company size. "·15薪" means 15 salary months, not the monthly amount; do not rank on the headline salary alone.
+- Open the job detail and verify the full description, location, company, and recruiter/BOSS identity and active-time indicators. Check for duplicate or agency listings and any mismatch with the result card before recommending it.
+- "立即沟通" / "开聊" starts a direct conversation; it is not an application or an offer. Treat starting the chat and sending its first message as an external social action, and require the user's explicit request and reviewed message.
+- Sending or attaching a resume, choosing "交换联系方式", and accepting an 面试邀请 are separate consequential actions that can expose the registered phone number or 微信. Ask for explicit confirmation immediately before each action; permission to find jobs does not authorize any of them.
+- Resume visibility controls are under "通知与隐私设置" and include "对BOSS隐藏简历" and "屏蔽公司". Report these options when relevant, but never change privacy or blocking settings without the user's request.
+- Login may require SMS, QR-code scanning, or the "安全验证" route at /web/passport/zp/verify.html. Pause for the user. A search route can also end at about:blank or show no content after an initial HTTP 200; treat that as an access/anti-automation restriction, not "no jobs", avoid rapid retries, and use a public /zhaopin/... listing or request user verification.
+- Verify completion from the resulting state: a sent chat must be visible in the message thread, a resume must show a sent/delivered status if one was requested, and an interview invitation must show its explicit status. Opening a card or clicking into a conversation is not proof of application, delivery, or an offer.
+    `,
+  },
+  {
     name: 'greenhouse',
     category: 'general',
     // Greenhouse hosts ATS for many employers under boards.greenhouse.io

--- a/test/run.js
+++ b/test/run.js
@@ -2418,6 +2418,52 @@ test('matches Zhihu reading and creation surfaces with login and publication gui
   assert.equal(firefoxAdapter?.notes, adapter?.notes);
 });
 
+test('matches BOSS Zhipin job surfaces with safe search and communication guidance', () => {
+  const trustedUrls = [
+    'https://zhipin.com/',
+    'https://www.zhipin.com/',
+    'https://www.zhipin.com/web/geek/jobs?query=webbrain&city=101020100',
+    'https://www.zhipin.com/job_detail/example.html',
+    'https://www.zhipin.com/web/geek/chat',
+    'https://www.zhipin.com/web/passport/zp/verify.html?callbackUrl=https%3A%2F%2Fwww.zhipin.com%2F',
+    'https://www.zhipin.com/zhaopin/example/',
+    'https://m.zhipin.com/zhaopin/example/',
+  ];
+  for (const url of trustedUrls) {
+    assert.equal(getActiveAdapter(url)?.name, 'boss-zhipin');
+    assert.equal(getActiveAdapterFx(url)?.name, 'boss-zhipin');
+  }
+
+  const rejectedUrls = [
+    'https://ir.zhipin.com/',
+    'https://static.zhipin.com/',
+    'https://zhipin.com.phishing.example/web/geek/jobs',
+    'https://www.zhipin.com@phishing.example/web/geek/jobs',
+    'https://example.com/?next=https://www.zhipin.com/web/geek/jobs',
+  ];
+  for (const url of rejectedUrls) {
+    assert.notEqual(getActiveAdapter(url)?.name, 'boss-zhipin');
+    assert.notEqual(getActiveAdapterFx(url)?.name, 'boss-zhipin');
+  }
+
+  const adapter = getActiveAdapter('https://www.zhipin.com/web/geek/jobs?query=webbrain&city=101020100');
+  const firefoxAdapter = getActiveAdapterFx('https://m.zhipin.com/zhaopin/example/');
+  assert.match(adapter?.notes || '', /2026-08/);
+  assert.match(adapter?.notes || '', /搜索职位、公司/);
+  assert.match(adapter?.notes || '', /city=.*城市/s);
+  assert.match(adapter?.notes || '', /K-denominated.*·15薪/s);
+  assert.match(adapter?.notes || '', /experience.*education.*company.*financing.*company size/s);
+  assert.match(adapter?.notes || '', /立即沟通.*开聊.*not an application or an offer/s);
+  assert.match(adapter?.notes || '', /交换联系方式.*面试邀请.*phone number.*微信/s);
+  assert.match(adapter?.notes || '', /explicit confirmation/);
+  assert.match(adapter?.notes || '', /通知与隐私设置.*对BOSS隐藏简历.*屏蔽公司/s);
+  assert.match(adapter?.notes || '', /安全验证.*\/web\/passport\/zp\/verify\.html/s);
+  assert.match(adapter?.notes || '', /about:blank.*HTTP 200.*access\/anti-automation restriction/s);
+  assert.match(adapter?.notes || '', /sent\/delivered status.*explicit status/s);
+  assert.equal((adapter?.notes || '').trim().split('\n').filter((line) => line.startsWith('- ')).length, 9);
+  assert.equal(firefoxAdapter?.notes, adapter?.notes);
+});
+
 test('matches Bilibili surfaces with mirrored regional guidance', () => {
   const urls = [
     'https://www.bilibili.com/video/BV1FD4y147uH/?p=2',


### PR DESCRIPTION
## Summary

Adds a mirrored BOSS Zhipin / BOSS直聘 adapter for Chrome and Firefox.

Without this adapter, the agent can silently search the wrong geolocated city, misread `·15薪` as a monthly amount, or treat opening a chat as a completed application.

- Cover the consumer desktop and mobile job surfaces while excluding IR and static subdomains.
- Verify the visible city, full job details, company/recruiter identity, and salary-period semantics before comparing roles.
- Separate read-only job research from direct chat, resume delivery, contact exchange, and interview-invitation actions.
- Document resume visibility and company-blocking controls without changing them automatically.
- Fail closed on SMS, QR, captcha, `安全验证`, and blank-page anti-automation states.
- Add trusted-host, lookalike-host, visible-label, action-boundary, completion-state, and Chrome/Firefox parity tests.

## Validation

- Test-first adapter assertion: failed before implementation, then passed.
- Targeted BOSS Zhipin production and guidance assertions: passed.
- Anonymous Chrome/Playwright read-only check: the home request returned HTTP 200 and redirected to `/web/passport/zp/verify.html`; the title was `安全验证 - BOSS直聘`, and the final URL selected the `boss-zhipin` adapter.
- `node test/run.js`: 1404/1405 passed; the single failure predates this branch (`package.json` 26.0.4 versus `CHANGELOG.md` 26.0.0).
- `node test/security/injection-corpus.mjs`: 60/60 passed.
- `git diff --check`: passed.

## Compatibility and risks

Prompt-only and mirrored across browser builds. Authenticated chat, resume, contact-exchange, and interview flows could not be exercised anonymously, so the guidance requires explicit confirmation and observable completion state for each action. No login, message, resume, privacy-setting, or application action was performed.
