### PR TITLE
agent: add adapter for Kuaishou

### DIFF
--- a/src/chrome/src/agent/adapters.js
+++ b/src/chrome/src/agent/adapters.js
@@ -16670,6 +16670,19 @@ const ADAPTERS = [
 
   // ─── Social (gaps) ────────────────────────────────────────────────────
   {
+    name: 'kuaishou', category: 'general',
+    matches: (url) => /^https?:\/\/(?:(?:www|live|v)\.)?kuaishou\.com\//.test(url),
+    notes: `
+- Observed 2026-08: www.kuaishou.com can return HTTP 200 with a JSON body such as {"result":2,"error_msg":null,...} and no page UI, while live.kuaishou.com remains readable. Treat the JSON as an access failure, not content or empty results; do not retry rapidly.
+- On the live site use "请输入内容进行搜索" and the visible 关注, 推荐, 热门, 赛事, and 分类 routes. Verify streamer/profile identity, title, category/game, live status, viewer count, and stable room/profile URL.
+- Search/feed ordering is personalized and counts can be abbreviated. Verify creator name/快手号, caption, publish time, and permalink; do not treat rank, popularity, "蓝光/超清" quality, or an official-looking name as authority.
+- Watching/searching is read-only. 关注, 点赞, 评论, 私信, sharing, joining interactions, recharge, purchases, and live gifts change external/account state; perform only the explicitly requested action.
+- For publishing, review the exact media, caption, mentions/topics, cover, location, visibility, comment/download permissions, and schedule, then require explicit confirmation at the final publish control.
+- Login/verification may require QR, SMS, captcha, or app handling. Stop for the user; never interact, recharge, buy, or gift merely to unlock content.
+- Report publication only after the work appears on the user's profile with its stable URL and intended visibility; upload/progress/review or a toast is not public completion.
+    `,
+  },
+  {
     name: 'bilibili',
     category: 'general',
     matches: isBilibiliUrl,

--- a/src/firefox/src/agent/adapters.js
+++ b/src/firefox/src/agent/adapters.js
@@ -16668,6 +16668,19 @@ const ADAPTERS = [
 
   // ─── Social (gaps) ────────────────────────────────────────────────────
   {
+    name: 'kuaishou', category: 'general',
+    matches: (url) => /^https?:\/\/(?:(?:www|live|v)\.)?kuaishou\.com\//.test(url),
+    notes: `
+- Observed 2026-08: www.kuaishou.com can return HTTP 200 with a JSON body such as {"result":2,"error_msg":null,...} and no page UI, while live.kuaishou.com remains readable. Treat the JSON as an access failure, not content or empty results; do not retry rapidly.
+- On the live site use "请输入内容进行搜索" and the visible 关注, 推荐, 热门, 赛事, and 分类 routes. Verify streamer/profile identity, title, category/game, live status, viewer count, and stable room/profile URL.
+- Search/feed ordering is personalized and counts can be abbreviated. Verify creator name/快手号, caption, publish time, and permalink; do not treat rank, popularity, "蓝光/超清" quality, or an official-looking name as authority.
+- Watching/searching is read-only. 关注, 点赞, 评论, 私信, sharing, joining interactions, recharge, purchases, and live gifts change external/account state; perform only the explicitly requested action.
+- For publishing, review the exact media, caption, mentions/topics, cover, location, visibility, comment/download permissions, and schedule, then require explicit confirmation at the final publish control.
+- Login/verification may require QR, SMS, captcha, or app handling. Stop for the user; never interact, recharge, buy, or gift merely to unlock content.
+- Report publication only after the work appears on the user's profile with its stable URL and intended visibility; upload/progress/review or a toast is not public completion.
+    `,
+  },
+  {
     name: 'bilibili',
     category: 'general',
     matches: isBilibiliUrl,

--- a/test/run.js
+++ b/test/run.js
@@ -2418,6 +2418,16 @@ test('matches Zhihu reading and creation surfaces with login and publication gui
   assert.equal(firefoxAdapter?.notes, adapter?.notes);
 });
 
+test('matches Kuaishou video and live surfaces with access and publication guidance', () => {
+  const urls=['https://kuaishou.com/','https://www.kuaishou.com/search/video?searchKey=x','https://www.kuaishou.com/short-video/abc','https://www.kuaishou.com/profile/abc','https://live.kuaishou.com/123','https://v.kuaishou.com/abc'];
+  for(const url of urls){assert.equal(getActiveAdapter(url)?.name,'kuaishou');assert.equal(getActiveAdapterFx(url)?.name,'kuaishou');}
+  for(const url of ['https://ir.kuaishou.com/','https://kuaishou.com.phishing.example/']) assert.notEqual(getActiveAdapter(url)?.name,'kuaishou');
+  const a=getActiveAdapter(urls[0]),f=getActiveAdapterFx(urls[4]);
+  assert.match(a?.notes||'',/2026-08.*HTTP 200.*"result":2.*live\.kuaishou\.com/s);
+  assert.match(a?.notes||'',/请输入内容进行搜索.*关注.*推荐.*热门.*赛事.*分类/s);
+  assert.match(a?.notes||'',/关注.*点赞.*评论.*私信/s);assert.match(a?.notes||'',/explicit confirmation.*final publish/s);assert.equal(f?.notes,a?.notes);
+});
+
 test('matches Bilibili surfaces with mirrored regional guidance', () => {
   const urls = [
     'https://www.bilibili.com/video/BV1FD4y147uH/?p=2',


### PR DESCRIPTION
## Summary

Adds mirrored Kuaishou guidance for video/search/live surfaces, the current HTTP-200 JSON access failure, safe interaction boundaries, login, and publication completion.

## Validation

- Test-first assertion failed before implementation, then passed.
- Playwright: main returned HTTP 200 with `{"result":2,...}`; live returned HTTP 200 with current navigation, stream metadata, and login controls.
- Full suite: 1404/1405 (sole pre-existing package/changelog mismatch). Security corpus: 60/60. `git diff --check`: passed.

## Risks

Prompt-only and browser-mirrored. No login, interaction, upload, publication, recharge, purchase, or gift action was performed.
