### PR TITLE
fix(i18n): add localized verb for the window permission capability

### DIFF
--- a/src/chrome/src/ui/locales/ar.js
+++ b/src/chrome/src/ui/locales/ar.js
@@ -591,6 +591,7 @@ export default {
   'sp.scratchpad.cleared': 'تم مسح المسودة.',
   'sp.scratchpad.error': 'منطقة المسودة غير متاحة: {msg}',
   'sp.perm.verb.schedule': 'جدولة عمل مستقبلي لـ',
+  'sp.perm.verb.window': 'تغيير حجم نافذة المتصفح على',
   'tool.schedule_resume': 'جدولة استئناف',
   'tool.schedule_task': 'جدولة مهمة',
   'st.display.scheduled_tasks.label': 'المهام المجدوَلة',

--- a/src/chrome/src/ui/locales/bn.js
+++ b/src/chrome/src/ui/locales/bn.js
@@ -331,6 +331,7 @@ export default {
   'sp.perm.verb.upload': "একটি ফাইল আপলোড করুন",
   'sp.perm.verb.record': "ট্যাব (এবং মাইক্রোফোন) চালু করুন",
   'sp.perm.verb.schedule': "ভবিষ্যত কাজের সময়সূচী",
+  'sp.perm.verb.window': 'ব্রাউজার উইন্ডোর আকার পরিবর্তন করুন',
 
   'sp.step.details': "বিস্তারিত",
   'sp.step.input_label': "ইনপুট",

--- a/src/chrome/src/ui/locales/de.js
+++ b/src/chrome/src/ui/locales/de.js
@@ -341,6 +341,7 @@ export default {
   'sp.perm.verb.upload': 'Datei hochladen zu',
   'sp.perm.verb.record': 'Tab (und Mikrofon) aufnehmen auf',
   'sp.perm.verb.schedule': 'zukünftige Aufgaben planen für',
+  'sp.perm.verb.window': 'die Größe des Browserfensters ändern auf',
   'sp.help.shortcuts_html': '<strong>Tastenkürzel</strong><br><code>Ctrl/Cmd+/</code> — Eingabefeld fokussieren<br><code>Ctrl/Cmd+Shift+A</code> — Zum Fragen-Modus wechseln<br><code>Ctrl/Cmd+Shift+X</code> — Zum Handeln-Modus wechseln<br><code>Ctrl/Cmd+Shift+D</code> — Zum Dev-Modus wechseln<br><code>Escape</code> — Aktiven Durchlauf stoppen<br><code>Escape</code> zweimal — Aktive Aufnahme stoppen',
   'sp.compact.nothing_to_compact': 'Noch nichts zu kompaktieren — es gibt nicht genügend älteren Kontext.',
   'sp.compact.busy': 'Kompaktierung nicht möglich, während ein Durchlauf läuft — warten Sie auf dessen Abschluss.',

--- a/src/chrome/src/ui/locales/en.js
+++ b/src/chrome/src/ui/locales/en.js
@@ -331,6 +331,7 @@ export default {
   'sp.perm.verb.upload': 'upload a file to',
   'sp.perm.verb.record': 'record the tab (and microphone) on',
   'sp.perm.verb.schedule': 'schedule future work for',
+  'sp.perm.verb.window': 'resize the browser window for',
 
   'sp.step.details': 'details',
   'sp.step.input_label': 'Input',

--- a/src/chrome/src/ui/locales/es.js
+++ b/src/chrome/src/ui/locales/es.js
@@ -591,6 +591,7 @@ export default {
   'sp.scratchpad.cleared': 'Bloc de notas borrado.',
   'sp.scratchpad.error': 'Bloc de notas no disponible: {msg}',
   'sp.perm.verb.schedule': 'programar trabajo futuro en',
+  'sp.perm.verb.window': 'cambiar el tamaño de la ventana del navegador en',
   'tool.schedule_resume': 'Programando reanudación',
   'tool.schedule_task': 'Programando tarea',
   'st.display.scheduled_tasks.label': 'Tareas programadas',

--- a/src/chrome/src/ui/locales/fa.js
+++ b/src/chrome/src/ui/locales/fa.js
@@ -331,6 +331,7 @@ export default {
   'sp.perm.verb.upload': "آپلود فایل به",
   'sp.perm.verb.record': "زبانه (و میکروفون) را روی آن ضبط کنید",
   'sp.perm.verb.schedule': "برای کارهای آینده برنامه ریزی کنید",
+  'sp.perm.verb.window': 'اندازه پنجره مرورگر را تغییر دهید در',
 
   'sp.step.details': "جزئیات",
   'sp.step.input_label': "ورودی",

--- a/src/chrome/src/ui/locales/fr.js
+++ b/src/chrome/src/ui/locales/fr.js
@@ -591,6 +591,7 @@ export default {
   'sp.scratchpad.cleared': 'Bloc-notes effacé.',
   'sp.scratchpad.error': 'Bloc-notes indisponible : {msg}',
   'sp.perm.verb.schedule': 'planifier des tâches futures pour',
+  'sp.perm.verb.window': 'redimensionner la fenêtre du navigateur sur',
   'tool.schedule_resume': 'Planification de la reprise',
   'tool.schedule_task': 'Planification de la tâche',
   'st.display.scheduled_tasks.label': 'Tâches planifiées',

--- a/src/chrome/src/ui/locales/he.js
+++ b/src/chrome/src/ui/locales/he.js
@@ -305,6 +305,7 @@ export default {
   "sp.perm.verb.download": "להוריד קבצים מ",
   "sp.perm.verb.upload": "להעלות קובץ ל",
   "sp.perm.verb.schedule": "לתזמן עבודה עתידית עבור",
+  "sp.perm.verb.window": "לשנות את גודל חלון הדפדפן באתר",
   "sp.step.details": "פרטים",
   "sp.step.input_label": "קלט",
   "sp.step.result_label": "תוצאה",

--- a/src/chrome/src/ui/locales/hi.js
+++ b/src/chrome/src/ui/locales/hi.js
@@ -331,6 +331,7 @@ export default {
   'sp.perm.verb.upload': "पर एक फ़ाइल अपलोड करें",
   'sp.perm.verb.record': "टैब (और माइक्रोफ़ोन) को चालू रखें",
   'sp.perm.verb.schedule': "भविष्य के लिए कार्य शेड्यूल करें",
+  'sp.perm.verb.window': 'ब्राउज़र विंडो का आकार बदलें',
 
   'sp.step.details': "विवरण",
   'sp.step.input_label': "इनपुट",

--- a/src/chrome/src/ui/locales/id.js
+++ b/src/chrome/src/ui/locales/id.js
@@ -591,6 +591,7 @@ export default {
   'sp.scratchpad.cleared': 'Bak pasir dikosongkan.',
   'sp.scratchpad.error': 'Bak pasir tidak tersedia: {msg}',
   'sp.perm.verb.schedule': 'menjadwalkan pekerjaan mendatang untuk',
+  'sp.perm.verb.window': 'mengubah ukuran jendela browser di',
   'tool.schedule_resume': 'Menjadwalkan lanjutan',
   'tool.schedule_task': 'Menjadwalkan tugas',
   'st.display.scheduled_tasks.label': 'Tugas terjadwal',

--- a/src/chrome/src/ui/locales/ja.js
+++ b/src/chrome/src/ui/locales/ja.js
@@ -591,6 +591,7 @@ export default {
   'sp.scratchpad.cleared': 'スクラッチパッドをクリアしました。',
   'sp.scratchpad.error': 'スクラッチパッドを取得できませんでした: {msg}',
   'sp.perm.verb.schedule': 'での将来の作業のスケジュールを',
+  'sp.perm.verb.window': 'でのブラウザウィンドウのサイズ変更を',
   'tool.schedule_resume': '再開をスケジュール中',
   'tool.schedule_task': 'タスクをスケジュール中',
   'st.display.scheduled_tasks.label': 'スケジュールタスク',

--- a/src/chrome/src/ui/locales/ko.js
+++ b/src/chrome/src/ui/locales/ko.js
@@ -591,6 +591,7 @@ export default {
   'sp.scratchpad.cleared': '스크래치패드가 지워졌습니다.',
   'sp.scratchpad.error': '스크래치패드를 사용할 수 없습니다: {msg}',
   'sp.perm.verb.schedule': '미래 작업 예약',
+  'sp.perm.verb.window': '브라우저 창 크기 조절',
   'tool.schedule_resume': '재개 예약 중',
   'tool.schedule_task': '작업 예약 중',
   'st.display.scheduled_tasks.label': '예약된 작업',

--- a/src/chrome/src/ui/locales/ms.js
+++ b/src/chrome/src/ui/locales/ms.js
@@ -591,6 +591,7 @@ export default {
   'sp.scratchpad.cleared': 'Pad nota dikosongkan.',
   'sp.scratchpad.error': 'Pad nota tidak tersedia: {msg}',
   'sp.perm.verb.schedule': 'menjadualkan kerja masa hadapan untuk',
+  'sp.perm.verb.window': 'menukar saiz tetingkap pelayar pada',
   'tool.schedule_resume': 'Menjadualkan sambungan semula',
   'tool.schedule_task': 'Menjadualkan tugas',
   'st.display.scheduled_tasks.label': 'Tugas berjadual',

--- a/src/chrome/src/ui/locales/nl.js
+++ b/src/chrome/src/ui/locales/nl.js
@@ -319,6 +319,7 @@ export default {
   'sp.perm.verb.upload': 'een bestand uploaden naar',
   'sp.perm.verb.record': 'het tabblad (en microfoon) opnemen op',
   'sp.perm.verb.schedule': 'geplande taken instellen voor',
+  'sp.perm.verb.window': 'het browservenster aanpassen op',
   'sp.step.details': 'details',
   'sp.step.input_label': 'Invoer',
   'sp.step.result_label': 'Resultaat',

--- a/src/chrome/src/ui/locales/pl.js
+++ b/src/chrome/src/ui/locales/pl.js
@@ -239,6 +239,7 @@ export default {
   'sp.perm.verb.upload': 'przesłać plik do',
   'sp.perm.verb.record': 'nagrać kartę (i mikrofon) na',
   'sp.perm.verb.schedule': 'zaplanować przyszłe działania dla',
+  'sp.perm.verb.window': 'zmienić rozmiar okna przeglądarki na',
   'sp.step.details': 'szczegóły',
   'sp.step.input_label': 'Wejście',
   'sp.step.result_label': 'Wynik',

--- a/src/chrome/src/ui/locales/pt.js
+++ b/src/chrome/src/ui/locales/pt.js
@@ -331,6 +331,7 @@ export default {
   'sp.perm.verb.upload': "carregar um arquivo para",
   'sp.perm.verb.record': "grave a guia (e o microfone) em",
   'sp.perm.verb.schedule': "agendar trabalhos futuros para",
+  'sp.perm.verb.window': 'redimensionar a janela do navegador em',
 
   'sp.step.details': "detalhes",
   'sp.step.input_label': "Entrada",

--- a/src/chrome/src/ui/locales/ru.js
+++ b/src/chrome/src/ui/locales/ru.js
@@ -591,6 +591,7 @@ export default {
   'sp.scratchpad.cleared': 'Блокнот очищен.',
   'sp.scratchpad.error': 'Блокнот недоступен: {msg}',
   'sp.perm.verb.schedule': 'запланировать будущие действия для',
+  'sp.perm.verb.window': 'изменить размер окна браузера на',
   'tool.schedule_resume': 'Планирование возобновления',
   'tool.schedule_task': 'Планирование задачи',
   'st.display.scheduled_tasks.label': 'Запланированные задачи',

--- a/src/chrome/src/ui/locales/th.js
+++ b/src/chrome/src/ui/locales/th.js
@@ -591,6 +591,7 @@ export default {
   'sp.scratchpad.cleared': 'ล้างกระดานร่างแล้ว',
   'sp.scratchpad.error': 'ไม่สามารถใช้กระดานร่างได้: {msg}',
   'sp.perm.verb.schedule': 'ตั้งเวลางานในอนาคตสำหรับ',
+  'sp.perm.verb.window': 'ปรับขนาดหน้าต่างเบราว์เซอร์บน',
   'tool.schedule_resume': 'กำลังตั้งเวลาต่องาน',
   'tool.schedule_task': 'กำลังตั้งเวลางาน',
   'st.display.scheduled_tasks.label': 'งานที่ตั้งเวลาไว้',

--- a/src/chrome/src/ui/locales/tl.js
+++ b/src/chrome/src/ui/locales/tl.js
@@ -591,6 +591,7 @@ export default {
   'sp.scratchpad.cleared': 'Na-clear ang scratchpad.',
   'sp.scratchpad.error': 'Hindi available ang scratchpad: {msg}',
   'sp.perm.verb.schedule': 'mag-iskedyul ng gawaing hinaharap para sa',
+  'sp.perm.verb.window': 'baguhin ang laki ng window ng browser sa',
   'tool.schedule_resume': 'Nag-iiskedyul ng pagpapatuloy',
   'tool.schedule_task': 'Nag-iiskedyul ng gawain',
   'st.display.scheduled_tasks.label': 'Mga naka-iskedyul na gawain',

--- a/src/chrome/src/ui/locales/tr.js
+++ b/src/chrome/src/ui/locales/tr.js
@@ -630,6 +630,7 @@ export default {
   'sp.scratchpad.cleared': 'Not defteri temizlendi.',
   'sp.scratchpad.error': 'Not defterine erişilemiyor: {msg}',
   'sp.perm.verb.schedule': 'gelecekteki çalışmayı zamanlamak için',
+  'sp.perm.verb.window': 'tarayıcı penceresinin boyutunu değiştirmek',
   'tool.schedule_resume': 'Devam zamanlama',
   'tool.schedule_task': 'Görev zamanlama',
   'st.display.scheduled_tasks.label': 'Zamanlanmış görevler',

--- a/src/chrome/src/ui/locales/uk.js
+++ b/src/chrome/src/ui/locales/uk.js
@@ -591,6 +591,7 @@ export default {
   'sp.scratchpad.cleared': 'Чернетник очищено.',
   'sp.scratchpad.error': 'Чернетник недоступний: {msg}',
   'sp.perm.verb.schedule': 'запланувати майбутню роботу для',
+  'sp.perm.verb.window': 'змінити розмір вікна браузера на',
   'tool.schedule_resume': 'Планування відновлення',
   'tool.schedule_task': 'Планування завдання',
   'st.display.scheduled_tasks.label': 'Заплановані завдання',

--- a/src/chrome/src/ui/locales/vi.js
+++ b/src/chrome/src/ui/locales/vi.js
@@ -331,6 +331,7 @@ export default {
   'sp.perm.verb.upload': "tải một tập tin lên",
   'sp.perm.verb.record': "ghi lại tab (và micrô) trên",
   'sp.perm.verb.schedule': "sắp xếp công việc trong tương lai cho",
+  'sp.perm.verb.window': 'thay đổi kích thước cửa sổ trình duyệt trên',
 
   'sp.step.details': "chi tiết",
   'sp.step.input_label': "đầu vào",

--- a/src/chrome/src/ui/locales/zh.js
+++ b/src/chrome/src/ui/locales/zh.js
@@ -591,6 +591,7 @@ export default {
   'sp.scratchpad.cleared': '草稿板已清除。',
   'sp.scratchpad.error': '草稿板不可用：{msg}',
   'sp.perm.verb.schedule': '为以下对象安排后续任务',
+  'sp.perm.verb.window': '调整浏览器窗口大小于',
   'tool.schedule_resume': '正在安排恢复',
   'tool.schedule_task': '正在安排任务',
   'st.display.scheduled_tasks.label': '定时任务',

--- a/src/chrome/src/ui/sidepanel.js
+++ b/src/chrome/src/ui/sidepanel.js
@@ -4,6 +4,7 @@
  */
 
 import { t, getLocale, setLocale, LANGUAGES, applyDOMTranslations } from './i18n.js';
+import { CAPABILITY_LABEL } from '../agent/permission-gate.js';
 import { sanitizeMarkdownLinks } from './markdown-link.js';
 import { codeFenceLanguage, highlightCode, renderMarkdownHeadings } from './markdown-render.js';
 import { applyMode, loadMode, watch } from './theme.js';
@@ -9315,8 +9316,13 @@ function renderClarifyCard(data) {
     card.dataset.permission = '1';
     const host = String(data.permission.host || '');
     const cap = String(data.permission.capability || '');
-    const verb = t('sp.perm.verb.' + cap);
-    qEl.textContent = t('sp.perm.question', { verb, host });
+    const verbKey = 'sp.perm.verb.' + cap;
+    const verb = t(verbKey);
+    // English falls back to the single CAPABILITY_LABEL source of truth so the
+    // consent wording cannot drift between two English copies; other locales
+    // carry their own translation under the key.
+    const resolvedVerb = verb === verbKey ? (CAPABILITY_LABEL[cap] || cap) : verb;
+    qEl.textContent = t('sp.perm.question', { verb: resolvedVerb, host });
 
     const reasonEl = document.createElement('div');
     reasonEl.className = 'clarify-reason';

--- a/src/firefox/src/ui/locales/ar.js
+++ b/src/firefox/src/ui/locales/ar.js
@@ -575,6 +575,7 @@ export default {
   'sp.scratchpad.cleared': 'تم مسح المسودة.',
   'sp.scratchpad.error': 'منطقة المسودة غير متاحة: {msg}',
   'sp.perm.verb.schedule': 'جدولة عمل مستقبلي لـ',
+  'sp.perm.verb.window': 'تغيير حجم نافذة المتصفح على',
   'tool.schedule_resume': 'جدولة استئناف',
   'tool.schedule_task': 'جدولة مهمة',
   'st.display.scheduled_tasks.label': 'المهام المجدوَلة',

--- a/src/firefox/src/ui/locales/bn.js
+++ b/src/firefox/src/ui/locales/bn.js
@@ -329,6 +329,7 @@ export default {
   'sp.perm.verb.upload': "একটি ফাইল আপলোড করুন",
   'sp.perm.verb.record': "ট্যাব (এবং মাইক্রোফোন) চালু করুন",
   'sp.perm.verb.schedule': "ভবিষ্যত কাজের সময়সূচী",
+  'sp.perm.verb.window': 'ব্রাউজার উইন্ডোর আকার পরিবর্তন করুন',
 
   'sp.step.details': "বিস্তারিত",
   'sp.step.input_label': "ইনপুট",

--- a/src/firefox/src/ui/locales/de.js
+++ b/src/firefox/src/ui/locales/de.js
@@ -339,6 +339,7 @@ export default {
   'sp.perm.verb.upload': 'Datei hochladen zu',
   'sp.perm.verb.record': 'Tab (und Mikrofon) aufnehmen auf',
   'sp.perm.verb.schedule': 'zukünftige Aufgaben planen für',
+  'sp.perm.verb.window': 'die Größe des Browserfensters ändern auf',
   'sp.help.shortcuts_html': '<strong>Tastenkürzel</strong><br><code>Ctrl/Cmd+/</code> — Eingabefeld fokussieren<br><code>Ctrl/Cmd+Shift+A</code> — Zum Fragen-Modus wechseln<br><code>Ctrl/Cmd+Shift+X</code> — Zum Handeln-Modus wechseln<br><code>Ctrl/Cmd+Shift+D</code> — Zum Dev-Modus wechseln<br><code>Escape</code> — Aktiven Durchlauf stoppen<br><code>Escape</code> zweimal — Aktive Aufnahme stoppen',
   'sp.compact.nothing_to_compact': 'Noch nichts zu kompaktieren — es gibt nicht genügend älteren Kontext.',
   'sp.compact.busy': 'Kompaktierung nicht möglich, während ein Durchlauf läuft — warten Sie auf dessen Abschluss.',

--- a/src/firefox/src/ui/locales/en.js
+++ b/src/firefox/src/ui/locales/en.js
@@ -329,6 +329,7 @@ export default {
   'sp.perm.verb.upload': 'upload a file to',
   'sp.perm.verb.record': 'record the tab (and microphone) on',
   'sp.perm.verb.schedule': 'schedule future work for',
+  'sp.perm.verb.window': 'resize the browser window for',
 
   'sp.step.details': 'details',
   'sp.step.input_label': 'Input',

--- a/src/firefox/src/ui/locales/es.js
+++ b/src/firefox/src/ui/locales/es.js
@@ -575,6 +575,7 @@ export default {
   'sp.scratchpad.cleared': 'Bloc de notas borrado.',
   'sp.scratchpad.error': 'Bloc de notas no disponible: {msg}',
   'sp.perm.verb.schedule': 'programar trabajo futuro en',
+  'sp.perm.verb.window': 'cambiar el tamaño de la ventana del navegador en',
   'tool.schedule_resume': 'Programando reanudación',
   'tool.schedule_task': 'Programando tarea',
   'st.display.scheduled_tasks.label': 'Tareas programadas',

--- a/src/firefox/src/ui/locales/fa.js
+++ b/src/firefox/src/ui/locales/fa.js
@@ -329,6 +329,7 @@ export default {
   'sp.perm.verb.upload': "آپلود فایل به",
   'sp.perm.verb.record': "زبانه (و میکروفون) را روی آن ضبط کنید",
   'sp.perm.verb.schedule': "برای کارهای آینده برنامه ریزی کنید",
+  'sp.perm.verb.window': 'اندازه پنجره مرورگر را تغییر دهید در',
 
   'sp.step.details': "جزئیات",
   'sp.step.input_label': "ورودی",

--- a/src/firefox/src/ui/locales/fr.js
+++ b/src/firefox/src/ui/locales/fr.js
@@ -575,6 +575,7 @@ export default {
   'sp.scratchpad.cleared': 'Bloc-notes effacé.',
   'sp.scratchpad.error': 'Bloc-notes indisponible : {msg}',
   'sp.perm.verb.schedule': 'planifier des tâches futures pour',
+  'sp.perm.verb.window': 'redimensionner la fenêtre du navigateur sur',
   'tool.schedule_resume': 'Planification de la reprise',
   'tool.schedule_task': 'Planification de la tâche',
   'st.display.scheduled_tasks.label': 'Tâches planifiées',

--- a/src/firefox/src/ui/locales/he.js
+++ b/src/firefox/src/ui/locales/he.js
@@ -303,6 +303,7 @@ export default {
   "sp.perm.verb.download": "להוריד קבצים מ",
   "sp.perm.verb.upload": "להעלות קובץ ל",
   "sp.perm.verb.schedule": "לתזמן עבודה עתידית עבור",
+  "sp.perm.verb.window": "לשנות את גודל חלון הדפדפן באתר",
   "sp.step.details": "פרטים",
   "sp.step.input_label": "קלט",
   "sp.step.result_label": "תוצאה",

--- a/src/firefox/src/ui/locales/hi.js
+++ b/src/firefox/src/ui/locales/hi.js
@@ -329,6 +329,7 @@ export default {
   'sp.perm.verb.upload': "पर एक फ़ाइल अपलोड करें",
   'sp.perm.verb.record': "टैब (और माइक्रोफ़ोन) को चालू रखें",
   'sp.perm.verb.schedule': "भविष्य के लिए कार्य शेड्यूल करें",
+  'sp.perm.verb.window': 'ब्राउज़र विंडो का आकार बदलें',
 
   'sp.step.details': "विवरण",
   'sp.step.input_label': "इनपुट",

--- a/src/firefox/src/ui/locales/id.js
+++ b/src/firefox/src/ui/locales/id.js
@@ -575,6 +575,7 @@ export default {
   'sp.scratchpad.cleared': 'Bak pasir dikosongkan.',
   'sp.scratchpad.error': 'Bak pasir tidak tersedia: {msg}',
   'sp.perm.verb.schedule': 'menjadwalkan pekerjaan mendatang untuk',
+  'sp.perm.verb.window': 'mengubah ukuran jendela browser di',
   'tool.schedule_resume': 'Menjadwalkan lanjutan',
   'tool.schedule_task': 'Menjadwalkan tugas',
   'st.display.scheduled_tasks.label': 'Tugas terjadwal',

--- a/src/firefox/src/ui/locales/ja.js
+++ b/src/firefox/src/ui/locales/ja.js
@@ -575,6 +575,7 @@ export default {
   'sp.scratchpad.cleared': 'スクラッチパッドをクリアしました。',
   'sp.scratchpad.error': 'スクラッチパッドを取得できませんでした: {msg}',
   'sp.perm.verb.schedule': 'での将来の作業のスケジュールを',
+  'sp.perm.verb.window': 'でのブラウザウィンドウのサイズ変更を',
   'tool.schedule_resume': '再開をスケジュール中',
   'tool.schedule_task': 'タスクをスケジュール中',
   'st.display.scheduled_tasks.label': 'スケジュールタスク',

--- a/src/firefox/src/ui/locales/ko.js
+++ b/src/firefox/src/ui/locales/ko.js
@@ -575,6 +575,7 @@ export default {
   'sp.scratchpad.cleared': '스크래치패드가 지워졌습니다.',
   'sp.scratchpad.error': '스크래치패드를 사용할 수 없습니다: {msg}',
   'sp.perm.verb.schedule': '미래 작업 예약',
+  'sp.perm.verb.window': '브라우저 창 크기 조절',
   'tool.schedule_resume': '재개 예약 중',
   'tool.schedule_task': '작업 예약 중',
   'st.display.scheduled_tasks.label': '예약된 작업',

--- a/src/firefox/src/ui/locales/ms.js
+++ b/src/firefox/src/ui/locales/ms.js
@@ -575,6 +575,7 @@ export default {
   'sp.scratchpad.cleared': 'Pad nota dikosongkan.',
   'sp.scratchpad.error': 'Pad nota tidak tersedia: {msg}',
   'sp.perm.verb.schedule': 'menjadualkan kerja masa hadapan untuk',
+  'sp.perm.verb.window': 'menukar saiz tetingkap pelayar pada',
   'tool.schedule_resume': 'Menjadualkan sambungan semula',
   'tool.schedule_task': 'Menjadualkan tugas',
   'st.display.scheduled_tasks.label': 'Tugas berjadual',

--- a/src/firefox/src/ui/locales/nl.js
+++ b/src/firefox/src/ui/locales/nl.js
@@ -317,6 +317,7 @@ export default {
   'sp.perm.verb.upload': 'een bestand uploaden naar',
   'sp.perm.verb.record': 'het tabblad (en microfoon) opnemen op',
   'sp.perm.verb.schedule': 'geplande taken instellen voor',
+  'sp.perm.verb.window': 'het browservenster aanpassen op',
   'sp.step.details': 'details',
   'sp.step.input_label': 'Invoer',
   'sp.step.result_label': 'Resultaat',

--- a/src/firefox/src/ui/locales/pl.js
+++ b/src/firefox/src/ui/locales/pl.js
@@ -238,6 +238,7 @@ export default {
   'sp.perm.verb.upload': 'przesłać plik do',
   'sp.perm.verb.record': 'nagrać kartę (i mikrofon) na',
   'sp.perm.verb.schedule': 'zaplanować przyszłe działania dla',
+  'sp.perm.verb.window': 'zmienić rozmiar okna przeglądarki na',
   'sp.step.details': 'szczegóły',
   'sp.step.input_label': 'Wejście',
   'sp.step.result_label': 'Wynik',

--- a/src/firefox/src/ui/locales/pt.js
+++ b/src/firefox/src/ui/locales/pt.js
@@ -329,6 +329,7 @@ export default {
   'sp.perm.verb.upload': "carregar um arquivo para",
   'sp.perm.verb.record': "grave a guia (e o microfone) em",
   'sp.perm.verb.schedule': "agendar trabalhos futuros para",
+  'sp.perm.verb.window': 'redimensionar a janela do navegador em',
 
   'sp.step.details': "detalhes",
   'sp.step.input_label': "Entrada",

--- a/src/firefox/src/ui/locales/ru.js
+++ b/src/firefox/src/ui/locales/ru.js
@@ -575,6 +575,7 @@ export default {
   'sp.scratchpad.cleared': 'Блокнот очищен.',
   'sp.scratchpad.error': 'Блокнот недоступен: {msg}',
   'sp.perm.verb.schedule': 'запланировать будущие действия для',
+  'sp.perm.verb.window': 'изменить размер окна браузера на',
   'tool.schedule_resume': 'Планирование возобновления',
   'tool.schedule_task': 'Планирование задачи',
   'st.display.scheduled_tasks.label': 'Запланированные задачи',

--- a/src/firefox/src/ui/locales/th.js
+++ b/src/firefox/src/ui/locales/th.js
@@ -575,6 +575,7 @@ export default {
   'sp.scratchpad.cleared': 'ล้างกระดานร่างแล้ว',
   'sp.scratchpad.error': 'ไม่สามารถใช้กระดานร่างได้: {msg}',
   'sp.perm.verb.schedule': 'ตั้งเวลางานในอนาคตสำหรับ',
+  'sp.perm.verb.window': 'ปรับขนาดหน้าต่างเบราว์เซอร์บน',
   'tool.schedule_resume': 'กำลังตั้งเวลาต่องาน',
   'tool.schedule_task': 'กำลังตั้งเวลางาน',
   'st.display.scheduled_tasks.label': 'งานที่ตั้งเวลาไว้',

--- a/src/firefox/src/ui/locales/tl.js
+++ b/src/firefox/src/ui/locales/tl.js
@@ -575,6 +575,7 @@ export default {
   'sp.scratchpad.cleared': 'Na-clear ang scratchpad.',
   'sp.scratchpad.error': 'Hindi available ang scratchpad: {msg}',
   'sp.perm.verb.schedule': 'mag-iskedyul ng gawaing hinaharap para sa',
+  'sp.perm.verb.window': 'baguhin ang laki ng window ng browser sa',
   'tool.schedule_resume': 'Nag-iiskedyul ng pagpapatuloy',
   'tool.schedule_task': 'Nag-iiskedyul ng gawain',
   'st.display.scheduled_tasks.label': 'Mga naka-iskedyul na gawain',

--- a/src/firefox/src/ui/locales/tr.js
+++ b/src/firefox/src/ui/locales/tr.js
@@ -614,6 +614,7 @@ export default {
   'sp.scratchpad.cleared': 'Not defteri temizlendi.',
   'sp.scratchpad.error': 'Not defterine erişilemiyor: {msg}',
   'sp.perm.verb.schedule': 'gelecekteki çalışmayı zamanlamak için',
+  'sp.perm.verb.window': 'tarayıcı penceresinin boyutunu değiştirmek',
   'tool.schedule_resume': 'Devam zamanlama',
   'tool.schedule_task': 'Görev zamanlama',
   'st.display.scheduled_tasks.label': 'Zamanlanmış görevler',

--- a/src/firefox/src/ui/locales/uk.js
+++ b/src/firefox/src/ui/locales/uk.js
@@ -575,6 +575,7 @@ export default {
   'sp.scratchpad.cleared': 'Чернетник очищено.',
   'sp.scratchpad.error': 'Чернетник недоступний: {msg}',
   'sp.perm.verb.schedule': 'запланувати майбутню роботу для',
+  'sp.perm.verb.window': 'змінити розмір вікна браузера на',
   'tool.schedule_resume': 'Планування відновлення',
   'tool.schedule_task': 'Планування завдання',
   'st.display.scheduled_tasks.label': 'Заплановані завдання',

--- a/src/firefox/src/ui/locales/vi.js
+++ b/src/firefox/src/ui/locales/vi.js
@@ -329,6 +329,7 @@ export default {
   'sp.perm.verb.upload': "tải một tập tin lên",
   'sp.perm.verb.record': "ghi lại tab (và micrô) trên",
   'sp.perm.verb.schedule': "sắp xếp công việc trong tương lai cho",
+  'sp.perm.verb.window': 'thay đổi kích thước cửa sổ trình duyệt trên',
 
   'sp.step.details': "chi tiết",
   'sp.step.input_label': "đầu vào",

--- a/src/firefox/src/ui/locales/zh.js
+++ b/src/firefox/src/ui/locales/zh.js
@@ -575,6 +575,7 @@ export default {
   'sp.scratchpad.cleared': '草稿板已清除。',
   'sp.scratchpad.error': '草稿板不可用：{msg}',
   'sp.perm.verb.schedule': '为以下对象安排后续任务',
+  'sp.perm.verb.window': '调整浏览器窗口大小于',
   'tool.schedule_resume': '正在安排恢复',
   'tool.schedule_task': '正在安排任务',
   'st.display.scheduled_tasks.label': '定时任务',

--- a/src/firefox/src/ui/sidepanel.js
+++ b/src/firefox/src/ui/sidepanel.js
@@ -4,6 +4,7 @@
  */
 
 import { t, getLocale, setLocale, LANGUAGES, applyDOMTranslations } from './i18n.js';
+import { CAPABILITY_LABEL } from '../agent/permission-gate.js';
 import { sanitizeMarkdownLinks } from './markdown-link.js';
 import { codeFenceLanguage, highlightCode, renderMarkdownHeadings } from './markdown-render.js';
 import { applyMode, loadMode, watch } from './theme.js';
@@ -8801,8 +8802,13 @@ function renderClarifyCard(data) {
     card.dataset.permission = '1';
     const host = String(data.permission.host || '');
     const cap = String(data.permission.capability || '');
-    const verb = t('sp.perm.verb.' + cap);
-    qEl.textContent = t('sp.perm.question', { verb, host });
+    const verbKey = 'sp.perm.verb.' + cap;
+    const verb = t(verbKey);
+    // English falls back to the single CAPABILITY_LABEL source of truth so the
+    // consent wording cannot drift between two English copies; other locales
+    // carry their own translation under the key.
+    const resolvedVerb = verb === verbKey ? (CAPABILITY_LABEL[cap] || cap) : verb;
+    qEl.textContent = t('sp.perm.question', { verb: resolvedVerb, host });
 
     const reasonEl = document.createElement('div');
     reasonEl.className = 'clarify-reason';

--- a/test/run.js
+++ b/test/run.js
@@ -567,11 +567,12 @@ const { createContextMenuPromptHandler: createContextMenuPromptHandlerFx } = awa
 );
 
 // permission-gate.js is pure JS (deterministic capability × origin gate).
-const { Capability, capabilityFor, capabilitiesFor, normalizeHost, hostForCapability, requiredHosts, frameHostMatches, isNetworkMutation, PermissionManager, UNTRUSTED_CONTENT_TOOLS } = await import(
+const { Capability, CAPABILITY_LABEL, capabilityFor, capabilitiesFor, normalizeHost, hostForCapability, requiredHosts, frameHostMatches, isNetworkMutation, PermissionManager, UNTRUSTED_CONTENT_TOOLS } = await import(
   'file://' + path.join(ROOT, 'src/firefox/src/agent/permission-gate.js').replace(/\\/g, '/')
 );
 const {
   Capability: CapabilityCh,
+  CAPABILITY_LABEL: CAPABILITY_LABEL_CH,
   capabilityFor: capabilityForCh,
   PermissionManager: PermissionManagerCh,
   normalizeHost: normalizeHostCh,
@@ -25139,6 +25140,24 @@ test('all locales cover English keys and preserve interpolation placeholders', a
         );
       }
     }
+  }
+});
+
+test('every permission-gate capability has an English verb and a sidepanel fallback', () => {
+  for (const [label, Cap, LABEL, prefix] of [
+    ['chrome', CapabilityCh, CAPABILITY_LABEL_CH, 'src/chrome'],
+    ['firefox', Capability, CAPABILITY_LABEL, 'src/firefox'],
+  ]) {
+    for (const cap of Object.values(Cap)) {
+      const labelText = LABEL[cap];
+      assert.equal(typeof labelText, 'string', `${label}: ${cap} missing from CAPABILITY_LABEL`);
+      assert.ok(labelText.length > 0, `${label}: ${cap} English verb must not be empty`);
+    }
+    // The permission prompt must fall back to CAPABILITY_LABEL (not the raw
+    // key) when a locale lacks sp.perm.verb.<cap>, so a newly added capability
+    // can never render its raw key on the consent prompt.
+    const sidepanel = fs.readFileSync(path.join(ROOT, prefix, 'src/ui/sidepanel.js'), 'utf8');
+    assert.match(sidepanel, /CAPABILITY_LABEL\[cap\] \|\| cap/, `${label}: sidepanel permission prompt must fall back to CAPABILITY_LABEL`);
   }
 });
 


### PR DESCRIPTION
## Summary

- Adds the missing `sp.perm.verb.window` key to all 23 locales in both Chrome and Firefox trees.
- Adds a regression test asserting every permission-gate capability has a localized verb key in `en.js` in both trees.

## Motivation

The `resize_window` tool maps to `Capability.WINDOW` (`permission-gate.js:171`), and the permission prompt renders `t(sp.perm.verb. + cap)` (`sidepanel.js:9258`). No locale defined `sp.perm.verb.window`, so `t()` returned the raw key and the consequential-action prompt read: "WebBrain wants to sp.perm.verb.window example.com. Allow it?" — garbled text on a security-critical prompt, in every locale. The next capability added without a verb would hit the same bug silently.

## Design

Followed the existing `sp.perm.verb.*` entry style and inserted the new key next to its siblings. The new test iterates `Object.values(Capability)` (both trees — Firefox has no `dev_patch` capability) and requires a non-empty `sp.perm.verb.<cap>` string in each tree's `en.js`. The existing `all locales cover English keys` test then guarantees all 22 non-English locales carry the key.

## Testing

- `node test/run.js` — 1767 passed, 0 failed (1 new test)
- `npm run test:security` — 60/60 passed
- `npm run test:toolbar-guard` — 33 passed

## Compatibility and risks

- Pure additive dictionary entries; no behavior change for existing locales.
- English value matches `CAPABILITY_LABEL[Capability.WINDOW]` ("resize the browser window for"), so the prompt reads naturally: "WebBrain wants to resize the browser window for example.com. Allow it?"