### PR TITLE
feat: add user-approved workflow locator healing

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -546,6 +546,15 @@ collects parameters in an ephemeral side-panel form. The replay executor then:
 5. either continues deterministically, delegates a known-safe mismatch to the
    normal Agent, or stops when a state-changing action has an unknown outcome.
 
+When strict target matching fails, replay may present up to five independently
+replayable semantic targets for explicit user selection. A selected target is
+used for that step only, then persisted as a locator repair only when the
+existing postcondition succeeds without inconclusive, stale, ambiguous, or
+wrong-target evidence. Repairs are applied atomically against the workflow's
+previous `updatedAt` value, so a concurrent edit wins instead of being
+overwritten. Duplicate semantic candidates and unattended clarification
+answers never authorize healing.
+
 Replay does not set `currentRunId`, because ordinary tool tracing would retain
 runtime values. It creates a separate run containing sanitized notes and
 redacted UI tool events. Runtime parameter values are also omitted from the

--- a/docs/privacy-and-data-flow.md
+++ b/docs/privacy-and-data-flow.md
@@ -146,6 +146,13 @@ delete or redact that source trace.
 Replay traces contain workflow/step IDs, semantic match status and score,
 postcondition status, fallback status, and estimated model calls saved. They do
 not contain runtime parameter values or freshly resolved element references.
+If a saved locator stops matching, WebBrain may show sanitized semantic target
+descriptions for the user to choose from. It never selects or persists a
+replacement automatically: the user must explicitly choose it, the attempted
+action must pass its saved postcondition, and the workflow must still be the
+same version. The temporary live `ref_id` is never written to storage. A field
+repair can upgrade its runtime parameter to sensitive (for example, when the
+new target is a password field), but it can never downgrade that protection.
 If deterministic replay cannot safely continue, a fallback Agent receives only
 saved metadata and must ask the user again for any still-needed value.
 

--- a/src/chrome/src/agent/agent.js
+++ b/src/chrome/src/agent/agent.js
@@ -73,6 +73,7 @@ import { buildCustomSkillsPrompt, buildSkillLoaderDefinition, buildSkillToolDefi
 import { publicMediaUrlNeedsExplicitTarget } from './public-media-url.js';
 import { USER_MEMORY_DEFAULT_MAX_PROMPT_CHARS, formatUserMemoryPrompt, normalizeUserMemoryMaxPromptChars, normalizeUserMemoryStore } from './user-memory.js';
 import {
+  findWorkflowHealingCandidates,
   findWorkflowTarget,
   parseAccessibilityTreeDescriptors,
   redactWorkflowArgsForTelemetry,
@@ -10925,6 +10926,43 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
     return 'deny';
   }
 
+  async _promptWorkflowTargetHealing(tabId, workflow, step, stepIndex, candidates, onUpdate) {
+    const choices = Array.isArray(candidates) ? candidates.slice(0, 5) : [];
+    if (!choices.length) return null;
+    const clarifyId = `workflow_heal_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 8)}`;
+    const tabPending = this._pendingClarifications.get(tabId) || new Map();
+    this._pendingClarifications.set(tabId, tabPending);
+    const responsePromise = new Promise((resolve) => {
+      tabPending.set(clarifyId, { resolve, ts: Date.now() });
+    });
+    try {
+      onUpdate('clarify', {
+        clarifyId,
+        workflowHealing: {
+          workflowId: workflow.id,
+          workflowName: workflow.name,
+          stepId: step.id,
+          stepNumber: stepIndex + 1,
+          tool: step.tool,
+          previousTarget: step.target,
+          candidates: choices.map((candidate, index) => ({
+            id: `candidate_${index}`,
+            target: candidate.target,
+          })),
+        },
+        question: `Choose a replacement target for saved workflow step ${stepIndex + 1}. The workflow will update only if the action succeeds and its postcondition is verified.`,
+        options: ['deny'],
+      });
+    } catch {}
+    const response = await responsePromise;
+    tabPending.delete(clarifyId);
+    if (tabPending.size === 0) this._pendingClarifications.delete(tabId);
+    if (response?.cancelled || ['timeout', 'auto'].includes(response?.source)) return null;
+    const match = String(response?.answer || '').match(/^candidate_(\d)$/);
+    const index = match ? Number(match[1]) : -1;
+    return choices[index] || null;
+  }
+
   /**
    * Check and clear abort flag.
    */
@@ -15579,6 +15617,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
     let traceStatus = 'workflow_stopped';
     let finalContent = '';
     let matchedSteps = 0;
+    const verifiedHealings = [];
 
     const finishStopped = (reason, stepIndex = 0) => {
       const summary = `Saved workflow "${workflow.name}" stopped safely at step ${stepIndex + 1}: ${reason}.`;
@@ -15588,7 +15627,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
       });
       traceStatus = 'workflow_stopped';
       finalContent = summary;
-      return { status: 'stopped', summary, reason, stepIndex, matchedSteps };
+      return { status: 'stopped', summary, reason, stepIndex, matchedSteps, healings: verifiedHealings };
     };
 
     try {
@@ -15605,6 +15644,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
           reason,
           stepIndex: 0,
           matchedSteps,
+          healings: verifiedHealings,
           prompt: workflowFallbackPrompt(workflow, 0, reason),
         };
       }
@@ -15629,6 +15669,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
             reason,
             stepIndex: index,
             matchedSteps,
+            healings: verifiedHealings,
             prompt: workflowFallbackPrompt(workflow, index, reason),
           };
         }
@@ -15640,6 +15681,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
         }
 
         let targetMatch = null;
+        let pendingHealing = null;
         if (step.target) {
           const treeResult = await this.executeTool(tabId, 'get_accessibility_tree', {
             filter: 'all',
@@ -15650,6 +15692,45 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
             : treeResult?.pageContent || treeResult?.tree || treeResult?.content || '';
           const candidates = parseAccessibilityTreeDescriptors(treeText);
           targetMatch = findWorkflowTarget(step.target, candidates);
+          if (targetMatch.status !== 'matched') {
+            const healingCandidates = findWorkflowHealingCandidates(step.target, candidates);
+            const approved = await this._promptWorkflowTargetHealing(
+              tabId, workflow, step, index, healingCandidates, onUpdate,
+            );
+            if (this._checkAbort(tabId)) return finishStopped('stopped by the user', index);
+            if (approved) {
+              const approvalUrl = await this._currentUrl(tabId);
+              const approvalScope = step.scope || workflow.start;
+              if (workflowUrlMatches(approvalScope, approvalUrl)) {
+                const refreshedTreeResult = await this.executeTool(tabId, 'get_accessibility_tree', {
+                  filter: 'all',
+                  maxChars: 60000,
+                });
+                const refreshedTreeText = typeof refreshedTreeResult === 'string'
+                  ? refreshedTreeResult
+                  : refreshedTreeResult?.pageContent || refreshedTreeResult?.tree
+                    || refreshedTreeResult?.content || '';
+                const refreshedMatch = findWorkflowTarget(
+                  approved.target,
+                  parseAccessibilityTreeDescriptors(refreshedTreeText),
+                );
+                if (refreshedMatch.status === 'matched') {
+                  targetMatch = refreshedMatch;
+                  pendingHealing = {
+                    stepId: step.id,
+                    previousTarget: step.target,
+                    target: approved.target,
+                  };
+                  trace.recordNote(traceRunId, index + 1, 'workflow_target_healing_approved', {
+                    workflowId: workflow.id,
+                    stepId: step.id,
+                    tool: step.tool,
+                    candidateScore: approved.score,
+                  });
+                }
+              }
+            }
+          }
           if (targetMatch.status !== 'matched') {
             trace.recordNote(traceRunId, index + 1, 'workflow_replay_target_miss', {
               workflowId: workflow.id,
@@ -15665,6 +15746,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
               reason,
               stepIndex: index,
               matchedSteps,
+              healings: verifiedHealings,
               prompt: workflowFallbackPrompt(workflow, index, reason),
             };
           }
@@ -15731,8 +15813,27 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
             reason: validation.reason,
             stepIndex: index,
             matchedSteps,
+            healings: verifiedHealings,
             prompt: workflowFallbackPrompt(workflow, index, validation.reason),
           };
+        }
+        if (pendingHealing) {
+          const healingVerified = rawResult?.success === true
+            && rawResult?.dispatched !== false
+            && rawResult?.verified !== false
+            && rawResult?.noProgress !== true
+            && rawResult?.inconclusive !== true
+            && rawResult?.outcomeUnknown !== true
+            && rawResult?.ambiguous !== true
+            && rawResult?.stale !== true
+            && rawResult?.wrongTarget !== true;
+          trace.recordNote(traceRunId, index + 1, 'workflow_target_healing_verification', {
+            workflowId: workflow.id,
+            stepId: step.id,
+            tool: step.tool,
+            verified: healingVerified,
+          });
+          if (healingVerified) verifiedHealings.push(pendingHealing);
         }
         matchedSteps += 1;
       }
@@ -15750,7 +15851,13 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
       });
       traceStatus = 'done';
       finalContent = summary;
-      return { status: 'completed', summary, matchedSteps, estimatedLlmCallsSaved: matchedSteps };
+      return {
+        status: 'completed',
+        summary,
+        matchedSteps,
+        estimatedLlmCallsSaved: matchedSteps,
+        healings: verifiedHealings,
+      };
     } finally {
       await trace.endRun(traceRunId, { status: traceStatus, finalContent });
       this.currentCostState.delete(tabId);

--- a/src/chrome/src/agent/workflows.js
+++ b/src/chrome/src/agent/workflows.js
@@ -842,6 +842,88 @@ export function findWorkflowTarget(target, candidates) {
   return { status: 'matched', candidate: ranked[0].candidate, score: ranked[0].score };
 }
 
+function workflowHealingTargetCompatible(previous, replacement) {
+  if (scoreWorkflowTarget(previous, replacement) <= 0) return false;
+  if (!!previous?.href !== !!replacement?.href) return false;
+  if (previous?.href) {
+    try {
+      if (new URL(previous.href).origin !== new URL(replacement.href).origin) return false;
+    } catch {
+      return false;
+    }
+  }
+  return true;
+}
+
+/**
+ * Return user-reviewable replacement targets after strict matching fails.
+ * Every replacement must be independently replayable, and duplicate semantic
+ * descriptors are removed rather than choosing an arbitrary live ref.
+ */
+export function findWorkflowHealingCandidates(target, candidates, options = {}) {
+  const expected = normalizeTarget(target);
+  if (!expected) return [];
+  const limit = Math.max(1, Math.min(5, Math.floor(Number(options.limit) || 5)));
+  const ranked = [];
+  const fingerprintCounts = new Map();
+  for (const candidate of Array.isArray(candidates) ? candidates : []) {
+    const refId = cleanText(candidate?.refId, 100);
+    const replacement = normalizeTarget(candidate);
+    if (!/^ref_[A-Za-z0-9_-]+$/.test(refId) || !isReplayableWorkflowTarget(replacement)) continue;
+    if (!workflowHealingTargetCompatible(expected, replacement)) continue;
+    const score = scoreWorkflowTarget(expected, replacement);
+    const fingerprint = JSON.stringify(replacement);
+    fingerprintCounts.set(fingerprint, (fingerprintCounts.get(fingerprint) || 0) + 1);
+    ranked.push({ refId, target: replacement, score, fingerprint });
+  }
+  return ranked
+    .filter((entry) => fingerprintCounts.get(entry.fingerprint) === 1)
+    .sort((a, b) => b.score - a.score || a.fingerprint.localeCompare(b.fingerprint))
+    .slice(0, limit)
+    .map(({ refId, target: replacement, score }) => ({ refId, target: replacement, score }));
+}
+
+/** Apply an approved batch of target replacements without changing workflow identity. */
+export function applyWorkflowTargetHealings(input, healings, options = {}) {
+  const ts = timestamp(options.now, nowMs());
+  const workflow = normalizeSavedWorkflow(input, { now: ts });
+  if (!workflow) return { changed: false, reason: 'invalid_workflow', workflow: null, healedStepCount: 0 };
+  const repairs = Array.isArray(healings) ? healings : [];
+  if (!repairs.length || repairs.length > MAX_STEPS) {
+    return { changed: false, reason: 'no_changes', workflow, healedStepCount: 0 };
+  }
+  const seen = new Set();
+  let healedStepCount = 0;
+  for (const repair of repairs) {
+    const stepId = cleanId(repair?.stepId);
+    const previousTarget = normalizeTarget(repair?.previousTarget);
+    const replacement = normalizeTarget(repair?.target);
+    if (!stepId || seen.has(stepId) || !previousTarget || !isReplayableWorkflowTarget(replacement)
+        || !workflowHealingTargetCompatible(previousTarget, replacement)) {
+      return { changed: false, reason: 'invalid_healing', workflow, healedStepCount: 0 };
+    }
+    seen.add(stepId);
+    const step = workflow.steps.find((candidate) => candidate.id === stepId);
+    if (!step || JSON.stringify(step.target || null) !== JSON.stringify(previousTarget)) {
+      return { changed: false, reason: 'stale_target', workflow, healedStepCount: 0 };
+    }
+    if (JSON.stringify(previousTarget) === JSON.stringify(replacement)) continue;
+    step.target = replacement;
+    if (['type_ax', 'set_field'].includes(step.tool) && sensitiveParameter(replacement)) {
+      const parameterId = cleanId(step.args?.text?.[WORKFLOW_PARAM_REF_KEY]);
+      const parameter = workflow.parameters.find((candidate) => candidate.id === parameterId);
+      if (parameter) parameter.sensitive = true;
+    }
+    healedStepCount += 1;
+  }
+  if (!healedStepCount) return { changed: false, reason: 'no_changes', workflow, healedStepCount: 0 };
+  workflow.updatedAt = ts;
+  const normalized = normalizeSavedWorkflow(workflow, { now: ts });
+  return normalized
+    ? { changed: true, reason: '', workflow: normalized, healedStepCount }
+    : { changed: false, reason: 'invalid_healing', workflow, healedStepCount: 0 };
+}
+
 export async function compileLatestSuccessfulWorkflow(traceReader, options = {}) {
   if (!traceReader?.listRuns || !traceReader?.getRunEvents) {
     return { workflow: null, warnings: [], reason: 'trace_reader_required' };
@@ -914,6 +996,20 @@ export function createSavedWorkflowStore(storageArea, options = {}) {
       };
       store.workflows[index] = workflow;
       return { changed: true, workflow, store: await write(store) };
+    },
+    async healTargets(id, input = {}) {
+      const store = await read();
+      const index = store.workflows.findIndex((item) => item.id === id);
+      if (index < 0) return { changed: false, reason: 'not_found', workflow: null, store, healedStepCount: 0 };
+      const current = store.workflows[index];
+      const expectedUpdatedAt = Number(input.expectedUpdatedAt);
+      if (!Number.isFinite(expectedUpdatedAt) || current.updatedAt !== expectedUpdatedAt) {
+        return { changed: false, reason: 'workflow_changed', workflow: current, store, healedStepCount: 0 };
+      }
+      const healed = applyWorkflowTargetHealings(current, input.healings, { now: now() });
+      if (!healed.changed) return { ...healed, store };
+      store.workflows[index] = healed.workflow;
+      return { ...healed, store: await write(store) };
     },
     async delete(id) {
       const store = await read();

--- a/src/chrome/src/background.js
+++ b/src/chrome/src/background.js
@@ -2363,6 +2363,18 @@ async function handleMessage(msg, sender) {
             runOptions,
           );
           result = replay.summary || '';
+          if (Array.isArray(replay.healings) && replay.healings.length) {
+            const healed = await withSavedWorkflowStoreLock(() => savedWorkflowStore.healTargets(
+              workflow.id,
+              { expectedUpdatedAt: workflow.updatedAt, healings: replay.healings },
+            ));
+            publishUpdate(healed.changed ? 'workflow_healed' : 'workflow_healing_not_saved', {
+              workflowId: workflow.id,
+              workflowName: workflow.name,
+              count: healed.healedStepCount || 0,
+              reason: healed.reason || '',
+            });
+          }
           if (replay.status === 'fallback') {
             publishUpdate('workflow_fallback', {
               workflowId: workflow.id,

--- a/src/chrome/src/ui/locales/ar.js
+++ b/src/chrome/src/ui/locales/ar.js
@@ -949,4 +949,10 @@ export default {
   'st.skills.cws.package_zip_only': 'اختر ملف إصدار بصيغة .zip.',
   'st.skills.cws.package_too_large': 'يجب أن يكون حجم الملف بين 1 بايت و100 ميجابايت.',
   'sp.run_progress_replay_gap': 'تعذّر إعادة عرض بعض تقدّم التشغيل السابق',
+  "sp.workflows.healing.question": "تعذّر على سير العمل «{name}» مطابقة الخطوة {step}. اختر بديلاً لتجربته؛ ولن يُحفظ إلا بعد تحقق ناجح.",
+  "sp.workflows.healing.previous": "الهدف المحفوظ: {target}",
+  "sp.workflows.healing.use": "جرّب واحفظ {target}",
+  "sp.workflows.healing.keep": "الاحتفاظ بالهدف المحفوظ",
+  "sp.workflows.healing.saved": "تم تحديث {count} محددات في «{name}».",
+  "sp.workflows.healing.not_saved": "لم يُحفظ المحدد الموافق عليه لـ «{name}» لأن سير العمل تغيّر أو لأن التحقق لم يكن حاسماً.",
 };

--- a/src/chrome/src/ui/locales/bn.js
+++ b/src/chrome/src/ui/locales/bn.js
@@ -947,4 +947,10 @@ export default {
   'st.provider.field.cache_write_cost_per_million': "আনুমানিক 5-মিনিট ক্যাশে লেখার খরচ ($ / 1M টোকেন)",
   'st.provider.field.cache_write_1h_cost_per_million': "আনুমানিক 1-ঘন্টা ক্যাশে লেখার খরচ ($ / 1M টোকেন)",
   'sp.run_progress_replay_gap': 'আগের কিছু রান অগ্রগতি পুনরায় দেখানো যায়নি',
+  "sp.workflows.healing.question": "“{name}” ওয়ার্কফ্লো ধাপ {step} মেলাতে পারেনি। চেষ্টা করার জন্য একটি বিকল্প বেছে নিন; সফল যাচাইয়ের পরেই এটি সংরক্ষিত হবে।",
+  "sp.workflows.healing.previous": "সংরক্ষিত লক্ষ্য: {target}",
+  "sp.workflows.healing.use": "{target} চেষ্টা করে সংরক্ষণ করুন",
+  "sp.workflows.healing.keep": "সংরক্ষিত লক্ষ্যটি রাখুন",
+  "sp.workflows.healing.saved": "“{name}”-এ {count}টি লোকেটর আপডেট করা হয়েছে।",
+  "sp.workflows.healing.not_saved": "ওয়ার্কফ্লো পরিবর্তিত হওয়ায় বা যাচাই অনিশ্চিত থাকায় “{name}”-এর অনুমোদিত লোকেটর সংরক্ষিত হয়নি।",
 };

--- a/src/chrome/src/ui/locales/de.js
+++ b/src/chrome/src/ui/locales/de.js
@@ -920,4 +920,10 @@ export default {
   'tr.event.result': 'Ergebnis',
   'tr.event.step': 'Schritt {step}',
   'sp.run_progress_replay_gap': 'Ein Teil des früheren Ausführungsverlaufs konnte nicht erneut angezeigt werden',
+  "sp.workflows.healing.question": "Workflow „{name}“ konnte Schritt {step} nicht zuordnen. Wähle ein Ersatzziel zum Testen; es wird erst nach erfolgreicher Prüfung gespeichert.",
+  "sp.workflows.healing.previous": "Gespeichertes Ziel: {target}",
+  "sp.workflows.healing.use": "{target} testen und speichern",
+  "sp.workflows.healing.keep": "Gespeichertes Ziel beibehalten",
+  "sp.workflows.healing.saved": "{count} Locator in „{name}“ aktualisiert.",
+  "sp.workflows.healing.not_saved": "Der bestätigte Locator für „{name}“ wurde nicht gespeichert, weil sich der Workflow geändert hat oder die Prüfung nicht eindeutig war.",
 };

--- a/src/chrome/src/ui/locales/en.js
+++ b/src/chrome/src/ui/locales/en.js
@@ -951,4 +951,10 @@ export default {
   'st.provider.field.cache_write_cost_per_million': "Estimated 5-minute cache write cost ($ / 1M tokens)",
   'st.provider.field.cache_write_1h_cost_per_million': "Estimated 1-hour cache write cost ($ / 1M tokens)",
   'sp.run_progress_replay_gap': 'Some earlier run progress could not be replayed',
+  "sp.workflows.healing.question": "Workflow “{name}” could not match step {step}. Choose a replacement to try; it will be saved only after successful verification.",
+  "sp.workflows.healing.previous": "Saved target: {target}",
+  "sp.workflows.healing.use": "Try and save {target}",
+  "sp.workflows.healing.keep": "Keep the saved target",
+  "sp.workflows.healing.saved": "Updated {count} locator(s) in “{name}”.",
+  "sp.workflows.healing.not_saved": "The approved locator for “{name}” was not saved because the workflow changed or verification was inconclusive.",
 };

--- a/src/chrome/src/ui/locales/es.js
+++ b/src/chrome/src/ui/locales/es.js
@@ -949,4 +949,10 @@ export default {
   'st.skills.cws.package_zip_only': 'Elige un paquete de publicación en formato .zip.',
   'st.skills.cws.package_too_large': 'El archivo ZIP debe tener entre 1 byte y 100 MB.',
   'sp.run_progress_replay_gap': 'No se pudo volver a mostrar parte del progreso anterior de la ejecución',
+  "sp.workflows.healing.question": "El flujo «{name}» no pudo encontrar el paso {step}. Elige un reemplazo para probarlo; solo se guardará después de una verificación correcta.",
+  "sp.workflows.healing.previous": "Objetivo guardado: {target}",
+  "sp.workflows.healing.use": "Probar y guardar {target}",
+  "sp.workflows.healing.keep": "Conservar el objetivo guardado",
+  "sp.workflows.healing.saved": "Se actualizaron {count} localizadores en «{name}».",
+  "sp.workflows.healing.not_saved": "El localizador aprobado para «{name}» no se guardó porque el flujo cambió o la verificación no fue concluyente.",
 };

--- a/src/chrome/src/ui/locales/fa.js
+++ b/src/chrome/src/ui/locales/fa.js
@@ -947,4 +947,10 @@ export default {
   'st.provider.field.cache_write_cost_per_million': "تخمینی هزینه نوشتن 5 دقیقه ای کش ($ / 1 میلیون توکن)",
   'st.provider.field.cache_write_1h_cost_per_million': "تخمینی هزینه نوشتن حافظه پنهان 1 ساعته ($ / 1 میلیون توکن)",
   'sp.run_progress_replay_gap': 'بخشی از پیشرفت پیشین اجرا قابل بازپخش نبود',
+  "sp.workflows.healing.question": "گردش‌کار «{name}» نتوانست مرحلهٔ {step} را تطبیق دهد. یک جایگزین برای آزمایش انتخاب کنید؛ فقط پس از تأیید موفق ذخیره می‌شود.",
+  "sp.workflows.healing.previous": "هدف ذخیره‌شده: {target}",
+  "sp.workflows.healing.use": "آزمایش و ذخیرهٔ {target}",
+  "sp.workflows.healing.keep": "حفظ هدف ذخیره‌شده",
+  "sp.workflows.healing.saved": "{count} مکان‌یاب در «{name}» به‌روزرسانی شد.",
+  "sp.workflows.healing.not_saved": "مکان‌یاب تأییدشدهٔ «{name}» ذخیره نشد، زیرا گردش‌کار تغییر کرده بود یا نتیجهٔ تأیید قطعی نبود.",
 };

--- a/src/chrome/src/ui/locales/fr.js
+++ b/src/chrome/src/ui/locales/fr.js
@@ -949,4 +949,10 @@ export default {
   'st.skills.cws.package_zip_only': "Choisissez un package de publication au format .zip.",
   'st.skills.cws.package_too_large': "Le fichier ZIP doit faire entre 1 octet et 100 Mo.",
   'sp.run_progress_replay_gap': 'Une partie de la progression précédente de l’exécution n’a pas pu être réaffichée',
+  "sp.workflows.healing.question": "Le workflow « {name} » n’a pas pu faire correspondre l’étape {step}. Choisissez une cible de remplacement à essayer ; elle ne sera enregistrée qu’après une vérification réussie.",
+  "sp.workflows.healing.previous": "Cible enregistrée : {target}",
+  "sp.workflows.healing.use": "Essayer et enregistrer {target}",
+  "sp.workflows.healing.keep": "Conserver la cible enregistrée",
+  "sp.workflows.healing.saved": "{count} localisateur(s) mis à jour dans « {name} ».",
+  "sp.workflows.healing.not_saved": "Le localisateur approuvé pour « {name} » n’a pas été enregistré, car le workflow a changé ou la vérification était incertaine.",
 };

--- a/src/chrome/src/ui/locales/he.js
+++ b/src/chrome/src/ui/locales/he.js
@@ -902,4 +902,10 @@ export default {
   'st.skills.cws.package_zip_only': 'בחר חבילת פרסום בפורמט .zip.',
   'st.skills.cws.package_too_large': 'קובץ ZIP חייב להיות בין 1 bait ל-100 MB.',
   'sp.run_progress_replay_gap': 'לא ניתן היה להציג מחדש חלק מהתקדמות ההרצה הקודמת',
+  "sp.workflows.healing.question": "תהליך העבודה „{name}” לא הצליח להתאים את שלב {step}. בחרו יעד חלופי לניסיון; הוא יישמר רק לאחר אימות מוצלח.",
+  "sp.workflows.healing.previous": "היעד השמור: {target}",
+  "sp.workflows.healing.use": "לנסות ולשמור את {target}",
+  "sp.workflows.healing.keep": "להשאיר את היעד השמור",
+  "sp.workflows.healing.saved": "עודכנו {count} מאתרים ב־„{name}”.",
+  "sp.workflows.healing.not_saved": "המאתר שאושר עבור „{name}” לא נשמר משום שתהליך העבודה השתנה או שהאימות לא היה חד־משמעי.",
 };

--- a/src/chrome/src/ui/locales/hi.js
+++ b/src/chrome/src/ui/locales/hi.js
@@ -947,4 +947,10 @@ export default {
   'st.provider.field.cache_write_cost_per_million': "अनुमानित 5-मिनट कैश लिखने की लागत ($ / 1M टोकन)",
   'st.provider.field.cache_write_1h_cost_per_million': "अनुमानित 1-घंटे कैश लिखने की लागत ($ / 1M टोकन)",
   'sp.run_progress_replay_gap': 'पहले की कुछ रन प्रगति दोबारा नहीं दिखाई जा सकी',
+  "sp.workflows.healing.question": "वर्कफ़्लो “{name}” चरण {step} से मेल नहीं खा सका। आज़माने के लिए कोई विकल्प चुनें; सफल सत्यापन के बाद ही वह सहेजा जाएगा।",
+  "sp.workflows.healing.previous": "सहेजा गया लक्ष्य: {target}",
+  "sp.workflows.healing.use": "{target} को आज़माएँ और सहेजें",
+  "sp.workflows.healing.keep": "सहेजा गया लक्ष्य रखें",
+  "sp.workflows.healing.saved": "“{name}” में {count} लोकेटर अपडेट किए गए।",
+  "sp.workflows.healing.not_saved": "“{name}” के लिए स्वीकृत लोकेटर सहेजा नहीं गया क्योंकि वर्कफ़्लो बदल गया था या सत्यापन निर्णायक नहीं था।",
 };

--- a/src/chrome/src/ui/locales/id.js
+++ b/src/chrome/src/ui/locales/id.js
@@ -949,4 +949,10 @@ export default {
   'st.skills.cws.package_zip_only': 'Pilih paket rilis berekstensi .zip.',
   'st.skills.cws.package_too_large': 'ZIP harus berukuran antara 1 byte hingga 100 MB.',
   'sp.run_progress_replay_gap': 'Sebagian kemajuan proses sebelumnya tidak dapat ditampilkan ulang',
+  "sp.workflows.healing.question": "Alur kerja “{name}” tidak dapat mencocokkan langkah {step}. Pilih pengganti untuk dicoba; pengganti hanya disimpan setelah verifikasi berhasil.",
+  "sp.workflows.healing.previous": "Target tersimpan: {target}",
+  "sp.workflows.healing.use": "Coba dan simpan {target}",
+  "sp.workflows.healing.keep": "Pertahankan target tersimpan",
+  "sp.workflows.healing.saved": "Memperbarui {count} locator di “{name}”.",
+  "sp.workflows.healing.not_saved": "Locator yang disetujui untuk “{name}” tidak disimpan karena alur kerja berubah atau verifikasi tidak meyakinkan.",
 };

--- a/src/chrome/src/ui/locales/ja.js
+++ b/src/chrome/src/ui/locales/ja.js
@@ -949,4 +949,10 @@ export default {
   'st.skills.cws.package_zip_only': '.zip リリースパッケージを選択してください。',
   'st.skills.cws.package_too_large': 'ZIP は 1 バイトから 100 MB の間でなければなりません。',
   'sp.run_progress_replay_gap': '以前の実行進捗の一部を再表示できませんでした',
+  "sp.workflows.healing.question": "ワークフロー「{name}」はステップ {step} の対象を特定できませんでした。試す代替対象を選んでください。検証に成功した場合のみ保存されます。",
+  "sp.workflows.healing.previous": "保存済みの対象: {target}",
+  "sp.workflows.healing.use": "{target} を試して保存",
+  "sp.workflows.healing.keep": "保存済みの対象を維持",
+  "sp.workflows.healing.saved": "「{name}」のロケーターを {count} 件更新しました。",
+  "sp.workflows.healing.not_saved": "ワークフローが変更されたか検証結果が不確実だったため、「{name}」で承認されたロケーターは保存されませんでした。",
 };

--- a/src/chrome/src/ui/locales/ko.js
+++ b/src/chrome/src/ui/locales/ko.js
@@ -949,4 +949,10 @@ export default {
   'st.skills.cws.package_zip_only': '.zip 릴리스 패키지를 선택하세요.',
   'st.skills.cws.package_too_large': 'ZIP은 1바이트에서 100MB 사이여야 합니다.',
   'sp.run_progress_replay_gap': '이전 실행 진행 상황 일부를 다시 표시할 수 없습니다',
+  "sp.workflows.healing.question": "워크플로 “{name}”에서 {step}단계 대상을 찾지 못했습니다. 시도할 대상을 선택하세요. 검증에 성공한 경우에만 저장됩니다.",
+  "sp.workflows.healing.previous": "저장된 대상: {target}",
+  "sp.workflows.healing.use": "{target} 시도 후 저장",
+  "sp.workflows.healing.keep": "저장된 대상 유지",
+  "sp.workflows.healing.saved": "“{name}”에서 로케이터 {count}개를 업데이트했습니다.",
+  "sp.workflows.healing.not_saved": "워크플로가 변경되었거나 검증 결과가 불확실하여 “{name}”에서 승인한 로케이터를 저장하지 않았습니다.",
 };

--- a/src/chrome/src/ui/locales/ms.js
+++ b/src/chrome/src/ui/locales/ms.js
@@ -949,4 +949,10 @@ export default {
   'st.skills.cws.package_zip_only': 'Pilih pakej pelepasan berformat .zip.',
   'st.skills.cws.package_too_large': 'ZIP mesti antara 1 bait hingga 100 MB.',
   'sp.run_progress_replay_gap': 'Sebahagian kemajuan larian terdahulu tidak dapat dipaparkan semula',
+  "sp.workflows.healing.question": "Aliran kerja “{name}” tidak dapat memadankan langkah {step}. Pilih pengganti untuk dicuba; ia hanya disimpan selepas pengesahan berjaya.",
+  "sp.workflows.healing.previous": "Sasaran tersimpan: {target}",
+  "sp.workflows.healing.use": "Cuba dan simpan {target}",
+  "sp.workflows.healing.keep": "Kekalkan sasaran tersimpan",
+  "sp.workflows.healing.saved": "Mengemas kini {count} pencari dalam “{name}”.",
+  "sp.workflows.healing.not_saved": "Pencari yang diluluskan untuk “{name}” tidak disimpan kerana aliran kerja berubah atau pengesahan tidak muktamad.",
 };

--- a/src/chrome/src/ui/locales/nl.js
+++ b/src/chrome/src/ui/locales/nl.js
@@ -900,4 +900,10 @@ export default {
   'st.skills.cws.package_zip_only': 'Kies een .zip release-pakket.',
   'st.skills.cws.package_too_large': 'De ZIP moet tussen 1 byte en 100 MB zijn.',
   'sp.run_progress_replay_gap': 'Een deel van de eerdere uitvoeringsvoortgang kon niet opnieuw worden weergegeven',
+  "sp.workflows.healing.question": "Workflow ‘{name}’ kon stap {step} niet koppelen. Kies een vervangend doel om te proberen; het wordt pas na geslaagde verificatie opgeslagen.",
+  "sp.workflows.healing.previous": "Opgeslagen doel: {target}",
+  "sp.workflows.healing.use": "{target} proberen en opslaan",
+  "sp.workflows.healing.keep": "Opgeslagen doel behouden",
+  "sp.workflows.healing.saved": "{count} locator(s) in ‘{name}’ bijgewerkt.",
+  "sp.workflows.healing.not_saved": "De goedgekeurde locator voor ‘{name}’ is niet opgeslagen omdat de workflow was gewijzigd of de verificatie niet overtuigend was.",
 };

--- a/src/chrome/src/ui/locales/pl.js
+++ b/src/chrome/src/ui/locales/pl.js
@@ -909,4 +909,10 @@ export default {
   'st.skills.cws.package_zip_only': 'Wybierz pakiet publikacji w formacie .zip.',
   'st.skills.cws.package_too_large': 'ZIP musi mieć rozmiar od 1 bajta do 100 MB.',
   'sp.run_progress_replay_gap': 'Nie udało się ponownie wyświetlić części wcześniejszego postępu wykonania',
+  "sp.workflows.healing.question": "Przepływ „{name}” nie dopasował kroku {step}. Wybierz cel zastępczy do wypróbowania; zostanie zapisany dopiero po pomyślnej weryfikacji.",
+  "sp.workflows.healing.previous": "Zapisany cel: {target}",
+  "sp.workflows.healing.use": "Wypróbuj i zapisz {target}",
+  "sp.workflows.healing.keep": "Zachowaj zapisany cel",
+  "sp.workflows.healing.saved": "Zaktualizowano {count} lokalizatorów w „{name}”.",
+  "sp.workflows.healing.not_saved": "Zatwierdzony lokalizator dla „{name}” nie został zapisany, ponieważ przepływ się zmienił lub weryfikacja nie była jednoznaczna.",
 };

--- a/src/chrome/src/ui/locales/pt.js
+++ b/src/chrome/src/ui/locales/pt.js
@@ -947,4 +947,10 @@ export default {
   'st.provider.field.cache_write_cost_per_million': "Custo estimado de gravação em cache de 5 minutos ($/1 milhão de tokens)",
   'st.provider.field.cache_write_1h_cost_per_million': "Custo estimado de gravação de cache em 1 hora ($/1 milhão de tokens)",
   'sp.run_progress_replay_gap': 'Não foi possível reexibir parte do progresso anterior da execução',
+  "sp.workflows.healing.question": "O fluxo “{name}” não conseguiu corresponder à etapa {step}. Escolha um substituto para testar; ele só será salvo após uma verificação bem-sucedida.",
+  "sp.workflows.healing.previous": "Alvo salvo: {target}",
+  "sp.workflows.healing.use": "Testar e salvar {target}",
+  "sp.workflows.healing.keep": "Manter o alvo salvo",
+  "sp.workflows.healing.saved": "Foram atualizados {count} localizadores em “{name}”.",
+  "sp.workflows.healing.not_saved": "O localizador aprovado para “{name}” não foi salvo porque o fluxo mudou ou a verificação foi inconclusiva.",
 };

--- a/src/chrome/src/ui/locales/ru.js
+++ b/src/chrome/src/ui/locales/ru.js
@@ -949,4 +949,10 @@ export default {
   'st.skills.cws.package_zip_only': 'Выберите пакет публикации в формате .zip.',
   'st.skills.cws.package_too_large': 'ZIP-файл должен быть от 1 байта до 100 МБ.',
   'sp.run_progress_replay_gap': 'Не удалось повторно показать часть предыдущего хода выполнения',
+  "sp.workflows.healing.question": "Сценарий «{name}» не смог сопоставить шаг {step}. Выберите замену для проверки; она сохранится только после успешной верификации.",
+  "sp.workflows.healing.previous": "Сохранённая цель: {target}",
+  "sp.workflows.healing.use": "Проверить и сохранить {target}",
+  "sp.workflows.healing.keep": "Оставить сохранённую цель",
+  "sp.workflows.healing.saved": "Обновлено локаторов в «{name}»: {count}.",
+  "sp.workflows.healing.not_saved": "Одобренный локатор для «{name}» не сохранён: сценарий изменился или результат проверки оказался неоднозначным.",
 };

--- a/src/chrome/src/ui/locales/th.js
+++ b/src/chrome/src/ui/locales/th.js
@@ -949,4 +949,10 @@ export default {
   'st.skills.cws.package_zip_only': 'เลือกแพ็คเกจการเผยแพร่รูปแบบ .zip',
   'st.skills.cws.package_too_large': 'ZIP ต้องมีขนาดระหว่าง 1 ไบต์ถึง 100 MB',
   'sp.run_progress_replay_gap': 'ไม่สามารถแสดงความคืบหน้าก่อนหน้านี้บางส่วนของการทำงานซ้ำได้',
+  "sp.workflows.healing.question": "เวิร์กโฟลว์ “{name}” จับคู่ขั้นตอนที่ {step} ไม่ได้ เลือกเป้าหมายทดแทนเพื่อทดลอง ระบบจะบันทึกเมื่อยืนยันผลสำเร็จแล้วเท่านั้น",
+  "sp.workflows.healing.previous": "เป้าหมายที่บันทึกไว้: {target}",
+  "sp.workflows.healing.use": "ลองและบันทึก {target}",
+  "sp.workflows.healing.keep": "ใช้เป้าหมายที่บันทึกไว้ต่อไป",
+  "sp.workflows.healing.saved": "อัปเดตตัวระบุตำแหน่ง {count} รายการใน “{name}” แล้ว",
+  "sp.workflows.healing.not_saved": "ไม่ได้บันทึกตัวระบุตำแหน่งที่อนุมัติสำหรับ “{name}” เพราะเวิร์กโฟลว์เปลี่ยนแปลงหรือผลการยืนยันไม่ชัดเจน",
 };

--- a/src/chrome/src/ui/locales/tl.js
+++ b/src/chrome/src/ui/locales/tl.js
@@ -949,4 +949,10 @@ export default {
   'st.skills.cws.package_zip_only': 'Pumili ng .zip release package.',
   'st.skills.cws.package_too_large': 'Ang ZIP ay dapat nasa pagitan ng 1 byte hanggang 100 MB.',
   'sp.run_progress_replay_gap': 'Hindi maipakita muli ang ilang naunang progreso ng run',
+  "sp.workflows.healing.question": "Hindi maitugma ng workflow na “{name}” ang hakbang {step}. Pumili ng kapalit na susubukan; ise-save lamang ito pagkatapos ng matagumpay na beripikasyon.",
+  "sp.workflows.healing.previous": "Naka-save na target: {target}",
+  "sp.workflows.healing.use": "Subukan at i-save ang {target}",
+  "sp.workflows.healing.keep": "Panatilihin ang naka-save na target",
+  "sp.workflows.healing.saved": "Na-update ang {count} locator sa “{name}”.",
+  "sp.workflows.healing.not_saved": "Hindi na-save ang inaprubahang locator para sa “{name}” dahil nagbago ang workflow o hindi tiyak ang beripikasyon.",
 };

--- a/src/chrome/src/ui/locales/tr.js
+++ b/src/chrome/src/ui/locales/tr.js
@@ -948,4 +948,10 @@ export default {
   'st.skills.cws.package_zip_only': '.zip biçiminde bir sürüm paketi seçin.',
   'st.skills.cws.package_too_large': 'ZIP 1 bayt ile 100 MB arasında olmalıdır.',
   'sp.run_progress_replay_gap': 'Önceki çalışma ilerlemesinin bir kısmı yeniden gösterilemedi',
+  "sp.workflows.healing.question": "“{name}” iş akışı {step}. adımı eşleştiremedi. Denemek için bir yedek hedef seçin; yalnızca başarılı doğrulamadan sonra kaydedilir.",
+  "sp.workflows.healing.previous": "Kayıtlı hedef: {target}",
+  "sp.workflows.healing.use": "{target} hedefini dene ve kaydet",
+  "sp.workflows.healing.keep": "Kayıtlı hedefi koru",
+  "sp.workflows.healing.saved": "“{name}” içinde {count} bulucu güncellendi.",
+  "sp.workflows.healing.not_saved": "İş akışı değiştiği veya doğrulama kesin olmadığı için “{name}” için onaylanan bulucu kaydedilmedi.",
 };

--- a/src/chrome/src/ui/locales/uk.js
+++ b/src/chrome/src/ui/locales/uk.js
@@ -949,4 +949,10 @@ export default {
   'st.skills.cws.package_zip_only': 'Виберіть пакет публікації у форматі .zip.',
   'st.skills.cws.package_too_large': 'ZIP-файл повинен бути від 1 байта до 100 МБ.',
   'sp.run_progress_replay_gap': 'Не вдалося повторно показати частину попереднього перебігу виконання',
+  "sp.workflows.healing.question": "Робочий процес «{name}» не зміг зіставити крок {step}. Виберіть заміну для перевірки; її буде збережено лише після успішної верифікації.",
+  "sp.workflows.healing.previous": "Збережена ціль: {target}",
+  "sp.workflows.healing.use": "Перевірити й зберегти {target}",
+  "sp.workflows.healing.keep": "Залишити збережену ціль",
+  "sp.workflows.healing.saved": "Оновлено локаторів у «{name}»: {count}.",
+  "sp.workflows.healing.not_saved": "Схвалений локатор для «{name}» не збережено: робочий процес змінився або результат перевірки був неоднозначним.",
 };

--- a/src/chrome/src/ui/locales/vi.js
+++ b/src/chrome/src/ui/locales/vi.js
@@ -947,4 +947,10 @@ export default {
   'st.provider.field.cache_write_cost_per_million': "Ước tính chi phí ghi vào bộ nhớ đệm trong 5 phút ($ / 1 triệu token)",
   'st.provider.field.cache_write_1h_cost_per_million': "Chi phí ghi bộ nhớ đệm trong 1 giờ ước tính ($ / 1 triệu token)",
   'sp.run_progress_replay_gap': 'Không thể hiển thị lại một phần tiến trình chạy trước đó',
+  "sp.workflows.healing.question": "Quy trình “{name}” không thể khớp bước {step}. Hãy chọn một mục tiêu thay thế để thử; mục tiêu chỉ được lưu sau khi xác minh thành công.",
+  "sp.workflows.healing.previous": "Mục tiêu đã lưu: {target}",
+  "sp.workflows.healing.use": "Thử và lưu {target}",
+  "sp.workflows.healing.keep": "Giữ mục tiêu đã lưu",
+  "sp.workflows.healing.saved": "Đã cập nhật {count} bộ định vị trong “{name}”.",
+  "sp.workflows.healing.not_saved": "Bộ định vị đã phê duyệt cho “{name}” không được lưu vì quy trình đã thay đổi hoặc kết quả xác minh chưa rõ ràng.",
 };

--- a/src/chrome/src/ui/locales/zh.js
+++ b/src/chrome/src/ui/locales/zh.js
@@ -949,4 +949,10 @@ export default {
   'st.skills.cws.package_zip_only': '请选择 .zip 格式的发布包。',
   'st.skills.cws.package_too_large': 'ZIP 文件大小必须在 1 字节到 100 MB 之间。',
   'sp.run_progress_replay_gap': '部分较早的运行进度无法重新显示',
+  "sp.workflows.healing.question": "工作流“{name}”无法匹配第 {step} 步。请选择一个替代目标进行尝试；只有验证成功后才会保存。",
+  "sp.workflows.healing.previous": "已保存的目标：{target}",
+  "sp.workflows.healing.use": "尝试并保存 {target}",
+  "sp.workflows.healing.keep": "保留原目标",
+  "sp.workflows.healing.saved": "已更新“{name}”中的 {count} 个定位器。",
+  "sp.workflows.healing.not_saved": "“{name}”中已批准的定位器未保存，因为工作流已发生变化或验证结果不确定。",
 };

--- a/src/chrome/src/ui/sidepanel.js
+++ b/src/chrome/src/ui/sidepanel.js
@@ -8364,6 +8364,19 @@ function handleAgentUpdateMessage(msg) {
       }
       break;
 
+    case 'workflow_healed':
+      showComposerToast(t('sp.workflows.healing.saved', {
+        name: data?.workflowName || '',
+        count: data?.count || 0,
+      }), { duration: 7000 });
+      break;
+
+    case 'workflow_healing_not_saved':
+      showComposerToast(t('sp.workflows.healing.not_saved', {
+        name: data?.workflowName || '',
+      }), { duration: 9000 });
+      break;
+
     case 'run_complete':
       if (currentAssistantEl) finalizeSteps(currentAssistantEl);
       invalidatePlanReviewCards({
@@ -8479,6 +8492,23 @@ chrome.runtime.onMessage.addListener((msg) => {
  * and routes the answer to the background. UI stays visible after answering
  * so the user can see what they chose.
  */
+function workflowHealingTargetLabel(target) {
+  const role = String(target?.role || 'element').slice(0, 40);
+  const primary = String(
+    target?.name || target?.label || target?.ariaLabel || target?.placeholder
+      || target?.fieldName || target?.id || target?.href || '',
+  ).trim().slice(0, 180);
+  const identity = [
+    target?.label && target.label !== primary ? `label=${String(target.label).slice(0, 80)}` : '',
+    target?.ariaLabel && target.ariaLabel !== primary ? `aria-label=${String(target.ariaLabel).slice(0, 80)}` : '',
+    target?.id ? `id=${String(target.id).slice(0, 80)}` : '',
+    target?.fieldName ? `name=${String(target.fieldName).slice(0, 80)}` : '',
+    target?.type ? `type=${String(target.type).slice(0, 40)}` : '',
+    target?.href && target.href !== primary ? `href=${String(target.href).slice(0, 120)}` : '',
+  ].filter(Boolean).join(', ');
+  return `${role}${primary ? ` “${primary}”` : ''}${identity ? ` (${identity})` : ''}`;
+}
+
 function renderClarifyCard(data) {
   hideActivity();
   const tabId = data?.scheduledTabId ?? data?.tabId ?? currentTabId;
@@ -8511,11 +8541,13 @@ function renderClarifyCard(data) {
   card.dataset.tabId = String(tabId);
   card.dataset.memorySource = scheduledJobId
     ? 'scheduled_clarification'
-    : data.submitConfirmation
-      ? 'form_confirmation'
-      : data.permission
-        ? 'permission'
-        : 'clarification_response';
+    : data.workflowHealing
+      ? ''
+      : data.submitConfirmation
+        ? 'form_confirmation'
+        : data.permission
+          ? 'permission'
+          : 'clarification_response';
   if (card.dataset.memorySource === 'clarification_response') {
     card.dataset.memoryQuestion = String(data.question || '').slice(0, 600);
   }
@@ -8538,6 +8570,49 @@ function renderClarifyCard(data) {
   qEl.className = 'clarify-question';
   qEl.textContent = String(data.question || '').slice(0, 600);
   card.appendChild(qEl);
+
+  if (data.workflowHealing) {
+    card.dataset.workflowHealing = '1';
+    const healing = data.workflowHealing;
+    qEl.textContent = t('sp.workflows.healing.question', {
+      name: String(healing.workflowName || '').slice(0, 80),
+      step: Number(healing.stepNumber) || 1,
+    });
+    const previousEl = document.createElement('div');
+    previousEl.className = 'clarify-reason';
+    previousEl.textContent = t('sp.workflows.healing.previous', {
+      target: workflowHealingTargetLabel(healing.previousTarget),
+    });
+    card.appendChild(previousEl);
+
+    const optionsEl = document.createElement('div');
+    optionsEl.className = 'clarify-options';
+    for (const candidate of Array.isArray(healing.candidates) ? healing.candidates.slice(0, 5) : []) {
+      if (!/^candidate_[0-4]$/.test(String(candidate?.id || ''))) continue;
+      const button = document.createElement('button');
+      button.type = 'button';
+      button.className = 'clarify-option';
+      button.textContent = t('sp.workflows.healing.use', {
+        target: workflowHealingTargetLabel(candidate.target),
+      });
+      button.dataset.value = candidate.id;
+      button.addEventListener('click', () => submitClarify(
+        card, tabId, clarifyId, candidate.id, 'option',
+      ));
+      optionsEl.appendChild(button);
+    }
+    const deny = document.createElement('button');
+    deny.type = 'button';
+    deny.className = 'clarify-option';
+    deny.textContent = t('sp.workflows.healing.keep');
+    deny.dataset.value = 'deny';
+    deny.addEventListener('click', () => submitClarify(card, tabId, clarifyId, 'deny', 'option'));
+    optionsEl.appendChild(deny);
+    card.appendChild(optionsEl);
+    content.appendChild(card);
+    scrollToBottom({ force: true });
+    return;
+  }
 
   if (data.submitConfirmation) {
     card.dataset.submitConfirmation = '1';

--- a/src/firefox/src/agent/agent.js
+++ b/src/firefox/src/agent/agent.js
@@ -74,6 +74,7 @@ import { buildCustomSkillsPrompt, buildSkillLoaderDefinition, buildSkillToolDefi
 import { publicMediaUrlNeedsExplicitTarget } from './public-media-url.js';
 import { USER_MEMORY_DEFAULT_MAX_PROMPT_CHARS, formatUserMemoryPrompt, normalizeUserMemoryMaxPromptChars, normalizeUserMemoryStore } from './user-memory.js';
 import {
+  findWorkflowHealingCandidates,
   findWorkflowTarget,
   parseAccessibilityTreeDescriptors,
   redactWorkflowArgsForTelemetry,
@@ -9702,6 +9703,43 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
     return 'deny';
   }
 
+  async _promptWorkflowTargetHealing(tabId, workflow, step, stepIndex, candidates, onUpdate) {
+    const choices = Array.isArray(candidates) ? candidates.slice(0, 5) : [];
+    if (!choices.length) return null;
+    const clarifyId = `workflow_heal_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 8)}`;
+    const tabPending = this._pendingClarifications.get(tabId) || new Map();
+    this._pendingClarifications.set(tabId, tabPending);
+    const responsePromise = new Promise((resolve) => {
+      tabPending.set(clarifyId, { resolve, ts: Date.now() });
+    });
+    try {
+      onUpdate('clarify', {
+        clarifyId,
+        workflowHealing: {
+          workflowId: workflow.id,
+          workflowName: workflow.name,
+          stepId: step.id,
+          stepNumber: stepIndex + 1,
+          tool: step.tool,
+          previousTarget: step.target,
+          candidates: choices.map((candidate, index) => ({
+            id: `candidate_${index}`,
+            target: candidate.target,
+          })),
+        },
+        question: `Choose a replacement target for saved workflow step ${stepIndex + 1}. The workflow will update only if the action succeeds and its postcondition is verified.`,
+        options: ['deny'],
+      });
+    } catch {}
+    const response = await responsePromise;
+    tabPending.delete(clarifyId);
+    if (tabPending.size === 0) this._pendingClarifications.delete(tabId);
+    if (response?.cancelled || ['timeout', 'auto'].includes(response?.source)) return null;
+    const match = String(response?.answer || '').match(/^candidate_(\d)$/);
+    const index = match ? Number(match[1]) : -1;
+    return choices[index] || null;
+  }
+
   /**
    * Check and clear abort flag.
    */
@@ -13818,6 +13856,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
     let traceStatus = 'workflow_stopped';
     let finalContent = '';
     let matchedSteps = 0;
+    const verifiedHealings = [];
 
     const finishStopped = (reason, stepIndex = 0) => {
       const summary = `Saved workflow "${workflow.name}" stopped safely at step ${stepIndex + 1}: ${reason}.`;
@@ -13827,7 +13866,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
       });
       traceStatus = 'workflow_stopped';
       finalContent = summary;
-      return { status: 'stopped', summary, reason, stepIndex, matchedSteps };
+      return { status: 'stopped', summary, reason, stepIndex, matchedSteps, healings: verifiedHealings };
     };
 
     try {
@@ -13844,6 +13883,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
           reason,
           stepIndex: 0,
           matchedSteps,
+          healings: verifiedHealings,
           prompt: workflowFallbackPrompt(workflow, 0, reason),
         };
       }
@@ -13868,6 +13908,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
             reason,
             stepIndex: index,
             matchedSteps,
+            healings: verifiedHealings,
             prompt: workflowFallbackPrompt(workflow, index, reason),
           };
         }
@@ -13879,6 +13920,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
         }
 
         let targetMatch = null;
+        let pendingHealing = null;
         if (step.target) {
           const treeResult = await this.executeTool(tabId, 'get_accessibility_tree', {
             filter: 'all',
@@ -13889,6 +13931,45 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
             : treeResult?.pageContent || treeResult?.tree || treeResult?.content || '';
           const candidates = parseAccessibilityTreeDescriptors(treeText);
           targetMatch = findWorkflowTarget(step.target, candidates);
+          if (targetMatch.status !== 'matched') {
+            const healingCandidates = findWorkflowHealingCandidates(step.target, candidates);
+            const approved = await this._promptWorkflowTargetHealing(
+              tabId, workflow, step, index, healingCandidates, onUpdate,
+            );
+            if (this._checkAbort(tabId)) return finishStopped('stopped by the user', index);
+            if (approved) {
+              const approvalUrl = await this._currentUrl(tabId);
+              const approvalScope = step.scope || workflow.start;
+              if (workflowUrlMatches(approvalScope, approvalUrl)) {
+                const refreshedTreeResult = await this.executeTool(tabId, 'get_accessibility_tree', {
+                  filter: 'all',
+                  maxChars: 60000,
+                });
+                const refreshedTreeText = typeof refreshedTreeResult === 'string'
+                  ? refreshedTreeResult
+                  : refreshedTreeResult?.pageContent || refreshedTreeResult?.tree
+                    || refreshedTreeResult?.content || '';
+                const refreshedMatch = findWorkflowTarget(
+                  approved.target,
+                  parseAccessibilityTreeDescriptors(refreshedTreeText),
+                );
+                if (refreshedMatch.status === 'matched') {
+                  targetMatch = refreshedMatch;
+                  pendingHealing = {
+                    stepId: step.id,
+                    previousTarget: step.target,
+                    target: approved.target,
+                  };
+                  trace.recordNote(traceRunId, index + 1, 'workflow_target_healing_approved', {
+                    workflowId: workflow.id,
+                    stepId: step.id,
+                    tool: step.tool,
+                    candidateScore: approved.score,
+                  });
+                }
+              }
+            }
+          }
           if (targetMatch.status !== 'matched') {
             trace.recordNote(traceRunId, index + 1, 'workflow_replay_target_miss', {
               workflowId: workflow.id,
@@ -13904,6 +13985,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
               reason,
               stepIndex: index,
               matchedSteps,
+              healings: verifiedHealings,
               prompt: workflowFallbackPrompt(workflow, index, reason),
             };
           }
@@ -13970,8 +14052,27 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
             reason: validation.reason,
             stepIndex: index,
             matchedSteps,
+            healings: verifiedHealings,
             prompt: workflowFallbackPrompt(workflow, index, validation.reason),
           };
+        }
+        if (pendingHealing) {
+          const healingVerified = rawResult?.success === true
+            && rawResult?.dispatched !== false
+            && rawResult?.verified !== false
+            && rawResult?.noProgress !== true
+            && rawResult?.inconclusive !== true
+            && rawResult?.outcomeUnknown !== true
+            && rawResult?.ambiguous !== true
+            && rawResult?.stale !== true
+            && rawResult?.wrongTarget !== true;
+          trace.recordNote(traceRunId, index + 1, 'workflow_target_healing_verification', {
+            workflowId: workflow.id,
+            stepId: step.id,
+            tool: step.tool,
+            verified: healingVerified,
+          });
+          if (healingVerified) verifiedHealings.push(pendingHealing);
         }
         matchedSteps += 1;
       }
@@ -13989,7 +14090,13 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
       });
       traceStatus = 'done';
       finalContent = summary;
-      return { status: 'completed', summary, matchedSteps, estimatedLlmCallsSaved: matchedSteps };
+      return {
+        status: 'completed',
+        summary,
+        matchedSteps,
+        estimatedLlmCallsSaved: matchedSteps,
+        healings: verifiedHealings,
+      };
     } finally {
       await trace.endRun(traceRunId, { status: traceStatus, finalContent });
       this.currentCostState.delete(tabId);

--- a/src/firefox/src/agent/workflows.js
+++ b/src/firefox/src/agent/workflows.js
@@ -842,6 +842,88 @@ export function findWorkflowTarget(target, candidates) {
   return { status: 'matched', candidate: ranked[0].candidate, score: ranked[0].score };
 }
 
+function workflowHealingTargetCompatible(previous, replacement) {
+  if (scoreWorkflowTarget(previous, replacement) <= 0) return false;
+  if (!!previous?.href !== !!replacement?.href) return false;
+  if (previous?.href) {
+    try {
+      if (new URL(previous.href).origin !== new URL(replacement.href).origin) return false;
+    } catch {
+      return false;
+    }
+  }
+  return true;
+}
+
+/**
+ * Return user-reviewable replacement targets after strict matching fails.
+ * Every replacement must be independently replayable, and duplicate semantic
+ * descriptors are removed rather than choosing an arbitrary live ref.
+ */
+export function findWorkflowHealingCandidates(target, candidates, options = {}) {
+  const expected = normalizeTarget(target);
+  if (!expected) return [];
+  const limit = Math.max(1, Math.min(5, Math.floor(Number(options.limit) || 5)));
+  const ranked = [];
+  const fingerprintCounts = new Map();
+  for (const candidate of Array.isArray(candidates) ? candidates : []) {
+    const refId = cleanText(candidate?.refId, 100);
+    const replacement = normalizeTarget(candidate);
+    if (!/^ref_[A-Za-z0-9_-]+$/.test(refId) || !isReplayableWorkflowTarget(replacement)) continue;
+    if (!workflowHealingTargetCompatible(expected, replacement)) continue;
+    const score = scoreWorkflowTarget(expected, replacement);
+    const fingerprint = JSON.stringify(replacement);
+    fingerprintCounts.set(fingerprint, (fingerprintCounts.get(fingerprint) || 0) + 1);
+    ranked.push({ refId, target: replacement, score, fingerprint });
+  }
+  return ranked
+    .filter((entry) => fingerprintCounts.get(entry.fingerprint) === 1)
+    .sort((a, b) => b.score - a.score || a.fingerprint.localeCompare(b.fingerprint))
+    .slice(0, limit)
+    .map(({ refId, target: replacement, score }) => ({ refId, target: replacement, score }));
+}
+
+/** Apply an approved batch of target replacements without changing workflow identity. */
+export function applyWorkflowTargetHealings(input, healings, options = {}) {
+  const ts = timestamp(options.now, nowMs());
+  const workflow = normalizeSavedWorkflow(input, { now: ts });
+  if (!workflow) return { changed: false, reason: 'invalid_workflow', workflow: null, healedStepCount: 0 };
+  const repairs = Array.isArray(healings) ? healings : [];
+  if (!repairs.length || repairs.length > MAX_STEPS) {
+    return { changed: false, reason: 'no_changes', workflow, healedStepCount: 0 };
+  }
+  const seen = new Set();
+  let healedStepCount = 0;
+  for (const repair of repairs) {
+    const stepId = cleanId(repair?.stepId);
+    const previousTarget = normalizeTarget(repair?.previousTarget);
+    const replacement = normalizeTarget(repair?.target);
+    if (!stepId || seen.has(stepId) || !previousTarget || !isReplayableWorkflowTarget(replacement)
+        || !workflowHealingTargetCompatible(previousTarget, replacement)) {
+      return { changed: false, reason: 'invalid_healing', workflow, healedStepCount: 0 };
+    }
+    seen.add(stepId);
+    const step = workflow.steps.find((candidate) => candidate.id === stepId);
+    if (!step || JSON.stringify(step.target || null) !== JSON.stringify(previousTarget)) {
+      return { changed: false, reason: 'stale_target', workflow, healedStepCount: 0 };
+    }
+    if (JSON.stringify(previousTarget) === JSON.stringify(replacement)) continue;
+    step.target = replacement;
+    if (['type_ax', 'set_field'].includes(step.tool) && sensitiveParameter(replacement)) {
+      const parameterId = cleanId(step.args?.text?.[WORKFLOW_PARAM_REF_KEY]);
+      const parameter = workflow.parameters.find((candidate) => candidate.id === parameterId);
+      if (parameter) parameter.sensitive = true;
+    }
+    healedStepCount += 1;
+  }
+  if (!healedStepCount) return { changed: false, reason: 'no_changes', workflow, healedStepCount: 0 };
+  workflow.updatedAt = ts;
+  const normalized = normalizeSavedWorkflow(workflow, { now: ts });
+  return normalized
+    ? { changed: true, reason: '', workflow: normalized, healedStepCount }
+    : { changed: false, reason: 'invalid_healing', workflow, healedStepCount: 0 };
+}
+
 export async function compileLatestSuccessfulWorkflow(traceReader, options = {}) {
   if (!traceReader?.listRuns || !traceReader?.getRunEvents) {
     return { workflow: null, warnings: [], reason: 'trace_reader_required' };
@@ -914,6 +996,20 @@ export function createSavedWorkflowStore(storageArea, options = {}) {
       };
       store.workflows[index] = workflow;
       return { changed: true, workflow, store: await write(store) };
+    },
+    async healTargets(id, input = {}) {
+      const store = await read();
+      const index = store.workflows.findIndex((item) => item.id === id);
+      if (index < 0) return { changed: false, reason: 'not_found', workflow: null, store, healedStepCount: 0 };
+      const current = store.workflows[index];
+      const expectedUpdatedAt = Number(input.expectedUpdatedAt);
+      if (!Number.isFinite(expectedUpdatedAt) || current.updatedAt !== expectedUpdatedAt) {
+        return { changed: false, reason: 'workflow_changed', workflow: current, store, healedStepCount: 0 };
+      }
+      const healed = applyWorkflowTargetHealings(current, input.healings, { now: now() });
+      if (!healed.changed) return { ...healed, store };
+      store.workflows[index] = healed.workflow;
+      return { ...healed, store: await write(store) };
     },
     async delete(id) {
       const store = await read();

--- a/src/firefox/src/background.js
+++ b/src/firefox/src/background.js
@@ -2060,6 +2060,18 @@ async function handleMessage(msg, sender) {
             runOptions,
           );
           result = replay.summary || '';
+          if (Array.isArray(replay.healings) && replay.healings.length) {
+            const healed = await withSavedWorkflowStoreLock(() => savedWorkflowStore.healTargets(
+              workflow.id,
+              { expectedUpdatedAt: workflow.updatedAt, healings: replay.healings },
+            ));
+            publishUpdate(healed.changed ? 'workflow_healed' : 'workflow_healing_not_saved', {
+              workflowId: workflow.id,
+              workflowName: workflow.name,
+              count: healed.healedStepCount || 0,
+              reason: healed.reason || '',
+            });
+          }
           if (replay.status === 'fallback') {
             publishUpdate('workflow_fallback', {
               workflowId: workflow.id,

--- a/src/firefox/src/ui/locales/ar.js
+++ b/src/firefox/src/ui/locales/ar.js
@@ -922,4 +922,10 @@ export default {
   'st.provider.field.cache_write_cost_per_million': "تكلفة كتابة ذاكرة التخزين المؤقت لمدة 5 دقائق ($ / مليون رمز)",
   'st.provider.field.cache_write_1h_cost_per_million': "تكلفة كتابة ذاكرة التخزين المؤقت لمدة ساعة واحدة ($ / مليون رمز)",
   'sp.run_progress_replay_gap': 'تعذّر إعادة عرض بعض تقدّم التشغيل السابق',
+  "sp.workflows.healing.question": "تعذّر على سير العمل «{name}» مطابقة الخطوة {step}. اختر بديلاً لتجربته؛ ولن يُحفظ إلا بعد تحقق ناجح.",
+  "sp.workflows.healing.previous": "الهدف المحفوظ: {target}",
+  "sp.workflows.healing.use": "جرّب واحفظ {target}",
+  "sp.workflows.healing.keep": "الاحتفاظ بالهدف المحفوظ",
+  "sp.workflows.healing.saved": "تم تحديث {count} محددات في «{name}».",
+  "sp.workflows.healing.not_saved": "لم يُحفظ المحدد الموافق عليه لـ «{name}» لأن سير العمل تغيّر أو لأن التحقق لم يكن حاسماً.",
 };

--- a/src/firefox/src/ui/locales/bn.js
+++ b/src/firefox/src/ui/locales/bn.js
@@ -942,4 +942,10 @@ export default {
   'st.provider.field.cache_write_cost_per_million': "আনুমানিক 5-মিনিট ক্যাশে লেখার খরচ ($ / 1M টোকেন)",
   'st.provider.field.cache_write_1h_cost_per_million': "আনুমানিক 1-ঘন্টা ক্যাশে লেখার খরচ ($ / 1M টোকেন)",
   'sp.run_progress_replay_gap': 'আগের কিছু রান অগ্রগতি পুনরায় দেখানো যায়নি',
+  "sp.workflows.healing.question": "“{name}” ওয়ার্কফ্লো ধাপ {step} মেলাতে পারেনি। চেষ্টা করার জন্য একটি বিকল্প বেছে নিন; সফল যাচাইয়ের পরেই এটি সংরক্ষিত হবে।",
+  "sp.workflows.healing.previous": "সংরক্ষিত লক্ষ্য: {target}",
+  "sp.workflows.healing.use": "{target} চেষ্টা করে সংরক্ষণ করুন",
+  "sp.workflows.healing.keep": "সংরক্ষিত লক্ষ্যটি রাখুন",
+  "sp.workflows.healing.saved": "“{name}”-এ {count}টি লোকেটর আপডেট করা হয়েছে।",
+  "sp.workflows.healing.not_saved": "ওয়ার্কফ্লো পরিবর্তিত হওয়ায় বা যাচাই অনিশ্চিত থাকায় “{name}”-এর অনুমোদিত লোকেটর সংরক্ষিত হয়নি।",
 };

--- a/src/firefox/src/ui/locales/de.js
+++ b/src/firefox/src/ui/locales/de.js
@@ -915,4 +915,10 @@ export default {
   'tr.event.result': 'Ergebnis',
   'tr.event.step': 'Schritt {step}',
   'sp.run_progress_replay_gap': 'Ein Teil des früheren Ausführungsverlaufs konnte nicht erneut angezeigt werden',
+  "sp.workflows.healing.question": "Workflow „{name}“ konnte Schritt {step} nicht zuordnen. Wähle ein Ersatzziel zum Testen; es wird erst nach erfolgreicher Prüfung gespeichert.",
+  "sp.workflows.healing.previous": "Gespeichertes Ziel: {target}",
+  "sp.workflows.healing.use": "{target} testen und speichern",
+  "sp.workflows.healing.keep": "Gespeichertes Ziel beibehalten",
+  "sp.workflows.healing.saved": "{count} Locator in „{name}“ aktualisiert.",
+  "sp.workflows.healing.not_saved": "Der bestätigte Locator für „{name}“ wurde nicht gespeichert, weil sich der Workflow geändert hat oder die Prüfung nicht eindeutig war.",
 };

--- a/src/firefox/src/ui/locales/en.js
+++ b/src/firefox/src/ui/locales/en.js
@@ -944,4 +944,10 @@ export default {
   'st.provider.field.cache_write_cost_per_million': "Estimated 5-minute cache write cost ($ / 1M tokens)",
   'st.provider.field.cache_write_1h_cost_per_million': "Estimated 1-hour cache write cost ($ / 1M tokens)",
   'sp.run_progress_replay_gap': 'Some earlier run progress could not be replayed',
+  "sp.workflows.healing.question": "Workflow “{name}” could not match step {step}. Choose a replacement to try; it will be saved only after successful verification.",
+  "sp.workflows.healing.previous": "Saved target: {target}",
+  "sp.workflows.healing.use": "Try and save {target}",
+  "sp.workflows.healing.keep": "Keep the saved target",
+  "sp.workflows.healing.saved": "Updated {count} locator(s) in “{name}”.",
+  "sp.workflows.healing.not_saved": "The approved locator for “{name}” was not saved because the workflow changed or verification was inconclusive.",
 };

--- a/src/firefox/src/ui/locales/es.js
+++ b/src/firefox/src/ui/locales/es.js
@@ -922,4 +922,10 @@ export default {
   'st.provider.field.cache_write_cost_per_million': "Coste estimado de escritura en caché de 5 min ($ / 1M tokens)",
   'st.provider.field.cache_write_1h_cost_per_million': "Coste estimado de escritura en caché de 1 h ($ / 1M tokens)",
   'sp.run_progress_replay_gap': 'No se pudo volver a mostrar parte del progreso anterior de la ejecución',
+  "sp.workflows.healing.question": "El flujo «{name}» no pudo encontrar el paso {step}. Elige un reemplazo para probarlo; solo se guardará después de una verificación correcta.",
+  "sp.workflows.healing.previous": "Objetivo guardado: {target}",
+  "sp.workflows.healing.use": "Probar y guardar {target}",
+  "sp.workflows.healing.keep": "Conservar el objetivo guardado",
+  "sp.workflows.healing.saved": "Se actualizaron {count} localizadores en «{name}».",
+  "sp.workflows.healing.not_saved": "El localizador aprobado para «{name}» no se guardó porque el flujo cambió o la verificación no fue concluyente.",
 };

--- a/src/firefox/src/ui/locales/fa.js
+++ b/src/firefox/src/ui/locales/fa.js
@@ -942,4 +942,10 @@ export default {
   'st.provider.field.cache_write_cost_per_million': "تخمینی هزینه نوشتن 5 دقیقه ای کش ($ / 1 میلیون توکن)",
   'st.provider.field.cache_write_1h_cost_per_million': "تخمینی هزینه نوشتن حافظه پنهان 1 ساعته ($ / 1 میلیون توکن)",
   'sp.run_progress_replay_gap': 'بخشی از پیشرفت پیشین اجرا قابل بازپخش نبود',
+  "sp.workflows.healing.question": "گردش‌کار «{name}» نتوانست مرحلهٔ {step} را تطبیق دهد. یک جایگزین برای آزمایش انتخاب کنید؛ فقط پس از تأیید موفق ذخیره می‌شود.",
+  "sp.workflows.healing.previous": "هدف ذخیره‌شده: {target}",
+  "sp.workflows.healing.use": "آزمایش و ذخیرهٔ {target}",
+  "sp.workflows.healing.keep": "حفظ هدف ذخیره‌شده",
+  "sp.workflows.healing.saved": "{count} مکان‌یاب در «{name}» به‌روزرسانی شد.",
+  "sp.workflows.healing.not_saved": "مکان‌یاب تأییدشدهٔ «{name}» ذخیره نشد، زیرا گردش‌کار تغییر کرده بود یا نتیجهٔ تأیید قطعی نبود.",
 };

--- a/src/firefox/src/ui/locales/fr.js
+++ b/src/firefox/src/ui/locales/fr.js
@@ -922,4 +922,10 @@ export default {
   'st.provider.field.cache_write_cost_per_million': "Coût estimé d’écriture du cache (5 min) ($ / 1M tokens)",
   'st.provider.field.cache_write_1h_cost_per_million': "Coût estimé d’écriture du cache (1 h) ($ / 1M tokens)",
   'sp.run_progress_replay_gap': 'Une partie de la progression précédente de l’exécution n’a pas pu être réaffichée',
+  "sp.workflows.healing.question": "Le workflow « {name} » n’a pas pu faire correspondre l’étape {step}. Choisissez une cible de remplacement à essayer ; elle ne sera enregistrée qu’après une vérification réussie.",
+  "sp.workflows.healing.previous": "Cible enregistrée : {target}",
+  "sp.workflows.healing.use": "Essayer et enregistrer {target}",
+  "sp.workflows.healing.keep": "Conserver la cible enregistrée",
+  "sp.workflows.healing.saved": "{count} localisateur(s) mis à jour dans « {name} ».",
+  "sp.workflows.healing.not_saved": "Le localisateur approuvé pour « {name} » n’a pas été enregistré, car le workflow a changé ou la vérification était incertaine.",
 };

--- a/src/firefox/src/ui/locales/he.js
+++ b/src/firefox/src/ui/locales/he.js
@@ -875,4 +875,10 @@ export default {
   'st.provider.field.cache_write_cost_per_million': "עלות משוערת לכתיבה למטמון ל-5 דקות ($ / מיליון אסימונים)",
   'st.provider.field.cache_write_1h_cost_per_million': "עלות משוערת לכתיבה למטמון לשעה ($ / מיליון אסימונים)",
   'sp.run_progress_replay_gap': 'לא ניתן היה להציג מחדש חלק מהתקדמות ההרצה הקודמת',
+  "sp.workflows.healing.question": "תהליך העבודה „{name}” לא הצליח להתאים את שלב {step}. בחרו יעד חלופי לניסיון; הוא יישמר רק לאחר אימות מוצלח.",
+  "sp.workflows.healing.previous": "היעד השמור: {target}",
+  "sp.workflows.healing.use": "לנסות ולשמור את {target}",
+  "sp.workflows.healing.keep": "להשאיר את היעד השמור",
+  "sp.workflows.healing.saved": "עודכנו {count} מאתרים ב־„{name}”.",
+  "sp.workflows.healing.not_saved": "המאתר שאושר עבור „{name}” לא נשמר משום שתהליך העבודה השתנה או שהאימות לא היה חד־משמעי.",
 };

--- a/src/firefox/src/ui/locales/hi.js
+++ b/src/firefox/src/ui/locales/hi.js
@@ -942,4 +942,10 @@ export default {
   'st.provider.field.cache_write_cost_per_million': "अनुमानित 5-मिनट कैश लिखने की लागत ($ / 1M टोकन)",
   'st.provider.field.cache_write_1h_cost_per_million': "अनुमानित 1-घंटे कैश लिखने की लागत ($ / 1M टोकन)",
   'sp.run_progress_replay_gap': 'पहले की कुछ रन प्रगति दोबारा नहीं दिखाई जा सकी',
+  "sp.workflows.healing.question": "वर्कफ़्लो “{name}” चरण {step} से मेल नहीं खा सका। आज़माने के लिए कोई विकल्प चुनें; सफल सत्यापन के बाद ही वह सहेजा जाएगा।",
+  "sp.workflows.healing.previous": "सहेजा गया लक्ष्य: {target}",
+  "sp.workflows.healing.use": "{target} को आज़माएँ और सहेजें",
+  "sp.workflows.healing.keep": "सहेजा गया लक्ष्य रखें",
+  "sp.workflows.healing.saved": "“{name}” में {count} लोकेटर अपडेट किए गए।",
+  "sp.workflows.healing.not_saved": "“{name}” के लिए स्वीकृत लोकेटर सहेजा नहीं गया क्योंकि वर्कफ़्लो बदल गया था या सत्यापन निर्णायक नहीं था।",
 };

--- a/src/firefox/src/ui/locales/id.js
+++ b/src/firefox/src/ui/locales/id.js
@@ -922,4 +922,10 @@ export default {
   'st.provider.field.cache_write_cost_per_million': "Perkiraan biaya tulis cache 5 menit ($ / 1 juta token)",
   'st.provider.field.cache_write_1h_cost_per_million': "Perkiraan biaya tulis cache 1 jam ($ / 1 juta token)",
   'sp.run_progress_replay_gap': 'Sebagian kemajuan proses sebelumnya tidak dapat ditampilkan ulang',
+  "sp.workflows.healing.question": "Alur kerja “{name}” tidak dapat mencocokkan langkah {step}. Pilih pengganti untuk dicoba; pengganti hanya disimpan setelah verifikasi berhasil.",
+  "sp.workflows.healing.previous": "Target tersimpan: {target}",
+  "sp.workflows.healing.use": "Coba dan simpan {target}",
+  "sp.workflows.healing.keep": "Pertahankan target tersimpan",
+  "sp.workflows.healing.saved": "Memperbarui {count} locator di “{name}”.",
+  "sp.workflows.healing.not_saved": "Locator yang disetujui untuk “{name}” tidak disimpan karena alur kerja berubah atau verifikasi tidak meyakinkan.",
 };

--- a/src/firefox/src/ui/locales/ja.js
+++ b/src/firefox/src/ui/locales/ja.js
@@ -922,4 +922,10 @@ export default {
   'st.provider.field.cache_write_cost_per_million': "5分キャッシュ書き込みの推定費用（$ / 100万トークン）",
   'st.provider.field.cache_write_1h_cost_per_million': "1時間キャッシュ書き込みの推定費用（$ / 100万トークン）",
   'sp.run_progress_replay_gap': '以前の実行進捗の一部を再表示できませんでした',
+  "sp.workflows.healing.question": "ワークフロー「{name}」はステップ {step} の対象を特定できませんでした。試す代替対象を選んでください。検証に成功した場合のみ保存されます。",
+  "sp.workflows.healing.previous": "保存済みの対象: {target}",
+  "sp.workflows.healing.use": "{target} を試して保存",
+  "sp.workflows.healing.keep": "保存済みの対象を維持",
+  "sp.workflows.healing.saved": "「{name}」のロケーターを {count} 件更新しました。",
+  "sp.workflows.healing.not_saved": "ワークフローが変更されたか検証結果が不確実だったため、「{name}」で承認されたロケーターは保存されませんでした。",
 };

--- a/src/firefox/src/ui/locales/ko.js
+++ b/src/firefox/src/ui/locales/ko.js
@@ -922,4 +922,10 @@ export default {
   'st.provider.field.cache_write_cost_per_million': "5분 캐시 쓰기 예상 비용($ / 100만 토큰)",
   'st.provider.field.cache_write_1h_cost_per_million': "1시간 캐시 쓰기 예상 비용($ / 100만 토큰)",
   'sp.run_progress_replay_gap': '이전 실행 진행 상황 일부를 다시 표시할 수 없습니다',
+  "sp.workflows.healing.question": "워크플로 “{name}”에서 {step}단계 대상을 찾지 못했습니다. 시도할 대상을 선택하세요. 검증에 성공한 경우에만 저장됩니다.",
+  "sp.workflows.healing.previous": "저장된 대상: {target}",
+  "sp.workflows.healing.use": "{target} 시도 후 저장",
+  "sp.workflows.healing.keep": "저장된 대상 유지",
+  "sp.workflows.healing.saved": "“{name}”에서 로케이터 {count}개를 업데이트했습니다.",
+  "sp.workflows.healing.not_saved": "워크플로가 변경되었거나 검증 결과가 불확실하여 “{name}”에서 승인한 로케이터를 저장하지 않았습니다.",
 };

--- a/src/firefox/src/ui/locales/ms.js
+++ b/src/firefox/src/ui/locales/ms.js
@@ -922,4 +922,10 @@ export default {
   'st.provider.field.cache_write_cost_per_million': "Anggaran kos tulis cache 5 minit ($ / 1 juta token)",
   'st.provider.field.cache_write_1h_cost_per_million': "Anggaran kos tulis cache 1 jam ($ / 1 juta token)",
   'sp.run_progress_replay_gap': 'Sebahagian kemajuan larian terdahulu tidak dapat dipaparkan semula',
+  "sp.workflows.healing.question": "Aliran kerja “{name}” tidak dapat memadankan langkah {step}. Pilih pengganti untuk dicuba; ia hanya disimpan selepas pengesahan berjaya.",
+  "sp.workflows.healing.previous": "Sasaran tersimpan: {target}",
+  "sp.workflows.healing.use": "Cuba dan simpan {target}",
+  "sp.workflows.healing.keep": "Kekalkan sasaran tersimpan",
+  "sp.workflows.healing.saved": "Mengemas kini {count} pencari dalam “{name}”.",
+  "sp.workflows.healing.not_saved": "Pencari yang diluluskan untuk “{name}” tidak disimpan kerana aliran kerja berubah atau pengesahan tidak muktamad.",
 };

--- a/src/firefox/src/ui/locales/nl.js
+++ b/src/firefox/src/ui/locales/nl.js
@@ -895,4 +895,10 @@ export default {
   'st.skills.cws.package_zip_only': 'Kies een .zip release-pakket.',
   'st.skills.cws.package_too_large': 'De ZIP moet tussen 1 byte en 100 MB zijn.',
   'sp.run_progress_replay_gap': 'Een deel van de eerdere uitvoeringsvoortgang kon niet opnieuw worden weergegeven',
+  "sp.workflows.healing.question": "Workflow ‘{name}’ kon stap {step} niet koppelen. Kies een vervangend doel om te proberen; het wordt pas na geslaagde verificatie opgeslagen.",
+  "sp.workflows.healing.previous": "Opgeslagen doel: {target}",
+  "sp.workflows.healing.use": "{target} proberen en opslaan",
+  "sp.workflows.healing.keep": "Opgeslagen doel behouden",
+  "sp.workflows.healing.saved": "{count} locator(s) in ‘{name}’ bijgewerkt.",
+  "sp.workflows.healing.not_saved": "De goedgekeurde locator voor ‘{name}’ is niet opgeslagen omdat de workflow was gewijzigd of de verificatie niet overtuigend was.",
 };

--- a/src/firefox/src/ui/locales/pl.js
+++ b/src/firefox/src/ui/locales/pl.js
@@ -882,4 +882,10 @@ export default {
   'st.provider.field.cache_write_cost_per_million': "Szacowany koszt zapisu do pamięci podręcznej (5 min) ($ / 1M tokenów)",
   'st.provider.field.cache_write_1h_cost_per_million': "Szacowany koszt zapisu do pamięci podręcznej (1 godz.) ($ / 1M tokenów)",
   'sp.run_progress_replay_gap': 'Nie udało się ponownie wyświetlić części wcześniejszego postępu wykonania',
+  "sp.workflows.healing.question": "Przepływ „{name}” nie dopasował kroku {step}. Wybierz cel zastępczy do wypróbowania; zostanie zapisany dopiero po pomyślnej weryfikacji.",
+  "sp.workflows.healing.previous": "Zapisany cel: {target}",
+  "sp.workflows.healing.use": "Wypróbuj i zapisz {target}",
+  "sp.workflows.healing.keep": "Zachowaj zapisany cel",
+  "sp.workflows.healing.saved": "Zaktualizowano {count} lokalizatorów w „{name}”.",
+  "sp.workflows.healing.not_saved": "Zatwierdzony lokalizator dla „{name}” nie został zapisany, ponieważ przepływ się zmienił lub weryfikacja nie była jednoznaczna.",
 };

--- a/src/firefox/src/ui/locales/pt.js
+++ b/src/firefox/src/ui/locales/pt.js
@@ -942,4 +942,10 @@ export default {
   'st.provider.field.cache_write_cost_per_million': "Custo estimado de gravação em cache de 5 minutos ($/1 milhão de tokens)",
   'st.provider.field.cache_write_1h_cost_per_million': "Custo estimado de gravação de cache em 1 hora ($/1 milhão de tokens)",
   'sp.run_progress_replay_gap': 'Não foi possível reexibir parte do progresso anterior da execução',
+  "sp.workflows.healing.question": "O fluxo “{name}” não conseguiu corresponder à etapa {step}. Escolha um substituto para testar; ele só será salvo após uma verificação bem-sucedida.",
+  "sp.workflows.healing.previous": "Alvo salvo: {target}",
+  "sp.workflows.healing.use": "Testar e salvar {target}",
+  "sp.workflows.healing.keep": "Manter o alvo salvo",
+  "sp.workflows.healing.saved": "Foram atualizados {count} localizadores em “{name}”.",
+  "sp.workflows.healing.not_saved": "O localizador aprovado para “{name}” não foi salvo porque o fluxo mudou ou a verificação foi inconclusiva.",
 };

--- a/src/firefox/src/ui/locales/ru.js
+++ b/src/firefox/src/ui/locales/ru.js
@@ -922,4 +922,10 @@ export default {
   'st.provider.field.cache_write_cost_per_million': "Расчётная стоимость записи в кэш на 5 минут ($ / 1 млн токенов)",
   'st.provider.field.cache_write_1h_cost_per_million': "Расчётная стоимость записи в кэш на 1 час ($ / 1 млн токенов)",
   'sp.run_progress_replay_gap': 'Не удалось повторно показать часть предыдущего хода выполнения',
+  "sp.workflows.healing.question": "Сценарий «{name}» не смог сопоставить шаг {step}. Выберите замену для проверки; она сохранится только после успешной верификации.",
+  "sp.workflows.healing.previous": "Сохранённая цель: {target}",
+  "sp.workflows.healing.use": "Проверить и сохранить {target}",
+  "sp.workflows.healing.keep": "Оставить сохранённую цель",
+  "sp.workflows.healing.saved": "Обновлено локаторов в «{name}»: {count}.",
+  "sp.workflows.healing.not_saved": "Одобренный локатор для «{name}» не сохранён: сценарий изменился или результат проверки оказался неоднозначным.",
 };

--- a/src/firefox/src/ui/locales/th.js
+++ b/src/firefox/src/ui/locales/th.js
@@ -922,4 +922,10 @@ export default {
   'st.provider.field.cache_write_cost_per_million': "ค่าการเขียนแคช 5 นาทีโดยประมาณ ($ / 1 ล้านโทเค็น)",
   'st.provider.field.cache_write_1h_cost_per_million': "ค่าการเขียนแคช 1 ชั่วโมงโดยประมาณ ($ / 1 ล้านโทเค็น)",
   'sp.run_progress_replay_gap': 'ไม่สามารถแสดงความคืบหน้าก่อนหน้านี้บางส่วนของการทำงานซ้ำได้',
+  "sp.workflows.healing.question": "เวิร์กโฟลว์ “{name}” จับคู่ขั้นตอนที่ {step} ไม่ได้ เลือกเป้าหมายทดแทนเพื่อทดลอง ระบบจะบันทึกเมื่อยืนยันผลสำเร็จแล้วเท่านั้น",
+  "sp.workflows.healing.previous": "เป้าหมายที่บันทึกไว้: {target}",
+  "sp.workflows.healing.use": "ลองและบันทึก {target}",
+  "sp.workflows.healing.keep": "ใช้เป้าหมายที่บันทึกไว้ต่อไป",
+  "sp.workflows.healing.saved": "อัปเดตตัวระบุตำแหน่ง {count} รายการใน “{name}” แล้ว",
+  "sp.workflows.healing.not_saved": "ไม่ได้บันทึกตัวระบุตำแหน่งที่อนุมัติสำหรับ “{name}” เพราะเวิร์กโฟลว์เปลี่ยนแปลงหรือผลการยืนยันไม่ชัดเจน",
 };

--- a/src/firefox/src/ui/locales/tl.js
+++ b/src/firefox/src/ui/locales/tl.js
@@ -922,4 +922,10 @@ export default {
   'st.provider.field.cache_write_cost_per_million': "Tinatayang gastos sa 5 minutong pagsulat ng cache ($ / 1M token)",
   'st.provider.field.cache_write_1h_cost_per_million': "Tinatayang gastos sa 1 oras na pagsulat ng cache ($ / 1M token)",
   'sp.run_progress_replay_gap': 'Hindi maipakita muli ang ilang naunang progreso ng run',
+  "sp.workflows.healing.question": "Hindi maitugma ng workflow na “{name}” ang hakbang {step}. Pumili ng kapalit na susubukan; ise-save lamang ito pagkatapos ng matagumpay na beripikasyon.",
+  "sp.workflows.healing.previous": "Naka-save na target: {target}",
+  "sp.workflows.healing.use": "Subukan at i-save ang {target}",
+  "sp.workflows.healing.keep": "Panatilihin ang naka-save na target",
+  "sp.workflows.healing.saved": "Na-update ang {count} locator sa “{name}”.",
+  "sp.workflows.healing.not_saved": "Hindi na-save ang inaprubahang locator para sa “{name}” dahil nagbago ang workflow o hindi tiyak ang beripikasyon.",
 };

--- a/src/firefox/src/ui/locales/tr.js
+++ b/src/firefox/src/ui/locales/tr.js
@@ -921,4 +921,10 @@ export default {
   'st.provider.field.cache_write_cost_per_million': "Tahmini 5 dakikalık önbellek yazma maliyeti ($ / 1M token)",
   'st.provider.field.cache_write_1h_cost_per_million': "Tahmini 1 saatlik önbellek yazma maliyeti ($ / 1M token)",
   'sp.run_progress_replay_gap': 'Önceki çalışma ilerlemesinin bir kısmı yeniden gösterilemedi',
+  "sp.workflows.healing.question": "“{name}” iş akışı {step}. adımı eşleştiremedi. Denemek için bir yedek hedef seçin; yalnızca başarılı doğrulamadan sonra kaydedilir.",
+  "sp.workflows.healing.previous": "Kayıtlı hedef: {target}",
+  "sp.workflows.healing.use": "{target} hedefini dene ve kaydet",
+  "sp.workflows.healing.keep": "Kayıtlı hedefi koru",
+  "sp.workflows.healing.saved": "“{name}” içinde {count} bulucu güncellendi.",
+  "sp.workflows.healing.not_saved": "İş akışı değiştiği veya doğrulama kesin olmadığı için “{name}” için onaylanan bulucu kaydedilmedi.",
 };

--- a/src/firefox/src/ui/locales/uk.js
+++ b/src/firefox/src/ui/locales/uk.js
@@ -922,4 +922,10 @@ export default {
   'st.provider.field.cache_write_cost_per_million': "Орієнтовна вартість запису в кеш на 5 хвилин ($ / 1 млн токенів)",
   'st.provider.field.cache_write_1h_cost_per_million': "Орієнтовна вартість запису в кеш на 1 годину ($ / 1 млн токенів)",
   'sp.run_progress_replay_gap': 'Не вдалося повторно показати частину попереднього перебігу виконання',
+  "sp.workflows.healing.question": "Робочий процес «{name}» не зміг зіставити крок {step}. Виберіть заміну для перевірки; її буде збережено лише після успішної верифікації.",
+  "sp.workflows.healing.previous": "Збережена ціль: {target}",
+  "sp.workflows.healing.use": "Перевірити й зберегти {target}",
+  "sp.workflows.healing.keep": "Залишити збережену ціль",
+  "sp.workflows.healing.saved": "Оновлено локаторів у «{name}»: {count}.",
+  "sp.workflows.healing.not_saved": "Схвалений локатор для «{name}» не збережено: робочий процес змінився або результат перевірки був неоднозначним.",
 };

--- a/src/firefox/src/ui/locales/vi.js
+++ b/src/firefox/src/ui/locales/vi.js
@@ -942,4 +942,10 @@ export default {
   'st.provider.field.cache_write_cost_per_million': "Ước tính chi phí ghi vào bộ nhớ đệm trong 5 phút ($ / 1 triệu token)",
   'st.provider.field.cache_write_1h_cost_per_million': "Chi phí ghi bộ nhớ đệm trong 1 giờ ước tính ($ / 1 triệu token)",
   'sp.run_progress_replay_gap': 'Không thể hiển thị lại một phần tiến trình chạy trước đó',
+  "sp.workflows.healing.question": "Quy trình “{name}” không thể khớp bước {step}. Hãy chọn một mục tiêu thay thế để thử; mục tiêu chỉ được lưu sau khi xác minh thành công.",
+  "sp.workflows.healing.previous": "Mục tiêu đã lưu: {target}",
+  "sp.workflows.healing.use": "Thử và lưu {target}",
+  "sp.workflows.healing.keep": "Giữ mục tiêu đã lưu",
+  "sp.workflows.healing.saved": "Đã cập nhật {count} bộ định vị trong “{name}”.",
+  "sp.workflows.healing.not_saved": "Bộ định vị đã phê duyệt cho “{name}” không được lưu vì quy trình đã thay đổi hoặc kết quả xác minh chưa rõ ràng.",
 };

--- a/src/firefox/src/ui/locales/zh.js
+++ b/src/firefox/src/ui/locales/zh.js
@@ -922,4 +922,10 @@ export default {
   'st.provider.field.cache_write_cost_per_million': "估算 5 分钟缓存写入费用（$ / 100 万 token）",
   'st.provider.field.cache_write_1h_cost_per_million': "估算 1 小时缓存写入费用（$ / 100 万 token）",
   'sp.run_progress_replay_gap': '部分较早的运行进度无法重新显示',
+  "sp.workflows.healing.question": "工作流“{name}”无法匹配第 {step} 步。请选择一个替代目标进行尝试；只有验证成功后才会保存。",
+  "sp.workflows.healing.previous": "已保存的目标：{target}",
+  "sp.workflows.healing.use": "尝试并保存 {target}",
+  "sp.workflows.healing.keep": "保留原目标",
+  "sp.workflows.healing.saved": "已更新“{name}”中的 {count} 个定位器。",
+  "sp.workflows.healing.not_saved": "“{name}”中已批准的定位器未保存，因为工作流已发生变化或验证结果不确定。",
 };

--- a/src/firefox/src/ui/sidepanel.js
+++ b/src/firefox/src/ui/sidepanel.js
@@ -7886,6 +7886,19 @@ function handleAgentUpdateMessage(msg) {
       }
       break;
 
+    case 'workflow_healed':
+      showComposerToast(t('sp.workflows.healing.saved', {
+        name: data?.workflowName || '',
+        count: data?.count || 0,
+      }), { duration: 7000 });
+      break;
+
+    case 'workflow_healing_not_saved':
+      showComposerToast(t('sp.workflows.healing.not_saved', {
+        name: data?.workflowName || '',
+      }), { duration: 9000 });
+      break;
+
     case 'run_complete':
       if (currentAssistantEl) finalizeSteps(currentAssistantEl);
       invalidatePlanReviewCards({ tabId: msg.tabId ?? currentTabId, requestId: msg.requestId, runId: msg.runId });
@@ -7997,6 +8010,23 @@ browser.runtime.onMessage.addListener((msg) => {
  * the card and routes the answer to the background. UI stays visible
  * after answering so the user can see what they chose.
  */
+function workflowHealingTargetLabel(target) {
+  const role = String(target?.role || 'element').slice(0, 40);
+  const primary = String(
+    target?.name || target?.label || target?.ariaLabel || target?.placeholder
+      || target?.fieldName || target?.id || target?.href || '',
+  ).trim().slice(0, 180);
+  const identity = [
+    target?.label && target.label !== primary ? `label=${String(target.label).slice(0, 80)}` : '',
+    target?.ariaLabel && target.ariaLabel !== primary ? `aria-label=${String(target.ariaLabel).slice(0, 80)}` : '',
+    target?.id ? `id=${String(target.id).slice(0, 80)}` : '',
+    target?.fieldName ? `name=${String(target.fieldName).slice(0, 80)}` : '',
+    target?.type ? `type=${String(target.type).slice(0, 40)}` : '',
+    target?.href && target.href !== primary ? `href=${String(target.href).slice(0, 120)}` : '',
+  ].filter(Boolean).join(', ');
+  return `${role}${primary ? ` “${primary}”` : ''}${identity ? ` (${identity})` : ''}`;
+}
+
 function renderClarifyCard(data) {
   hideActivity();
   const tabId = data?.scheduledTabId ?? data?.tabId ?? currentTabId;
@@ -8029,11 +8059,13 @@ function renderClarifyCard(data) {
   card.dataset.tabId = String(tabId);
   card.dataset.memorySource = scheduledJobId
     ? 'scheduled_clarification'
-    : data.submitConfirmation
-      ? 'form_confirmation'
-      : data.permission
-        ? 'permission'
-        : 'clarification_response';
+    : data.workflowHealing
+      ? ''
+      : data.submitConfirmation
+        ? 'form_confirmation'
+        : data.permission
+          ? 'permission'
+          : 'clarification_response';
   if (card.dataset.memorySource === 'clarification_response') {
     card.dataset.memoryQuestion = String(data.question || '').slice(0, 600);
   }
@@ -8056,6 +8088,49 @@ function renderClarifyCard(data) {
   qEl.className = 'clarify-question';
   qEl.textContent = String(data.question || '').slice(0, 600);
   card.appendChild(qEl);
+
+  if (data.workflowHealing) {
+    card.dataset.workflowHealing = '1';
+    const healing = data.workflowHealing;
+    qEl.textContent = t('sp.workflows.healing.question', {
+      name: String(healing.workflowName || '').slice(0, 80),
+      step: Number(healing.stepNumber) || 1,
+    });
+    const previousEl = document.createElement('div');
+    previousEl.className = 'clarify-reason';
+    previousEl.textContent = t('sp.workflows.healing.previous', {
+      target: workflowHealingTargetLabel(healing.previousTarget),
+    });
+    card.appendChild(previousEl);
+
+    const optionsEl = document.createElement('div');
+    optionsEl.className = 'clarify-options';
+    for (const candidate of Array.isArray(healing.candidates) ? healing.candidates.slice(0, 5) : []) {
+      if (!/^candidate_[0-4]$/.test(String(candidate?.id || ''))) continue;
+      const button = document.createElement('button');
+      button.type = 'button';
+      button.className = 'clarify-option';
+      button.textContent = t('sp.workflows.healing.use', {
+        target: workflowHealingTargetLabel(candidate.target),
+      });
+      button.dataset.value = candidate.id;
+      button.addEventListener('click', () => submitClarify(
+        card, tabId, clarifyId, candidate.id, 'option',
+      ));
+      optionsEl.appendChild(button);
+    }
+    const deny = document.createElement('button');
+    deny.type = 'button';
+    deny.className = 'clarify-option';
+    deny.textContent = t('sp.workflows.healing.keep');
+    deny.dataset.value = 'deny';
+    deny.addEventListener('click', () => submitClarify(card, tabId, clarifyId, 'deny', 'option'));
+    optionsEl.appendChild(deny);
+    card.appendChild(optionsEl);
+    content.appendChild(card);
+    scrollToBottom({ force: true });
+    return;
+  }
 
   if (data.submitConfirmation) {
     card.dataset.submitConfirmation = '1';

--- a/test/run.js
+++ b/test/run.js
@@ -25989,8 +25989,8 @@ test('sidepanel long replies use reading-first turn navigation', () => {
     );
     assert.equal(
       (clarifySource.match(/scrollToBottom\(\{ force: true \}\);/g) || []).length,
-      3,
-      `${label}: submit, permission, and clarify prompts should override reading-first scroll suppression`,
+      4,
+      `${label}: workflow healing, submit, permission, and clarify prompts should override reading-first scroll suppression`,
     );
     assert.match(
       panel,
@@ -63800,6 +63800,100 @@ test('saved workflow target matching fails closed on ambiguity', () => {
   assert.equal(matched.candidate.refId, 'ref_3');
 });
 
+test('saved workflow healing candidates remain strong, user-reviewable, and unambiguous', () => {
+  for (const module of [SavedWorkflowsCh, SavedWorkflowsFx]) {
+    const candidates = module.findWorkflowHealingCandidates(
+      { role: 'button', name: 'Submit order' },
+      [
+        { refId: 'ref_1', role: 'button', name: 'Place order', id: 'checkout-primary', selector: '#raw' },
+        { refId: 'ref_2', role: 'button', name: 'Cancel order' },
+        { refId: 'ref_3', role: 'link', name: 'Place order' },
+        { refId: 'ref_4', role: 'button', name: 'Duplicate' },
+        { refId: 'ref_5', role: 'button', name: 'Duplicate' },
+      ],
+    );
+    assert.deepEqual(candidates.map((candidate) => candidate.refId).sort(), ['ref_1', 'ref_2']);
+    assert.deepEqual(candidates.find((candidate) => candidate.refId === 'ref_1').target, {
+      role: 'button',
+      name: 'Place order',
+      id: 'checkout-primary',
+    });
+    assert.doesNotMatch(JSON.stringify(candidates), /selector|#raw|ref_3|ref_4|ref_5/);
+    const links = module.findWorkflowHealingCandidates(
+      { role: 'link', name: 'Old docs', href: 'https://example.com/docs/old' },
+      [
+        { refId: 'ref_6', role: 'link', name: 'New docs', href: 'https://example.com/docs/new' },
+        { refId: 'ref_7', role: 'link', name: 'New docs', href: 'https://evil.example/docs/new' },
+        { refId: 'ref_8', role: 'link', name: 'New docs' },
+      ],
+    );
+    assert.deepEqual(links.map((candidate) => candidate.refId), ['ref_6']);
+  }
+});
+
+test('approved workflow target healings apply atomically without storing live refs', () => {
+  for (const module of [SavedWorkflowsCh, SavedWorkflowsFx]) {
+    const workflow = module.normalizeSavedWorkflow({
+      schema: module.SAVED_WORKFLOW_SCHEMA,
+      id: 'workflow_heal',
+      name: 'Checkout',
+      createdAt: 1000,
+      updatedAt: 1000,
+      start: { origin: 'https://example.com', pathFamily: '/checkout' },
+      parameters: [],
+      steps: [{
+        id: 'step_1',
+        tool: 'click_ax',
+        args: {},
+        target: { role: 'button', name: 'Submit order' },
+        expected: { kind: 'tool_success' },
+      }],
+    }, { now: 1000 });
+    const healed = module.applyWorkflowTargetHealings(workflow, [{
+      stepId: 'step_1',
+      previousTarget: { role: 'button', name: 'Submit order' },
+      target: { role: 'button', name: 'Place order', id: 'checkout-primary', refId: 'ref_9' },
+    }], { now: 2000 });
+    assert.equal(healed.changed, true);
+    assert.equal(healed.healedStepCount, 1);
+    assert.deepEqual(healed.workflow.steps[0].target, {
+      role: 'button', name: 'Place order', id: 'checkout-primary',
+    });
+    assert.equal(healed.workflow.updatedAt, 2000);
+    assert.doesNotMatch(JSON.stringify(healed.workflow), /ref_9/);
+
+    const stale = module.applyWorkflowTargetHealings(workflow, [{
+      stepId: 'step_1',
+      previousTarget: { role: 'button', name: 'Something else' },
+      target: { role: 'button', name: 'Place order' },
+    }], { now: 2000 });
+    assert.equal(stale.changed, false);
+    assert.equal(stale.reason, 'stale_target');
+
+    const fieldWorkflow = module.normalizeSavedWorkflow({
+      schema: module.SAVED_WORKFLOW_SCHEMA,
+      id: 'workflow_sensitive_heal',
+      name: 'Fill credential',
+      start: { origin: 'https://example.com', pathFamily: '/account' },
+      parameters: [{ id: 'account', label: 'Account', required: true, sensitive: false, type: 'text' }],
+      steps: [{
+        id: 'step_1',
+        tool: 'type_ax',
+        args: { text: { [module.WORKFLOW_PARAM_REF_KEY]: 'account' }, clear: true },
+        target: { role: 'textbox', name: 'Account' },
+        expected: { kind: 'tool_verified' },
+      }],
+    }, { now: 1000 });
+    const sensitive = module.applyWorkflowTargetHealings(fieldWorkflow, [{
+      stepId: 'step_1',
+      previousTarget: { role: 'textbox', name: 'Account' },
+      target: { role: 'textbox', name: 'Password', type: 'password' },
+    }], { now: 2000 });
+    assert.equal(sensitive.changed, true);
+    assert.equal(sensitive.workflow.parameters[0].sensitive, true);
+  }
+});
+
 test('saved workflow telemetry redacts runtime parameters and validates postconditions', () => {
   const template = { text: { [SavedWorkflowsCh.WORKFLOW_PARAM_REF_KEY]: 'password' }, clear: true };
   const redactedArgs = SavedWorkflowsCh.redactWorkflowArgsForTelemetry(template, {
@@ -63925,6 +64019,167 @@ for (const [browser, AgentClass] of [['chrome', AgentCh], ['firefox', AgentFx]])
     assert.equal(agent.isRunning(77), false);
     assert.equal(agent.selectionGroundingScopes.has(77), false, `${browser}: completed replay kept stale selection scope`);
     assert.ok(persistCalls >= 1, `${browser}: completed replay did not persist selection-scope removal`);
+  });
+
+  test(`${browser} saved workflow heals only an explicitly approved and verified target`, async () => {
+    const workflow = {
+      schema: SavedWorkflowsCh.SAVED_WORKFLOW_SCHEMA,
+      id: 'workflow_healing',
+      name: 'Checkout',
+      updatedAt: 1000,
+      start: { origin: 'https://example.com', pathFamily: '/checkout' },
+      parameters: [],
+      steps: [{
+        id: 'step_1',
+        tool: 'click_ax',
+        args: {},
+        target: { role: 'button', name: 'Submit order' },
+        expected: { kind: 'tool_success' },
+      }],
+    };
+    const agent = new AgentClass({ getActive: () => ({ model: 'test-model' }) });
+    const updates = [];
+    let executedArgs = null;
+    agent._hydrate = async () => {};
+    agent._persist = () => {};
+    agent.ensureConversationId = async () => 'conversation_test';
+    agent._currentUrl = async () => 'https://example.com/checkout';
+    agent.executeTool = async () => ({
+      pageContent: 'button "Place order" [ref_9] id="checkout-primary"',
+    });
+    agent._executeToolBatch = async (_tabId, calls, _messages, onUpdate) => {
+      executedArgs = JSON.parse(calls[0].function.arguments);
+      onUpdate('tool_result', {
+        name: 'click_ax',
+        result: { success: true, dispatched: true },
+      });
+      return { action: 'continue' };
+    };
+
+    const replayPromise = agent.replaySavedWorkflow(
+      84, workflow, {}, (type, data) => updates.push({ type, data }),
+    );
+    while (!updates.some((update) => update.type === 'clarify')) {
+      await new Promise(resolve => setTimeout(resolve, 0));
+    }
+    const prompt = updates.find((update) => update.type === 'clarify').data;
+    assert.equal(prompt.workflowHealing.previousTarget.name, 'Submit order');
+    assert.equal(prompt.workflowHealing.candidates[0].target.name, 'Place order');
+    assert.equal(agent.submitClarifyResponse(84, prompt.clarifyId, 'candidate_0', 'option'), true);
+    const result = await replayPromise;
+
+    assert.equal(result.status, 'completed');
+    assert.equal(executedArgs.ref_id, 'ref_9');
+    assert.deepEqual(result.healings, [{
+      stepId: 'step_1',
+      previousTarget: { role: 'button', name: 'Submit order' },
+      target: { role: 'button', name: 'Place order', id: 'checkout-primary' },
+    }]);
+    assert.doesNotMatch(JSON.stringify(result.healings), /ref_9/);
+  });
+
+  test(`${browser} saved workflow does not persist an approved target after inconclusive verification`, async () => {
+    const workflow = {
+      schema: SavedWorkflowsCh.SAVED_WORKFLOW_SCHEMA,
+      id: 'workflow_healing_inconclusive',
+      name: 'Checkout',
+      updatedAt: 1000,
+      start: { origin: 'https://example.com', pathFamily: '/checkout' },
+      parameters: [],
+      steps: [{
+        id: 'step_1',
+        tool: 'click_ax',
+        args: {},
+        target: { role: 'button', name: 'Submit order' },
+        expected: { kind: 'tool_success' },
+      }],
+    };
+    const agent = new AgentClass({ getActive: () => ({ model: 'test-model' }) });
+    const updates = [];
+    agent._hydrate = async () => {};
+    agent._persist = () => {};
+    agent.ensureConversationId = async () => 'conversation_test';
+    agent._currentUrl = async () => 'https://example.com/checkout';
+    agent.executeTool = async () => ({ pageContent: 'button "Place order" [ref_9]' });
+    agent._executeToolBatch = async (_tabId, _calls, _messages, onUpdate) => {
+      onUpdate('tool_result', {
+        name: 'click_ax',
+        result: { success: true, dispatched: true, inconclusive: true },
+      });
+      return { action: 'continue' };
+    };
+    const replayPromise = agent.replaySavedWorkflow(
+      85, workflow, {}, (type, data) => updates.push({ type, data }),
+    );
+    while (!updates.some((update) => update.type === 'clarify')) {
+      await new Promise(resolve => setTimeout(resolve, 0));
+    }
+    const prompt = updates.find((update) => update.type === 'clarify').data;
+    agent.submitClarifyResponse(85, prompt.clarifyId, 'candidate_0', 'option');
+    const result = await replayPromise;
+    assert.equal(result.status, 'completed');
+    assert.deepEqual(result.healings, []);
+  });
+
+  test(`${browser} saved workflow revalidates an approved target before dispatch`, async () => {
+    const workflow = {
+      schema: SavedWorkflowsCh.SAVED_WORKFLOW_SCHEMA,
+      id: 'workflow_healing_stale_page',
+      name: 'Checkout',
+      updatedAt: 1000,
+      start: { origin: 'https://example.com', pathFamily: '/checkout' },
+      parameters: [],
+      steps: [{
+        id: 'step_1', tool: 'click_ax', args: {},
+        target: { role: 'button', name: 'Submit order' },
+        expected: { kind: 'tool_success' },
+      }],
+    };
+    const agent = new AgentClass({ getActive: () => ({ model: 'test-model' }) });
+    const updates = [];
+    let treeReads = 0;
+    let dispatched = false;
+    agent._hydrate = async () => {};
+    agent._persist = () => {};
+    agent.ensureConversationId = async () => 'conversation_test';
+    agent._currentUrl = async () => 'https://example.com/checkout';
+    agent.executeTool = async () => ({
+      pageContent: ++treeReads === 1
+        ? 'button "Place order" [ref_9]'
+        : 'button "Cancel" [ref_10]',
+    });
+    agent._executeToolBatch = async () => {
+      dispatched = true;
+      throw new Error('stale approved target must not dispatch');
+    };
+    const replayPromise = agent.replaySavedWorkflow(
+      86, workflow, {}, (type, data) => updates.push({ type, data }),
+    );
+    while (!updates.some((update) => update.type === 'clarify')) {
+      await new Promise(resolve => setTimeout(resolve, 0));
+    }
+    const prompt = updates.find((update) => update.type === 'clarify').data;
+    agent.submitClarifyResponse(86, prompt.clarifyId, 'candidate_0', 'option');
+    const result = await replayPromise;
+    assert.equal(result.status, 'fallback');
+    assert.equal(dispatched, false);
+    assert.deepEqual(result.healings, []);
+  });
+
+  test(`${browser} saved workflow rejects unattended locator-healing approval`, async () => {
+    const agent = new AgentClass({ getActive: () => ({ model: 'test-model' }) });
+    const updates = [];
+    const choicePromise = agent._promptWorkflowTargetHealing(
+      87,
+      { id: 'workflow_heal_prompt', name: 'Checkout' },
+      { id: 'step_1', tool: 'click_ax', target: { role: 'button', name: 'Submit order' } },
+      0,
+      [{ refId: 'ref_9', target: { role: 'button', name: 'Place order' }, score: 2 }],
+      (type, data) => updates.push({ type, data }),
+    );
+    const prompt = updates[0].data;
+    assert.equal(agent.submitClarifyResponse(87, prompt.clarifyId, 'candidate_0', 'auto'), true);
+    assert.equal(await choicePromise, null);
   });
 
   test(`${browser} saved workflow replay fails closed before a semantic target miss`, async () => {
@@ -64175,6 +64430,77 @@ test('saved workflow store normalizes writes and resolves runtime parameters wit
   assert.equal((await store.rename('workflow_missing', 'Missing')).reason, 'not_found');
   assert.equal((await store.delete(compiled.id)).changed, true);
   assert.equal((await store.list()).length, 0);
+});
+
+test('saved workflow store rejects healing after a concurrent workflow update', async () => {
+  for (const module of [SavedWorkflowsCh, SavedWorkflowsFx]) {
+    const memory = {};
+    const storage = {
+      async get(key) { return { [key]: structuredClone(memory[key]) }; },
+      async set(values) { Object.assign(memory, structuredClone(values)); },
+    };
+    let now = 5000;
+    const store = module.createSavedWorkflowStore(storage, { now: () => now++ });
+    const put = await store.put({
+      schema: module.SAVED_WORKFLOW_SCHEMA,
+      id: 'workflow_atomic_heal',
+      name: 'Checkout',
+      start: { origin: 'https://example.com', pathFamily: '/checkout' },
+      parameters: [],
+      steps: [{
+        id: 'step_1', tool: 'click_ax', args: {},
+        target: { role: 'button', name: 'Submit order' },
+        expected: { kind: 'tool_success' },
+      }],
+    });
+    const healed = await store.healTargets('workflow_atomic_heal', {
+      expectedUpdatedAt: put.workflow.updatedAt,
+      healings: [{
+        stepId: 'step_1',
+        previousTarget: { role: 'button', name: 'Submit order' },
+        target: { role: 'button', name: 'Place order', refId: 'ref_9' },
+      }],
+    });
+    assert.equal(healed.changed, true);
+    assert.equal(healed.healedStepCount, 1);
+    assert.equal((await store.get('workflow_atomic_heal')).steps[0].target.name, 'Place order');
+    assert.doesNotMatch(JSON.stringify(memory), /ref_9/);
+
+    const staleTimestamp = healed.workflow.updatedAt;
+    await store.put({ ...healed.workflow, name: 'Checkout renamed' });
+    const rejected = await store.healTargets('workflow_atomic_heal', {
+      expectedUpdatedAt: staleTimestamp,
+      healings: [{
+        stepId: 'step_1',
+        previousTarget: { role: 'button', name: 'Place order' },
+        target: { role: 'button', name: 'Confirm order' },
+      }],
+    });
+    assert.equal(rejected.changed, false);
+    assert.equal(rejected.reason, 'workflow_changed');
+    assert.equal((await store.get('workflow_atomic_heal')).name, 'Checkout renamed');
+  }
+});
+
+test('workflow healing approval and persistence wiring is mirrored across browsers', () => {
+  for (const build of ['chrome', 'firefox']) {
+    const agent = fs.readFileSync(path.join(ROOT, `src/${build}/src/agent/agent.js`), 'utf8');
+    const background = fs.readFileSync(path.join(ROOT, `src/${build}/src/background.js`), 'utf8');
+    const panel = fs.readFileSync(path.join(ROOT, `src/${build}/src/ui/sidepanel.js`), 'utf8');
+    assert.match(agent, /workflowHealing:[\s\S]*?previousTarget:[\s\S]*?candidates:/);
+    assert.match(agent, /\['timeout', 'auto'\]\.includes\(response\?\.source\)/,
+      `${build}: unattended clarification could authorize workflow healing`);
+    assert.match(agent, /rawResult\?\.success === true[\s\S]*?rawResult\?\.inconclusive !== true/,
+      `${build}: healing did not require a conclusive successful result`);
+    assert.match(agent, /const refreshedTreeResult = await this\.executeTool[\s\S]*?findWorkflowTarget\([\s\S]*?approved\.target/,
+      `${build}: approved target was not re-resolved before dispatch`);
+    assert.match(background, /savedWorkflowStore\.healTargets\([\s\S]*?expectedUpdatedAt: workflow\.updatedAt/,
+      `${build}: verified healing was not persisted with optimistic concurrency`);
+    assert.match(panel, /if \(data\.workflowHealing\)[\s\S]*?button\.textContent = t\('sp\.workflows\.healing\.use'/,
+      `${build}: structured healing card missing`);
+    assert.match(panel, /submitClarify\([\s\S]*?candidate\.id, 'option'/,
+      `${build}: candidate selection must return a stable value`);
+  }
 });
 
 test('saved workflow store rejects a new workflow after the 100-workflow limit', async () => {


### PR DESCRIPTION
## Summary

- offer user-reviewable replacement targets when strict saved-workflow matching fails
- re-resolve the selected semantic target immediately before dispatch
- persist approved repairs only after the saved postcondition succeeds conclusively
- apply repairs atomically without storing live element references
- add localized healing approval UI for Chrome and Firefox

## Design

When deterministic replay cannot strictly match a saved target, WebBrain may
present up to five independently replayable semantic candidates.

The model never selects or persists a replacement. The user must explicitly
choose a candidate from a structured confirmation card. Timeout and unattended
auto-selection responses cannot authorize healing.

After approval, replay checks the page scope again and reads a fresh
accessibility tree. The selected semantic descriptor must still resolve to
exactly one current target before the action can run. This prevents an old
`ref_id` from being reused after the page changes while the user is deciding.

The existing permission, submit-confirmation, execution, and postcondition
validation paths remain authoritative. A repair is returned for persistence
only when the action succeeds without inconclusive, stale, ambiguous,
wrong-target, or no-progress evidence.

The background applies all verified repairs atomically against the workflow's
previous `updatedAt` value. Concurrent workflow edits win and are never
overwritten.

## Safety boundaries

- no model-selected or automatic healing
- no timeout/Instant clarification approval
- no persistence before successful postcondition verification
- candidates must be independently strong enough for future replay
- duplicate semantic descriptors are excluded
- role-incompatible and cross-origin link replacements are rejected
- the selected target is re-resolved after user approval
- live `ref_id` values and selectors are never persisted
- sensitive field repairs can upgrade parameter protection but never downgrade it
- existing Agent fallback remains unchanged when safe healing is unavailable

## Testing

- `node test/run.js`: 1527 passed, 1 existing upstream failure
  - existing failure: package version `26.2.2` is newer than the latest
    changelog entry `26.2.0`
- security injection corpus: 60/60 passed
- rich-text toolbar guard: 33 passed
- CI unit scenarios: 14 passed
- cloud capture test passed
- Chrome/Firefox syntax, locale coverage, and workflow-module parity passed
- regression coverage includes:
  - candidate strength and duplicate rejection
  - cross-origin link rejection
  - explicit approval requirement
  - post-approval DOM revalidation
  - inconclusive-result rejection
  - atomic concurrent-update protection
  - live-ref non-retention
  - sensitive-parameter upgrades

Follow-up to #442