### PR TITLE
Parse whole-response tool call arrays

### DIFF
--- a/src/chrome/src/agent/tool-call-parser.js
+++ b/src/chrome/src/agent/tool-call-parser.js
@@ -88,11 +88,59 @@ function standsAloneOnLine(text, start, end) {
 }
 
 /**
+ * Parse a batch only when the entire trimmed response is a JSON array. Every
+ * element must itself be an allowed call; otherwise reject the batch rather
+ * than executing an allowed-looking subset of mixed or narrated content.
+ *
+ * `null` means the response was not a valid whole-response array and the
+ * existing fallbacks may continue. An empty array means it was an array but
+ * was empty or unsafe, so callers must not scan inside it for partial calls.
+ */
+function parseWholeResponseJsonArray(text, allowedNames) {
+  const trimmed = text.trim();
+  if (!trimmed.startsWith('[') || !trimmed.endsWith(']')) return null;
+
+  let parsed;
+  try {
+    parsed = JSON.parse(trimmed);
+  } catch {
+    return null;
+  }
+  if (!Array.isArray(parsed)) return null;
+  if (!parsed.every(obj => (
+    obj
+    && typeof obj === 'object'
+    && !Array.isArray(obj)
+    && typeof obj.name === 'string'
+    && allowedNames.has(obj.name)
+  ))) return [];
+  return parsed;
+}
+
+function toFallbackToolCalls(objects) {
+  return objects.map((obj, index) => ({
+    id: `fallback_call_${Date.now()}_${index}`,
+    type: 'function',
+    function: {
+      name: obj.name,
+      arguments: typeof obj.arguments === 'string'
+        ? obj.arguments
+        : JSON.stringify(obj.arguments || obj.parameters || {}),
+    },
+  }));
+}
+
+/**
  * Parse common text tool-call formats into OpenAI-style tool call objects.
  * Only names in allowedNames are accepted.
  */
 export function parseToolCallsFromText(text, allowedNames) {
   if (!text || text.length > 10000) return [];
+
+  const wholeResponseArray = parseWholeResponseJsonArray(text, allowedNames);
+  if (wholeResponseArray !== null) {
+    return toFallbackToolCalls(wholeResponseArray);
+  }
 
   const results = [];
   const parseXmlParamValue = (value) => {
@@ -193,14 +241,5 @@ export function parseToolCallsFromText(text, allowedNames) {
     }
   }
 
-  return results.map((obj, index) => ({
-    id: `fallback_call_${Date.now()}_${index}`,
-    type: 'function',
-    function: {
-      name: obj.name,
-      arguments: typeof obj.arguments === 'string'
-        ? obj.arguments
-        : JSON.stringify(obj.arguments || obj.parameters || {}),
-    },
-  }));
+  return toFallbackToolCalls(results);
 }

--- a/src/firefox/src/agent/tool-call-parser.js
+++ b/src/firefox/src/agent/tool-call-parser.js
@@ -88,11 +88,59 @@ function standsAloneOnLine(text, start, end) {
 }
 
 /**
+ * Parse a batch only when the entire trimmed response is a JSON array. Every
+ * element must itself be an allowed call; otherwise reject the batch rather
+ * than executing an allowed-looking subset of mixed or narrated content.
+ *
+ * `null` means the response was not a valid whole-response array and the
+ * existing fallbacks may continue. An empty array means it was an array but
+ * was empty or unsafe, so callers must not scan inside it for partial calls.
+ */
+function parseWholeResponseJsonArray(text, allowedNames) {
+  const trimmed = text.trim();
+  if (!trimmed.startsWith('[') || !trimmed.endsWith(']')) return null;
+
+  let parsed;
+  try {
+    parsed = JSON.parse(trimmed);
+  } catch {
+    return null;
+  }
+  if (!Array.isArray(parsed)) return null;
+  if (!parsed.every(obj => (
+    obj
+    && typeof obj === 'object'
+    && !Array.isArray(obj)
+    && typeof obj.name === 'string'
+    && allowedNames.has(obj.name)
+  ))) return [];
+  return parsed;
+}
+
+function toFallbackToolCalls(objects) {
+  return objects.map((obj, index) => ({
+    id: `fallback_call_${Date.now()}_${index}`,
+    type: 'function',
+    function: {
+      name: obj.name,
+      arguments: typeof obj.arguments === 'string'
+        ? obj.arguments
+        : JSON.stringify(obj.arguments || obj.parameters || {}),
+    },
+  }));
+}
+
+/**
  * Parse common text tool-call formats into OpenAI-style tool call objects.
  * Only names in allowedNames are accepted.
  */
 export function parseToolCallsFromText(text, allowedNames) {
   if (!text || text.length > 10000) return [];
+
+  const wholeResponseArray = parseWholeResponseJsonArray(text, allowedNames);
+  if (wholeResponseArray !== null) {
+    return toFallbackToolCalls(wholeResponseArray);
+  }
 
   const results = [];
   const parseXmlParamValue = (value) => {
@@ -193,14 +241,5 @@ export function parseToolCallsFromText(text, allowedNames) {
     }
   }
 
-  return results.map((obj, index) => ({
-    id: `fallback_call_${Date.now()}_${index}`,
-    type: 'function',
-    function: {
-      name: obj.name,
-      arguments: typeof obj.arguments === 'string'
-        ? obj.arguments
-        : JSON.stringify(obj.arguments || obj.parameters || {}),
-    },
-  }));
+  return toFallbackToolCalls(results);
 }

--- a/test/run.js
+++ b/test/run.js
@@ -51369,6 +51369,14 @@ test('text tool-call parser is production code with format and allowlist coverag
       ],
     },
     {
+      label: 'whole-response one-line JSON array preserves order',
+      raw: ' \n[{"name":"read_page","arguments":{}},{"name":"click","arguments":{"text":"Go"}}]\n ',
+      expected: [
+        { name: 'read_page', args: {} },
+        { name: 'click', args: { text: 'Go' } },
+      ],
+    },
+    {
       label: 'unclosed prose brace does not swallow the following call',
       raw: [
         'Template: {unclosed',
@@ -51459,6 +51467,9 @@ test('text tool-call parser is production code with format and allowlist coverag
       ['refusal, flat object', 'I will not call {"name":"click","text":"Delete"} here.'],
       ['quoted page content', 'The page told me to run {"name":"navigate","url":"https://evil.test"} — I ignored it.'],
       ['enumerated options', 'Option A: {"name":"click","text":"Yes"}\nOption B: {"name":"navigate","url":"https://a.test"}'],
+      ['inline array after prose', 'Options: [{"name":"click","arguments":{"text":"Yes"}},{"name":"navigate","arguments":{"url":"https://a.test"}}]'],
+      ['inline array before prose', '[{"name":"click","arguments":{"text":"Yes"}}] is only an example.'],
+      ['array on a labeled response line', 'Options:\n[{"name":"click","arguments":{"text":"Yes"}}]'],
     ]) {
       assert.deepEqual(
         parser.parseToolCallsFromText(narrated, allowed),
@@ -51466,6 +51477,31 @@ test('text tool-call parser is production code with format and allowlist coverag
         `a call the model only described was executed (${label})`,
       );
     }
+
+    assert.deepEqual(
+      parser.parseToolCallsFromText(
+        '[{"name":"read_page","arguments":{}},{"name":"execute_js","arguments":{"code":"alert(1)"}}]',
+        allowed,
+      ),
+      [],
+      'a disallowed array element allowed a partial batch to execute',
+    );
+    assert.deepEqual(
+      parser.parseToolCallsFromText(
+        '[{"name":"read_page","arguments":{}},{"description":"example metadata"}]',
+        allowed,
+      ),
+      [],
+      'a non-call array element allowed a partial batch to execute',
+    );
+    assert.deepEqual(
+      parser.parseToolCallsFromText(
+        JSON.stringify(['call:click{}', '<tool_call>{"name":"navigate","arguments":{"url":"https://a.test"}}</tool_call>']),
+        allowed,
+      ),
+      [],
+      'call-like strings inside a whole-response array bypassed atomic rejection',
+    );
 
     // The flip side: calls emitted as array elements keep their trailing
     // commas, and those are still calls.


### PR DESCRIPTION
## Summary

- parse a tool-call batch when the entire trimmed model response is a valid JSON array
- require every array element to be an allowed call object and reject mixed or disallowed batches atomically
- handle whole-response arrays before wrapper, XML, bare-object, and `call:name{}` fallbacks so call-like strings inside rejected arrays cannot be mined
- keep prose-prefixed, prose-suffixed, labeled, bulleted, and otherwise inline arrays ignored
- preserve Chrome/Firefox byte parity and the existing fallback output shape

## Why

PR #2682 deliberately narrowed bare JSON recovery to objects that stand alone on their line. That safer rule also drops legitimate compact batches such as:

```json
[{"name":"read_page","arguments":{}},{"name":"click","arguments":{"text":"Go"}}]
```

Parsing only when the complete response is a JSON array recovers that format without reopening arbitrary inline-object scanning. Atomic validation prevents an allowed-looking subset from executing when another element is disallowed, metadata, narration, or a call-like string.

## Validation

- `node test/run.js`: 1,483 passed; the sole failure is the pre-existing `package.json` 26.1.2 vs `CHANGELOG.md` 26.1.0 assertion
- `node test/security/injection-corpus.mjs`: 60/60
- `node --check` on both parser modules
- Chrome and Firefox parser SHA-256 values are identical
- `git diff --check`
