### PR TITLE
agent: add adapter for Dianping

### DIFF
--- a/src/chrome/src/agent/adapters.js
+++ b/src/chrome/src/agent/adapters.js
@@ -16294,6 +16294,21 @@ const ADAPTERS = [
 - Report success only with "订单号" plus "预订成功" or the applicable "出票成功" status. Pending confirmation, a payment redirect, or an itinerary held for payment is incomplete.`,
   },
   {
+    name: 'dianping',
+    category: 'general',
+    matches: (url) => /^https?:\/\/(?:(?:www|m|h5|s)\.)?dianping\.com\//.test(url) || /^https?:\/\/verify\.meituan\.com\//.test(url),
+    notes: `
+- Observed 2026-08: use a city page such as www.dianping.com/shanghai when the bare www.dianping.com page is empty. Verify the visible city via "更换" before using the "搜索商户名、地址、菜名、外卖等" search; city, category, business district, and metro filters materially change results.
+- A shop page should be matched by exact name and branch, address/map location, phone, current 营业时间, category, and price basis. Similar branch names are not interchangeable; confirm the branch before directions, contact, booking, or purchase.
+- Read rating together with review count and recency, category scores such as 口味/环境/服务, 人均 price, and recent detailed reviews. Ratings summarize member feedback; low review counts and old reviews are weaker evidence, and merchant-provided or promoted content is not an independent review.
+- Separate public business facts from user claims. A visible 商户认证 badge confirms merchant identity/credentials submitted for that profile, not every review, price, service outcome, or current opening state; call out conflicting recent evidence instead of resolving it silently.
+- Opening a shop, reading reviews, or comparing offers is read-only. Collecting a coupon, writing a review, favoriting, calling, requesting directions, "预约订座", or contacting the merchant changes account or external state; perform only the action the user explicitly requested.
+- 团购, 优惠券, 买单, 预约, and 预订 are different products. Verify the exact branch, included items, party/date/time, validity and blackout dates, reservation requirement, refund/expiry rules, quantity, and final payable total before creating an order; require explicit confirmation before order submission or payment.
+- Anonymous desktop city pages can work while m.dianping.com redirects after HTTP 200 to verify.meituan.com with "身份核实" and "请向右拖动滑块". Stop for the user; do not drag, retry, bypass, or interpret the wall as no shops. Login, SMS, QR, and app-only prompts likewise require user handling.
+- Report a purchase/reservation complete only from the account order/coupon page with an order number or coupon and explicit paid/confirmed status. A shop page, selected time, submitted request, payment redirect, or "待支付" state is not a confirmed booking or consumed voucher.
+    `,
+  },
+  {
     name: 'google-maps',
     category: 'general',
     matches: (url) => /^https?:\/\/(www\.)?google\.[a-z.]+\/maps/.test(url) || /^https?:\/\/maps\.google\.[a-z.]+\//.test(url),

--- a/src/firefox/src/agent/adapters.js
+++ b/src/firefox/src/agent/adapters.js
@@ -16292,6 +16292,21 @@ const ADAPTERS = [
 - Report success only with "订单号" plus "预订成功" or the applicable "出票成功" status. Pending confirmation, a payment redirect, or an itinerary held for payment is incomplete.`,
   },
   {
+    name: 'dianping',
+    category: 'general',
+    matches: (url) => /^https?:\/\/(?:(?:www|m|h5|s)\.)?dianping\.com\//.test(url) || /^https?:\/\/verify\.meituan\.com\//.test(url),
+    notes: `
+- Observed 2026-08: use a city page such as www.dianping.com/shanghai when the bare www.dianping.com page is empty. Verify the visible city via "更换" before using the "搜索商户名、地址、菜名、外卖等" search; city, category, business district, and metro filters materially change results.
+- A shop page should be matched by exact name and branch, address/map location, phone, current 营业时间, category, and price basis. Similar branch names are not interchangeable; confirm the branch before directions, contact, booking, or purchase.
+- Read rating together with review count and recency, category scores such as 口味/环境/服务, 人均 price, and recent detailed reviews. Ratings summarize member feedback; low review counts and old reviews are weaker evidence, and merchant-provided or promoted content is not an independent review.
+- Separate public business facts from user claims. A visible 商户认证 badge confirms merchant identity/credentials submitted for that profile, not every review, price, service outcome, or current opening state; call out conflicting recent evidence instead of resolving it silently.
+- Opening a shop, reading reviews, or comparing offers is read-only. Collecting a coupon, writing a review, favoriting, calling, requesting directions, "预约订座", or contacting the merchant changes account or external state; perform only the action the user explicitly requested.
+- 团购, 优惠券, 买单, 预约, and 预订 are different products. Verify the exact branch, included items, party/date/time, validity and blackout dates, reservation requirement, refund/expiry rules, quantity, and final payable total before creating an order; require explicit confirmation before order submission or payment.
+- Anonymous desktop city pages can work while m.dianping.com redirects after HTTP 200 to verify.meituan.com with "身份核实" and "请向右拖动滑块". Stop for the user; do not drag, retry, bypass, or interpret the wall as no shops. Login, SMS, QR, and app-only prompts likewise require user handling.
+- Report a purchase/reservation complete only from the account order/coupon page with an order number or coupon and explicit paid/confirmed status. A shop page, selected time, submitted request, payment redirect, or "待支付" state is not a confirmed booking or consumed voucher.
+    `,
+  },
+  {
     name: 'google-maps',
     category: 'general',
     matches: (url) => /^https?:\/\/(www\.)?google\.[a-z.]+\/maps/.test(url) || /^https?:\/\/maps\.google\.[a-z.]+\//.test(url),

--- a/test/run.js
+++ b/test/run.js
@@ -2674,6 +2674,31 @@ test('matches Mercado Libre LATAM storefronts and includes marketplace guidance'
   assert.equal(firefoxAdapter?.notes, adapter?.notes);
 });
 
+test('matches Dianping city, shop, and verification surfaces with local-service guidance', () => {
+  const trusted = ['https://dianping.com/','https://www.dianping.com/shanghai','https://www.dianping.com/search/keyword/1/10_food','https://www.dianping.com/shop/example','https://m.dianping.com/shanghai','https://h5.dianping.com/app/m-static-base-page/dpuserservice.html','https://verify.meituan.com/v2/app/general_page?requestCode=x'];
+  for (const url of trusted) {
+    assert.equal(getActiveAdapter(url)?.name, 'dianping');
+    assert.equal(getActiveAdapterFx(url)?.name, 'dianping');
+  }
+  for (const url of ['https://events.dianping.com/help/11.htm','https://www.dpfile.com/file.pdf','https://dianping.com.phishing.example/shop/x','https://verify.meituan.com.phishing.example/']) {
+    assert.notEqual(getActiveAdapter(url)?.name, 'dianping');
+    assert.notEqual(getActiveAdapterFx(url)?.name, 'dianping');
+  }
+  const adapter = getActiveAdapter('https://www.dianping.com/shanghai');
+  const firefoxAdapter = getActiveAdapterFx('https://verify.meituan.com/v2/app/general_page');
+  assert.match(adapter?.notes || '', /2026-08/);
+  assert.match(adapter?.notes || '', /bare www\.dianping\.com page is empty.*更换.*搜索商户名、地址、菜名、外卖等/s);
+  assert.match(adapter?.notes || '', /exact name and branch.*营业时间/s);
+  assert.match(adapter?.notes || '', /口味\/环境\/服务.*人均/s);
+  assert.match(adapter?.notes || '', /商户认证.*not every review/s);
+  assert.match(adapter?.notes || '', /预约订座.*explicitly requested/s);
+  assert.match(adapter?.notes || '', /团购.*优惠券.*买单.*预约.*预订/s);
+  assert.match(adapter?.notes || '', /HTTP 200.*verify\.meituan\.com.*身份核实.*请向右拖动滑块/s);
+  assert.match(adapter?.notes || '', /待支付.*not a confirmed booking/s);
+  assert.equal((adapter?.notes || '').trim().split('\n').filter(line => line.startsWith('- ')).length, 8);
+  assert.equal(firefoxAdapter?.notes, adapter?.notes);
+});
+
 test('matches Ctrip travel surfaces and includes Chinese booking guidance', () => {
   const trustedUrls = [
     'https://www.ctrip.com/',


### PR DESCRIPTION
## Summary

Adds a mirrored Dianping / 大众点评 adapter for Chrome and Firefox.

- Cover desktop/mobile/city/shop surfaces and the real Meituan verification handoff.
- Verify city, exact branch, business facts, rating evidence, merchant certification, and offer terms.
- Distinguish read-only research from contact, review, coupon, reservation, order, and payment actions.
- Fail closed on slider/login/app walls and require observable order/coupon status.
- Add trusted/rejected host, current-label, action-boundary, verification, and parity tests.

## Validation

- Test-first assertion failed before implementation, then passed.
- Anonymous Playwright: the Shanghai city page returned HTTP 200 with current categories; the bare desktop page was empty; mobile Shanghai returned HTTP 200 then redirected to `verify.meituan.com` with `身份核实` / `请向右拖动滑块`.
- Targeted assertions passed.
- Full suite: 1404/1405 passed; sole pre-existing failure is package 26.0.4 vs changelog 26.0.0.
- Security corpus: 60/60 passed. `git diff --check`: passed.

## Compatibility and risks

Prompt-only and browser-mirrored. No login, slider, contact, review, reservation, order, or payment action was performed.
