### PR TITLE
agent: add adapter for Lazada

### DIFF
--- a/src/chrome/src/agent/adapters.js
+++ b/src/chrome/src/agent/adapters.js
@@ -16595,7 +16595,23 @@ const ADAPTERS = [
 - "Order Received" can release held purchase funds to the seller and affect guarantee or return timing. Never select it from tracking status alone; require the user's explicit confirmation that the exact goods arrived and were inspected. Report a placed order only from the confirmation or My Purchases page with an order ID; a cart, checkout, payment prompt, or submitted request is incomplete.`,
   },
 
-  // ─── Regional — Flipkart (India) ─────────────────────────────────────
+  // ─── Regional — Lazada (Southeast Asia) ─────────────────────────
+  {
+    name: 'lazada',
+    category: 'general',
+    matches: (url) => /^https?:\/\/(?:(?:www|m|my|member|pages)\.)?lazada\.(?:co\.id|com\.ph|com\.my|sg|co\.th|vn)\//.test(url),
+    notes: `
+- Observed 2026-08: Lazada uses separate Indonesia, Philippines, Malaysia, Singapore, Thailand, and Vietnam storefronts. Choose the user's market before searching; accounts, language, currency, catalog, stock, delivery addresses, vouchers, and payment methods are region-specific, so one market's offer is not proof another can fulfill it.
+- Catalog or product navigation can redirect to a path containing /_____tmd_____/punish and expose only "Click to feedback >". Stop retries and ask the user to complete the traffic check manually in the current tab, then re-read it; do not bypass the check or report the empty page as no products.
+- Select the exact variation and quantity before comparing price, stock, delivery, warranty, or returns. Lazada product pages can combine color, size, storage, pack count, and seller-specific offers, and changing a variation can change all of those details.
+- LazMall identifies a participating brand or authorized-store program, not a universal guarantee for every offer. Read the selected seller, store rating, item reviews, return policy, shipping origin, delivery estimate, and warranty rather than transferring a product-level badge or review score to every seller.
+- Treat vouchers, free shipping, coins, cashback, flash-sale prices, and payment promotions as conditional. Check product, seller, minimum-spend, user, payment-method, quota, and expiry requirements, and quote the final payable checkout total separately from advertised savings.
+- "Add to Cart" / Indonesian "Tambah ke Troli" preserves a review step; "Buy Now" / "Beli Sekarang" enters checkout directly. Do not use Buy Now for research, and re-read the exact item, variation, seller, quantity, shipping option, and price after adding it.
+- Login or checkout can require password, SMS OTP, QR/app confirmation, CAPTCHA, or trusted-device approval. Ask the user to complete verification manually; never request, read, repeat, or expose a verification code, and continue from the returned page instead of restarting.
+- Before "Place Order" or any payment control, re-read the address, items, variations, sellers, quantities, delivery, returns, vouchers, payment method, and final total, then require the user's explicit confirmation. Report success only from My Orders or a confirmation page with an order number and explicit state; a cart, checkout page, payment redirect, or pending order is incomplete.`,
+  },
+
+  // ─── Regional — Flipkart (India) ────────────────────
   {
     name: 'flipkart',
     category: 'general',

--- a/src/firefox/src/agent/adapters.js
+++ b/src/firefox/src/agent/adapters.js
@@ -16593,7 +16593,23 @@ const ADAPTERS = [
 - "Order Received" can release held purchase funds to the seller and affect guarantee or return timing. Never select it from tracking status alone; require the user's explicit confirmation that the exact goods arrived and were inspected. Report a placed order only from the confirmation or My Purchases page with an order ID; a cart, checkout, payment prompt, or submitted request is incomplete.`,
   },
 
-  // ─── Regional — Flipkart (India) ─────────────────────────────────────
+  // ─── Regional — Lazada (Southeast Asia) ─────────────────────────
+  {
+    name: 'lazada',
+    category: 'general',
+    matches: (url) => /^https?:\/\/(?:(?:www|m|my|member|pages)\.)?lazada\.(?:co\.id|com\.ph|com\.my|sg|co\.th|vn)\//.test(url),
+    notes: `
+- Observed 2026-08: Lazada uses separate Indonesia, Philippines, Malaysia, Singapore, Thailand, and Vietnam storefronts. Choose the user's market before searching; accounts, language, currency, catalog, stock, delivery addresses, vouchers, and payment methods are region-specific, so one market's offer is not proof another can fulfill it.
+- Catalog or product navigation can redirect to a path containing /_____tmd_____/punish and expose only "Click to feedback >". Stop retries and ask the user to complete the traffic check manually in the current tab, then re-read it; do not bypass the check or report the empty page as no products.
+- Select the exact variation and quantity before comparing price, stock, delivery, warranty, or returns. Lazada product pages can combine color, size, storage, pack count, and seller-specific offers, and changing a variation can change all of those details.
+- LazMall identifies a participating brand or authorized-store program, not a universal guarantee for every offer. Read the selected seller, store rating, item reviews, return policy, shipping origin, delivery estimate, and warranty rather than transferring a product-level badge or review score to every seller.
+- Treat vouchers, free shipping, coins, cashback, flash-sale prices, and payment promotions as conditional. Check product, seller, minimum-spend, user, payment-method, quota, and expiry requirements, and quote the final payable checkout total separately from advertised savings.
+- "Add to Cart" / Indonesian "Tambah ke Troli" preserves a review step; "Buy Now" / "Beli Sekarang" enters checkout directly. Do not use Buy Now for research, and re-read the exact item, variation, seller, quantity, shipping option, and price after adding it.
+- Login or checkout can require password, SMS OTP, QR/app confirmation, CAPTCHA, or trusted-device approval. Ask the user to complete verification manually; never request, read, repeat, or expose a verification code, and continue from the returned page instead of restarting.
+- Before "Place Order" or any payment control, re-read the address, items, variations, sellers, quantities, delivery, returns, vouchers, payment method, and final total, then require the user's explicit confirmation. Report success only from My Orders or a confirmation page with an order number and explicit state; a cart, checkout page, payment redirect, or pending order is incomplete.`,
+  },
+
+  // ─── Regional — Flipkart (India) ────────────────────
   {
     name: 'flipkart',
     category: 'general',

--- a/test/run.js
+++ b/test/run.js
@@ -3043,6 +3043,49 @@ test('matches current Shopee regional storefronts with marketplace guidance', ()
   assert.equal(firefoxAdapter?.notes, adapter?.notes);
 });
 
+test('matches Lazada consumer storefronts and stops at the observed traffic gate', () => {
+  const trustedUrls = [
+    'https://www.lazada.co.id/',
+    'https://www.lazada.com.ph/products/example-item.html',
+    'https://www.lazada.com.my/catalog/?q=phone',
+    'https://www.lazada.sg/shop-mobiles/',
+    'https://m.lazada.co.th/products/example-item.html',
+    'https://www.lazada.vn/',
+    'https://my.lazada.co.id/customer/order/index/',
+    'https://member.lazada.com.ph/user/account#/',
+    'https://pages.lazada.com.my/wow/example',
+  ];
+  for (const url of trustedUrls) {
+    assert.equal(getActiveAdapter(url)?.name, 'lazada');
+    assert.equal(getActiveAdapterFx(url)?.name, 'lazada');
+  }
+
+  const rejectedUrls = [
+    'https://sellercenter.lazada.co.id/apps/register/index',
+    'https://helpcenter.lazada.com.ph/',
+    'https://careers.lazada.sg/',
+    'https://lazada.co.id.phishing.example/products/item',
+    'https://example.com/?next=https://www.lazada.vn/',
+  ];
+  for (const url of rejectedUrls) {
+    assert.notEqual(getActiveAdapter(url)?.name, 'lazada');
+    assert.notEqual(getActiveAdapterFx(url)?.name, 'lazada');
+  }
+
+  const adapter = getActiveAdapter(trustedUrls[0]);
+  const firefoxAdapter = getActiveAdapterFx(trustedUrls[5]);
+  assert.match(adapter?.notes || '', /2026-08.*separate Indonesia.*Vietnam storefronts/s);
+  assert.match(adapter?.notes || '', /_____tmd_____\/punish.*Click to feedback.*complete the traffic check manually/s);
+  assert.match(adapter?.notes || '', /exact variation.*changing a variation.*change all of those details/s);
+  assert.match(adapter?.notes || '', /LazMall.*selected seller.*return policy/s);
+  assert.match(adapter?.notes || '', /vouchers.*minimum-spend.*final payable checkout total/s);
+  assert.match(adapter?.notes || '', /Add to Cart.*Tambah ke Troli.*Buy Now.*Beli Sekarang/s);
+  assert.match(adapter?.notes || '', /OTP.*verification manually.*never request.*verification code/s);
+  assert.match(adapter?.notes || '', /Place Order.*explicit confirmation.*order number.*explicit state/s);
+  assert.equal((adapter?.notes || '').trim().split('\n').filter((line) => line.startsWith('- ')).length, 8);
+  assert.equal(firefoxAdapter?.notes, adapter?.notes);
+});
+
 test('matches Flipkart shopping surfaces with India marketplace guidance', () => {
   const trustedUrls = [
     'https://flipkart.com/',


### PR DESCRIPTION
## Summary

- add a Lazada site adapter for the six current Southeast Asian storefront families
- stop the agent from retrying Lazada's observed `_____tmd_____/punish` traffic gate or treating its empty page as an empty catalog
- keep Chrome and Firefox routing and guidance aligned with positive and negative host coverage

## Motivation

Lazada was one of the regional marketplaces listed in the contribution guide but had no adapter. A live anonymous browser check reached all six storefront homepages, while catalog and product navigation repeatedly redirected to a traffic-check path that exposed only `Click to feedback >`. Without site guidance, that shape invites repeated reads/retries and can be misreported as no products.

## Design

The matcher covers the Indonesia, Philippines, Malaysia, Singapore, Thailand, and Vietnam storefront domains plus the observed consumer-facing `m`, `my`, `member`, and `pages` subdomains. Seller, help, careers, lookalike suffixes, and domains embedded in another URL remain excluded.

The eight guidance bullets focus on Lazada-specific market separation and traffic-gate behavior, then preserve marketplace safety around variations, LazMall/seller attribution, conditional promotions, cart versus direct checkout, verification, and final order confirmation. A global marketplace preamble was rejected because it would add prompt cost to unrelated sites and could not identify Lazada's exact gate.

## Testing

- `node --check src/chrome/src/agent/adapters.js` - passed
- `node --check src/firefox/src/agent/adapters.js` - passed
- targeted inline Node routing/parity assertions - passed
- `node test/run.js` - 1437 passed, 2 inherited failures: the changelog still ends at 26.0.0 while `package.json` is 26.0.10, and the randomized promotion test selected the Chinese variant while expecting English (the baseline had the same two failures at 1436 passed)
- `npm run test:security` - 60/60 checks passed
- anonymous headless Chromium inspection - all six storefront homepages returned HTTP 200; catalog and product routes reproduced the documented traffic gate

## Compatibility and risks

This is additive and does not change tool schemas, permissions, public APIs, or existing adapter matches. The main residual risk is normal marketplace UI drift; the volatile traffic-gate observation is dated, the matcher is an explicit host allowlist, and the notes avoid CSS selectors.

No signed-in checkout or manual challenge completion was performed.

## Scope

Tokopedia, Gojek, Grab, and other regional adapters are intentionally deferred to separate PRs.
