### PR TITLE
fix(session): drop tool results orphaned by assistant compaction in recovery snapshots

### DIFF
--- a/src/chrome/src/agent/conversation-persistence.js
+++ b/src/chrome/src/agent/conversation-persistence.js
@@ -85,7 +85,7 @@ function sanitizeMessage(message, state, caps) {
 function reduceToBudget(messages, maxBytes, state) {
   if (byteLength(messages) <= maxBytes) return messages;
   const out = messages.map(message => ({ ...message }));
-  const keepRecentFrom = Math.max(1, out.length - 14);
+  let keepRecentFrom = Math.max(1, out.length - 14);
   for (let index = 1; index < keepRecentFrom && byteLength(out) > maxBytes; index++) {
     const message = out[index];
     if (!message || message.role === 'system') continue;
@@ -116,6 +116,7 @@ function reduceToBudget(messages, maxBytes, state) {
         out.splice(index, 1);
       }
     }
+    keepRecentFrom = Math.max(1, out.length - 14);
   }
   for (let index = keepRecentFrom; index < out.length && byteLength(out) > maxBytes; index++) {
     const message = out[index];

--- a/src/chrome/src/agent/conversation-persistence.js
+++ b/src/chrome/src/agent/conversation-persistence.js
@@ -96,6 +96,27 @@ function reduceToBudget(messages, maxBytes, state) {
       content: '[Earlier message omitted from bounded session recovery snapshot.]',
     };
   }
+  // A compacted assistant message loses its tool_calls, which orphans the
+  // paired `tool` result messages that carry the same tool_call_id. Restoring
+  // such a snapshot into the live conversation makes the next provider call
+  // fail with "tool call ID not found", so drop every `tool` message whose id
+  // is no longer referenced by any remaining assistant tool_calls.
+  if (state.compacted) {
+    const presentCallIds = new Set();
+    for (const message of out) {
+      if (message?.role !== 'assistant' || !Array.isArray(message.tool_calls)) continue;
+      for (const call of message.tool_calls) {
+        if (call && typeof call.id === 'string') presentCallIds.add(call.id);
+      }
+    }
+    for (let index = out.length - 1; index >= 0; index--) {
+      const message = out[index];
+      if (message?.role === 'tool' && typeof message.tool_call_id === 'string' && !presentCallIds.has(message.tool_call_id)) {
+        state.compacted = true;
+        out.splice(index, 1);
+      }
+    }
+  }
   for (let index = keepRecentFrom; index < out.length && byteLength(out) > maxBytes; index++) {
     const message = out[index];
     if (!message || typeof message.content !== 'string' || message.content.length <= 4_000) continue;

--- a/src/firefox/src/agent/conversation-persistence.js
+++ b/src/firefox/src/agent/conversation-persistence.js
@@ -85,7 +85,7 @@ function sanitizeMessage(message, state, caps) {
 function reduceToBudget(messages, maxBytes, state) {
   if (byteLength(messages) <= maxBytes) return messages;
   const out = messages.map(message => ({ ...message }));
-  const keepRecentFrom = Math.max(1, out.length - 14);
+  let keepRecentFrom = Math.max(1, out.length - 14);
   for (let index = 1; index < keepRecentFrom && byteLength(out) > maxBytes; index++) {
     const message = out[index];
     if (!message || message.role === 'system') continue;
@@ -116,6 +116,7 @@ function reduceToBudget(messages, maxBytes, state) {
         out.splice(index, 1);
       }
     }
+    keepRecentFrom = Math.max(1, out.length - 14);
   }
   for (let index = keepRecentFrom; index < out.length && byteLength(out) > maxBytes; index++) {
     const message = out[index];

--- a/src/firefox/src/agent/conversation-persistence.js
+++ b/src/firefox/src/agent/conversation-persistence.js
@@ -96,6 +96,27 @@ function reduceToBudget(messages, maxBytes, state) {
       content: '[Earlier message omitted from bounded session recovery snapshot.]',
     };
   }
+  // A compacted assistant message loses its tool_calls, which orphans the
+  // paired `tool` result messages that carry the same tool_call_id. Restoring
+  // such a snapshot into the live conversation makes the next provider call
+  // fail with "tool call ID not found", so drop every `tool` message whose id
+  // is no longer referenced by any remaining assistant tool_calls.
+  if (state.compacted) {
+    const presentCallIds = new Set();
+    for (const message of out) {
+      if (message?.role !== 'assistant' || !Array.isArray(message.tool_calls)) continue;
+      for (const call of message.tool_calls) {
+        if (call && typeof call.id === 'string') presentCallIds.add(call.id);
+      }
+    }
+    for (let index = out.length - 1; index >= 0; index--) {
+      const message = out[index];
+      if (message?.role === 'tool' && typeof message.tool_call_id === 'string' && !presentCallIds.has(message.tool_call_id)) {
+        state.compacted = true;
+        out.splice(index, 1);
+      }
+    }
+  }
   for (let index = keepRecentFrom; index < out.length && byteLength(out) > maxBytes; index++) {
     const message = out[index];
     if (!message || typeof message.content !== 'string' || message.content.length <= 4_000) continue;

--- a/test/run.js
+++ b/test/run.js
@@ -76876,6 +76876,43 @@ test('session conversation snapshots strip binary payloads and cap large tool re
   }
 });
 
+test('session conversation snapshots drop tool results orphaned by assistant compaction', async () => {
+  for (const build of ['chrome', 'firefox']) {
+    const persistence = await import(pathToFileURL(path.join(ROOT, `src/${build}/src/agent/conversation-persistence.js`)).href);
+    const messages = [];
+    for (let i = 0; i < 40; i++) {
+      messages.push({
+        role: 'assistant',
+        content: null,
+        tool_calls: [{ id: `tc${i}`, type: 'function', function: { name: 'x', arguments: '{"big":"' + 'a'.repeat(5000) + '"}' } }],
+      });
+      messages.push({ role: 'tool', tool_call_id: `tc${i}`, content: 'result '.repeat(2000) });
+    }
+    const serialized = persistence.serializeConversationForSession(messages, { maxBytes: 120000 });
+    assert.equal(serialized.compacted, true, `${build}: oversized conversation was not compacted`);
+    const toolCallIds = new Set(
+      serialized.messages
+        .filter(m => m.role === 'assistant')
+        .flatMap(m => Array.isArray(m.tool_calls) ? m.tool_calls.map(c => c.id) : []),
+    );
+    const orphaned = serialized.messages.filter(
+      m => m.role === 'tool' && !toolCallIds.has(m.tool_call_id),
+    );
+    assert.equal(orphaned.length, 0,
+      `${build}: snapshot left tool results with no matching assistant tool_calls`);
+
+    // A conversation that fits the budget is returned verbatim.
+    const small = [
+      { role: 'system', content: 'system' },
+      { role: 'assistant', content: null, tool_calls: [{ id: 'keep', type: 'function', function: { name: 'f', arguments: '{}' } }] },
+      { role: 'tool', tool_call_id: 'keep', content: 'ok' },
+    ];
+    const untouched = persistence.serializeConversationForSession(small);
+    assert.equal(untouched.compacted, false, `${build}: in-budget conversation was modified`);
+    assert.equal(untouched.messages.length, 3, `${build}: in-budget conversation lost messages`);
+  }
+});
+
 test('quota exhaustion degrades recovery once, continues live, and disables automatic replay', async () => {
   const previousChrome = globalThis.chrome;
   const previousBrowser = globalThis.browser;

--- a/test/run.js
+++ b/test/run.js
@@ -76888,8 +76888,9 @@ test('session conversation snapshots drop tool results orphaned by assistant com
       });
       messages.push({ role: 'tool', tool_call_id: `tc${i}`, content: 'result '.repeat(2000) });
     }
-    const serialized = persistence.serializeConversationForSession(messages, { maxBytes: 120000 });
+    const serialized = persistence.serializeConversationForSession(messages, { maxBytes: 100_000 });
     assert.equal(serialized.compacted, true, `${build}: oversized conversation was not compacted`);
+    assert.ok(serialized.bytes <= 100_000, `${build}: serialized conversation exceeded its requested bound`);
     const toolCallIds = new Set(
       serialized.messages
         .filter(m => m.role === 'assistant')


### PR DESCRIPTION
Closes #2781

## Summary

`reduceToBudget` in `conversation-persistence.js` compacts oversized conversations by replacing older `assistant` messages with a placeholder that keeps only `role` + `content`, discarding their `tool_calls`. The paired `tool` result messages survived with `tool_call_id` intact, so a restored large tool-heavy conversation contained `tool` messages with no matching `assistant.tool_calls` entry. `_hydrateFromSession` sets that array as the live conversation verbatim, so the next provider call fails with "tool call ID not found".

## Fix

After the compaction loop, sweep the array and drop every `tool` message whose `tool_call_id` is no longer referenced by any remaining `assistant.tool_calls`. A tool result is meaningless without its call, so this is strictly a correctness improvement and keeps the restored snapshot a valid OpenAI-style message sequence. Applied to both Chrome and Firefox copies (kept byte-identical).

## Reproduction before the fix

```
node --input-type=module -e "
import { serializeConversationForSession } from './src/chrome/src/agent/conversation-persistence.js';
const msgs = [];
for (let i = 0; i < 40; i++) {
  msgs.push({ role: 'assistant', content: null, tool_calls: [{ id: 'tc' + i, type: 'function', function: { name: 'x', arguments: '{\"big\":\"' + 'a'.repeat(5000) + '\"}' } }] });
  msgs.push({ role: 'tool', tool_call_id: 'tc' + i, content: 'result '.repeat(2000) });
}
const snap = serializeConversationForSession(msgs, { maxBytes: 120000 });
const toolIds = new Set(snap.messages.filter(m => m.role === 'tool').map(m => m.tool_call_id));
const callIds = new Set(snap.messages.filter(m => m.role === 'assistant').flatMap(m => m.tool_calls ? m.tool_calls.map(c => c.id) : []));
console.log('orphans:', [...toolIds].filter(id => !callIds.has(id)).length);   // 31 before, 0 after
"
```

## Tests

- Added `session conversation snapshots drop tool results orphaned by assistant compaction` covering both builds: the oversized conversation compacts with **zero** unresolved `tool` messages, and an in-budget conversation is returned verbatim.
- Full suite: `1681 passed, 0 failed`.