### PR TITLE
fix(captcha): retire post-solve read inference

### DIFF
--- a/src/chrome/src/agent/agent.js
+++ b/src/chrome/src/agent/agent.js
@@ -227,8 +227,8 @@ function captchaCandidateMatchesGate(candidate, identity) {
     ['alsoResponseFieldIndex', identity.alsoResponseFieldIndex],
   ].filter(([, value]) => Number.isInteger(value));
   // Token-backed clearance requires an exact response-field identity. When
-  // the page exposes no stable id or index, retain the existing read-based
-  // verification path instead of borrowing another widget's token state.
+  // the page exposes no stable id or index, fail closed instead of borrowing
+  // another widget's token state or inferring success from dialog copy.
   return expectedIndexes.length > 0
     && expectedIndexes.some(([field, value]) => candidate[field] === value);
 }
@@ -248,6 +248,45 @@ function captchaPostSolveTokenState(detection, identity) {
     candidate,
     responseTokenPresent: candidate?.responseTokenPresent === true,
     visibleActiveChallenge,
+  };
+}
+
+function withoutLegacyCaptchaVerificationState(gate) {
+  if (!gate || typeof gate !== 'object') return gate;
+  const {
+    verificationAttempts: _verificationAttempts,
+    verificationRetryRequired: _verificationRetryRequired,
+    verificationReadRequired: _verificationReadRequired,
+    verificationFrameReadRequired: _verificationFrameReadRequired,
+    solveFailedToClearChallenge: _solveFailedToClearChallenge,
+    clearedByReadOnlyVerification: _clearedByReadOnlyVerification,
+    ...current
+  } = gate;
+  return current;
+}
+
+function normalizeCaptchaGateState(gate) {
+  const inferredClearance = gate?.clearedByReadOnlyVerification === true
+    || gate?.publicGate?.clearedByReadOnlyVerification === true;
+  const current = withoutLegacyCaptchaVerificationState(gate);
+  if (!current || typeof current !== 'object') return current;
+  const publicGate = withoutLegacyCaptchaVerificationState(current.publicGate);
+  if (inferredClearance) {
+    const status = current.captchaCandidateIdentity
+      ? 'verification_pending'
+      : 'manual_required';
+    return {
+      ...current,
+      status,
+      publicGate: {
+        ...publicGate,
+        status,
+      },
+    };
+  }
+  return {
+    ...current,
+    publicGate,
   };
 }
 
@@ -4016,8 +4055,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
   _shouldRetryCaptchaManualGate(gate) {
     const publicGate = gate?.publicGate;
     const postSolveFailure = publicGate?.solveAttempted === true
-      || publicGate?.solveFailed === true
-      || publicGate?.solveFailedToClearChallenge === true;
+      || publicGate?.solveFailed === true;
     return gate?.status === 'manual_required'
       && this.captchaSolverEnabled
       && !postSolveFailure
@@ -4052,7 +4090,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
         captchaGate: true,
         manualCompletionRequired: true,
         captchaDiagnostics: gate.publicGate?.diagnostics || null,
-        error: 'A verification challenge requires manual completion. Do not dismiss or close it, and do not click Continue/Submit again. After the user completes it, first read a complete root accessibility tree with filter "visible" to confirm the dialog is gone.',
+        error: 'A verification challenge requires manual completion. Do not dismiss or close it, and do not click Continue/Submit again. After the user completes it, read the page again so the runtime can verify the exact widget state or directly confirm that an unrecognized challenge surface is gone.',
       };
     }
     if (gate.status === 'verification_pending') {
@@ -4063,7 +4101,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
         captchaGate: true,
         captchaVerificationRequired: true,
         captchaDiagnostics: gate.publicGate?.diagnostics || null,
-        error: 'The one allowed CAPTCHA solve returned, but the verification dialog has not been confirmed cleared. Wait briefly, then read a complete root accessibility tree with filter "visible"; do not submit, dismiss, or call solve_captcha again.',
+        error: 'The one allowed CAPTCHA solve returned, but the exact widget token and active challenge-frame state have not confirmed clearance. Wait briefly, then read the page again; do not submit, dismiss, or call solve_captcha again.',
       };
     }
     return {
@@ -4360,57 +4398,9 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
         }
       }
     }
-    const requestedPage = toolArgs?.page;
-    const requestedMaxDepth = toolArgs?.maxDepth;
-    const parsedMaxDepth = Number(requestedMaxDepth);
-    const authoritativeRootRead = !toolArgs?.ref_id
-      && (
-        requestedPage === undefined
-        || requestedPage === null
-        || requestedPage === ''
-        || Number(requestedPage) === 1
-      )
-      && treeFilter !== 'interactive'
-      && (
-        requestedMaxDepth === undefined
-        || requestedMaxDepth === null
-        || requestedMaxDepth === ''
-        || (Number.isFinite(parsedMaxDepth) && parsedMaxDepth >= 15)
-      )
-      && toolResult.truncated !== true
-      && toolResult.hasMore !== true
-      && toolResult.autoDegraded !== true;
-    if (
-      !challenge
-      && activeGate
-      && authoritativeRootRead
-      && Number.isInteger(activeGate.challengeFrameId)
-    ) {
-      const frameInspection = await this._detectChallengeDialogBeforeMutation(tabId, {
-        includeStatus: true,
-        expectedFrameId: activeGate.challengeFrameId,
-        allowGenericFailure: true,
-      });
-      if (frameInspection.challenge?.label) {
-        challenge = detectChallengeDialog(
-          `dialog ${JSON.stringify(String(frameInspection.challenge.label).slice(0, 200))}`
-        );
-      } else if (!frameInspection.inspectionComplete) {
-        const guardedGate = {
-          ...activeGate.publicGate,
-          verificationFrameReadRequired: true,
-        };
-        this._captchaGateStates.set(tabId, {
-          ...activeGate,
-          publicGate: guardedGate,
-        });
-        toolResult.captchaGate = guardedGate;
-        return { gate: guardedGate, loopCheck: { kind: 'none' } };
-      }
-    }
     let postSolveTokenState = null;
     if (
-      ['verification_pending', 'cleared'].includes(activeGate?.status)
+      ['verification_pending', 'manual_required', 'cleared'].includes(activeGate?.status)
       && activeGate.captchaCandidateIdentity
     ) {
       await inspectCaptchaFrames();
@@ -4421,7 +4411,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
         );
       }
     }
-    const loopCheck = challenge || authoritativeRootRead
+    const loopCheck = challenge
       ? this._checkVerificationChallengeLoop(tabId, {
           pageUrl,
           dialogLabel: challenge?.normalizedLabel || '',
@@ -4433,13 +4423,13 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
     ) {
       const alreadyCleared = activeGate.status === 'cleared';
       const clearedGate = {
-        ...activeGate.publicGate,
+        ...withoutLegacyCaptchaVerificationState(activeGate.publicGate),
         status: 'cleared',
         responseTokenPresent: true,
         clearedByResponseToken: true,
       };
       this._captchaGateStates.set(tabId, {
-        ...activeGate,
+        ...withoutLegacyCaptchaVerificationState(activeGate),
         status: 'cleared',
         publicGate: clearedGate,
       });
@@ -4447,23 +4437,57 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
       toolResult.captchaGate = clearedGate;
       return { gate: clearedGate, loopCheck };
     }
+    if (
+      postSolveTokenState?.visibleActiveChallenge === true
+      && ['verification_pending', 'cleared'].includes(activeGate?.status)
+    ) {
+      const manualGate = {
+        ...withoutLegacyCaptchaVerificationState(activeGate.publicGate),
+        status: 'manual_required',
+        responseTokenPresent: postSolveTokenState.responseTokenPresent,
+        activeChallengeAfterSolve: true,
+        ...(challenge?.label ? { challengeDialog: { label: challenge.label } } : {}),
+      };
+      this._captchaGateStates.set(tabId, {
+        ...withoutLegacyCaptchaVerificationState(activeGate),
+        status: 'manual_required',
+        publicGate: manualGate,
+      });
+      toolResult.captchaGate = manualGate;
+      return { gate: manualGate, loopCheck };
+    }
     if (!challenge) {
-      if (activeGate && authoritativeRootRead) {
-        const clearedGate = {
-          ...activeGate.publicGate,
-          status: 'cleared',
-          clearedByReadOnlyVerification: true,
-        };
-        this._captchaGateStates.delete(tabId);
-        toolResult.captchaGate = clearedGate;
-        return { gate: clearedGate, loopCheck };
+      if (
+        activeGate?.status === 'manual_required'
+        && !activeGate.captchaCandidateIdentity
+        && activeGate.publicGate?.languageNeutralFrameTrigger !== true
+      ) {
+        const manualInspection = await this._detectChallengeDialogBeforeMutation(tabId, {
+          includeStatus: true,
+          allowGenericFailure: true,
+          ...(Number.isInteger(activeGate.challengeFrameId)
+            ? { expectedFrameId: activeGate.challengeFrameId }
+            : {}),
+        });
+        if (manualInspection.inspectionComplete && !manualInspection.challenge) {
+          const clearedGate = {
+            ...withoutLegacyCaptchaVerificationState(activeGate.publicGate),
+            status: 'cleared',
+            clearedByManualCompletion: true,
+          };
+          this._captchaGateStates.delete(tabId);
+          toolResult.captchaGate = clearedGate;
+          return { gate: clearedGate, loopCheck };
+        }
       }
       if (activeGate?.status === 'cleared') {
         return { gate: null, loopCheck };
       }
       if (activeGate) {
-        toolResult.captchaGate = activeGate.publicGate;
-        return { gate: activeGate.publicGate, loopCheck };
+        const guardedState = normalizeCaptchaGateState(activeGate);
+        this._captchaGateStates.set(tabId, guardedState);
+        toolResult.captchaGate = guardedState.publicGate;
+        return { gate: guardedState.publicGate, loopCheck };
       }
       return { gate: null, loopCheck };
     }
@@ -4471,16 +4495,15 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
     const key = captchaChallengeKey(pageUrl, challenge.normalizedLabel);
     const existing = activeGate;
     const retryManualDetection = existing?.status === 'manual_required'
-      && authoritativeRootRead
       && this._shouldRetryCaptchaManualGate(existing);
     if (existing?.status === 'manual_required' && !retryManualDetection) {
       const manualGate = {
-        ...existing.publicGate,
+        ...withoutLegacyCaptchaVerificationState(existing.publicGate),
         status: 'manual_required',
         challengeDialog: { label: challenge.label },
       };
       this._captchaGateStates.set(tabId, {
-        ...existing,
+        ...withoutLegacyCaptchaVerificationState(existing),
         status: 'manual_required',
         publicGate: manualGate,
       });
@@ -4488,60 +4511,23 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
       return { gate: manualGate, loopCheck };
     }
     if (existing?.status === 'verification_pending') {
-      if (!authoritativeRootRead) {
-        const pendingGate = {
-          ...existing.publicGate,
-          status: 'verification_pending',
-          challengeDialog: { label: challenge.label },
-          verificationReadRequired: true,
-        };
-        this._captchaGateStates.set(tabId, {
-          ...existing,
-          publicGate: pendingGate,
-        });
-        toolResult.captchaGate = pendingGate;
-        return { gate: pendingGate, loopCheck };
-      }
-
-      const verificationAttempts = Math.max(
-        0,
-        Number(existing.verificationAttempts) || 0
-      ) + 1;
-      if (verificationAttempts < 2) {
-        const pendingGate = {
-          ...existing.publicGate,
-          status: 'verification_pending',
-          challengeDialog: { label: challenge.label },
-          verificationAttempts,
-          verificationRetryRequired: true,
-        };
-        this._captchaGateStates.set(tabId, {
-          ...existing,
-          status: 'verification_pending',
-          publicGate: pendingGate,
-          verificationAttempts,
-        });
-        toolResult.captchaGate = pendingGate;
-        return { gate: pendingGate, loopCheck };
-      }
-
-      const manualGate = {
-        ...existing.publicGate,
-        status: 'manual_required',
+      const pendingGate = {
+        ...withoutLegacyCaptchaVerificationState(existing.publicGate),
+        status: 'verification_pending',
         challengeDialog: { label: challenge.label },
-        solveFailedToClearChallenge: true,
-        verificationAttempts,
       };
       this._captchaGateStates.set(tabId, {
-        ...existing,
-        status: 'manual_required',
-        publicGate: manualGate,
-        verificationAttempts,
+        ...withoutLegacyCaptchaVerificationState(existing),
+        status: 'verification_pending',
+        publicGate: pendingGate,
       });
-      toolResult.captchaGate = manualGate;
-      return { gate: manualGate, loopCheck };
+      toolResult.captchaGate = pendingGate;
+      return { gate: pendingGate, loopCheck };
     }
-    if (existing?.key === key && existing.status !== 'cleared' && !retryManualDetection) {
+    if (existing?.status === 'cleared') {
+      return { gate: null, loopCheck };
+    }
+    if (existing?.key === key && !retryManualDetection) {
       toolResult.captchaGate = existing.publicGate;
       return { gate: existing.publicGate, loopCheck };
     }
@@ -5459,17 +5445,15 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
       if (fnName === 'solve_captcha' && activeCaptchaGate && toolResult && typeof toolResult === 'object') {
         if (toolResult.success === true && toolResult.injected === true) {
           const verificationGate = {
-            ...activeCaptchaGate.publicGate,
+            ...withoutLegacyCaptchaVerificationState(activeCaptchaGate.publicGate),
             status: 'verification_pending',
             solveAttempted: true,
-            verificationAttempts: 0,
           };
           captchaSolveOutcome = verificationGate;
           this._captchaGateStates.set(tabId, {
-            ...activeCaptchaGate,
+            ...withoutLegacyCaptchaVerificationState(activeCaptchaGate),
             status: 'verification_pending',
             publicGate: verificationGate,
-            verificationAttempts: 0,
           });
         } else {
           const manualGate = {
@@ -5722,22 +5706,22 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
         resultContent += '\n[TRUSTED CAPTCHA GATE: A supported verification challenge is active. Call solve_captcha once now. Do not dismiss or close the dialog, click Continue/Submit, or use another page-changing tool until solve_captcha returns.]';
         onUpdate('warning', { message: 'Supported verification challenge detected; solve_captcha is required.' });
       } else if (captchaGateDecision?.status === 'manual_required') {
-        resultContent += '\n[TRUSTED CAPTCHA GATE: A verification challenge is active, but no safely selectable supported widget was detected. Stop automation and ask the user to complete it manually. Do not dismiss, close, or resubmit the challenge.]';
+        resultContent += captchaGateDecision.activeChallengeAfterSolve === true
+          ? '\n[TRUSTED CAPTCHA GATE: The active challenge frame is visible again after the one automatic solve. The site may have rejected the token. Do not call solve_captcha again; stop automation and ask the user to complete the challenge manually.]'
+          : '\n[TRUSTED CAPTCHA GATE: A verification challenge is active, but no safely selectable supported widget was detected. Stop automation and ask the user to complete it manually. Do not dismiss, close, or resubmit the challenge.]';
         onUpdate('warning', { message: 'Verification challenge requires manual completion.' });
       } else if (captchaGateDecision?.status === 'cleared') {
         if (captchaGateDecision.clearedByResponseToken === true) {
           resultContent += '\n[TRUSTED CAPTCHA GATE: The gated widget now exposes a response token and no active challenge frame remains. The CAPTCHA gate is cleared. Choose any continuation or submit action only on a fresh model turn; the mutation preflight will re-arm the gate if the site rejects the token and shows the challenge again.]';
           onUpdate('warning', { message: 'Response-token verification confirmed the CAPTCHA widget cleared.' });
         } else {
-          resultContent += '\n[TRUSTED CAPTCHA GATE: A read-only root check confirmed that the verification dialog is gone. The CAPTCHA gate is cleared. Choose any continuation or submit action only on a fresh model turn.]';
-          onUpdate('warning', { message: 'Read-only verification confirmed the CAPTCHA dialog cleared.' });
+          resultContent += '\n[TRUSTED CAPTCHA GATE: Manual completion was confirmed for an unrecognized challenge with no correlated widget state. The CAPTCHA gate is cleared. Choose any continuation or submit action only on a fresh model turn.]';
+          onUpdate('warning', { message: 'Manual completion confirmed the unrecognized challenge cleared.' });
         }
       } else if (captchaGateDecision?.status === 'verification_pending') {
-        resultContent += captchaGateDecision.verificationRetryRequired
-          ? '\n[TRUSTED CAPTCHA GATE: The verification dialog was still present on the first complete post-solve check. Wait briefly, then make one final complete root accessibility-tree read with filter "visible". Do not submit, dismiss, or call solve_captcha again.]'
-          : '\n[TRUSTED CAPTCHA GATE: Verification is still pending. Read-only subtree, paginated, truncated, auto-degraded, or interactive-only tree reads cannot clear this gate. Wait briefly, then read a complete root accessibility tree with filter "visible".]';
+        resultContent += '\n[TRUSTED CAPTCHA GATE: Verification is still pending because the exact widget has no response token or its frame state could not be inspected conclusively. Wait briefly, then read the page again. Do not submit, dismiss, or call solve_captcha again.]';
       } else if (captchaSolveOutcome?.status === 'verification_pending') {
-        resultContent += '\n[TRUSTED CAPTCHA GATE: The supported CAPTCHA token was injected, but the challenge is not yet verified cleared. Wait briefly, then read a complete root accessibility tree with filter "visible". Until that read confirms the dialog is absent, do not submit, dismiss, or call solve_captcha again.]';
+        resultContent += '\n[TRUSTED CAPTCHA GATE: The supported CAPTCHA token was injected, but clearance must be confirmed from the exact widget token and active challenge-frame state. Wait briefly, then read the page again. Do not submit, dismiss, or call solve_captcha again.]';
       } else if (captchaSolveOutcome?.status === 'manual_required') {
         resultContent += '\n[TRUSTED CAPTCHA GATE: The one allowed automatic solve did not clear the verification challenge. Stop automation and ask the user to complete it manually. Do not retry solve_captcha, dismiss, close, or resubmit the challenge.]';
         onUpdate('warning', { message: 'Automatic CAPTCHA solve did not clear the challenge; manual completion is required.' });
@@ -5808,7 +5792,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
           () => ({ success: false, skipped: true, error: 'skipped: manual CAPTCHA completion is required' }),
         );
         const captchaRunId = this.currentRunId.get(tabId);
-        const value = 'A verification challenge is active, but WebBrain could not safely solve a supported widget. Please complete the verification manually, then start or continue the task.';
+        const value = 'A verification challenge is active, and WebBrain cannot continue safely with automatic solving. Please complete the verification manually, then start or continue the task.';
         if (captchaRunId) trace.recordError(captchaRunId, step, 'captcha_gate', value);
         this._persist(tabId);
         return { action: 'return', value, status: 'captcha_manual_required' };
@@ -7852,7 +7836,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
           && captchaGateState.publicGate
           && typeof captchaGateState.publicGate === 'object'
         ) {
-          this._captchaGateStates.set(tabId, captchaGateState);
+          this._captchaGateStates.set(tabId, normalizeCaptchaGateState(captchaGateState));
         }
       }
     } catch (e) { /* session storage may be unavailable */ }

--- a/src/chrome/src/agent/agent.js
+++ b/src/chrome/src/agent/agent.js
@@ -265,6 +265,16 @@ function withoutLegacyCaptchaVerificationState(gate) {
   return current;
 }
 
+function withoutCaptchaTokenClearanceState(gate) {
+  if (!gate || typeof gate !== 'object') return gate;
+  const {
+    responseTokenPresent: _responseTokenPresent,
+    clearedByResponseToken: _clearedByResponseToken,
+    ...current
+  } = gate;
+  return current;
+}
+
 function normalizeCaptchaGateState(gate) {
   const inferredClearance = gate?.clearedByReadOnlyVerification === true
     || gate?.publicGate?.clearedByReadOnlyVerification === true;
@@ -4442,7 +4452,9 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
       && ['verification_pending', 'cleared'].includes(activeGate?.status)
     ) {
       const manualGate = {
-        ...withoutLegacyCaptchaVerificationState(activeGate.publicGate),
+        ...withoutCaptchaTokenClearanceState(
+          withoutLegacyCaptchaVerificationState(activeGate.publicGate),
+        ),
         status: 'manual_required',
         responseTokenPresent: postSolveTokenState.responseTokenPresent,
         activeChallengeAfterSolve: true,
@@ -4455,6 +4467,26 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
       });
       toolResult.captchaGate = manualGate;
       return { gate: manualGate, loopCheck };
+    }
+    if (
+      activeGate?.status === 'cleared'
+      && activeGate.captchaCandidateIdentity
+      && postSolveTokenState?.responseTokenPresent !== true
+    ) {
+      const pendingGate = {
+        ...withoutCaptchaTokenClearanceState(
+          withoutLegacyCaptchaVerificationState(activeGate.publicGate),
+        ),
+        status: 'verification_pending',
+        ...(challenge?.label ? { challengeDialog: { label: challenge.label } } : {}),
+      };
+      this._captchaGateStates.set(tabId, {
+        ...withoutLegacyCaptchaVerificationState(activeGate),
+        status: 'verification_pending',
+        publicGate: pendingGate,
+      });
+      toolResult.captchaGate = pendingGate;
+      return { gate: pendingGate, loopCheck };
     }
     if (!challenge) {
       if (

--- a/src/firefox/src/agent/agent.js
+++ b/src/firefox/src/agent/agent.js
@@ -258,6 +258,16 @@ function withoutLegacyCaptchaVerificationState(gate) {
   return current;
 }
 
+function withoutCaptchaTokenClearanceState(gate) {
+  if (!gate || typeof gate !== 'object') return gate;
+  const {
+    responseTokenPresent: _responseTokenPresent,
+    clearedByResponseToken: _clearedByResponseToken,
+    ...current
+  } = gate;
+  return current;
+}
+
 function normalizeCaptchaGateState(gate) {
   const inferredClearance = gate?.clearedByReadOnlyVerification === true
     || gate?.publicGate?.clearedByReadOnlyVerification === true;
@@ -3877,7 +3887,9 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
       && ['verification_pending', 'cleared'].includes(activeGate?.status)
     ) {
       const manualGate = {
-        ...withoutLegacyCaptchaVerificationState(activeGate.publicGate),
+        ...withoutCaptchaTokenClearanceState(
+          withoutLegacyCaptchaVerificationState(activeGate.publicGate),
+        ),
         status: 'manual_required',
         responseTokenPresent: postSolveTokenState.responseTokenPresent,
         activeChallengeAfterSolve: true,
@@ -3890,6 +3902,26 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
       });
       toolResult.captchaGate = manualGate;
       return { gate: manualGate, loopCheck };
+    }
+    if (
+      activeGate?.status === 'cleared'
+      && activeGate.captchaCandidateIdentity
+      && postSolveTokenState?.responseTokenPresent !== true
+    ) {
+      const pendingGate = {
+        ...withoutCaptchaTokenClearanceState(
+          withoutLegacyCaptchaVerificationState(activeGate.publicGate),
+        ),
+        status: 'verification_pending',
+        ...(challenge?.label ? { challengeDialog: { label: challenge.label } } : {}),
+      };
+      this._captchaGateStates.set(tabId, {
+        ...withoutLegacyCaptchaVerificationState(activeGate),
+        status: 'verification_pending',
+        publicGate: pendingGate,
+      });
+      toolResult.captchaGate = pendingGate;
+      return { gate: pendingGate, loopCheck };
     }
     if (!challenge) {
       if (

--- a/src/firefox/src/agent/agent.js
+++ b/src/firefox/src/agent/agent.js
@@ -220,8 +220,8 @@ function captchaCandidateMatchesGate(candidate, identity) {
     ['alsoResponseFieldIndex', identity.alsoResponseFieldIndex],
   ].filter(([, value]) => Number.isInteger(value));
   // Token-backed clearance requires an exact response-field identity. When
-  // the page exposes no stable id or index, retain the existing read-based
-  // verification path instead of borrowing another widget's token state.
+  // the page exposes no stable id or index, fail closed instead of borrowing
+  // another widget's token state or inferring success from dialog copy.
   return expectedIndexes.length > 0
     && expectedIndexes.some(([field, value]) => candidate[field] === value);
 }
@@ -241,6 +241,45 @@ function captchaPostSolveTokenState(detection, identity) {
     candidate,
     responseTokenPresent: candidate?.responseTokenPresent === true,
     visibleActiveChallenge,
+  };
+}
+
+function withoutLegacyCaptchaVerificationState(gate) {
+  if (!gate || typeof gate !== 'object') return gate;
+  const {
+    verificationAttempts: _verificationAttempts,
+    verificationRetryRequired: _verificationRetryRequired,
+    verificationReadRequired: _verificationReadRequired,
+    verificationFrameReadRequired: _verificationFrameReadRequired,
+    solveFailedToClearChallenge: _solveFailedToClearChallenge,
+    clearedByReadOnlyVerification: _clearedByReadOnlyVerification,
+    ...current
+  } = gate;
+  return current;
+}
+
+function normalizeCaptchaGateState(gate) {
+  const inferredClearance = gate?.clearedByReadOnlyVerification === true
+    || gate?.publicGate?.clearedByReadOnlyVerification === true;
+  const current = withoutLegacyCaptchaVerificationState(gate);
+  if (!current || typeof current !== 'object') return current;
+  const publicGate = withoutLegacyCaptchaVerificationState(current.publicGate);
+  if (inferredClearance) {
+    const status = current.captchaCandidateIdentity
+      ? 'verification_pending'
+      : 'manual_required';
+    return {
+      ...current,
+      status,
+      publicGate: {
+        ...publicGate,
+        status,
+      },
+    };
+  }
+  return {
+    ...current,
+    publicGate,
   };
 }
 
@@ -959,7 +998,7 @@ export class Agent extends LoopDetector {
           && captchaGateState.publicGate
           && typeof captchaGateState.publicGate === 'object'
         ) {
-          this._captchaGateStates.set(tabId, captchaGateState);
+          this._captchaGateStates.set(tabId, normalizeCaptchaGateState(captchaGateState));
         }
       }
     } catch (e) { /* session storage may be unavailable */ }
@@ -3460,8 +3499,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
   _shouldRetryCaptchaManualGate(gate) {
     const publicGate = gate?.publicGate;
     const postSolveFailure = publicGate?.solveAttempted === true
-      || publicGate?.solveFailed === true
-      || publicGate?.solveFailedToClearChallenge === true;
+      || publicGate?.solveFailed === true;
     return gate?.status === 'manual_required'
       && this.captchaSolverEnabled
       && !postSolveFailure
@@ -3496,7 +3534,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
         captchaGate: true,
         manualCompletionRequired: true,
         captchaDiagnostics: gate.publicGate?.diagnostics || null,
-        error: 'A verification challenge requires manual completion. Do not dismiss or close it, and do not click Continue/Submit again. After the user completes it, first read a complete root accessibility tree with filter "visible" to confirm the dialog is gone.',
+        error: 'A verification challenge requires manual completion. Do not dismiss or close it, and do not click Continue/Submit again. After the user completes it, read the page again so the runtime can verify the exact widget state or directly confirm that an unrecognized challenge surface is gone.',
       };
     }
     if (gate.status === 'verification_pending') {
@@ -3507,7 +3545,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
         captchaGate: true,
         captchaVerificationRequired: true,
         captchaDiagnostics: gate.publicGate?.diagnostics || null,
-        error: 'The one allowed CAPTCHA solve returned, but the verification dialog has not been confirmed cleared. Wait briefly, then read a complete root accessibility tree with filter "visible"; do not submit, dismiss, or call solve_captcha again.',
+        error: 'The one allowed CAPTCHA solve returned, but the exact widget token and active challenge-frame state have not confirmed clearance. Wait briefly, then read the page again; do not submit, dismiss, or call solve_captcha again.',
       };
     }
     return {
@@ -3795,57 +3833,9 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
         }
       }
     }
-    const requestedPage = toolArgs?.page;
-    const requestedMaxDepth = toolArgs?.maxDepth;
-    const parsedMaxDepth = Number(requestedMaxDepth);
-    const authoritativeRootRead = !toolArgs?.ref_id
-      && (
-        requestedPage === undefined
-        || requestedPage === null
-        || requestedPage === ''
-        || Number(requestedPage) === 1
-      )
-      && treeFilter !== 'interactive'
-      && (
-        requestedMaxDepth === undefined
-        || requestedMaxDepth === null
-        || requestedMaxDepth === ''
-        || (Number.isFinite(parsedMaxDepth) && parsedMaxDepth >= 15)
-      )
-      && toolResult.truncated !== true
-      && toolResult.hasMore !== true
-      && toolResult.autoDegraded !== true;
-    if (
-      !challenge
-      && activeGate
-      && authoritativeRootRead
-      && Number.isInteger(activeGate.challengeFrameId)
-    ) {
-      const frameInspection = await this._detectChallengeDialogBeforeMutation(tabId, {
-        includeStatus: true,
-        expectedFrameId: activeGate.challengeFrameId,
-        allowGenericFailure: true,
-      });
-      if (frameInspection.challenge?.label) {
-        challenge = detectChallengeDialog(
-          `dialog ${JSON.stringify(String(frameInspection.challenge.label).slice(0, 200))}`
-        );
-      } else if (!frameInspection.inspectionComplete) {
-        const guardedGate = {
-          ...activeGate.publicGate,
-          verificationFrameReadRequired: true,
-        };
-        this._captchaGateStates.set(tabId, {
-          ...activeGate,
-          publicGate: guardedGate,
-        });
-        toolResult.captchaGate = guardedGate;
-        return { gate: guardedGate, loopCheck: { kind: 'none' } };
-      }
-    }
     let postSolveTokenState = null;
     if (
-      ['verification_pending', 'cleared'].includes(activeGate?.status)
+      ['verification_pending', 'manual_required', 'cleared'].includes(activeGate?.status)
       && activeGate.captchaCandidateIdentity
     ) {
       await inspectCaptchaFrames();
@@ -3856,7 +3846,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
         );
       }
     }
-    const loopCheck = challenge || authoritativeRootRead
+    const loopCheck = challenge
       ? this._checkVerificationChallengeLoop(tabId, {
           pageUrl,
           dialogLabel: challenge?.normalizedLabel || '',
@@ -3868,13 +3858,13 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
     ) {
       const alreadyCleared = activeGate.status === 'cleared';
       const clearedGate = {
-        ...activeGate.publicGate,
+        ...withoutLegacyCaptchaVerificationState(activeGate.publicGate),
         status: 'cleared',
         responseTokenPresent: true,
         clearedByResponseToken: true,
       };
       this._captchaGateStates.set(tabId, {
-        ...activeGate,
+        ...withoutLegacyCaptchaVerificationState(activeGate),
         status: 'cleared',
         publicGate: clearedGate,
       });
@@ -3882,23 +3872,57 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
       toolResult.captchaGate = clearedGate;
       return { gate: clearedGate, loopCheck };
     }
+    if (
+      postSolveTokenState?.visibleActiveChallenge === true
+      && ['verification_pending', 'cleared'].includes(activeGate?.status)
+    ) {
+      const manualGate = {
+        ...withoutLegacyCaptchaVerificationState(activeGate.publicGate),
+        status: 'manual_required',
+        responseTokenPresent: postSolveTokenState.responseTokenPresent,
+        activeChallengeAfterSolve: true,
+        ...(challenge?.label ? { challengeDialog: { label: challenge.label } } : {}),
+      };
+      this._captchaGateStates.set(tabId, {
+        ...withoutLegacyCaptchaVerificationState(activeGate),
+        status: 'manual_required',
+        publicGate: manualGate,
+      });
+      toolResult.captchaGate = manualGate;
+      return { gate: manualGate, loopCheck };
+    }
     if (!challenge) {
-      if (activeGate && authoritativeRootRead) {
-        const clearedGate = {
-          ...activeGate.publicGate,
-          status: 'cleared',
-          clearedByReadOnlyVerification: true,
-        };
-        this._captchaGateStates.delete(tabId);
-        toolResult.captchaGate = clearedGate;
-        return { gate: clearedGate, loopCheck };
+      if (
+        activeGate?.status === 'manual_required'
+        && !activeGate.captchaCandidateIdentity
+        && activeGate.publicGate?.languageNeutralFrameTrigger !== true
+      ) {
+        const manualInspection = await this._detectChallengeDialogBeforeMutation(tabId, {
+          includeStatus: true,
+          allowGenericFailure: true,
+          ...(Number.isInteger(activeGate.challengeFrameId)
+            ? { expectedFrameId: activeGate.challengeFrameId }
+            : {}),
+        });
+        if (manualInspection.inspectionComplete && !manualInspection.challenge) {
+          const clearedGate = {
+            ...withoutLegacyCaptchaVerificationState(activeGate.publicGate),
+            status: 'cleared',
+            clearedByManualCompletion: true,
+          };
+          this._captchaGateStates.delete(tabId);
+          toolResult.captchaGate = clearedGate;
+          return { gate: clearedGate, loopCheck };
+        }
       }
       if (activeGate?.status === 'cleared') {
         return { gate: null, loopCheck };
       }
       if (activeGate) {
-        toolResult.captchaGate = activeGate.publicGate;
-        return { gate: activeGate.publicGate, loopCheck };
+        const guardedState = normalizeCaptchaGateState(activeGate);
+        this._captchaGateStates.set(tabId, guardedState);
+        toolResult.captchaGate = guardedState.publicGate;
+        return { gate: guardedState.publicGate, loopCheck };
       }
       return { gate: null, loopCheck };
     }
@@ -3906,16 +3930,15 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
     const key = captchaChallengeKey(pageUrl, challenge.normalizedLabel);
     const existing = activeGate;
     const retryManualDetection = existing?.status === 'manual_required'
-      && authoritativeRootRead
       && this._shouldRetryCaptchaManualGate(existing);
     if (existing?.status === 'manual_required' && !retryManualDetection) {
       const manualGate = {
-        ...existing.publicGate,
+        ...withoutLegacyCaptchaVerificationState(existing.publicGate),
         status: 'manual_required',
         challengeDialog: { label: challenge.label },
       };
       this._captchaGateStates.set(tabId, {
-        ...existing,
+        ...withoutLegacyCaptchaVerificationState(existing),
         status: 'manual_required',
         publicGate: manualGate,
       });
@@ -3923,60 +3946,23 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
       return { gate: manualGate, loopCheck };
     }
     if (existing?.status === 'verification_pending') {
-      if (!authoritativeRootRead) {
-        const pendingGate = {
-          ...existing.publicGate,
-          status: 'verification_pending',
-          challengeDialog: { label: challenge.label },
-          verificationReadRequired: true,
-        };
-        this._captchaGateStates.set(tabId, {
-          ...existing,
-          publicGate: pendingGate,
-        });
-        toolResult.captchaGate = pendingGate;
-        return { gate: pendingGate, loopCheck };
-      }
-
-      const verificationAttempts = Math.max(
-        0,
-        Number(existing.verificationAttempts) || 0
-      ) + 1;
-      if (verificationAttempts < 2) {
-        const pendingGate = {
-          ...existing.publicGate,
-          status: 'verification_pending',
-          challengeDialog: { label: challenge.label },
-          verificationAttempts,
-          verificationRetryRequired: true,
-        };
-        this._captchaGateStates.set(tabId, {
-          ...existing,
-          status: 'verification_pending',
-          publicGate: pendingGate,
-          verificationAttempts,
-        });
-        toolResult.captchaGate = pendingGate;
-        return { gate: pendingGate, loopCheck };
-      }
-
-      const manualGate = {
-        ...existing.publicGate,
-        status: 'manual_required',
+      const pendingGate = {
+        ...withoutLegacyCaptchaVerificationState(existing.publicGate),
+        status: 'verification_pending',
         challengeDialog: { label: challenge.label },
-        solveFailedToClearChallenge: true,
-        verificationAttempts,
       };
       this._captchaGateStates.set(tabId, {
-        ...existing,
-        status: 'manual_required',
-        publicGate: manualGate,
-        verificationAttempts,
+        ...withoutLegacyCaptchaVerificationState(existing),
+        status: 'verification_pending',
+        publicGate: pendingGate,
       });
-      toolResult.captchaGate = manualGate;
-      return { gate: manualGate, loopCheck };
+      toolResult.captchaGate = pendingGate;
+      return { gate: pendingGate, loopCheck };
     }
-    if (existing?.key === key && existing.status !== 'cleared' && !retryManualDetection) {
+    if (existing?.status === 'cleared') {
+      return { gate: null, loopCheck };
+    }
+    if (existing?.key === key && !retryManualDetection) {
       toolResult.captchaGate = existing.publicGate;
       return { gate: existing.publicGate, loopCheck };
     }
@@ -4821,17 +4807,15 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
       if (fnName === 'solve_captcha' && activeCaptchaGate && toolResult && typeof toolResult === 'object') {
         if (toolResult.success === true && toolResult.injected === true) {
           const verificationGate = {
-            ...activeCaptchaGate.publicGate,
+            ...withoutLegacyCaptchaVerificationState(activeCaptchaGate.publicGate),
             status: 'verification_pending',
             solveAttempted: true,
-            verificationAttempts: 0,
           };
           captchaSolveOutcome = verificationGate;
           this._captchaGateStates.set(tabId, {
-            ...activeCaptchaGate,
+            ...withoutLegacyCaptchaVerificationState(activeCaptchaGate),
             status: 'verification_pending',
             publicGate: verificationGate,
-            verificationAttempts: 0,
           });
         } else {
           const manualGate = {
@@ -5073,22 +5057,22 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
         resultContent += '\n[TRUSTED CAPTCHA GATE: A supported verification challenge is active. Call solve_captcha once now. Do not dismiss or close the dialog, click Continue/Submit, or use another page-changing tool until solve_captcha returns.]';
         onUpdate('warning', { message: 'Supported verification challenge detected; solve_captcha is required.' });
       } else if (captchaGateDecision?.status === 'manual_required') {
-        resultContent += '\n[TRUSTED CAPTCHA GATE: A verification challenge is active, but no safely selectable supported widget was detected. Stop automation and ask the user to complete it manually. Do not dismiss, close, or resubmit the challenge.]';
+        resultContent += captchaGateDecision.activeChallengeAfterSolve === true
+          ? '\n[TRUSTED CAPTCHA GATE: The active challenge frame is visible again after the one automatic solve. The site may have rejected the token. Do not call solve_captcha again; stop automation and ask the user to complete the challenge manually.]'
+          : '\n[TRUSTED CAPTCHA GATE: A verification challenge is active, but no safely selectable supported widget was detected. Stop automation and ask the user to complete it manually. Do not dismiss, close, or resubmit the challenge.]';
         onUpdate('warning', { message: 'Verification challenge requires manual completion.' });
       } else if (captchaGateDecision?.status === 'cleared') {
         if (captchaGateDecision.clearedByResponseToken === true) {
           resultContent += '\n[TRUSTED CAPTCHA GATE: The gated widget now exposes a response token and no active challenge frame remains. The CAPTCHA gate is cleared. Choose any continuation or submit action only on a fresh model turn; the mutation preflight will re-arm the gate if the site rejects the token and shows the challenge again.]';
           onUpdate('warning', { message: 'Response-token verification confirmed the CAPTCHA widget cleared.' });
         } else {
-          resultContent += '\n[TRUSTED CAPTCHA GATE: A read-only root check confirmed that the verification dialog is gone. The CAPTCHA gate is cleared. Choose any continuation or submit action only on a fresh model turn.]';
-          onUpdate('warning', { message: 'Read-only verification confirmed the CAPTCHA dialog cleared.' });
+          resultContent += '\n[TRUSTED CAPTCHA GATE: Manual completion was confirmed for an unrecognized challenge with no correlated widget state. The CAPTCHA gate is cleared. Choose any continuation or submit action only on a fresh model turn.]';
+          onUpdate('warning', { message: 'Manual completion confirmed the unrecognized challenge cleared.' });
         }
       } else if (captchaGateDecision?.status === 'verification_pending') {
-        resultContent += captchaGateDecision.verificationRetryRequired
-          ? '\n[TRUSTED CAPTCHA GATE: The verification dialog was still present on the first complete post-solve check. Wait briefly, then make one final complete root accessibility-tree read with filter "visible". Do not submit, dismiss, or call solve_captcha again.]'
-          : '\n[TRUSTED CAPTCHA GATE: Verification is still pending. Read-only subtree, paginated, truncated, auto-degraded, or interactive-only tree reads cannot clear this gate. Wait briefly, then read a complete root accessibility tree with filter "visible".]';
+        resultContent += '\n[TRUSTED CAPTCHA GATE: Verification is still pending because the exact widget has no response token or its frame state could not be inspected conclusively. Wait briefly, then read the page again. Do not submit, dismiss, or call solve_captcha again.]';
       } else if (captchaSolveOutcome?.status === 'verification_pending') {
-        resultContent += '\n[TRUSTED CAPTCHA GATE: The supported CAPTCHA token was injected, but the challenge is not yet verified cleared. Wait briefly, then read a complete root accessibility tree with filter "visible". Until that read confirms the dialog is absent, do not submit, dismiss, or call solve_captcha again.]';
+        resultContent += '\n[TRUSTED CAPTCHA GATE: The supported CAPTCHA token was injected, but clearance must be confirmed from the exact widget token and active challenge-frame state. Wait briefly, then read the page again. Do not submit, dismiss, or call solve_captcha again.]';
       } else if (captchaSolveOutcome?.status === 'manual_required') {
         resultContent += '\n[TRUSTED CAPTCHA GATE: The one allowed automatic solve did not clear the verification challenge. Stop automation and ask the user to complete it manually. Do not retry solve_captcha, dismiss, close, or resubmit the challenge.]';
         onUpdate('warning', { message: 'Automatic CAPTCHA solve did not clear the challenge; manual completion is required.' });
@@ -5153,7 +5137,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
           () => ({ success: false, skipped: true, error: 'skipped: manual CAPTCHA completion is required' }),
         );
         const captchaRunId = this.currentRunId.get(tabId);
-        const value = 'A verification challenge is active, but WebBrain could not safely solve a supported widget. Please complete the verification manually, then start or continue the task.';
+        const value = 'A verification challenge is active, and WebBrain cannot continue safely with automatic solving. Please complete the verification manually, then start or continue the task.';
         if (captchaRunId) trace.recordError(captchaRunId, step, 'captcha_gate', value);
         this._persist(tabId);
         return { action: 'return', value, status: 'captcha_manual_required' };

--- a/test/run.js
+++ b/test/run.js
@@ -67492,10 +67492,33 @@ test('post-solve CAPTCHA gates consume only the correlated response token and re
         `${build}: preflight discarded the token-clearance recheck marker`,
       );
 
-      activeFrame.hidden = false;
-      const rearmed = await agent._captchaMutationPreflight(1, 'click_ax');
+      responseField.value = '';
+      const tokenMissing = await agent._captchaMutationPreflight(1, 'click_ax');
       assert.equal(
-        rearmed?.status,
+        tokenMissing?.status,
+        'verification_pending',
+        `${build}: a missing correlated token left stale clearance fail-open`,
+      );
+      assert.equal(
+        tokenMissing?.clearedByResponseToken,
+        undefined,
+        `${build}: missing-token downgrade retained the stale clearance reason`,
+      );
+      assert.equal(
+        agent._captchaGateStates.get(1)?.publicGate?.responseTokenPresent,
+        undefined,
+        `${build}: missing-token downgrade retained the stale token-presence flag`,
+      );
+
+      activeFrame.hidden = false;
+      const rearmed = await agent._observeCaptchaChallenge(
+        1,
+        'get_accessibility_tree',
+        { pageContent: 'dialog "Security verification" [ref_1]' },
+        { filter: 'visible' },
+      );
+      assert.equal(
+        rearmed.gate?.status,
         'manual_required',
         `${build}: reappearing challenge frame allowed another paid solve after token rejection`,
       );

--- a/test/run.js
+++ b/test/run.js
@@ -8014,7 +8014,7 @@ test('CAPTCHA challenge gate blocks dismiss/resubmit mutations but allows the on
   }
 });
 
-test('one CAPTCHA solve remains gated until a root read confirms clearance', async () => {
+test('one CAPTCHA solve remains gated until exact token and frame state confirms clearance', async () => {
   for (const [label, AgentClass] of [['chrome', AgentCh], ['firefox', AgentFx]]) {
     const tabId = label === 'chrome' ? 8821 : 8822;
     const agent = new AgentClass({ getVisionProvider: async () => null });
@@ -8073,7 +8073,7 @@ test('one CAPTCHA solve remains gated until a root read confirms clearance', asy
       new Set(['solve_captcha']),
       2,
     );
-    assert.deepEqual(retry, { action: 'continue' }, `${label}: repeat solve block should request a root-read turn`);
+    assert.deepEqual(retry, { action: 'continue' }, `${label}: repeat solve block should request a verification turn`);
     assert.deepEqual(executed, ['solve_captcha'], `${label}: second paid solve dispatched`);
     assert.match(String(retryMessages[0]?.content), /do not submit, dismiss, or call solve_captcha again/i);
 
@@ -8088,7 +8088,7 @@ test('one CAPTCHA solve remains gated until a root read confirms clearance', asy
       { filter: 'visible' },
     );
     assert.equal(firstPersistent.gate?.status, 'verification_pending', `${label}: changed challenge key reset the attempted solve`);
-    assert.equal(firstPersistent.gate?.verificationRetryRequired, true, `${label}: bounded verification retry was not requested`);
+    assert.equal(firstPersistent.gate?.verificationRetryRequired, undefined, `${label}: legacy read retry state survived`);
     assert.equal(agent._captchaGateStates.get(tabId)?.key, 'https://example.test/signup\nsecurity verification', `${label}: changed challenge key replaced the attempted-solve identity`);
     const persistent = await agent._observeCaptchaChallenge(
       tabId,
@@ -8096,8 +8096,8 @@ test('one CAPTCHA solve remains gated until a root read confirms clearance', asy
       changedChallengeResult,
       { filter: 'visible' },
     );
-    assert.equal(persistent.gate?.status, 'manual_required', `${label}: dialog surviving the bounded retry offered another solve`);
-    assert.equal(persistent.gate?.solveFailedToClearChallenge, true, `${label}: persistent-dialog reason missing`);
+    assert.equal(persistent.gate?.status, 'verification_pending', `${label}: renamed dialog text overrode inconclusive widget state`);
+    assert.equal(persistent.gate?.solveFailedToClearChallenge, undefined, `${label}: legacy dialog inference state survived`);
     const changedManual = await agent._observeCaptchaChallenge(
       tabId,
       'get_accessibility_tree',
@@ -8107,14 +8107,13 @@ test('one CAPTCHA solve remains gated until a root read confirms clearance', asy
       },
       { filter: 'visible' },
     );
-    assert.equal(changedManual.gate?.status, 'cleared', `${label}: unrelated post-CAPTCHA dialog kept the failed solve gated`);
-    assert.equal(agent._captchaGateStates.has(tabId), false, `${label}: unrelated post-CAPTCHA dialog left a persisted gate`);
+    assert.equal(changedManual.gate?.status, 'verification_pending', `${label}: unrelated dialog text independently cleared the pending gate`);
+    assert.equal(agent._captchaGateStates.has(tabId), true, `${label}: inconclusive post-solve gate was discarded`);
 
     const confirmationAgent = new AgentClass({});
     confirmationAgent._captchaGateStates.set(tabId, {
       key: 'https://example.test/signup\nsecurity verification',
       status: 'verification_pending',
-      verificationAttempts: 0,
       publicGate: {
         status: 'verification_pending',
         solveAttempted: true,
@@ -8132,8 +8131,8 @@ test('one CAPTCHA solve remains gated until a root read confirms clearance', asy
       },
       { filter: 'visible' },
     );
-    assert.equal(confirmation.gate?.status, 'cleared', `${label}: non-challenge confirmation dialog kept the solved CAPTCHA gated`);
-    assert.equal(confirmationAgent._captchaGateStates.has(tabId), false, `${label}: confirmation dialog leaked a cleared CAPTCHA gate`);
+    assert.equal(confirmation.gate?.status, 'verification_pending', `${label}: confirmation copy independently cleared the pending gate`);
+    assert.equal(confirmationAgent._captchaGateStates.has(tabId), true, `${label}: confirmation copy discarded inconclusive widget state`);
 
     const clearedAgent = new AgentClass({});
     clearedAgent._captchaGateStates.set(tabId, {
@@ -8155,12 +8154,12 @@ test('one CAPTCHA solve remains gated until a root read confirms clearance', asy
       clearedResult,
       {},
     );
-    assert.equal(cleared.gate?.status, 'cleared', `${label}: absent root dialog did not clear gate`);
-    assert.equal(clearedAgent._captchaGateStates.has(tabId), false, `${label}: verified gate state leaked`);
+    assert.equal(cleared.gate?.status, 'verification_pending', `${label}: absent root dialog independently cleared the pending gate`);
+    assert.equal(clearedAgent._captchaGateStates.has(tabId), true, `${label}: absent dialog discarded inconclusive widget state`);
   }
 });
 
-test('CAPTCHA gate survives user continuations and only a complete dialog-capable root read clears it', async () => {
+test('manual CAPTCHA gate survives user continuations until page inspection confirms completion', async () => {
   for (const [label, AgentClass] of [['chrome', AgentCh], ['firefox', AgentFx]]) {
     const tabId = label === 'chrome' ? 8823 : 8824;
     const agent = new AgentClass({});
@@ -8176,6 +8175,11 @@ test('CAPTCHA gate survives user continuations and only a complete dialog-capabl
     };
     agent._captchaGateStates.set(tabId, state);
     agent.conversations.set(tabId, [{ role: 'system', content: 'test' }]);
+    let challengePresent = true;
+    agent._detectChallengeDialogBeforeMutation = async () => ({
+      challenge: challengePresent ? { label: 'Security verification' } : null,
+      inspectionComplete: true,
+    });
 
     agent._clearRunLoopState(tabId);
     assert.equal(agent._captchaGateStates.get(tabId)?.status, 'manual_required', `${label}: run continuation discarded the unresolved gate`);
@@ -8204,6 +8208,7 @@ test('CAPTCHA gate survives user continuations and only a complete dialog-capabl
       assert.equal(agent._captchaGateStates.get(tabId)?.status, 'manual_required', `${label}: ${description} cleared the unresolved gate`);
     }
 
+    challengePresent = false;
     const cleared = await agent._observeCaptchaChallenge(
       tabId,
       'get_accessibility_tree',
@@ -8211,9 +8216,10 @@ test('CAPTCHA gate survives user continuations and only a complete dialog-capabl
         pageContent: 'main [ref_1]\n heading "Welcome" [ref_2]',
         pageUrl: 'https://example.test/signup',
       },
-      { filter: 'visible' },
+      { filter: 'interactive', ref_id: 'ref_1', page: 2, maxDepth: 3 },
     );
-    assert.equal(cleared.gate?.status, 'cleared', `${label}: complete visible root read did not clear the gate`);
+    assert.equal(cleared.gate?.status, 'cleared', `${label}: completed manual challenge did not clear after direct page inspection`);
+    assert.equal(cleared.gate?.clearedByManualCompletion, true, `${label}: manual completion reason missing`);
     assert.equal(agent._captchaGateStates.has(tabId), false, `${label}: cleared gate remained active`);
 
     agent._captchaGateStates.set(tabId, state);
@@ -8222,7 +8228,7 @@ test('CAPTCHA gate survives user continuations and only a complete dialog-capabl
   }
 });
 
-test('pending and token-cleared CAPTCHA gates hydrate after a background worker restart', async () => {
+test('pending, legacy-cleared, and token-cleared CAPTCHA gates hydrate safely after restart', async () => {
   for (const [label, AgentClass, apiName] of [
     ['chrome', AgentCh, 'chrome'],
     ['firefox', AgentFx, 'browser'],
@@ -8233,10 +8239,45 @@ test('pending and token-cleared CAPTCHA gates hydrate after a background worker 
     const clearedTabId = tabId + 10;
     const clearedAgent = new AgentClass({});
     const clearedKey = clearedAgent._convKey(clearedTabId);
-    const captchaGateState = {
+    const legacyClearedTabId = tabId + 20;
+    const legacyClearedAgent = new AgentClass({});
+    const legacyClearedKey = legacyClearedAgent._convKey(legacyClearedTabId);
+    const persistedCaptchaGateState = {
       key: 'https://example.test/signup\nsecurity verification',
       status: 'verification_pending',
       verificationAttempts: 1,
+      verificationFrameReadRequired: true,
+      publicGate: {
+        status: 'verification_pending',
+        verificationRetryRequired: true,
+        verificationReadRequired: true,
+        solveFailedToClearChallenge: true,
+        challengeDialog: { label: 'Security verification' },
+        diagnostics: { vendors: ['recaptcha'], frames: [] },
+      },
+    };
+    const persistedLegacyClearedState = {
+      key: 'https://example.test/signup\nsecurity verification',
+      status: 'cleared',
+      publicGate: {
+        status: 'cleared',
+        solveAttempted: true,
+        clearedByReadOnlyVerification: true,
+        challengeDialog: { label: 'Security verification' },
+      },
+    };
+    const legacyClearedState = {
+      key: 'https://example.test/signup\nsecurity verification',
+      status: 'manual_required',
+      publicGate: {
+        status: 'manual_required',
+        solveAttempted: true,
+        challengeDialog: { label: 'Security verification' },
+      },
+    };
+    const captchaGateState = {
+      key: 'https://example.test/signup\nsecurity verification',
+      status: 'verification_pending',
       publicGate: {
         status: 'verification_pending',
         challengeDialog: { label: 'Security verification' },
@@ -8269,12 +8310,17 @@ test('pending and token-cleared CAPTCHA gates hydrate after a background worker 
             [key]: {
               messages: [{ role: 'system', content: 'test' }],
               mode: 'act',
-              captchaGateState,
+              captchaGateState: persistedCaptchaGateState,
             },
             [clearedKey]: {
               messages: [{ role: 'system', content: 'test' }],
               mode: 'act',
               captchaGateState: clearedCaptchaGateState,
+            },
+            [legacyClearedKey]: {
+              messages: [{ role: 'system', content: 'test' }],
+              mode: 'act',
+              captchaGateState: persistedLegacyClearedState,
             },
           }),
         },
@@ -8288,6 +8334,12 @@ test('pending and token-cleared CAPTCHA gates hydrate after a background worker 
         clearedAgent._captchaGateStates.get(clearedTabId),
         clearedCaptchaGateState,
         `${label}: worker restart lost the token-clearance recheck marker`,
+      );
+      await legacyClearedAgent._hydrate(legacyClearedTabId);
+      assert.deepEqual(
+        legacyClearedAgent._captchaGateStates.get(legacyClearedTabId),
+        legacyClearedState,
+        `${label}: worker restart trusted legacy read-only clearance`,
       );
     } finally {
       globalThis[apiName] = previousApi;
@@ -67394,9 +67446,10 @@ test('post-solve CAPTCHA gates consume only the correlated response token and re
       );
       assert.equal(
         stillActive.gate?.status,
-        'verification_pending',
-        `${build}: token cleared the gate while its active frame remained visible`,
+        'manual_required',
+        `${build}: active challenge after the one solve did not fail closed`,
       );
+      assert.equal(stillActive.gate?.activeChallengeAfterSolve, true, `${build}: active post-solve challenge reason missing`);
       assert.equal(
         stillActive.gate?.clearedByResponseToken,
         undefined,
@@ -67443,8 +67496,8 @@ test('post-solve CAPTCHA gates consume only the correlated response token and re
       const rearmed = await agent._captchaMutationPreflight(1, 'click_ax');
       assert.equal(
         rearmed?.status,
-        'solve_required',
-        `${build}: reappearing challenge frame did not re-arm after token rejection`,
+        'manual_required',
+        `${build}: reappearing challenge frame allowed another paid solve after token rejection`,
       );
       assert.equal(agent._captchaGateStates.has(1), true, `${build}: re-armed gate was not persisted`);
     });
@@ -67694,7 +67747,6 @@ test('challenge-dialog preflight honors ancestor iframe visibility across extens
       agent._captchaGateStates.set(1, {
         key: 'https://example.test/signup\nsecurity verification',
         status: 'verification_pending',
-        verificationAttempts: 0,
         challengeFrameId: 7,
         challengeFrameUrl: 'https://challenge.example.test/verify',
         publicGate: {
@@ -67727,7 +67779,7 @@ test('challenge-dialog preflight honors ancestor iframe visibility across extens
         { filter: 'visible' },
       );
       assert.equal(childUninspectable.gate?.status, 'verification_pending', `${build}: inaccessible challenge frame cleared the gate`);
-      assert.equal(childUninspectable.gate?.verificationFrameReadRequired, true, `${build}: inaccessible frame did not fail closed`);
+      assert.equal(childUninspectable.gate?.verificationFrameReadRequired, undefined, `${build}: inaccessible frame recreated legacy read state`);
 
       childInspectionFails = false;
       childChallengeVisible = false;
@@ -67740,8 +67792,8 @@ test('challenge-dialog preflight honors ancestor iframe visibility across extens
         },
         { filter: 'visible' },
       );
-      assert.equal(childCleared.gate?.status, 'cleared', `${build}: cleared child frame kept CAPTCHA gate active`);
-      assert.equal(agent._captchaGateStates.has(1), false, `${build}: cleared child-frame gate remained persisted`);
+      assert.equal(childCleared.gate?.status, 'verification_pending', `${build}: absent child dialog independently cleared an uncorrelated gate`);
+      assert.equal(agent._captchaGateStates.has(1), true, `${build}: inconclusive child-frame gate was discarded`);
     } finally {
       globalThis.chrome = previousChrome;
       globalThis.browser = previousBrowser;


### PR DESCRIPTION
## Summary

- make the correlated response token and visible active-challenge frame authoritative after the one automatic CAPTCHA solve
- keep inconclusive or missing widget state fail-closed without the two-read accessibility-tree retry ladder
- route a reappearing active challenge to manual completion instead of allowing another paid solve
- remove legacy verification counters/flags from live transitions and safely downgrade persisted read-inferred clearance after an extension update
- preserve Chrome/Firefox parity and re-express the existing renamed-dialog, multi-widget, hCaptcha compatibility, child-frame, and worker-restart regressions

## Why

This is the next focused cleanup from #505 after #2637 began consuming exact per-widget token state. Dialog disappearance, tree pagination, and read depth should no longer decide whether an automatically solved widget cleared.

The remaining English-matcher consolidation and full-page Cloudflare managed-challenge detection stay out of this PR.

## Verification

- `node test/run.js`: 1564 passed, 1 inherited failure (`package.json` is `27.1.5`, latest changelog entry is `27.1.0`)
- `npm run test:security`: 60/60 passed
- `npm run test:fixtures`: 143/145; the same Chrome/Firefox selection-dialog failures reproduce on a clean `upstream/main` worktree
- `npm run test:webmcp`: both protocol and extension smoke assertions print PASS; cleanup then hits the existing timeout, reproduced unchanged on clean `upstream/main`
- `npm run build:zip`: Chrome, Edge, and Firefox packages built successfully

Part of #505.
