### PR TITLE
agent: add adapter for Traveloka

### DIFF
--- a/src/chrome/src/agent/adapters.js
+++ b/src/chrome/src/agent/adapters.js
@@ -16294,6 +16294,20 @@ const ADAPTERS = [
 - Report success only with "订单号" plus "预订成功" or the applicable "出票成功" status. Pending confirmation, a payment redirect, or an itinerary held for payment is incomplete.`,
   },
   {
+    name: 'traveloka',
+    category: 'general',
+    matches: (url) => /^https?:\/\/(?:www\.)?traveloka\.com\//.test(url),
+    notes: `
+- Observed 2026-08: an automated visit can return HTTP 405 with "Human Verification", "Let's confirm you are human", and a "Begin" control instead of inventory. Stop and ask the user to complete it manually; do not retry, bypass it, or report that no trips or rooms exist.
+- Choose the requested product before entering details: "Flights" and "Hotels" have different search, traveler/guest, payment, and fulfillment rules. Re-read locale, language, and currency, then set exact cities or properties, local dates, rooms or travelers, and one-way/round-trip intent.
+- For a flight, verify airports, local departure/arrival dates and times, operating and marketing carrier for a code-share, stops, connection requirements, cabin, and fare rules. A round trip built from two one-way tickets can create separate bookings and separate payments with independent change, cancellation, and disruption handling.
+- Compare the selected offer's supplier and final payable amount, not a headline or crossed-out fare. Read included baggage, taxes, fees, currency, refund/change conditions, and all ancillaries such as seats, meals, insurance, or extra baggage; keep unrequested paid additions out of the order.
+- For a hotel, verify the exact property and room, occupancy, bed, meals, inclusions, taxes, supplier charges, check-in/out, and policy. "Pay Now" and "Pay at Hotel" differ in payment timing and possible hotel-side charges; read the cancellation deadline, refundability, and no-show consequence for the selected room.
+- On order review, re-read every traveler/guest name, required document data, contact, itinerary or stay, supplier, add-ons, policy, payment timing, currency, and total. Never invent identity details, and require explicit confirmation before creating the booking or making payment.
+- After payment, obtain the voucher, e-ticket, or booking confirmation and verify the supplier's confirmation state. Use that booking's own policy and Help flow for a refund or reschedule; eligibility, fees, method, timing, and any Traveloka balance depend on the fare/room and supplier.
+- Report success only from "Bookings" with a booking ID and explicit confirmed/ticketed status for every product or leg. Search results, a selected offer, payment redirect, pending supplier confirmation, or an unconfirmed itinerary are incomplete.`,
+  },
+  {
     name: 'dianping',
     category: 'general',
     matches: (url) => /^https?:\/\/(?:(?:www|m|h5|s)\.)?dianping\.com\//.test(url) || /^https?:\/\/verify\.meituan\.com\//.test(url),

--- a/src/firefox/src/agent/adapters.js
+++ b/src/firefox/src/agent/adapters.js
@@ -16292,6 +16292,20 @@ const ADAPTERS = [
 - Report success only with "订单号" plus "预订成功" or the applicable "出票成功" status. Pending confirmation, a payment redirect, or an itinerary held for payment is incomplete.`,
   },
   {
+    name: 'traveloka',
+    category: 'general',
+    matches: (url) => /^https?:\/\/(?:www\.)?traveloka\.com\//.test(url),
+    notes: `
+- Observed 2026-08: an automated visit can return HTTP 405 with "Human Verification", "Let's confirm you are human", and a "Begin" control instead of inventory. Stop and ask the user to complete it manually; do not retry, bypass it, or report that no trips or rooms exist.
+- Choose the requested product before entering details: "Flights" and "Hotels" have different search, traveler/guest, payment, and fulfillment rules. Re-read locale, language, and currency, then set exact cities or properties, local dates, rooms or travelers, and one-way/round-trip intent.
+- For a flight, verify airports, local departure/arrival dates and times, operating and marketing carrier for a code-share, stops, connection requirements, cabin, and fare rules. A round trip built from two one-way tickets can create separate bookings and separate payments with independent change, cancellation, and disruption handling.
+- Compare the selected offer's supplier and final payable amount, not a headline or crossed-out fare. Read included baggage, taxes, fees, currency, refund/change conditions, and all ancillaries such as seats, meals, insurance, or extra baggage; keep unrequested paid additions out of the order.
+- For a hotel, verify the exact property and room, occupancy, bed, meals, inclusions, taxes, supplier charges, check-in/out, and policy. "Pay Now" and "Pay at Hotel" differ in payment timing and possible hotel-side charges; read the cancellation deadline, refundability, and no-show consequence for the selected room.
+- On order review, re-read every traveler/guest name, required document data, contact, itinerary or stay, supplier, add-ons, policy, payment timing, currency, and total. Never invent identity details, and require explicit confirmation before creating the booking or making payment.
+- After payment, obtain the voucher, e-ticket, or booking confirmation and verify the supplier's confirmation state. Use that booking's own policy and Help flow for a refund or reschedule; eligibility, fees, method, timing, and any Traveloka balance depend on the fare/room and supplier.
+- Report success only from "Bookings" with a booking ID and explicit confirmed/ticketed status for every product or leg. Search results, a selected offer, payment redirect, pending supplier confirmation, or an unconfirmed itinerary are incomplete.`,
+  },
+  {
     name: 'dianping',
     category: 'general',
     matches: (url) => /^https?:\/\/(?:(?:www|m|h5|s)\.)?dianping\.com\//.test(url) || /^https?:\/\/verify\.meituan\.com\//.test(url),

--- a/test/run.js
+++ b/test/run.js
@@ -2866,6 +2866,48 @@ test('matches Ctrip travel surfaces and includes Chinese booking guidance', () =
   assert.equal(firefoxAdapter?.notes, adapter?.notes);
 });
 
+test('matches Traveloka consumer pages and distinguishes booking and fulfillment states', () => {
+  const trustedUrls = [
+    'https://traveloka.com/en-id/',
+    'https://www.traveloka.com/en-id/flight',
+    'https://www.traveloka.com/en-id/hotel',
+    'https://www.traveloka.com/en-id/help',
+  ];
+  for (const url of trustedUrls) {
+    assert.equal(getActiveAdapter(url)?.name, 'traveloka');
+    assert.equal(getActiveAdapterFx(url)?.name, 'traveloka');
+  }
+
+  const rejectedUrls = [
+    'https://partner.traveloka.com/',
+    'https://careers.traveloka.com/',
+    'https://affiliate.traveloka.com/',
+    'https://traveloka.com.phishing.example/en-id/flight',
+    'https://example.com/?next=https://www.traveloka.com/en-id/hotel',
+  ];
+  for (const url of rejectedUrls) {
+    assert.notEqual(getActiveAdapter(url)?.name, 'traveloka');
+    assert.notEqual(getActiveAdapterFx(url)?.name, 'traveloka');
+  }
+
+  const adapter = getActiveAdapter('https://www.traveloka.com/en-id/flight');
+  const firefoxAdapter = getActiveAdapterFx('https://traveloka.com/en-id/hotel');
+  assert.match(adapter?.notes || '', /2026-08/);
+  assert.match(adapter?.notes || '', /Human Verification.*Let's confirm you are human.*Begin/s);
+  assert.match(adapter?.notes || '', /Flights.*Hotels/s);
+  assert.match(adapter?.notes || '', /code-share.*separate bookings.*separate payments/s);
+  assert.match(adapter?.notes || '', /baggage.*taxes.*fees/s);
+  assert.match(adapter?.notes || '', /Pay Now.*Pay at Hotel/s);
+  assert.match(adapter?.notes || '', /cancellation.*no-show/s);
+  assert.match(adapter?.notes || '', /ancillaries/);
+  assert.match(adapter?.notes || '', /explicit confirmation/);
+  assert.match(adapter?.notes || '', /voucher.*e-ticket.*booking confirmation/s);
+  assert.match(adapter?.notes || '', /refund.*reschedule/s);
+  assert.match(adapter?.notes || '', /Bookings.*booking ID.*status/s);
+  assert.equal((adapter?.notes || '').trim().split('\n').filter((line) => line.startsWith('- ')).length, 8);
+  assert.equal(firefoxAdapter?.notes, adapter?.notes);
+});
+
 test('matches Qunar travel surfaces and distinguishes search, supplier, order, and ticket states', () => {
   const trustedUrls = [
     'https://qunar.com/', 'https://www.qunar.com/', 'https://flight.qunar.com/',


### PR DESCRIPTION
## Summary

- add a narrowly scoped Traveloka adapter for consumer flight and hotel booking pages
- mirror the guidance across Chrome and Firefox
- stop safely on the observed Human Verification response
- distinguish split one-way tickets, code-shares, fare/room rules, and supplier identity
- cover baggage, taxes, fees, ancillaries, Pay Now/Pay at Hotel, cancellation, and no-show terms
- separate payment from voucher/e-ticket/supplier confirmation and final booking status
- reject partner, careers, affiliate, embedded-domain, and suffix-look-alike URLs
- add positive, negative, content, bullet-count, and browser-parity coverage

## Research

The guidance is dated `2026-08` and reflects the current Traveloka verification response, Terms and Conditions, and official Help guidance for confirmation documents, payment timing, cancellation, refund, and rescheduling.

## Test plan

- `node test/run.js` — new Traveloka coverage passes; 1412 passed / 1 inherited failure because `package.json` is `26.0.4` while the newest `CHANGELOG.md` entry is `26.0.0`
- `npm run test:fixtures` — 125/125 passed
- `npm run test:security` — 60/60 passed
- `npm run test:ci` — passed
- `npm run test:webmcp` — passed with Chrome 150.0.7871.187

Anonymous LLM scenarios were not run because they require an externally configured provider/API key and interactive headed setup; they are not part of the adapter-specific test seam.
