### PR TITLE
fix(memory): safely accept omitted extraction confidence

### DIFF
--- a/src/chrome/src/agent/user-memory.js
+++ b/src/chrome/src/agent/user-memory.js
@@ -228,6 +228,16 @@ export function clearUserMemoryStore(opts = {}) {
   return { version: STORE_VERSION, updatedAt: ts, records: [] };
 }
 
+function normalizeUserMemoryExtractionConfidence(value) {
+  if (value === undefined) return USER_MEMORY_EXTRACTION_CONFIDENCE_THRESHOLD;
+  const numeric = typeof value === 'number'
+    ? value
+    : typeof value === 'string' && value.trim()
+      ? Number(value)
+      : NaN;
+  return Number.isFinite(numeric) ? Math.max(0, Math.min(1, numeric)) : 0;
+}
+
 export function parseUserMemoryExtractionResult(content) {
   let parsed = null;
   const text = String(content || '').trim();
@@ -245,7 +255,7 @@ export function parseUserMemoryExtractionResult(content) {
     id: item?.id ? String(item.id) : '',
     text: normalizeUserMemoryText(item?.text),
     kind: normalizeUserMemoryKind(item?.kind),
-    confidence: Number.isFinite(Number(item?.confidence)) ? Math.max(0, Math.min(1, Number(item.confidence))) : 1,
+    confidence: normalizeUserMemoryExtractionConfidence(item?.confidence),
   })).filter((item) => item.op !== 'none');
 }
 

--- a/src/chrome/src/agent/user-memory.js
+++ b/src/chrome/src/agent/user-memory.js
@@ -245,7 +245,7 @@ export function parseUserMemoryExtractionResult(content) {
     id: item?.id ? String(item.id) : '',
     text: normalizeUserMemoryText(item?.text),
     kind: normalizeUserMemoryKind(item?.kind),
-    confidence: Number.isFinite(Number(item?.confidence)) ? Math.max(0, Math.min(1, Number(item.confidence))) : 0,
+    confidence: Number.isFinite(Number(item?.confidence)) ? Math.max(0, Math.min(1, Number(item.confidence))) : 1,
   })).filter((item) => item.op !== 'none');
 }
 

--- a/src/firefox/src/agent/user-memory.js
+++ b/src/firefox/src/agent/user-memory.js
@@ -228,6 +228,16 @@ export function clearUserMemoryStore(opts = {}) {
   return { version: STORE_VERSION, updatedAt: ts, records: [] };
 }
 
+function normalizeUserMemoryExtractionConfidence(value) {
+  if (value === undefined) return USER_MEMORY_EXTRACTION_CONFIDENCE_THRESHOLD;
+  const numeric = typeof value === 'number'
+    ? value
+    : typeof value === 'string' && value.trim()
+      ? Number(value)
+      : NaN;
+  return Number.isFinite(numeric) ? Math.max(0, Math.min(1, numeric)) : 0;
+}
+
 export function parseUserMemoryExtractionResult(content) {
   let parsed = null;
   const text = String(content || '').trim();
@@ -245,7 +255,7 @@ export function parseUserMemoryExtractionResult(content) {
     id: item?.id ? String(item.id) : '',
     text: normalizeUserMemoryText(item?.text),
     kind: normalizeUserMemoryKind(item?.kind),
-    confidence: Number.isFinite(Number(item?.confidence)) ? Math.max(0, Math.min(1, Number(item.confidence))) : 1,
+    confidence: normalizeUserMemoryExtractionConfidence(item?.confidence),
   })).filter((item) => item.op !== 'none');
 }
 

--- a/src/firefox/src/agent/user-memory.js
+++ b/src/firefox/src/agent/user-memory.js
@@ -245,7 +245,7 @@ export function parseUserMemoryExtractionResult(content) {
     id: item?.id ? String(item.id) : '',
     text: normalizeUserMemoryText(item?.text),
     kind: normalizeUserMemoryKind(item?.kind),
-    confidence: Number.isFinite(Number(item?.confidence)) ? Math.max(0, Math.min(1, Number(item.confidence))) : 0,
+    confidence: Number.isFinite(Number(item?.confidence)) ? Math.max(0, Math.min(1, Number(item.confidence))) : 1,
   })).filter((item) => item.op !== 'none');
 }
 

--- a/test/run.js
+++ b/test/run.js
@@ -2738,6 +2738,17 @@ test('user memory extraction applies only high-confidence safe operations', () =
     assert.equal(deduped.changed, true, `${label}: duplicate adds may refresh the existing record`);
     assert.equal(deduped.created, false, `${label}: duplicate adds should not report a newly formed memory`);
 
+    // A memory extracted without an explicit confidence is a stable model
+    // assertion and must default to full confidence, not zero (which would
+    // silently drop it at the 0.85 threshold).
+    const defaulted = memory.parseUserMemoryExtractionResult(JSON.stringify({
+      memories: [{ op: 'add', text: 'Always cite sources in drafts.', kind: 'workflow_preference' }],
+    }));
+    assert.equal(defaulted[0].confidence, 1, `${label}: missing confidence should default to 1`);
+    const defaultedApplied = memory.applyUserMemoryExtractionOperations(base, defaulted, { now: 600, threshold: 0.85 });
+    assert.equal(defaultedApplied.created, true, `${label}: confidence-less extraction should apply`);
+    assert.equal(defaultedApplied.store.records.length, 2, `${label}: confidence-less extraction should persist a record`);
+
     const extractionMessages = memory.buildUserMemoryExtractionMessages({
       userText: 'Remember that I prefer terse replies.',
       assistantText: 'Saved.',

--- a/test/run.js
+++ b/test/run.js
@@ -2738,16 +2738,30 @@ test('user memory extraction applies only high-confidence safe operations', () =
     assert.equal(deduped.changed, true, `${label}: duplicate adds may refresh the existing record`);
     assert.equal(deduped.created, false, `${label}: duplicate adds should not report a newly formed memory`);
 
-    // A memory extracted without an explicit confidence is a stable model
-    // assertion and must default to full confidence, not zero (which would
-    // silently drop it at the 0.85 threshold).
+    // Missing confidence is accepted at the configured threshold, but malformed
+    // confidence must not be promoted to a trusted memory.
     const defaulted = memory.parseUserMemoryExtractionResult(JSON.stringify({
       memories: [{ op: 'add', text: 'Always cite sources in drafts.', kind: 'workflow_preference' }],
     }));
-    assert.equal(defaulted[0].confidence, 1, `${label}: missing confidence should default to 1`);
+    assert.equal(defaulted[0].confidence, memory.USER_MEMORY_EXTRACTION_CONFIDENCE_THRESHOLD,
+      `${label}: missing confidence should default to the acceptance threshold`);
     const defaultedApplied = memory.applyUserMemoryExtractionOperations(base, defaulted, { now: 600, threshold: 0.85 });
     assert.equal(defaultedApplied.created, true, `${label}: confidence-less extraction should apply`);
     assert.equal(defaultedApplied.store.records.length, 2, `${label}: confidence-less extraction should persist a record`);
+
+    for (const invalidConfidence of [null, '', 'high', true, {}, []]) {
+      const malformed = memory.parseUserMemoryExtractionResult(JSON.stringify({
+        memories: [{ op: 'add', text: 'Use a questionable preference.', kind: 'preference', confidence: invalidConfidence }],
+      }));
+      assert.equal(malformed[0].confidence, 0, `${label}: malformed confidence should be rejected`);
+      const malformedApplied = memory.applyUserMemoryExtractionOperations(base, malformed, { now: 700, threshold: 0.85 });
+      assert.equal(malformedApplied.changed, false, `${label}: malformed confidence should not apply`);
+    }
+
+    const numericString = memory.parseUserMemoryExtractionResult(JSON.stringify({
+      memories: [{ op: 'add', text: 'Prefer compact tables.', kind: 'preference', confidence: '0.9' }],
+    }));
+    assert.equal(numericString[0].confidence, 0.9, `${label}: nonblank numeric confidence should remain supported`);
 
     const extractionMessages = memory.buildUserMemoryExtractionMessages({
       userText: 'Remember that I prefer terse replies.',


### PR DESCRIPTION
Closes #2783

## Summary

`parseUserMemoryExtractionResult` previously assigned missing confidence `0`, so otherwise valid memory operations were silently rejected by the `0.85` application threshold.

## Fix

- Default an omitted `confidence` to `USER_MEMORY_EXTRACTION_CONFIDENCE_THRESHOLD` (`0.85`), allowing the operation without claiming maximum confidence.
- Continue accepting finite numeric values and nonblank numeric strings, clamped to `0..1`.
- Map malformed values—including `null`, blank or nonnumeric strings, booleans, arrays, and objects—to `0`, so they cannot become trusted persistent memory.
- Apply identical behavior to Chrome and Firefox.

Explicit low-confidence operations remain rejected, and existing sensitive-memory filtering remains in force.

## Tests

Extended `user memory extraction applies only high-confidence safe operations` across both builds to cover omitted, null, blank, malformed, boolean, object, array, and numeric-string confidence values.

Full suite: `1680 passed, 0 failed`.
