### PR TITLE
agent: add adapter for 58.com

### DIFF
--- a/src/chrome/src/agent/adapters.js
+++ b/src/chrome/src/agent/adapters.js
@@ -16478,6 +16478,23 @@ const ADAPTERS = [
 - Treat "结算" as order review; "提交订单" creates an order and can leave it in "待付款" even before payment completes. Re-read items, quantities, address, delivery, invoice, discounts, and final total, and do not click "提交订单" without the user's explicit confirmation. Report completion only from the resulting "订单编号" and payment/order status.`,
   },
 
+  // ─── Regional — 58.com (China) ─────────────────────────────
+  {
+    name: '58-com',
+    category: 'general',
+    matches: (url) => /^https?:\/\/(?!(?:about|biz|down|e|static|wbactivity)\.)(?:[a-z0-9-]+\.)?58\.com\//.test(url),
+    notes: `
+- As observed 2026-08, 58同城 is a Chinese CLASSIFIEDS platform spanning 招聘, 房产, 二手车, 二手市场, and 本地服务, not one uniform store. www.58.com and m.58.com can redirect by geolocation to a city host such as sh.58.com; verify the visible city or use "切换城市" before searching or comparing.
+- Category routes and filters differ. For rentals, /zufang/ exposes 区域, 地铁线路, 租金, 厅室, 方式, and "只看有图"; other entry points include /job.shtml, /ershoufang/, /ershouche/, /sale.shtml, and /huangye/. Use the visible category controls instead of guessing one site's filter shape for another.
+- Listings are posted by users, agents, or businesses. Read the exact price unit, location, date, description, poster identity, and category-specific facts; labels such as "来自经纪人", "安选", "实拍真房", or "7日内实拍验真" are distinct signals, not a blanket guarantee. Treat "广告" as paid placement and do not rank it as organic relevance.
+- Opening a listing is read-only; revealing a phone number, starting chat, calling, booking a viewing/service, applying for a job, or sending a resume is a separate external action. Require the user's explicit request before contact, never expose a private phone number in the response unnecessarily, and verify the intended listing and recipient first.
+- The platform's own agreement says listing information is user-published and transactions require independent judgment. Preserve the listing URL, screenshots, chat, receipts, and other evidence; do not send deposits, recruitment fees, verification codes, ID scans, or payment through seller-supplied external links. Use an on-platform protected-payment path only when the exact listing visibly offers it and review the full payable total.
+- "免费发布信息" opens post.58.com/2/ and first asks for a precise category. Before the final publish action, review city, category, title, facts, price, contact visibility, images, and any fees with the user; publishing, editing, deleting, promoting, or refreshing a listing each requires explicit authorization.
+- Report a post as complete only after "我的发布" shows the new listing and its actual status or public URL. "修改/删除信息" can route to help.58.com and offer account login or "手机短信删除"; do not claim deletion from opening that help page or submitting a verification request.
+- Login can require SMS/captcha. Rapid list access may redirect an initial HTTP 200 response to callback.58.com/antibot/verifycode with "访问过于频繁", "请在五分钟内完成验证", and "点击按钮进行验证". Stop for the user and do not retry or bypass it; the wall is not evidence that no listings exist.
+    `,
+  },
+
   // ─── Regional — Allegro (Poland) ─────────────────────────────────────
   {
     name: 'allegro',

--- a/src/chrome/src/agent/adapters.js
+++ b/src/chrome/src/agent/adapters.js
@@ -16520,7 +16520,7 @@ const ADAPTERS = [
 - The platform's own agreement says listing information is user-published and transactions require independent judgment. Preserve the listing URL, screenshots, chat, receipts, and other evidence; do not send deposits, recruitment fees, verification codes, ID scans, or payment through seller-supplied external links. Use an on-platform protected-payment path only when the exact listing visibly offers it and review the full payable total.
 - "免费发布信息" opens post.58.com/2/ and first asks for a precise category. Before the final publish action, review city, category, title, facts, price, contact visibility, images, and any fees with the user; publishing, editing, deleting, promoting, or refreshing a listing each requires explicit authorization.
 - Report a post as complete only after "我的发布" shows the new listing and its actual status or public URL. "修改/删除信息" can route to help.58.com and offer account login or "手机短信删除"; do not claim deletion from opening that help page or submitting a verification request.
-- Login can require SMS/captcha. Rapid list access may redirect an initial HTTP 200 response to callback.58.com/antibot/verifycode with "访问过于频繁", "请在五分钟内完成验证", and "点击按钮进行验证". Stop for the user and do not retry or bypass it; the wall is not evidence that no listings exist.
+- Login can require SMS or CAPTCHA. If either challenge appears, stop and require the user to complete it manually before continuing; do not request, enter, or relay an SMS code, and do not solve or bypass a CAPTCHA. Rapid list access may redirect an initial HTTP 200 response to callback.58.com/antibot/verifycode with "访问过于频繁", "请在五分钟内完成验证", and "点击按钮进行验证". The wall is not evidence that no listings exist, so do not retry or bypass it.
     `,
   },
 

--- a/src/firefox/src/agent/adapters.js
+++ b/src/firefox/src/agent/adapters.js
@@ -16518,7 +16518,7 @@ const ADAPTERS = [
 - The platform's own agreement says listing information is user-published and transactions require independent judgment. Preserve the listing URL, screenshots, chat, receipts, and other evidence; do not send deposits, recruitment fees, verification codes, ID scans, or payment through seller-supplied external links. Use an on-platform protected-payment path only when the exact listing visibly offers it and review the full payable total.
 - "免费发布信息" opens post.58.com/2/ and first asks for a precise category. Before the final publish action, review city, category, title, facts, price, contact visibility, images, and any fees with the user; publishing, editing, deleting, promoting, or refreshing a listing each requires explicit authorization.
 - Report a post as complete only after "我的发布" shows the new listing and its actual status or public URL. "修改/删除信息" can route to help.58.com and offer account login or "手机短信删除"; do not claim deletion from opening that help page or submitting a verification request.
-- Login can require SMS/captcha. Rapid list access may redirect an initial HTTP 200 response to callback.58.com/antibot/verifycode with "访问过于频繁", "请在五分钟内完成验证", and "点击按钮进行验证". Stop for the user and do not retry or bypass it; the wall is not evidence that no listings exist.
+- Login can require SMS or CAPTCHA. If either challenge appears, stop and require the user to complete it manually before continuing; do not request, enter, or relay an SMS code, and do not solve or bypass a CAPTCHA. Rapid list access may redirect an initial HTTP 200 response to callback.58.com/antibot/verifycode with "访问过于频繁", "请在五分钟内完成验证", and "点击按钮进行验证". The wall is not evidence that no listings exist, so do not retry or bypass it.
     `,
   },
 

--- a/src/firefox/src/agent/adapters.js
+++ b/src/firefox/src/agent/adapters.js
@@ -16476,6 +16476,23 @@ const ADAPTERS = [
 - Treat "结算" as order review; "提交订单" creates an order and can leave it in "待付款" even before payment completes. Re-read items, quantities, address, delivery, invoice, discounts, and final total, and do not click "提交订单" without the user's explicit confirmation. Report completion only from the resulting "订单编号" and payment/order status.`,
   },
 
+  // ─── Regional — 58.com (China) ─────────────────────────────
+  {
+    name: '58-com',
+    category: 'general',
+    matches: (url) => /^https?:\/\/(?!(?:about|biz|down|e|static|wbactivity)\.)(?:[a-z0-9-]+\.)?58\.com\//.test(url),
+    notes: `
+- As observed 2026-08, 58同城 is a Chinese CLASSIFIEDS platform spanning 招聘, 房产, 二手车, 二手市场, and 本地服务, not one uniform store. www.58.com and m.58.com can redirect by geolocation to a city host such as sh.58.com; verify the visible city or use "切换城市" before searching or comparing.
+- Category routes and filters differ. For rentals, /zufang/ exposes 区域, 地铁线路, 租金, 厅室, 方式, and "只看有图"; other entry points include /job.shtml, /ershoufang/, /ershouche/, /sale.shtml, and /huangye/. Use the visible category controls instead of guessing one site's filter shape for another.
+- Listings are posted by users, agents, or businesses. Read the exact price unit, location, date, description, poster identity, and category-specific facts; labels such as "来自经纪人", "安选", "实拍真房", or "7日内实拍验真" are distinct signals, not a blanket guarantee. Treat "广告" as paid placement and do not rank it as organic relevance.
+- Opening a listing is read-only; revealing a phone number, starting chat, calling, booking a viewing/service, applying for a job, or sending a resume is a separate external action. Require the user's explicit request before contact, never expose a private phone number in the response unnecessarily, and verify the intended listing and recipient first.
+- The platform's own agreement says listing information is user-published and transactions require independent judgment. Preserve the listing URL, screenshots, chat, receipts, and other evidence; do not send deposits, recruitment fees, verification codes, ID scans, or payment through seller-supplied external links. Use an on-platform protected-payment path only when the exact listing visibly offers it and review the full payable total.
+- "免费发布信息" opens post.58.com/2/ and first asks for a precise category. Before the final publish action, review city, category, title, facts, price, contact visibility, images, and any fees with the user; publishing, editing, deleting, promoting, or refreshing a listing each requires explicit authorization.
+- Report a post as complete only after "我的发布" shows the new listing and its actual status or public URL. "修改/删除信息" can route to help.58.com and offer account login or "手机短信删除"; do not claim deletion from opening that help page or submitting a verification request.
+- Login can require SMS/captcha. Rapid list access may redirect an initial HTTP 200 response to callback.58.com/antibot/verifycode with "访问过于频繁", "请在五分钟内完成验证", and "点击按钮进行验证". Stop for the user and do not retry or bypass it; the wall is not evidence that no listings exist.
+    `,
+  },
+
   // ─── Regional — Allegro (Poland) ─────────────────────────────────────
   {
     name: 'allegro',

--- a/test/run.js
+++ b/test/run.js
@@ -2919,6 +2919,72 @@ test('matches Taobao shopping surfaces and includes Chinese marketplace guidance
   assert.equal(firefoxAdapter?.notes, adapter?.notes);
 });
 
+test('matches 58.com city and service surfaces with safe classifieds guidance', () => {
+  const trustedUrls = [
+    'https://58.com/',
+    'https://www.58.com/',
+    'https://m.58.com/',
+    'https://wap.58.com/wap.html',
+    'https://sh.58.com/',
+    'https://szkunshan.58.com/zufang/',
+    'https://sh.58.com/job.shtml',
+    'https://sh.58.com/zufang/',
+    'https://sh.58.com/ershoufang/',
+    'https://sh.58.com/ershouche/',
+    'https://sh.58.com/sale.shtml',
+    'https://sh.58.com/huangye/',
+    'https://passport.58.com/login/',
+    'https://my.58.com/index',
+    'https://vip.58.com/vcenter/myinfo/',
+    'https://employer.58.com/',
+    'https://post.58.com/2/',
+    'https://help.58.com/maoyonginfo/index/',
+    'https://helps.58.com/base/home',
+    'https://fanqizha.58.com/',
+    'https://weiquan.58.com/home',
+    'https://callback.58.com/antibot/verifycode?url=https%3A%2F%2Fsh.58.com%2Fjob.shtml',
+    'https://info5.58.com/sh/ershouche/',
+  ];
+  for (const url of trustedUrls) {
+    assert.equal(getActiveAdapter(url)?.name, '58-com');
+    assert.equal(getActiveAdapterFx(url)?.name, '58-com');
+  }
+
+  const rejectedUrls = [
+    'https://about.58.com/',
+    'https://static.58.com/ui7/help/',
+    'https://down.58.com/',
+    'https://biz.58.com/',
+    'https://e.58.com/',
+    'https://wbactivity.58.com/pc/adIndex',
+    'https://58.com.phishing.example/zufang/',
+    'https://sh.58.com@phishing.example/zufang/',
+    'https://example.com/?next=https://sh.58.com/zufang/',
+  ];
+  for (const url of rejectedUrls) {
+    assert.notEqual(getActiveAdapter(url)?.name, '58-com');
+    assert.notEqual(getActiveAdapterFx(url)?.name, '58-com');
+  }
+
+  const adapter = getActiveAdapter('https://sh.58.com/zufang/');
+  const firefoxAdapter = getActiveAdapterFx('https://post.58.com/2/');
+  assert.match(adapter?.notes || '', /2026-08/);
+  assert.match(adapter?.notes || '', /CLASSIFIEDS/);
+  assert.match(adapter?.notes || '', /www\.58\.com.*m\.58\.com.*sh\.58\.com.*切换城市/s);
+  assert.match(adapter?.notes || '', /招聘.*房产.*二手车.*二手市场.*本地服务/s);
+  assert.match(adapter?.notes || '', /\/zufang\/.*区域.*地铁线路.*租金.*厅室.*方式.*只看有图/s);
+  assert.match(adapter?.notes || '', /来自经纪人.*安选.*实拍真房.*7日内实拍验真.*广告/s);
+  assert.match(adapter?.notes || '', /revealing a phone number.*sending a resume.*explicit request/s);
+  assert.match(adapter?.notes || '', /deposits.*recruitment fees.*verification codes.*ID scans.*external links/s);
+  assert.match(adapter?.notes || '', /免费发布信息.*post\.58\.com\/2\//s);
+  assert.match(adapter?.notes || '', /publishing.*editing.*deleting.*promoting.*refreshing.*explicit authorization/s);
+  assert.match(adapter?.notes || '', /我的发布.*actual status or public URL/s);
+  assert.match(adapter?.notes || '', /修改\/删除信息.*help\.58\.com.*手机短信删除/s);
+  assert.match(adapter?.notes || '', /HTTP 200.*callback\.58\.com\/antibot\/verifycode.*访问过于频繁.*请在五分钟内完成验证.*点击按钮进行验证/s);
+  assert.equal((adapter?.notes || '').trim().split('\n').filter((line) => line.startsWith('- ')).length, 8);
+  assert.equal(firefoxAdapter?.notes, adapter?.notes);
+});
+
 test('matches Allegro.pl shopping surfaces and includes Polish marketplace guidance', () => {
   const trustedUrls = [
     'https://allegro.pl/',

--- a/test/run.js
+++ b/test/run.js
@@ -3058,6 +3058,7 @@ test('matches 58.com city and service surfaces with safe classifieds guidance', 
   assert.match(adapter?.notes || '', /publishing.*editing.*deleting.*promoting.*refreshing.*explicit authorization/s);
   assert.match(adapter?.notes || '', /我的发布.*actual status or public URL/s);
   assert.match(adapter?.notes || '', /修改\/删除信息.*help\.58\.com.*手机短信删除/s);
+  assert.match(adapter?.notes || '', /SMS or CAPTCHA.*stop.*user.*complete it manually.*do not request, enter, or relay an SMS code.*do not solve or bypass a CAPTCHA/s);
   assert.match(adapter?.notes || '', /HTTP 200.*callback\.58\.com\/antibot\/verifycode.*访问过于频繁.*请在五分钟内完成验证.*点击按钮进行验证/s);
   assert.equal((adapter?.notes || '').trim().split('\n').filter((line) => line.startsWith('- ')).length, 8);
   assert.equal(firefoxAdapter?.notes, adapter?.notes);


### PR DESCRIPTION
## Summary

Adds a mirrored 58.com / 58同城 adapter for Chrome and Firefox.

Without this adapter, the agent can silently use a geolocated city, assume every category has the same filters, treat paid or user-posted information as verified, or mistake opening a publish/delete flow for completion.

- Cover city, listing, login, account, publish, help, support, and anti-bot surfaces while excluding corporate, download, static, and advertising subdomains.
- Distinguish recruitment, property, vehicle, second-hand marketplace, and local-service workflows.
- Verify city, price units, location, poster identity, category-specific facts, and verification/advertising labels.
- Separate read-only listing research from contact, job application, resume delivery, booking, publishing, editing, deletion, and promotion actions.
- Preserve evidence and keep payment/contact inside a visibly supported platform path.
- Fail closed on SMS, captcha, and frequency-verification redirects.
- Add host-scope, lookalike-host, category-label, action-boundary, completion-state, and Chrome/Firefox parity tests.

## Validation

- Test-first adapter assertion: failed before implementation, then passed.
- Targeted 58.com production and guidance assertions: passed.
- Anonymous Chrome/Playwright read-only checks:
  - `www.58.com` returned HTTP 200 and redirected to the geolocated `cs.58.com` city page.
  - Recruitment and rental list requests returned HTTP 200 before redirecting to `callback.58.com/antibot/verifycode` with the `请输入验证码` title.
  - `post.58.com/2/` returned HTTP 200 with the `免费发布信息` category page.
  - Every final URL selected the `58-com` adapter.
- `node test/run.js`: 1404/1405 passed; the single failure predates this branch (`package.json` 26.0.4 versus `CHANGELOG.md` 26.0.0).
- `node test/security/injection-corpus.mjs`: 60/60 passed.
- `git diff --check`: passed.

## Compatibility and risks

Prompt-only and mirrored across browser builds. Authenticated contact, application, publishing, editing, deletion, and payment paths were not exercised; each is guarded by explicit authorization and observable completion-state guidance. No login, contact, application, publish, delete, verification, or payment action was performed.
