### PR TITLE
fix(cloud-output): reject non-finite numbers in output schema validation

### DIFF
--- a/src/chrome/src/agent/cloud-output.js
+++ b/src/chrome/src/agent/cloud-output.js
@@ -203,7 +203,7 @@ export function validateCloudOutput(value, schema) {
       }
       const valid = shorthand === 'any'
         || (shorthand === 'string' && typeof item === 'string')
-        || (shorthand === 'number' && typeof item === 'number' && !Number.isNaN(item))
+        || (shorthand === 'number' && Number.isFinite(item))
         || (shorthand === 'integer' && Number.isInteger(item))
         || (shorthand === 'boolean' && typeof item === 'boolean')
         || (shorthand === 'object' && isObject(item))
@@ -272,7 +272,7 @@ export function validateCloudOutput(value, schema) {
         if (type === 'array') return Array.isArray(item);
         if (type === 'object') return isObject(item);
         if (type === 'integer') return Number.isInteger(item);
-        if (type === 'number') return typeof item === 'number' && !Number.isNaN(item);
+        if (type === 'number') return Number.isFinite(item);
         if (type === 'null') return item === null;
         return typeof item === type;
       });
@@ -284,9 +284,16 @@ export function validateCloudOutput(value, schema) {
       if (Number.isInteger(spec.maxLength) && length > spec.maxLength) push(path, `expected at most ${spec.maxLength} characters`);
       if (typeof spec.pattern === 'string' && !new RegExp(spec.pattern).test(item)) push(path, `expected to match ${JSON.stringify(spec.pattern)}`);
     }
-    if (typeof item === 'number' && Number.isFinite(item)) {
-      if (typeof spec.minimum === 'number' && item < spec.minimum) push(path, `expected at least ${spec.minimum}`);
-      if (typeof spec.maximum === 'number' && item > spec.maximum) push(path, `expected at most ${spec.maximum}`);
+    // JSON numerals cannot overflow to a non-finite value, so a non-finite
+    // instance is never a valid bound. Reject it explicitly so a constraint-only
+    // schema (no `type`) cannot let Infinity slip past minimum/maximum.
+    if (typeof item === 'number' && (typeof spec.minimum === 'number' || typeof spec.maximum === 'number')) {
+      if (!Number.isFinite(item)) {
+        push(path, 'expected a finite number');
+      } else {
+        if (typeof spec.minimum === 'number' && item < spec.minimum) push(path, `expected at least ${spec.minimum}`);
+        if (typeof spec.maximum === 'number' && item > spec.maximum) push(path, `expected at most ${spec.maximum}`);
+      }
     }
     if (Array.isArray(item)) {
       if (Number.isInteger(spec.minItems) && item.length < spec.minItems) push(path, `expected at least ${spec.minItems} items`);

--- a/src/chrome/src/agent/cloud-output.js
+++ b/src/chrome/src/agent/cloud-output.js
@@ -284,9 +284,10 @@ export function validateCloudOutput(value, schema) {
       if (Number.isInteger(spec.maxLength) && length > spec.maxLength) push(path, `expected at most ${spec.maxLength} characters`);
       if (typeof spec.pattern === 'string' && !new RegExp(spec.pattern).test(item)) push(path, `expected to match ${JSON.stringify(spec.pattern)}`);
     }
-    // JSON numerals cannot overflow to a non-finite value, so a non-finite
-    // instance is never a valid bound. Reject it explicitly so a constraint-only
-    // schema (no `type`) cannot let Infinity slip past minimum/maximum.
+    // JSON has no Infinity literal, but a parser can still overflow a numeral
+    // like 1e400 into a non-finite value. Such a value is never a valid JSON
+    // instance, so reject it explicitly — a constraint-only schema (no `type`)
+    // would otherwise let Infinity slip past minimum/maximum.
     if (typeof item === 'number' && (typeof spec.minimum === 'number' || typeof spec.maximum === 'number')) {
       if (!Number.isFinite(item)) {
         push(path, 'expected a finite number');

--- a/src/firefox/src/agent/cloud-output.js
+++ b/src/firefox/src/agent/cloud-output.js
@@ -203,7 +203,7 @@ export function validateCloudOutput(value, schema) {
       }
       const valid = shorthand === 'any'
         || (shorthand === 'string' && typeof item === 'string')
-        || (shorthand === 'number' && typeof item === 'number' && !Number.isNaN(item))
+        || (shorthand === 'number' && Number.isFinite(item))
         || (shorthand === 'integer' && Number.isInteger(item))
         || (shorthand === 'boolean' && typeof item === 'boolean')
         || (shorthand === 'object' && isObject(item))
@@ -272,7 +272,7 @@ export function validateCloudOutput(value, schema) {
         if (type === 'array') return Array.isArray(item);
         if (type === 'object') return isObject(item);
         if (type === 'integer') return Number.isInteger(item);
-        if (type === 'number') return typeof item === 'number' && !Number.isNaN(item);
+        if (type === 'number') return Number.isFinite(item);
         if (type === 'null') return item === null;
         return typeof item === type;
       });
@@ -284,9 +284,16 @@ export function validateCloudOutput(value, schema) {
       if (Number.isInteger(spec.maxLength) && length > spec.maxLength) push(path, `expected at most ${spec.maxLength} characters`);
       if (typeof spec.pattern === 'string' && !new RegExp(spec.pattern).test(item)) push(path, `expected to match ${JSON.stringify(spec.pattern)}`);
     }
-    if (typeof item === 'number' && Number.isFinite(item)) {
-      if (typeof spec.minimum === 'number' && item < spec.minimum) push(path, `expected at least ${spec.minimum}`);
-      if (typeof spec.maximum === 'number' && item > spec.maximum) push(path, `expected at most ${spec.maximum}`);
+    // JSON numerals cannot overflow to a non-finite value, so a non-finite
+    // instance is never a valid bound. Reject it explicitly so a constraint-only
+    // schema (no `type`) cannot let Infinity slip past minimum/maximum.
+    if (typeof item === 'number' && (typeof spec.minimum === 'number' || typeof spec.maximum === 'number')) {
+      if (!Number.isFinite(item)) {
+        push(path, 'expected a finite number');
+      } else {
+        if (typeof spec.minimum === 'number' && item < spec.minimum) push(path, `expected at least ${spec.minimum}`);
+        if (typeof spec.maximum === 'number' && item > spec.maximum) push(path, `expected at most ${spec.maximum}`);
+      }
     }
     if (Array.isArray(item)) {
       if (Number.isInteger(spec.minItems) && item.length < spec.minItems) push(path, `expected at least ${spec.minItems} items`);

--- a/src/firefox/src/agent/cloud-output.js
+++ b/src/firefox/src/agent/cloud-output.js
@@ -284,9 +284,10 @@ export function validateCloudOutput(value, schema) {
       if (Number.isInteger(spec.maxLength) && length > spec.maxLength) push(path, `expected at most ${spec.maxLength} characters`);
       if (typeof spec.pattern === 'string' && !new RegExp(spec.pattern).test(item)) push(path, `expected to match ${JSON.stringify(spec.pattern)}`);
     }
-    // JSON numerals cannot overflow to a non-finite value, so a non-finite
-    // instance is never a valid bound. Reject it explicitly so a constraint-only
-    // schema (no `type`) cannot let Infinity slip past minimum/maximum.
+    // JSON has no Infinity literal, but a parser can still overflow a numeral
+    // like 1e400 into a non-finite value. Such a value is never a valid JSON
+    // instance, so reject it explicitly — a constraint-only schema (no `type`)
+    // would otherwise let Infinity slip past minimum/maximum.
     if (typeof item === 'number' && (typeof spec.minimum === 'number' || typeof spec.maximum === 'number')) {
       if (!Number.isFinite(item)) {
         push(path, 'expected a finite number');

--- a/test/run.js
+++ b/test/run.js
@@ -14841,6 +14841,19 @@ test('done_json accepts free-form and shorthand output schemas it advertises', a
       [{ items: false }, [1], false],
       [{ anyOf: [false, { minLength: 3 }] }, 'abc', true],
       [{ anyOf: [false, { minLength: 3 }] }, 'a', false],
+      // A JSON numeral can overflow to Infinity (JSON.parse('1e400')). A
+      // non-finite number is never a valid JSON instance, so it must fail the
+      // type check and the minimum/maximum bounds instead of passing both.
+      [{ type: 'number', maximum: 100 }, Infinity, false],
+      [{ type: 'number', maximum: 100 }, -Infinity, false],
+      [{ type: 'number', minimum: 0 }, Infinity, false],
+      [{ type: 'number', minimum: 0 }, -Infinity, false],
+      [{ type: 'number' }, Infinity, false],
+      [{ type: 'number', maximum: 100 }, JSON.parse('1e400'), false],
+      // Constraint-only schemas have no type check, so the bounds themselves
+      // have to reject a non-finite instance.
+      [{ maximum: 100 }, Infinity, false],
+      [{ minimum: 0 }, -Infinity, false],
     ]) {
       assert.equal(
         cloudModule.validateCloudOutput(value, spec).ok,
@@ -14920,6 +14933,55 @@ test('done_json accepts free-form and shorthand output schemas it advertises', a
       false,
       `${label}: nullable optional widened past its declared type`,
     );
+  }
+});
+
+test('done_json and validateCloudOutput reject non-finite numbers instead of completing with null', async () => {
+  const cloudModules = [];
+  for (const label of ['chrome', 'firefox']) {
+    cloudModules.push(await import(
+      pathToFileURL(path.join(ROOT, `src/${label}/src/agent/cloud-output.js`)).href
+    ));
+  }
+  for (const [label, handle, cloudModule] of [
+    ['chrome', handleDoneJsonCh, cloudModules[0]],
+    ['firefox', handleDoneJsonFx, cloudModules[1]],
+  ]) {
+    const schema = {
+      type: 'object',
+      properties: { count: { type: 'number', maximum: 100 } },
+      required: ['count'],
+      additionalProperties: false,
+    };
+    const overflow = JSON.parse('1e400');
+    const underflow = JSON.parse('-1e400');
+
+    // A bounded number must not accept a numeral-overflow instance.
+    const first = handle({ outputSchema: schema, schemaRepairUsed: false }, {
+      result: { count: overflow },
+      summary: 's',
+    });
+    assert.equal(first.done, undefined, `[${label}] Infinity passed number maximum bounds`);
+    assert.equal(first.schemaValidationError, true, `[${label}] Infinity was not a schema failure`);
+    assert.equal(first.cloudResult, undefined, `[${label}] Infinity completed a run with a corrupt result`);
+
+    // The one repair attempt must not complete the run either.
+    const terminal = handle({ outputSchema: schema, schemaRepairUsed: true }, {
+      result: { count: underflow },
+      summary: 's',
+    });
+    assert.equal(terminal.done, true, `[${label}] -Infinity did not terminate the run after repair`);
+    assert.equal(terminal.cloudFailed, true, `[${label}] -Infinity completed a failed cloud run`);
+
+    // The shorthand number token has the same finiteness contract.
+    assert.equal(cloudModule.validateCloudOutput(overflow, 'number').ok, false,
+      `[${label}] shorthand number accepted Infinity`);
+    assert.equal(cloudModule.validateCloudOutput(underflow, 'number').ok, false,
+      `[${label}] shorthand number accepted -Infinity`);
+
+    // A finite value that respects the bounds still validates.
+    assert.equal(cloudModule.validateCloudOutput(100, { type: 'number', maximum: 100 }).ok, true,
+      `[${label}] a finite bound-respecting number was rejected`);
   }
 });
 


### PR DESCRIPTION
Closes #2779

## Summary

`validateCloudOutput` accepted `Infinity`/`-Infinity` as a `type: 'number'` instance and silently bypassed the schema's `maximum`/`minimum` bounds. A model emitting a JSON numeral with an overflowing exponent (e.g. `1e400`, which `JSON.parse` turns into `Infinity`) made the run "complete" with a result that violates the caller's schema, and the value was serialized to `null` in the returned structured output.

## Root cause

Two defects combined in the `validate` function:

1. The JSON-Schema `number` type check was `typeof item === 'number' && !Number.isNaN(item)` — `Infinity` satisfies it.
2. The `minimum`/`maximum` checks were wrapped in `if (typeof item === 'number' && Number.isFinite(item))`, so they were skipped entirely for non-finite values.

The same accept-`Infinity` gap existed in the shorthand leaf branch (`shorthand === 'number'`).

## Fix

- Require `Number.isFinite(item)` in the `number` type check in both the JSON-Schema branch and the shorthand branch (`Number.isFinite` also implies `typeof === 'number'`).
- Reject non-finite instances explicitly when `minimum`/`maximum` bounds are present, which also covers constraint-only schemas (no `type` keyword) where no type check runs.

## Reproduction before the fix

```
validateCloudOutput(200, {type:'number', maximum:100})                → ok:false  (control)
validateCloudOutput(JSON.parse('1e400'), {type:'number', maximum:100}) → ok:true   (BUG)
validateCloudOutput(JSON.parse('-1e400'), {type:'number', minimum:0})  → ok:true   (BUG)
handleDoneJson(ctx, { result: { count: JSON.parse('1e400') } })        → done:true, result.count null
```

## After the fix

```
validateCloudOutput(JSON.parse('1e400'), {type:'number', maximum:100}) → ok:false
handleDoneJson(...)                                                     → schemaValidationError, repair attempt
```

## Tests

- Added non-finite cases (`Infinity`, `-Infinity`, `JSON.parse('1e400')`) to the constraint sweep in `test/run.js` covering typed, bounded, and constraint-only schemas.
- Added a `done_json`/`validateCloudOutput` end-to-end regression test for both Chrome and Firefox builds mirroring the issue reproduction, plus the shorthand `number` token.

Full suite: `1680 passed, 0 failed`, plus toolbar-guard (33) and security corpus (60/60) all green.