### PR TITLE
fix(media): require LinkedIn permalink IDs

### DIFF
--- a/src/chrome/src/agent/public-media-url.js
+++ b/src/chrome/src/agent/public-media-url.js
@@ -58,7 +58,7 @@ export function isDirectPublicMediaUrl(rawUrl) {
     return hasPathId(path, /^\/[^/?#]+/);
   }
   if (hostMatches(host, 'pinterest.com')) return hasPathId(path, /^\/pin\/[^/?#]+/i);
-  if (hostMatches(host, 'linkedin.com')) return hasPathId(path, /^\/(?:posts\/|feed\/update\/)/i);
+  if (hostMatches(host, 'linkedin.com')) return hasPathId(path, /^\/(?:posts|feed\/update)\/[^/?#]+/i);
   if (hostMatches(host, 'threads.net')) return hasPathId(path, /^\/@[^/]+\/post\/[^/?#]+/i);
   if (hostMatches(host, 'facebook.com') || hostMatches(host, 'fb.com')) {
     return (

--- a/src/firefox/src/agent/public-media-url.js
+++ b/src/firefox/src/agent/public-media-url.js
@@ -58,7 +58,7 @@ export function isDirectPublicMediaUrl(rawUrl) {
     return hasPathId(path, /^\/[^/?#]+/);
   }
   if (hostMatches(host, 'pinterest.com')) return hasPathId(path, /^\/pin\/[^/?#]+/i);
-  if (hostMatches(host, 'linkedin.com')) return hasPathId(path, /^\/(?:posts\/|feed\/update\/)/i);
+  if (hostMatches(host, 'linkedin.com')) return hasPathId(path, /^\/(?:posts|feed\/update)\/[^/?#]+/i);
   if (hostMatches(host, 'threads.net')) return hasPathId(path, /^\/@[^/]+\/post\/[^/?#]+/i);
   if (hostMatches(host, 'facebook.com') || hostMatches(host, 'fb.com')) {
     return (

--- a/test/run.js
+++ b/test/run.js
@@ -10410,6 +10410,7 @@ test('public media recommendations carry immediate download_public_media fast pa
     { url: 'https://www.facebook.com/example/videos/123', title: 'Facebook video', media: { videoCount: 1, imageCount: 0 }, expectedKind: 'video' },
     { url: 'https://www.reddit.com/r/pics/comments/abc/photo/', title: 'A photo post', media: { imageCount: 1, videoCount: 0 }, expectedKind: 'image' },
     { url: 'https://www.linkedin.com/posts/example_123', title: 'LinkedIn public post video', media: { videoCount: 1, imageCount: 0 }, expectedKind: 'video' },
+    { url: 'https://www.linkedin.com/feed/update/urn:li:activity:123', title: 'LinkedIn public feed update', media: { videoCount: 1, imageCount: 0 }, expectedKind: 'video' },
     { url: 'https://threads.net/@user/post/abc', title: 'Threads photo', media: { imageCount: 1, videoCount: 0 }, expectedKind: 'image' },
   ];
 
@@ -10454,6 +10455,16 @@ test('public media recommendations carry immediate download_public_media fast pa
     assert.equal(feedAction?.runOptions?.firstTool, 'screenshot', 'feed download should take a screenshot before the first model call');
     assert.deepEqual(feedAction?.runOptions?.args, { save: false }, 'feed screenshot should not save an extra file');
     assert.ok(feedAction?.runOptions?.steps?.some((step) => /explicit permalink/.test(step)), 'feed plan should pin explicit permalink resolution');
+
+    for (const url of ['https://www.linkedin.com/posts/', 'https://www.linkedin.com/feed/update/']) {
+      const linkedinFeedAction = buildRecommendedActions({
+        url,
+        title: 'LinkedIn',
+        media: { videoCount: 1, imageCount: 0 },
+      }).find((a) => a.id === 'download-media');
+      assert.equal(linkedinFeedAction?.runOptions?.firstTool, 'screenshot', `empty LinkedIn permalink should resolve a visible target first for ${url}`);
+      assert.match(linkedinFeedAction?.prompt || '', /exact public post\/reel URL/i, `empty LinkedIn permalink should require an explicit target for ${url}`);
+    }
 
     const mobileFeedAction = buildRecommendedActions({
       url: 'https://m.twitter.com/home',


### PR DESCRIPTION
## Summary

- require a non-empty post identifier after LinkedIn `/posts/` and `/feed/update/` prefixes
- route empty LinkedIn container paths through the existing screenshot/permalink-resolution flow
- preserve direct-download behavior for both supported LinkedIn permalink shapes in Chrome and Firefox

## Problem

`isDirectPublicMediaUrl` treated the bare `/posts/` and `/feed/update/` paths as concrete public media items. Recommended downloads therefore skipped visual target resolution and could send a non-item URL to `download_public_media`.

LinkedIn's documented `/feed/update/<activityUrn>` permalink shape requires a dynamic identifier: https://learn.microsoft.com/en-us/linkedin/marketing/community-management/shares#constructing-permalinks

## Testing

- `node test/run.js`: 1449 passed, 1 pre-existing repository failure (`package.json` is `26.0.10`, newest `CHANGELOG.md` entry is `26.0.0`)
- `node test/security/injection-corpus.mjs`: 60/60 checks passed
- verified empty `/posts/` and `/feed/update/` paths start with screenshot preflight
- verified `/posts/<id>` and `/feed/update/<activityUrn>` retain the direct fast path
- Chrome/Firefox URL helpers are byte-identical

## Scope

This only tightens LinkedIn's two existing permalink patterns; no other host recognition or download behavior changes.
