### PR TITLE
agent: add adapter for Douyin

### DIFF
--- a/src/chrome/src/agent/adapters.js
+++ b/src/chrome/src/agent/adapters.js
@@ -16670,6 +16670,19 @@ const ADAPTERS = [
 
   // ─── Social (gaps) ────────────────────────────────────────────────────
   {
+    name: 'douyin', category: 'general',
+    matches: (url) => /^https?:\/\/(?:(?:www|live|v)\.)?douyin\.com\//.test(url),
+    notes: `
+- Observed 2026-08: www.douyin.com and /search/video can return HTTP 200 with title "验证码中间页" and no readable body, while live.douyin.com remains readable. Treat that as verification, not empty search results; do not retry or bypass it.
+- Use the visible "搜索你感兴趣的内容" field. Search tabs include 综合, 视频, 用户, and 直播; select the requested type and preserve the query rather than substituting the personalized 推荐 feed.
+- Verify a result by creator name/抖音号, caption, publish date, duration, and stable video/profile URL. Counts may be abbreviated and feeds personalized; do not infer authority, recency, or completeness from rank, likes, or an official-looking name alone.
+- Playback, search, and opening a profile are read-only. 关注, 点赞, 收藏, 评论, 私信, sharing, gifts/recharge, and entering a live interaction change external/account state; perform only the explicitly requested action.
+- "投稿" opens creation. Before publishing, review the exact media, caption, mentions/hashtags, location, cover, visibility, comment/download permissions, and scheduled time; require explicit confirmation for the final publish control.
+- Login or verification can require QR, SMS, captcha, or app handling. Pause for the user. Never send a comment/message, expose contacts, recharge, buy, or send a live gift merely to unlock content.
+- Report publication only when the new work appears on the user's profile with its stable URL and intended visibility; drafts, upload progress, processing/review, or a success toast alone are not public completion.
+    `,
+  },
+  {
     name: 'bilibili',
     category: 'general',
     matches: isBilibiliUrl,

--- a/src/firefox/src/agent/adapters.js
+++ b/src/firefox/src/agent/adapters.js
@@ -16668,6 +16668,19 @@ const ADAPTERS = [
 
   // ─── Social (gaps) ────────────────────────────────────────────────────
   {
+    name: 'douyin', category: 'general',
+    matches: (url) => /^https?:\/\/(?:(?:www|live|v)\.)?douyin\.com\//.test(url),
+    notes: `
+- Observed 2026-08: www.douyin.com and /search/video can return HTTP 200 with title "验证码中间页" and no readable body, while live.douyin.com remains readable. Treat that as verification, not empty search results; do not retry or bypass it.
+- Use the visible "搜索你感兴趣的内容" field. Search tabs include 综合, 视频, 用户, and 直播; select the requested type and preserve the query rather than substituting the personalized 推荐 feed.
+- Verify a result by creator name/抖音号, caption, publish date, duration, and stable video/profile URL. Counts may be abbreviated and feeds personalized; do not infer authority, recency, or completeness from rank, likes, or an official-looking name alone.
+- Playback, search, and opening a profile are read-only. 关注, 点赞, 收藏, 评论, 私信, sharing, gifts/recharge, and entering a live interaction change external/account state; perform only the explicitly requested action.
+- "投稿" opens creation. Before publishing, review the exact media, caption, mentions/hashtags, location, cover, visibility, comment/download permissions, and scheduled time; require explicit confirmation for the final publish control.
+- Login or verification can require QR, SMS, captcha, or app handling. Pause for the user. Never send a comment/message, expose contacts, recharge, buy, or send a live gift merely to unlock content.
+- Report publication only when the new work appears on the user's profile with its stable URL and intended visibility; drafts, upload progress, processing/review, or a success toast alone are not public completion.
+    `,
+  },
+  {
     name: 'bilibili',
     category: 'general',
     matches: isBilibiliUrl,

--- a/test/run.js
+++ b/test/run.js
@@ -2418,6 +2418,18 @@ test('matches Zhihu reading and creation surfaces with login and publication gui
   assert.equal(firefoxAdapter?.notes, adapter?.notes);
 });
 
+test('matches Douyin video and live surfaces with verification and publication guidance', () => {
+  const urls=['https://douyin.com/','https://www.douyin.com/search/video','https://www.douyin.com/video/123','https://www.douyin.com/user/abc','https://live.douyin.com/123','https://v.douyin.com/abc/'];
+  for(const url of urls){assert.equal(getActiveAdapter(url)?.name,'douyin');assert.equal(getActiveAdapterFx(url)?.name,'douyin');}
+  for(const url of ['https://open.douyin.com/','https://douyin.com.phishing.example/']) assert.notEqual(getActiveAdapter(url)?.name,'douyin');
+  const a=getActiveAdapter(urls[1]); const f=getActiveAdapterFx(urls[4]);
+  assert.match(a?.notes||'',/2026-08.*HTTP 200.*验证码中间页.*live\.douyin\.com/s);
+  assert.match(a?.notes||'',/搜索你感兴趣的内容.*综合.*视频.*用户.*直播/s);
+  assert.match(a?.notes||'',/关注.*点赞.*收藏.*评论.*私信/s);
+  assert.match(a?.notes||'',/投稿.*explicit confirmation/s); assert.match(a?.notes||'',/stable URL.*intended visibility/s);
+  assert.equal(f?.notes,a?.notes);
+});
+
 test('matches Bilibili surfaces with mirrored regional guidance', () => {
   const urls = [
     'https://www.bilibili.com/video/BV1FD4y147uH/?p=2',


### PR DESCRIPTION
## Summary

Adds mirrored Douyin guidance for video/search/live surfaces, current HTTP-200 verification pages, safe interaction boundaries, login, and publication completion.

## Validation

- Test-first assertion failed before implementation, then passed.
- Playwright: main/search returned HTTP 200 with `验证码中间页`; live returned HTTP 200 with current navigation/search/login controls.
- Full suite: 1404/1405 (sole pre-existing package/changelog mismatch). Security corpus: 60/60. `git diff --check`: passed.

## Risks

Prompt-only and browser-mirrored. No login, interaction, upload, publication, recharge, purchase, or gift action was performed.
