### PR TITLE
agent: add adapter for Qunar

### DIFF
--- a/src/chrome/src/agent/adapters.js
+++ b/src/chrome/src/agent/adapters.js
@@ -16294,6 +16294,21 @@ const ADAPTERS = [
 - Report success only with "订单号" plus "预订成功" or the applicable "出票成功" status. Pending confirmation, a payment redirect, or an itinerary held for payment is incomplete.`,
   },
   {
+    name: 'qunar',
+    category: 'general',
+    matches: (url) => /^https?:\/\/(?!(?:source|yun|adqunar|security)\.)(?:[a-z0-9-]+\.)*qunar\.com\//.test(url),
+    notes: `
+- Observed 2026-08: the desktop business surfaces span flight.qunar.com, hotel.qunar.com, train.qunar.com, piao.qunar.com, dujia.qunar.com, and other nested qunar.com hosts. www.qunar.com may render only its footer while a business page remains usable; use the requested product entry instead of treating that shell as an empty inventory.
+- Start by selecting 机票, 酒店, 火车票, 门票, or 度假. The flight form distinguishes 单程, 往返, and 多程 and labels origin/destination as "从" / "到"; verify cities or airports, local dates, travelers, and every leg before searching.
+- Qunar is a comparison/booking platform with products supplied by airlines, agents, hotels, or other third parties. Read the supplier, information update time, exact itinerary or room/product, taxes and fees, baggage/inclusions, and refund/change/cancellation terms; a headline or "起" price is not the final payable total.
+- A flight result can expose several supplier offers for one itinerary. "预订" may hand off to a supplier site or a Qunar-supported order page; re-read the host, supplier, selected offer, currency, and terms after the transition, and preserve the supplier name and order number for after-sales support.
+- For hotels verify 入住/离店, guests, room and bed type, meals, cancellation deadline, prepayment/deposit, and taxes. For train, ticket, and holiday products verify the exact date, traveler eligibility, inventory, inclusions, exclusions, and fulfillment provider rather than transferring flight assumptions to them.
+- Searching and opening an offer are read-only. Creating an order, submitting traveler/contact identity, accepting terms, and paying are separate consequential actions; ask for explicit confirmation immediately before the control that creates/submits the order and again before payment when it is a distinct step.
+- Login routes through user.qunar.com and may require the user's password, SMS, QR code, or another verification step. Pause for the user and never invent traveler identity, document, phone, or membership details.
+- A search result, supplier redirect, payment page, or unpaid order is not a completed booking. Report success only from the relevant 查看订单 / order page with an order number and the explicit product status; for flights distinguish pending payment, paid, issuing, 出票成功, cancelled, and refund/change states.
+    `,
+  },
+  {
     name: 'google-maps',
     category: 'general',
     matches: (url) => /^https?:\/\/(www\.)?google\.[a-z.]+\/maps/.test(url) || /^https?:\/\/maps\.google\.[a-z.]+\//.test(url),

--- a/src/firefox/src/agent/adapters.js
+++ b/src/firefox/src/agent/adapters.js
@@ -16292,6 +16292,21 @@ const ADAPTERS = [
 - Report success only with "订单号" plus "预订成功" or the applicable "出票成功" status. Pending confirmation, a payment redirect, or an itinerary held for payment is incomplete.`,
   },
   {
+    name: 'qunar',
+    category: 'general',
+    matches: (url) => /^https?:\/\/(?!(?:source|yun|adqunar|security)\.)(?:[a-z0-9-]+\.)*qunar\.com\//.test(url),
+    notes: `
+- Observed 2026-08: the desktop business surfaces span flight.qunar.com, hotel.qunar.com, train.qunar.com, piao.qunar.com, dujia.qunar.com, and other nested qunar.com hosts. www.qunar.com may render only its footer while a business page remains usable; use the requested product entry instead of treating that shell as an empty inventory.
+- Start by selecting 机票, 酒店, 火车票, 门票, or 度假. The flight form distinguishes 单程, 往返, and 多程 and labels origin/destination as "从" / "到"; verify cities or airports, local dates, travelers, and every leg before searching.
+- Qunar is a comparison/booking platform with products supplied by airlines, agents, hotels, or other third parties. Read the supplier, information update time, exact itinerary or room/product, taxes and fees, baggage/inclusions, and refund/change/cancellation terms; a headline or "起" price is not the final payable total.
+- A flight result can expose several supplier offers for one itinerary. "预订" may hand off to a supplier site or a Qunar-supported order page; re-read the host, supplier, selected offer, currency, and terms after the transition, and preserve the supplier name and order number for after-sales support.
+- For hotels verify 入住/离店, guests, room and bed type, meals, cancellation deadline, prepayment/deposit, and taxes. For train, ticket, and holiday products verify the exact date, traveler eligibility, inventory, inclusions, exclusions, and fulfillment provider rather than transferring flight assumptions to them.
+- Searching and opening an offer are read-only. Creating an order, submitting traveler/contact identity, accepting terms, and paying are separate consequential actions; ask for explicit confirmation immediately before the control that creates/submits the order and again before payment when it is a distinct step.
+- Login routes through user.qunar.com and may require the user's password, SMS, QR code, or another verification step. Pause for the user and never invent traveler identity, document, phone, or membership details.
+- A search result, supplier redirect, payment page, or unpaid order is not a completed booking. Report success only from the relevant 查看订单 / order page with an order number and the explicit product status; for flights distinguish pending payment, paid, issuing, 出票成功, cancelled, and refund/change states.
+    `,
+  },
+  {
     name: 'google-maps',
     category: 'general',
     matches: (url) => /^https?:\/\/(www\.)?google\.[a-z.]+\/maps/.test(url) || /^https?:\/\/maps\.google\.[a-z.]+\//.test(url),

--- a/test/run.js
+++ b/test/run.js
@@ -2723,6 +2723,42 @@ test('matches Ctrip travel surfaces and includes Chinese booking guidance', () =
   assert.equal(firefoxAdapter?.notes, adapter?.notes);
 });
 
+test('matches Qunar travel surfaces and distinguishes search, supplier, order, and ticket states', () => {
+  const trustedUrls = [
+    'https://qunar.com/', 'https://www.qunar.com/', 'https://flight.qunar.com/',
+    'https://hotel.qunar.com/', 'https://train.qunar.com/', 'https://piao.qunar.com/',
+    'https://dujia.qunar.com/', 'https://fh.dujia.qunar.com/', 'https://diy.dujia.qunar.com/',
+    'https://user.qunar.com/passport/login.jsp', 'https://order.qunar.com/flight/',
+    'https://help.qunar.com/', 'https://m.qunar.com/', 'https://app.qunar.com/',
+  ];
+  for (const url of trustedUrls) {
+    assert.equal(getActiveAdapter(url)?.name, 'qunar');
+    assert.equal(getActiveAdapterFx(url)?.name, 'qunar');
+  }
+  for (const url of [
+    'https://source.qunar.com/file.pdf', 'https://yun.qunar.com/uploads/file.pdf',
+    'https://adqunar.qunar.com/travelnews/', 'https://security.qunar.com/',
+    'https://qunar.com.phishing.example/', 'https://example.com/?next=https://flight.qunar.com/',
+  ]) {
+    assert.notEqual(getActiveAdapter(url)?.name, 'qunar');
+    assert.notEqual(getActiveAdapterFx(url)?.name, 'qunar');
+  }
+  const adapter = getActiveAdapter('https://flight.qunar.com/');
+  const firefoxAdapter = getActiveAdapterFx('https://fh.dujia.qunar.com/');
+  assert.match(adapter?.notes || '', /2026-08/);
+  assert.match(adapter?.notes || '', /www\.qunar\.com.*footer.*business page/s);
+  assert.match(adapter?.notes || '', /机票.*酒店.*火车票.*门票.*度假/s);
+  assert.match(adapter?.notes || '', /单程.*往返.*多程.*"从".*"到"/s);
+  assert.match(adapter?.notes || '', /supplier.*taxes and fees.*baggage.*refund\/change\/cancellation/s);
+  assert.match(adapter?.notes || '', /预订.*supplier site.*order page/s);
+  assert.match(adapter?.notes || '', /入住\/离店.*cancellation deadline.*prepayment\/deposit/s);
+  assert.match(adapter?.notes || '', /explicit confirmation.*before payment/s);
+  assert.match(adapter?.notes || '', /user\.qunar\.com.*password.*SMS.*QR code/s);
+  assert.match(adapter?.notes || '', /查看订单.*order number.*出票成功/s);
+  assert.equal((adapter?.notes || '').trim().split('\n').filter((line) => line.startsWith('- ')).length, 8);
+  assert.equal(firefoxAdapter?.notes, adapter?.notes);
+});
+
 test('matches Coupang shopping surfaces and includes Korean marketplace guidance', () => {
   const trustedUrls = [
     'https://coupang.com/',


### PR DESCRIPTION
## Summary

Adds a mirrored Qunar / 去哪儿 adapter for Chrome and Firefox.

- Cover flight, hotel, train, ticket, holiday, account, order, mobile, and nested product hosts while excluding asset/announcement/security hosts.
- Recover from the current footer-only `www.qunar.com` shell by using the requested business surface.
- Verify itinerary/product, supplier, update time, inclusions, restrictions, and final total.
- Distinguish search, supplier handoff, order creation, payment, and confirmed/issued states.
- Require explicit confirmation for order creation and payment and preserve supplier/order details.
- Add trusted-host, nested-host, lookalike-host, product-state, action-boundary, and browser-parity tests.

## Validation

- Test-first assertion failed before implementation, then passed.
- Anonymous Playwright check: `flight.qunar.com` returned HTTP 200 with current one-way/round-trip inputs, order links, and product navigation; `www.qunar.com` returned HTTP 200 but rendered only its footer.
- Targeted assertions: passed.
- `node test/run.js`: 1404/1405 passed; the sole pre-existing failure is `package.json` 26.0.4 versus `CHANGELOG.md` 26.0.0.
- Security corpus: 60/60 passed.
- `git diff --check`: passed.

## Compatibility and risks

Prompt-only and mirrored across browser builds. No authenticated identity, order, supplier redirect, or payment action was performed; consequential steps require explicit confirmation and final order-status evidence.
