### PR TITLE
fix(content): submit set_field forms exactly once via requestSubmit

### DIFF
--- a/src/chrome/src/content/content.js
+++ b/src/chrome/src/content/content.js
@@ -3815,14 +3815,14 @@
   }
 
   // Pick the single commit path for set_field({submit:true}). Synthetic
-  // Synthetic (isTrusted:false) Enter events never trigger native submission —
+  // (isTrusted:false) Enter events never trigger native submission —
   // they only reach the page's own keydown listeners. A non-combobox field
   // inside a form that has requestSubmit therefore needs a native submit as
   // its only reliable commit path; comboboxes are committed by page JS
   // listeners instead, because submitting the enclosing form while a picker
   // popup is open is usually wrong.
-  function _setFieldUsesNativeSubmit(isCombobox, form) {
-    return !isCombobox && !!form && typeof form.requestSubmit === 'function';
+  function _setFieldUsesNativeSubmit(isCombobox, isContentEditable, form) {
+    return !isCombobox && !isContentEditable && !!form && typeof form.requestSubmit === 'function';
   }
 
   // The rich-text toolbar heuristic lives in one file shared by both builds
@@ -5723,7 +5723,9 @@
           const verified = _setFieldValueMatches(actual, prevValue, text, clear, el.isContentEditable);
           const fallbackAttempted = false;
           let nativeSubmitAttempted = false;
+          let submissionOutcomeUnknown = false;
           if (submit && verified) {
+            submissionOutcomeUnknown = true;
             try {
               // Detect combobox/searchbox pattern: if the element is a searchbox,
               // has role=combobox, has aria-controls pointing to a listbox, or a
@@ -5750,32 +5752,12 @@
                 } catch {}
               }
               const dispatchKey = (type, key, keyCode) => {
-                // Return the dispatch result: `false` means the page cancelled
-                // the event (preventDefault), which is how we detect that a
-                // keydown listener already handled Enter.
                 return el.dispatchEvent(new KeyboardEvent(type, { key, code: key, keyCode, bubbles: true, cancelable: true }));
               };
-              if (isCombobox) {
-                // Give the listbox a tick to filter, then highlight the first
-                // option with ArrowDown, then commit with Enter.
-                await new Promise(r => setTimeout(r, 80));
-                dispatchKey('keydown', 'ArrowDown', 40);
-                dispatchKey('keyup', 'ArrowDown', 40);
-                await new Promise(r => setTimeout(r, 30));
-              }
               const form = el.form || (el.closest && el.closest('form'));
+              const usesNativeSubmit = _setFieldUsesNativeSubmit(isCombobox, el.isContentEditable, form);
               let submissionObserved = false;
               let submissionCancelled = false;
-              let submissionOutcomeUnknown = false;
-              let removeSubmitObserver = () => {};
-              if (form && typeof form.addEventListener === 'function') {
-                const onSubmit = event => {
-                  submissionObserved = true;
-                  submissionCancelled = event.defaultPrevented === true;
-                };
-                form.addEventListener('submit', onSubmit, true);
-                removeSubmitObserver = () => form.removeEventListener?.('submit', onSubmit, true);
-              }
               if (msg.params?.messageRecipientGuardRequired === true) {
                 const recipientValidation = _consumeMessageRecipientDispatchBinding(msg.params, el);
                 if (recipientValidation.success !== true) {
@@ -5788,16 +5770,20 @@
                   });
                 }
               }
+              let removeSubmitObserver = () => {};
+              if (form && typeof form.addEventListener === 'function') {
+                const onSubmit = event => {
+                  submissionObserved = true;
+                  submissionCancelled = event.defaultPrevented === true;
+                };
+                form.addEventListener('submit', onSubmit, true);
+                removeSubmitObserver = () => form.removeEventListener?.('submit', onSubmit, true);
+              }
               try {
-                // Always dispatch the Enter trio: bare forms, tag-chip / email
-                // inputs that transform the value on Enter, and contenteditable
-                // composers only commit through their own keydown listener.
-                const enterCancelled = !dispatchKey('keydown', 'Enter', 13);
-                dispatchKey('keypress', 'Enter', 13);
-                dispatchKey('keyup', 'Enter', 13);
-                if (submissionObserved) {
-                  submissionOutcomeUnknown = submissionCancelled;
-                } else if (!enterCancelled && _setFieldUsesNativeSubmit(isCombobox, form)) {
+                if (usesNativeSubmit) {
+                  // Ordinary form controls use one native path. Dispatching a
+                  // synthetic Enter first could make page code act and then
+                  // make this fallback repeat the consequential action.
                   // requestSubmit performs interactive constraint validation and
                   // silently aborts on an invalid form; surface that instead of
                   // reporting a successful submission.
@@ -5809,20 +5795,30 @@
                   }
                   try {
                     form.requestSubmit();
-                  } catch {
-                    submissionOutcomeUnknown = true;
-                  }
-                  if (!submissionObserved) submissionOutcomeUnknown = true;
+                  } catch {}
                 } else {
-                  // preventDefault, combobox handling, contenteditable custom
-                  // handlers, and form-less widgets do not prove submission.
-                  submissionOutcomeUnknown = true;
+                  // Comboboxes, contenteditables, and form-less widgets are
+                  // committed by page-owned keyboard handlers. Never follow
+                  // this path with requestSubmit: cancellation is not proof of
+                  // submission, and an unobserved handler may already have acted.
+                  if (isCombobox) {
+                    await new Promise(r => setTimeout(r, 80));
+                    dispatchKey('keydown', 'ArrowDown', 40);
+                    dispatchKey('keyup', 'ArrowDown', 40);
+                    await new Promise(r => setTimeout(r, 30));
+                  }
+                  dispatchKey('keydown', 'Enter', 13);
+                  dispatchKey('keypress', 'Enter', 13);
+                  dispatchKey('keyup', 'Enter', 13);
                 }
                 nativeSubmitAttempted = submissionObserved && !submissionCancelled;
+                submissionOutcomeUnknown = !nativeSubmitAttempted;
               } finally {
                 removeSubmitObserver();
               }
-            } catch {}
+            } catch {
+              submissionOutcomeUnknown = true;
+            }
           }
           if (!verified) {
             return failure(

--- a/src/chrome/src/content/content.js
+++ b/src/chrome/src/content/content.js
@@ -5771,10 +5771,11 @@
                 }
               }
               let removeSubmitObserver = () => {};
+              let submitEvent = null;
               if (form && typeof form.addEventListener === 'function') {
                 const onSubmit = event => {
                   submissionObserved = true;
-                  submissionCancelled = event.defaultPrevented === true;
+                  submitEvent = event;
                 };
                 form.addEventListener('submit', onSubmit, true);
                 removeSubmitObserver = () => form.removeEventListener?.('submit', onSubmit, true);
@@ -5787,7 +5788,7 @@
                   // requestSubmit performs interactive constraint validation and
                   // silently aborts on an invalid form; surface that instead of
                   // reporting a successful submission.
-                  if (typeof form.checkValidity === 'function' && !form.checkValidity()) {
+                  if (form.noValidate !== true && typeof form.checkValidity === 'function' && !form.checkValidity()) {
                     return failure(
                       'The form did not submit: a required field is empty or a value is invalid. Fix the field and retry with a fresh ref_id.',
                       { verified: true, submitted: false, invalid: true, ref_id, rect },
@@ -5811,6 +5812,7 @@
                   dispatchKey('keypress', 'Enter', 13);
                   dispatchKey('keyup', 'Enter', 13);
                 }
+                submissionCancelled = submitEvent?.defaultPrevented === true;
                 nativeSubmitAttempted = submissionObserved && !submissionCancelled;
                 submissionOutcomeUnknown = !nativeSubmitAttempted;
               } finally {

--- a/src/chrome/src/content/content.js
+++ b/src/chrome/src/content/content.js
@@ -5764,6 +5764,18 @@
                 await new Promise(r => setTimeout(r, 30));
               }
               const form = el.form || (el.closest && el.closest('form'));
+              let submissionObserved = false;
+              let submissionCancelled = false;
+              let submissionOutcomeUnknown = false;
+              let removeSubmitObserver = () => {};
+              if (form && typeof form.addEventListener === 'function') {
+                const onSubmit = event => {
+                  submissionObserved = true;
+                  submissionCancelled = event.defaultPrevented === true;
+                };
+                form.addEventListener('submit', onSubmit, true);
+                removeSubmitObserver = () => form.removeEventListener?.('submit', onSubmit, true);
+              }
               if (msg.params?.messageRecipientGuardRequired === true) {
                 const recipientValidation = _consumeMessageRecipientDispatchBinding(msg.params, el);
                 if (recipientValidation.success !== true) {
@@ -5776,26 +5788,39 @@
                   });
                 }
               }
-              // Always dispatch the Enter trio: bare forms, tag-chip / email
-              // inputs that transform the value on Enter, and contenteditable
-              // composers only commit through their own keydown listener. If
-              // the page cancelled the keydown it already handled Enter, so a
-              // second submit would double-send.
-              const enterHandled = !dispatchKey('keydown', 'Enter', 13);
-              dispatchKey('keypress', 'Enter', 13);
-              dispatchKey('keyup', 'Enter', 13);
-              if (!enterHandled && _setFieldUsesNativeSubmit(isCombobox, form)) {
-                // requestSubmit performs interactive constraint validation and
-                // silently aborts on an invalid form; surface that instead of
-                // reporting a successful submission.
-                if (typeof form.checkValidity === 'function' && !form.checkValidity()) {
-                  return failure(
-                    'The form did not submit: a required field is empty or a value is invalid. Fix the field and retry with a fresh ref_id.',
-                    { verified: true, submitted: false, invalid: true, ref_id, rect },
-                  );
+              try {
+                // Always dispatch the Enter trio: bare forms, tag-chip / email
+                // inputs that transform the value on Enter, and contenteditable
+                // composers only commit through their own keydown listener.
+                const enterCancelled = !dispatchKey('keydown', 'Enter', 13);
+                dispatchKey('keypress', 'Enter', 13);
+                dispatchKey('keyup', 'Enter', 13);
+                if (submissionObserved) {
+                  submissionOutcomeUnknown = submissionCancelled;
+                } else if (!enterCancelled && _setFieldUsesNativeSubmit(isCombobox, form)) {
+                  // requestSubmit performs interactive constraint validation and
+                  // silently aborts on an invalid form; surface that instead of
+                  // reporting a successful submission.
+                  if (typeof form.checkValidity === 'function' && !form.checkValidity()) {
+                    return failure(
+                      'The form did not submit: a required field is empty or a value is invalid. Fix the field and retry with a fresh ref_id.',
+                      { verified: true, submitted: false, invalid: true, ref_id, rect },
+                    );
+                  }
+                  try {
+                    form.requestSubmit();
+                  } catch {
+                    submissionOutcomeUnknown = true;
+                  }
+                  if (!submissionObserved) submissionOutcomeUnknown = true;
+                } else {
+                  // preventDefault, combobox handling, contenteditable custom
+                  // handlers, and form-less widgets do not prove submission.
+                  submissionOutcomeUnknown = true;
                 }
-                form.requestSubmit();
-                nativeSubmitAttempted = true;
+                nativeSubmitAttempted = submissionObserved && !submissionCancelled;
+              } finally {
+                removeSubmitObserver();
               }
             } catch {}
           }
@@ -5826,6 +5851,7 @@
             fieldMeta,
             fallbackAttempted,
             submitted: nativeSubmitAttempted || undefined,
+            outcomeUnknown: submissionOutcomeUnknown || undefined,
           };
         } catch (e) {
           return failure(e && e.message || String(e));

--- a/src/chrome/src/content/content.js
+++ b/src/chrome/src/content/content.js
@@ -3814,6 +3814,17 @@
     return typeof el.innerText === 'string' ? el.innerText : (el.textContent || '');
   }
 
+  // Pick the single commit path for set_field({submit:true}). Synthetic
+  // Synthetic (isTrusted:false) Enter events never trigger native submission —
+  // they only reach the page's own keydown listeners. A non-combobox field
+  // inside a form that has requestSubmit therefore needs a native submit as
+  // its only reliable commit path; comboboxes are committed by page JS
+  // listeners instead, because submitting the enclosing form while a picker
+  // popup is open is usually wrong.
+  function _setFieldUsesNativeSubmit(isCombobox, form) {
+    return !isCombobox && !!form && typeof form.requestSubmit === 'function';
+  }
+
   // The rich-text toolbar heuristic lives in one file shared by both builds
   // and by the CDP main-world probe — see
   // src/content/rich-text-toolbar-heuristic.js. Delegating keeps the scoring
@@ -5711,6 +5722,7 @@
           const actual = el.isContentEditable ? _editableTextValue(el) : (el.value || '');
           const verified = _setFieldValueMatches(actual, prevValue, text, clear, el.isContentEditable);
           const fallbackAttempted = false;
+          let nativeSubmitAttempted = false;
           if (submit && verified) {
             try {
               // Detect combobox/searchbox pattern: if the element is a searchbox,
@@ -5738,7 +5750,10 @@
                 } catch {}
               }
               const dispatchKey = (type, key, keyCode) => {
-                el.dispatchEvent(new KeyboardEvent(type, { key, code: key, keyCode, bubbles: true, cancelable: true }));
+                // Return the dispatch result: `false` means the page cancelled
+                // the event (preventDefault), which is how we detect that a
+                // keydown listener already handled Enter.
+                return el.dispatchEvent(new KeyboardEvent(type, { key, code: key, keyCode, bubbles: true, cancelable: true }));
               };
               if (isCombobox) {
                 // Give the listbox a tick to filter, then highlight the first
@@ -5748,6 +5763,7 @@
                 dispatchKey('keyup', 'ArrowDown', 40);
                 await new Promise(r => setTimeout(r, 30));
               }
+              const form = el.form || (el.closest && el.closest('form'));
               if (msg.params?.messageRecipientGuardRequired === true) {
                 const recipientValidation = _consumeMessageRecipientDispatchBinding(msg.params, el);
                 if (recipientValidation.success !== true) {
@@ -5760,15 +5776,26 @@
                   });
                 }
               }
-              dispatchKey('keydown', 'Enter', 13);
+              // Always dispatch the Enter trio: bare forms, tag-chip / email
+              // inputs that transform the value on Enter, and contenteditable
+              // composers only commit through their own keydown listener. If
+              // the page cancelled the keydown it already handled Enter, so a
+              // second submit would double-send.
+              const enterHandled = !dispatchKey('keydown', 'Enter', 13);
               dispatchKey('keypress', 'Enter', 13);
               dispatchKey('keyup', 'Enter', 13);
-              // Form submission: only fall back to requestSubmit for non-combobox
-              // inputs. Submitting a form while a combobox popup is open is
-              // usually wrong and can prematurely post the enclosing form.
-              if (!isCombobox) {
-                const form = el.form || (el.closest && el.closest('form'));
-                if (form && typeof form.requestSubmit === 'function') form.requestSubmit();
+              if (!enterHandled && _setFieldUsesNativeSubmit(isCombobox, form)) {
+                // requestSubmit performs interactive constraint validation and
+                // silently aborts on an invalid form; surface that instead of
+                // reporting a successful submission.
+                if (typeof form.checkValidity === 'function' && !form.checkValidity()) {
+                  return failure(
+                    'The form did not submit: a required field is empty or a value is invalid. Fix the field and retry with a fresh ref_id.',
+                    { verified: true, submitted: false, invalid: true, ref_id, rect },
+                  );
+                }
+                form.requestSubmit();
+                nativeSubmitAttempted = true;
               }
             } catch {}
           }
@@ -5798,6 +5825,7 @@
             verified: true,
             fieldMeta,
             fallbackAttempted,
+            submitted: nativeSubmitAttempted || undefined,
           };
         } catch (e) {
           return failure(e && e.message || String(e));

--- a/src/chrome/src/content/content.js
+++ b/src/chrome/src/content/content.js
@@ -3815,7 +3815,7 @@
   }
 
   // Pick the single commit path for set_field({submit:true}). Synthetic
-  // Synthetic (isTrusted:false) Enter events never trigger native submission —
+  // (isTrusted:false) Enter events never trigger native submission —
   // they only reach the page's own keydown listeners. A non-combobox field
   // inside a form that has requestSubmit therefore needs a native submit as
   // its only reliable commit path; comboboxes are committed by page JS
@@ -5766,12 +5766,13 @@
               const form = el.form || (el.closest && el.closest('form'));
               let submissionObserved = false;
               let submissionCancelled = false;
+              let submitEvent = null;
               let submissionOutcomeUnknown = false;
               let removeSubmitObserver = () => {};
               if (form && typeof form.addEventListener === 'function') {
                 const onSubmit = event => {
                   submissionObserved = true;
-                  submissionCancelled = event.defaultPrevented === true;
+                  submitEvent = event;
                 };
                 form.addEventListener('submit', onSubmit, true);
                 removeSubmitObserver = () => form.removeEventListener?.('submit', onSubmit, true);
@@ -5796,12 +5797,13 @@
                 dispatchKey('keypress', 'Enter', 13);
                 dispatchKey('keyup', 'Enter', 13);
                 if (submissionObserved) {
+                  submissionCancelled = submitEvent?.defaultPrevented === true;
                   submissionOutcomeUnknown = submissionCancelled;
                 } else if (!enterCancelled && _setFieldUsesNativeSubmit(isCombobox, form)) {
                   // requestSubmit performs interactive constraint validation and
                   // silently aborts on an invalid form; surface that instead of
                   // reporting a successful submission.
-                  if (typeof form.checkValidity === 'function' && !form.checkValidity()) {
+                  if (form.noValidate !== true && typeof form.checkValidity === 'function' && !form.checkValidity()) {
                     return failure(
                       'The form did not submit: a required field is empty or a value is invalid. Fix the field and retry with a fresh ref_id.',
                       { verified: true, submitted: false, invalid: true, ref_id, rect },
@@ -5812,6 +5814,7 @@
                   } catch {
                     submissionOutcomeUnknown = true;
                   }
+                  submissionCancelled = submitEvent?.defaultPrevented === true;
                   if (!submissionObserved) submissionOutcomeUnknown = true;
                 } else {
                   // preventDefault, combobox handling, contenteditable custom

--- a/src/firefox/src/content/content.js
+++ b/src/firefox/src/content/content.js
@@ -4899,10 +4899,11 @@
                 }
               }
               let removeSubmitObserver = () => {};
+              let submitEvent = null;
               if (form && typeof form.addEventListener === 'function') {
                 const onSubmit = event => {
                   submissionObserved = true;
-                  submissionCancelled = event.defaultPrevented === true;
+                  submitEvent = event;
                 };
                 form.addEventListener('submit', onSubmit, true);
                 removeSubmitObserver = () => form.removeEventListener?.('submit', onSubmit, true);
@@ -4915,7 +4916,7 @@
                   // requestSubmit performs interactive constraint validation and
                   // silently aborts on an invalid form; surface that instead of
                   // reporting a successful submission.
-                  if (typeof form.checkValidity === 'function' && !form.checkValidity()) {
+                  if (form.noValidate !== true && typeof form.checkValidity === 'function' && !form.checkValidity()) {
                     return failure(
                       'The form did not submit: a required field is empty or a value is invalid. Fix the field and retry with a fresh ref_id.',
                       { verified: true, submitted: false, invalid: true, ref_id, rect },
@@ -4939,6 +4940,7 @@
                   dispatchKey('keypress', 'Enter', 13);
                   dispatchKey('keyup', 'Enter', 13);
                 }
+                submissionCancelled = submitEvent?.defaultPrevented === true;
                 nativeSubmitAttempted = submissionObserved && !submissionCancelled;
                 submissionOutcomeUnknown = !nativeSubmitAttempted;
               } finally {

--- a/src/firefox/src/content/content.js
+++ b/src/firefox/src/content/content.js
@@ -3080,6 +3080,16 @@
     return typeof el.innerText === 'string' ? el.innerText : (el.textContent || '');
   }
 
+  // Synthetic (isTrusted:false) Enter events never trigger native submission —
+  // they only reach the page's own keydown listeners. A non-combobox field
+  // inside a form that has requestSubmit therefore needs a native submit as
+  // its only reliable commit path; comboboxes are committed by page JS
+  // listeners instead, because submitting the enclosing form while a picker
+  // popup is open is usually wrong.
+  function _setFieldUsesNativeSubmit(isCombobox, form) {
+    return !isCombobox && !!form && typeof form.requestSubmit === 'function';
+  }
+
   // Above this length the per-candidate rescan below stops being worth its
   // cost. The edit still succeeds; it is reported unproven, which the callers
   // treat as "no positive proof", not as a failure.
@@ -4840,6 +4850,7 @@
           let actual = el.isContentEditable ? _editableTextValue(el) : (el.value || '');
           let verified = _setFieldValueMatches(actual, prevValue, text, clear, el.isContentEditable);
           let fallbackAttempted = false;
+          let nativeSubmitAttempted = false;
           if (!verified) {
             fallbackAttempted = true;
             await _retryFieldWithExecCommand(el, (clear ? '' : prevValue) + text);
@@ -4867,7 +4878,10 @@
                 } catch {}
               }
               const dispatchKey = (type, key, keyCode) => {
-                el.dispatchEvent(new KeyboardEvent(type, { key, code: key, keyCode, bubbles: true, cancelable: true }));
+                // Return the dispatch result: `false` means the page cancelled
+                // the event (preventDefault), which is how we detect that a
+                // keydown listener already handled Enter.
+                return el.dispatchEvent(new KeyboardEvent(type, { key, code: key, keyCode, bubbles: true, cancelable: true }));
               };
               if (isCombobox) {
                 await new Promise(r => setTimeout(r, 80));
@@ -4875,6 +4889,7 @@
                 dispatchKey('keyup', 'ArrowDown', 40);
                 await new Promise(r => setTimeout(r, 30));
               }
+              const form = el.form || (el.closest && el.closest('form'));
               if (msg.params?.messageRecipientGuardRequired === true) {
                 const recipientValidation = _consumeMessageRecipientDispatchBinding(msg.params, el);
                 if (recipientValidation.success !== true) {
@@ -4887,12 +4902,26 @@
                   });
                 }
               }
-              dispatchKey('keydown', 'Enter', 13);
+              // Always dispatch the Enter trio: bare forms, tag-chip / email
+              // inputs that transform the value on Enter, and contenteditable
+              // composers only commit through their own keydown listener. If
+              // the page cancelled the keydown it already handled Enter, so a
+              // second submit would double-send.
+              const enterHandled = !dispatchKey('keydown', 'Enter', 13);
               dispatchKey('keypress', 'Enter', 13);
               dispatchKey('keyup', 'Enter', 13);
-              if (!isCombobox) {
-                const form = el.form || (el.closest && el.closest('form'));
-                if (form && typeof form.requestSubmit === 'function') form.requestSubmit();
+              if (!enterHandled && _setFieldUsesNativeSubmit(isCombobox, form)) {
+                // requestSubmit performs interactive constraint validation and
+                // silently aborts on an invalid form; surface that instead of
+                // reporting a successful submission.
+                if (typeof form.checkValidity === 'function' && !form.checkValidity()) {
+                  return failure(
+                    'The form did not submit: a required field is empty or a value is invalid. Fix the field and retry with a fresh ref_id.',
+                    { verified: true, submitted: false, invalid: true, ref_id, rect },
+                  );
+                }
+                form.requestSubmit();
+                nativeSubmitAttempted = true;
               }
             } catch {}
           }
@@ -4921,6 +4950,7 @@
             verified: true,
             fieldMeta,
             fallbackAttempted,
+            submitted: nativeSubmitAttempted || undefined,
           };
         } catch (e) {
           return failure(e && e.message || String(e));

--- a/src/firefox/src/content/content.js
+++ b/src/firefox/src/content/content.js
@@ -4890,6 +4890,18 @@
                 await new Promise(r => setTimeout(r, 30));
               }
               const form = el.form || (el.closest && el.closest('form'));
+              let submissionObserved = false;
+              let submissionCancelled = false;
+              let submissionOutcomeUnknown = false;
+              let removeSubmitObserver = () => {};
+              if (form && typeof form.addEventListener === 'function') {
+                const onSubmit = event => {
+                  submissionObserved = true;
+                  submissionCancelled = event.defaultPrevented === true;
+                };
+                form.addEventListener('submit', onSubmit, true);
+                removeSubmitObserver = () => form.removeEventListener?.('submit', onSubmit, true);
+              }
               if (msg.params?.messageRecipientGuardRequired === true) {
                 const recipientValidation = _consumeMessageRecipientDispatchBinding(msg.params, el);
                 if (recipientValidation.success !== true) {
@@ -4902,26 +4914,39 @@
                   });
                 }
               }
-              // Always dispatch the Enter trio: bare forms, tag-chip / email
-              // inputs that transform the value on Enter, and contenteditable
-              // composers only commit through their own keydown listener. If
-              // the page cancelled the keydown it already handled Enter, so a
-              // second submit would double-send.
-              const enterHandled = !dispatchKey('keydown', 'Enter', 13);
-              dispatchKey('keypress', 'Enter', 13);
-              dispatchKey('keyup', 'Enter', 13);
-              if (!enterHandled && _setFieldUsesNativeSubmit(isCombobox, form)) {
-                // requestSubmit performs interactive constraint validation and
-                // silently aborts on an invalid form; surface that instead of
-                // reporting a successful submission.
-                if (typeof form.checkValidity === 'function' && !form.checkValidity()) {
-                  return failure(
-                    'The form did not submit: a required field is empty or a value is invalid. Fix the field and retry with a fresh ref_id.',
-                    { verified: true, submitted: false, invalid: true, ref_id, rect },
-                  );
+              try {
+                // Always dispatch the Enter trio: bare forms, tag-chip / email
+                // inputs that transform the value on Enter, and contenteditable
+                // composers only commit through their own keydown listener.
+                const enterCancelled = !dispatchKey('keydown', 'Enter', 13);
+                dispatchKey('keypress', 'Enter', 13);
+                dispatchKey('keyup', 'Enter', 13);
+                if (submissionObserved) {
+                  submissionOutcomeUnknown = submissionCancelled;
+                } else if (!enterCancelled && _setFieldUsesNativeSubmit(isCombobox, form)) {
+                  // requestSubmit performs interactive constraint validation and
+                  // silently aborts on an invalid form; surface that instead of
+                  // reporting a successful submission.
+                  if (typeof form.checkValidity === 'function' && !form.checkValidity()) {
+                    return failure(
+                      'The form did not submit: a required field is empty or a value is invalid. Fix the field and retry with a fresh ref_id.',
+                      { verified: true, submitted: false, invalid: true, ref_id, rect },
+                    );
+                  }
+                  try {
+                    form.requestSubmit();
+                  } catch {
+                    submissionOutcomeUnknown = true;
+                  }
+                  if (!submissionObserved) submissionOutcomeUnknown = true;
+                } else {
+                  // preventDefault, combobox handling, contenteditable custom
+                  // handlers, and form-less widgets do not prove submission.
+                  submissionOutcomeUnknown = true;
                 }
-                form.requestSubmit();
-                nativeSubmitAttempted = true;
+                nativeSubmitAttempted = submissionObserved && !submissionCancelled;
+              } finally {
+                removeSubmitObserver();
               }
             } catch {}
           }
@@ -4951,6 +4976,7 @@
             fieldMeta,
             fallbackAttempted,
             submitted: nativeSubmitAttempted || undefined,
+            outcomeUnknown: submissionOutcomeUnknown || undefined,
           };
         } catch (e) {
           return failure(e && e.message || String(e));

--- a/src/firefox/src/content/content.js
+++ b/src/firefox/src/content/content.js
@@ -4892,12 +4892,13 @@
               const form = el.form || (el.closest && el.closest('form'));
               let submissionObserved = false;
               let submissionCancelled = false;
+              let submitEvent = null;
               let submissionOutcomeUnknown = false;
               let removeSubmitObserver = () => {};
               if (form && typeof form.addEventListener === 'function') {
                 const onSubmit = event => {
                   submissionObserved = true;
-                  submissionCancelled = event.defaultPrevented === true;
+                  submitEvent = event;
                 };
                 form.addEventListener('submit', onSubmit, true);
                 removeSubmitObserver = () => form.removeEventListener?.('submit', onSubmit, true);
@@ -4922,12 +4923,13 @@
                 dispatchKey('keypress', 'Enter', 13);
                 dispatchKey('keyup', 'Enter', 13);
                 if (submissionObserved) {
+                  submissionCancelled = submitEvent?.defaultPrevented === true;
                   submissionOutcomeUnknown = submissionCancelled;
                 } else if (!enterCancelled && _setFieldUsesNativeSubmit(isCombobox, form)) {
                   // requestSubmit performs interactive constraint validation and
                   // silently aborts on an invalid form; surface that instead of
                   // reporting a successful submission.
-                  if (typeof form.checkValidity === 'function' && !form.checkValidity()) {
+                  if (form.noValidate !== true && typeof form.checkValidity === 'function' && !form.checkValidity()) {
                     return failure(
                       'The form did not submit: a required field is empty or a value is invalid. Fix the field and retry with a fresh ref_id.',
                       { verified: true, submitted: false, invalid: true, ref_id, rect },
@@ -4938,6 +4940,7 @@
                   } catch {
                     submissionOutcomeUnknown = true;
                   }
+                  submissionCancelled = submitEvent?.defaultPrevented === true;
                   if (!submissionObserved) submissionOutcomeUnknown = true;
                 } else {
                   // preventDefault, combobox handling, contenteditable custom

--- a/src/firefox/src/content/content.js
+++ b/src/firefox/src/content/content.js
@@ -3086,8 +3086,8 @@
   // its only reliable commit path; comboboxes are committed by page JS
   // listeners instead, because submitting the enclosing form while a picker
   // popup is open is usually wrong.
-  function _setFieldUsesNativeSubmit(isCombobox, form) {
-    return !isCombobox && !!form && typeof form.requestSubmit === 'function';
+  function _setFieldUsesNativeSubmit(isCombobox, isContentEditable, form) {
+    return !isCombobox && !isContentEditable && !!form && typeof form.requestSubmit === 'function';
   }
 
   // Above this length the per-candidate rescan below stops being worth its
@@ -4851,6 +4851,7 @@
           let verified = _setFieldValueMatches(actual, prevValue, text, clear, el.isContentEditable);
           let fallbackAttempted = false;
           let nativeSubmitAttempted = false;
+          let submissionOutcomeUnknown = false;
           if (!verified) {
             fallbackAttempted = true;
             await _retryFieldWithExecCommand(el, (clear ? '' : prevValue) + text);
@@ -4859,6 +4860,7 @@
           }
 
           if (submit && verified) {
+            submissionOutcomeUnknown = true;
             try {
               const roleAttr = (el.getAttribute && el.getAttribute('role') || '').toLowerCase();
               const controls = el.getAttribute && el.getAttribute('aria-controls');
@@ -4878,30 +4880,12 @@
                 } catch {}
               }
               const dispatchKey = (type, key, keyCode) => {
-                // Return the dispatch result: `false` means the page cancelled
-                // the event (preventDefault), which is how we detect that a
-                // keydown listener already handled Enter.
                 return el.dispatchEvent(new KeyboardEvent(type, { key, code: key, keyCode, bubbles: true, cancelable: true }));
               };
-              if (isCombobox) {
-                await new Promise(r => setTimeout(r, 80));
-                dispatchKey('keydown', 'ArrowDown', 40);
-                dispatchKey('keyup', 'ArrowDown', 40);
-                await new Promise(r => setTimeout(r, 30));
-              }
               const form = el.form || (el.closest && el.closest('form'));
+              const usesNativeSubmit = _setFieldUsesNativeSubmit(isCombobox, el.isContentEditable, form);
               let submissionObserved = false;
               let submissionCancelled = false;
-              let submissionOutcomeUnknown = false;
-              let removeSubmitObserver = () => {};
-              if (form && typeof form.addEventListener === 'function') {
-                const onSubmit = event => {
-                  submissionObserved = true;
-                  submissionCancelled = event.defaultPrevented === true;
-                };
-                form.addEventListener('submit', onSubmit, true);
-                removeSubmitObserver = () => form.removeEventListener?.('submit', onSubmit, true);
-              }
               if (msg.params?.messageRecipientGuardRequired === true) {
                 const recipientValidation = _consumeMessageRecipientDispatchBinding(msg.params, el);
                 if (recipientValidation.success !== true) {
@@ -4914,16 +4898,20 @@
                   });
                 }
               }
+              let removeSubmitObserver = () => {};
+              if (form && typeof form.addEventListener === 'function') {
+                const onSubmit = event => {
+                  submissionObserved = true;
+                  submissionCancelled = event.defaultPrevented === true;
+                };
+                form.addEventListener('submit', onSubmit, true);
+                removeSubmitObserver = () => form.removeEventListener?.('submit', onSubmit, true);
+              }
               try {
-                // Always dispatch the Enter trio: bare forms, tag-chip / email
-                // inputs that transform the value on Enter, and contenteditable
-                // composers only commit through their own keydown listener.
-                const enterCancelled = !dispatchKey('keydown', 'Enter', 13);
-                dispatchKey('keypress', 'Enter', 13);
-                dispatchKey('keyup', 'Enter', 13);
-                if (submissionObserved) {
-                  submissionOutcomeUnknown = submissionCancelled;
-                } else if (!enterCancelled && _setFieldUsesNativeSubmit(isCombobox, form)) {
+                if (usesNativeSubmit) {
+                  // Ordinary form controls use one native path. Dispatching a
+                  // synthetic Enter first could make page code act and then
+                  // make this fallback repeat the consequential action.
                   // requestSubmit performs interactive constraint validation and
                   // silently aborts on an invalid form; surface that instead of
                   // reporting a successful submission.
@@ -4935,20 +4923,30 @@
                   }
                   try {
                     form.requestSubmit();
-                  } catch {
-                    submissionOutcomeUnknown = true;
-                  }
-                  if (!submissionObserved) submissionOutcomeUnknown = true;
+                  } catch {}
                 } else {
-                  // preventDefault, combobox handling, contenteditable custom
-                  // handlers, and form-less widgets do not prove submission.
-                  submissionOutcomeUnknown = true;
+                  // Comboboxes, contenteditables, and form-less widgets are
+                  // committed by page-owned keyboard handlers. Never follow
+                  // this path with requestSubmit: cancellation is not proof of
+                  // submission, and an unobserved handler may already have acted.
+                  if (isCombobox) {
+                    await new Promise(r => setTimeout(r, 80));
+                    dispatchKey('keydown', 'ArrowDown', 40);
+                    dispatchKey('keyup', 'ArrowDown', 40);
+                    await new Promise(r => setTimeout(r, 30));
+                  }
+                  dispatchKey('keydown', 'Enter', 13);
+                  dispatchKey('keypress', 'Enter', 13);
+                  dispatchKey('keyup', 'Enter', 13);
                 }
                 nativeSubmitAttempted = submissionObserved && !submissionCancelled;
+                submissionOutcomeUnknown = !nativeSubmitAttempted;
               } finally {
                 removeSubmitObserver();
               }
-            } catch {}
+            } catch {
+              submissionOutcomeUnknown = true;
+            }
           }
           if (!verified) {
             return failure(

--- a/test/run.js
+++ b/test/run.js
@@ -55026,7 +55026,9 @@ test('set_field waits for reconciliation and verifies the complete value', () =>
     assert.match(branch, /(?:const|let) actual = el\.isContentEditable \? _editableTextValue\(el\)/, `${label}: rich-editor verification must use rendered text`);
     assert.match(branch, /_setFieldValueMatches\(actual, prevValue, text, clear, el\.isContentEditable\)/, `${label}: newline normalization must remain contenteditable-only`);
     assert.match(branch, /!el\.isConnected \|\| !rect \|\| rect\.w < 1 \|\| rect\.h < 1/, `${label}: stale or zero-sized targets must fail before typing`);
-    assert.match(branch, /if \(submit && verified\)/, `${label}: mismatched field values must not be submitted`);
+     assert.match(branch, /if \(submit && verified\)/, `${label}: mismatched field values must not be submitted`);
+     assert.match(branch, /addEventListener\('submit'/, `${label}: submit handling must observe actual submit events`);
+     assert.match(branch, /outcomeUnknown: submissionOutcomeUnknown/, `${label}: unproven submissions must be surfaced as unknown`);
     assert.match(branch, /if \(!verified\) \{[\s\S]*return failure\(/, `${label}: mismatched field values must be explicit failed actions`);
     assert.match(branch, /dispatched\s*\?\s*\{ dispatched: true \}/, `${label}: post-dispatch verification failures must preserve action evidence`);
     assert.doesNotMatch(branch, /actual\.includes\(text\)/, `${label}: substring matches must not count as verified field values`);
@@ -55063,11 +55065,30 @@ test('set_field submit dispatches Enter once and submits natively only when unha
       return nativeSubmitAttempted;
     }`);
 
-    const exercise = ({ keydownCancelled, checkValidity = () => true, isCombobox = false }) => {
+    const exercise = ({ keydownCancelled, checkValidity = () => true, isCombobox = false, pageSubmitsOnKeydown = false, submitCancelled = false }) => {
       const calls = [];
-      const form = { requestSubmit: () => calls.push('requestSubmit'), checkValidity };
+      const submitListeners = [];
+      const emitSubmit = () => {
+        const event = { defaultPrevented: submitCancelled };
+        for (const listener of submitListeners) listener(event);
+      };
+      const form = {
+        requestSubmit: () => { calls.push('requestSubmit'); emitSubmit(); },
+        checkValidity,
+        addEventListener: (type, listener) => { if (type === 'submit') submitListeners.push(listener); },
+        removeEventListener: (type, listener) => {
+          if (type === 'submit') {
+            const index = submitListeners.indexOf(listener);
+            if (index >= 0) submitListeners.splice(index, 1);
+          }
+        },
+      };
       const el = { dispatchEvent: (ev) => (keydownCancelled && ev.type === 'keydown' ? false : true), form, closest: () => null };
-      const dispatchKey = (type) => { calls.push(type); return el.dispatchEvent({ type }); };
+      const dispatchKey = (type) => {
+        calls.push(type);
+        if (type === 'keydown' && pageSubmitsOnKeydown) emitSubmit();
+        return el.dispatchEvent({ type });
+      };
       let failureResult = null;
       const failure = (msg, data) => { failureResult = data; return { success: false, ...data }; };
       const submitted = runner({
@@ -55086,17 +55107,31 @@ test('set_field submit dispatches Enter once and submits natively only when unha
     // Plain field + valid form + unhandled keydown: Enter trio + one submit.
     const plain = exercise({});
     assert.deepEqual(plain.calls, ['keydown', 'keypress', 'keyup', 'requestSubmit'], `${label}: plain field must dispatch Enter then submit natively once`);
-    assert.equal(plain.submitted, true, `${label}: native submit must be reported`);
+    assert.equal(plain.submitted, true, `${label}: observed native submit must be reported`);
+    assert.equal(plain.failureResult, null, `${label}: observed native submit must not fail`);
+
+    // A page listener may submit without cancelling Enter; the fallback must
+    // see the submit event and avoid a second requestSubmit call.
+    const pageSubmitted = exercise({ pageSubmitsOnKeydown: true });
+    assert.deepEqual(pageSubmitted.calls, ['keydown', 'keypress', 'keyup'], `${label}: page-handled submit must not be submitted twice`);
+    assert.equal(pageSubmitted.submitted, true, `${label}: page-handled submit should be reported from the observed event`);
 
     // Page already handled Enter (keydown cancelled): no second submit.
     const handled = exercise({ keydownCancelled: true });
     assert.deepEqual(handled.calls, ['keydown', 'keypress', 'keyup'], `${label}: handled Enter must not double-submit`);
     assert.equal(handled.submitted, false, `${label}: handled Enter reports no native submit`);
+    assert.equal(handled.failureResult, null, `${label}: handled Enter should preserve a non-failing unknown result`);
 
     // Combobox: never native-submits (the Enter trio reaches page JS).
     const combobox = exercise({ isCombobox: true });
     assert.deepEqual(combobox.calls, ['keydown', 'keypress', 'keyup'], `${label}: combobox must commit via synthetic keys only`);
     assert.equal(combobox.submitted, false, `${label}: combobox reports no native submit`);
+
+    // A page can cancel a submit event after observing it; that is not proof
+    // that the consequential action reached the server.
+    const cancelledSubmit = exercise({ submitCancelled: true });
+    assert.deepEqual(cancelledSubmit.calls, ['keydown', 'keypress', 'keyup', 'requestSubmit'], `${label}: cancelled submit still has one native attempt`);
+    assert.equal(cancelledSubmit.submitted, false, `${label}: cancelled submit must not be reported as submitted`);
 
     // Invalid form: surface the silent requestSubmit abort.
     const invalid = exercise({ checkValidity: () => false });

--- a/test/run.js
+++ b/test/run.js
@@ -55065,16 +55065,18 @@ test('set_field submit dispatches Enter once and submits natively only when unha
       return nativeSubmitAttempted;
     }`);
 
-    const exercise = ({ keydownCancelled, checkValidity = () => true, isCombobox = false, pageSubmitsOnKeydown = false, submitCancelled = false }) => {
+    const exercise = ({ keydownCancelled, checkValidity = () => true, isCombobox = false, pageSubmitsOnKeydown = false, submitCancelled = false, noValidate = false }) => {
       const calls = [];
       const submitListeners = [];
       const emitSubmit = () => {
-        const event = { defaultPrevented: submitCancelled };
+        const event = { defaultPrevented: false };
         for (const listener of submitListeners) listener(event);
+        if (submitCancelled) event.defaultPrevented = true;
       };
       const form = {
         requestSubmit: () => { calls.push('requestSubmit'); emitSubmit(); },
         checkValidity,
+        noValidate,
         addEventListener: (type, listener) => { if (type === 'submit') submitListeners.push(listener); },
         removeEventListener: (type, listener) => {
           if (type === 'submit') {
@@ -55132,6 +55134,10 @@ test('set_field submit dispatches Enter once and submits natively only when unha
     const cancelledSubmit = exercise({ submitCancelled: true });
     assert.deepEqual(cancelledSubmit.calls, ['keydown', 'keypress', 'keyup', 'requestSubmit'], `${label}: cancelled submit still has one native attempt`);
     assert.equal(cancelledSubmit.submitted, false, `${label}: cancelled submit must not be reported as submitted`);
+
+    const noValidate = exercise({ noValidate: true, checkValidity: () => false });
+    assert.deepEqual(noValidate.calls, ['keydown', 'keypress', 'keyup', 'requestSubmit'], `${label}: novalidate forms must still attempt native submit`);
+    assert.equal(noValidate.submitted, true, `${label}: novalidate submit should rely on the observed submit event`);
 
     // Invalid form: surface the silent requestSubmit abort.
     const invalid = exercise({ checkValidity: () => false });

--- a/test/run.js
+++ b/test/run.js
@@ -55076,16 +55076,19 @@ test('set_field submit chooses exactly one native or page-owned commit path', as
       pageSubmitsOnKeydown = false,
       pageUsesDirectSubmitOnKeydown = false,
       submitCancelled = false,
+      noValidate = false,
     } = {}) => {
       const calls = [];
       const submitListeners = [];
       const emitSubmit = () => {
-        const event = { defaultPrevented: submitCancelled };
+        const event = { defaultPrevented: false };
         for (const listener of submitListeners) listener(event);
+        if (submitCancelled) event.defaultPrevented = true;
       };
       const form = {
         requestSubmit: () => { calls.push('requestSubmit'); emitSubmit(); },
         checkValidity,
+        noValidate,
         addEventListener: (type, listener) => { if (type === 'submit') submitListeners.push(listener); },
         removeEventListener: (type, listener) => {
           if (type === 'submit') {
@@ -55152,6 +55155,10 @@ test('set_field submit chooses exactly one native or page-owned commit path', as
     const cancelledSubmit = await exercise({ submitCancelled: true });
     assert.deepEqual(cancelledSubmit.calls, ['requestSubmit'], `${label}: cancelled native submit must not dispatch Enter`);
     assert.deepEqual({ ...cancelledSubmit.result }, { nativeSubmitAttempted: false, submissionOutcomeUnknown: true });
+
+    const noValidate = await exercise({ noValidate: true, checkValidity: () => false });
+    assert.deepEqual(noValidate.calls, ['requestSubmit'], `${label}: novalidate forms must still use native submission`);
+    assert.deepEqual({ ...noValidate.result }, { nativeSubmitAttempted: true, submissionOutcomeUnknown: false });
 
     // Invalid form: surface the silent requestSubmit abort.
     const invalid = await exercise({ checkValidity: () => false });

--- a/test/run.js
+++ b/test/run.js
@@ -55035,7 +55035,7 @@ test('set_field waits for reconciliation and verifies the complete value', () =>
   }
 });
 
-test('set_field submit dispatches Enter once and submits natively only when unhandled', () => {
+test('set_field submit chooses exactly one native or page-owned commit path', async () => {
   for (const [label, rel] of [
     ['chrome', 'src/chrome/src/content/content.js'],
     ['firefox', 'src/firefox/src/content/content.js'],
@@ -55048,24 +55048,35 @@ test('set_field submit dispatches Enter once and submits natively only when unha
     assert.ok(helperStart >= 0 && helperEnd > helperStart, `${label}: submit helper should remain independently testable`);
     const usesNativeSubmit = vm.runInNewContext(`(${source.slice(helperStart, helperEnd)})`);
     const formWithSubmit = { requestSubmit() {} };
-    assert.equal(usesNativeSubmit(true, formWithSubmit), false, `${label}: combobox never uses native submit`);
-    assert.equal(usesNativeSubmit(false, formWithSubmit), true, `${label}: plain field in a form uses native submit`);
-    assert.equal(usesNativeSubmit(false, null), false, `${label}: form-less field does not use native submit`);
-    assert.equal(usesNativeSubmit(false, {}), false, `${label}: form without requestSubmit does not use native submit`);
+    assert.equal(usesNativeSubmit(true, false, formWithSubmit), false, `${label}: combobox never uses native submit`);
+    assert.equal(usesNativeSubmit(false, true, formWithSubmit), false, `${label}: contenteditable never uses native submit`);
+    assert.equal(usesNativeSubmit(false, false, formWithSubmit), true, `${label}: plain field in a form uses native submit`);
+    assert.equal(usesNativeSubmit(false, false, null), false, `${label}: form-less field does not use native submit`);
+    assert.equal(usesNativeSubmit(false, false, {}), false, `${label}: form without requestSubmit does not use native submit`);
 
     // Behavioral slice of the submit block, run against stubs.
     const blockStart = source.indexOf("const form = el.form || (el.closest && el.closest('form'));");
-    const blockEnd = source.indexOf('} catch {}', blockStart);
+    const blockEnd = source.indexOf('\n            } catch {\n              submissionOutcomeUnknown = true;', blockStart);
     assert.ok(blockStart >= 0 && blockEnd > blockStart, `${label}: submit block not found`);
     const block = source.slice(blockStart, blockEnd);
-    const runner = vm.runInNewContext(`(stubs) => {
+    const runner = vm.runInNewContext(`async (stubs) => {
       const { dispatchKey, el, msg, failure, isCombobox, _setFieldUsesNativeSubmit, _consumeMessageRecipientDispatchBinding, ref_id, rect } = stubs;
       let nativeSubmitAttempted = false;
+      let submissionOutcomeUnknown = true;
       ${block}
-      return nativeSubmitAttempted;
-    }`);
+      return { nativeSubmitAttempted, submissionOutcomeUnknown };
+    }`, { setTimeout: callback => callback() });
 
-    const exercise = ({ keydownCancelled, checkValidity = () => true, isCombobox = false, pageSubmitsOnKeydown = false, submitCancelled = false }) => {
+    const exercise = async ({
+      keydownCancelled = false,
+      checkValidity = () => true,
+      isCombobox = false,
+      isContentEditable = false,
+      hasForm = true,
+      pageSubmitsOnKeydown = false,
+      pageUsesDirectSubmitOnKeydown = false,
+      submitCancelled = false,
+    } = {}) => {
       const calls = [];
       const submitListeners = [];
       const emitSubmit = () => {
@@ -55083,15 +55094,21 @@ test('set_field submit dispatches Enter once and submits natively only when unha
           }
         },
       };
-      const el = { dispatchEvent: (ev) => (keydownCancelled && ev.type === 'keydown' ? false : true), form, closest: () => null };
-      const dispatchKey = (type) => {
-        calls.push(type);
-        if (type === 'keydown' && pageSubmitsOnKeydown) emitSubmit();
-        return el.dispatchEvent({ type });
+      const el = {
+        dispatchEvent: event => !(keydownCancelled && event.type === 'keydown' && event.key === 'Enter'),
+        form: hasForm ? form : null,
+        closest: () => null,
+        isContentEditable,
+      };
+      const dispatchKey = (type, key) => {
+        calls.push(`${type}:${key}`);
+        if (type === 'keydown' && key === 'Enter' && pageSubmitsOnKeydown) emitSubmit();
+        if (type === 'keydown' && key === 'Enter' && pageUsesDirectSubmitOnKeydown) calls.push('form.submit');
+        return el.dispatchEvent({ type, key });
       };
       let failureResult = null;
       const failure = (msg, data) => { failureResult = data; return { success: false, ...data }; };
-      const submitted = runner({
+      const result = await runner({
         dispatchKey, el,
         msg: { params: {} },
         failure,
@@ -55101,41 +55118,44 @@ test('set_field submit dispatches Enter once and submits natively only when unha
         ref_id: 'ref_1',
         rect: { x: 0, y: 0, w: 1, h: 1 },
       });
-      return { calls, submitted, failureResult };
+      return { calls, result, failureResult };
     };
 
-    // Plain field + valid form + unhandled keydown: Enter trio + one submit.
-    const plain = exercise({});
-    assert.deepEqual(plain.calls, ['keydown', 'keypress', 'keyup', 'requestSubmit'], `${label}: plain field must dispatch Enter then submit natively once`);
-    assert.equal(plain.submitted, true, `${label}: observed native submit must be reported`);
+    const plain = await exercise();
+    assert.deepEqual(plain.calls, ['requestSubmit'], `${label}: plain form field must use only native submission`);
+    assert.deepEqual({ ...plain.result }, { nativeSubmitAttempted: true, submissionOutcomeUnknown: false });
     assert.equal(plain.failureResult, null, `${label}: observed native submit must not fail`);
 
-    // A page listener may submit without cancelling Enter; the fallback must
-    // see the submit event and avoid a second requestSubmit call.
-    const pageSubmitted = exercise({ pageSubmitsOnKeydown: true });
-    assert.deepEqual(pageSubmitted.calls, ['keydown', 'keypress', 'keyup'], `${label}: page-handled submit must not be submitted twice`);
-    assert.equal(pageSubmitted.submitted, true, `${label}: page-handled submit should be reported from the observed event`);
+    const combobox = await exercise({ isCombobox: true, pageSubmitsOnKeydown: true });
+    assert.deepEqual(combobox.calls, [
+      'keydown:ArrowDown',
+      'keyup:ArrowDown',
+      'keydown:Enter',
+      'keypress:Enter',
+      'keyup:Enter',
+    ], `${label}: combobox must use only its page-owned keyboard path`);
+    assert.deepEqual({ ...combobox.result }, { nativeSubmitAttempted: true, submissionOutcomeUnknown: false });
 
-    // Page already handled Enter (keydown cancelled): no second submit.
-    const handled = exercise({ keydownCancelled: true });
-    assert.deepEqual(handled.calls, ['keydown', 'keypress', 'keyup'], `${label}: handled Enter must not double-submit`);
-    assert.equal(handled.submitted, false, `${label}: handled Enter reports no native submit`);
-    assert.equal(handled.failureResult, null, `${label}: handled Enter should preserve a non-failing unknown result`);
+    // form.submit() deliberately emits no submit event. The result remains
+    // unknown, but the native fallback must still not repeat the action.
+    const directSubmit = await exercise({ isCombobox: true, pageUsesDirectSubmitOnKeydown: true });
+    assert.equal(directSubmit.calls.includes('form.submit'), true, `${label}: direct page submit was not exercised`);
+    assert.equal(directSubmit.calls.includes('requestSubmit'), false, `${label}: unobserved page action must not trigger a second submit`);
+    assert.deepEqual({ ...directSubmit.result }, { nativeSubmitAttempted: false, submissionOutcomeUnknown: true });
 
-    // Combobox: never native-submits (the Enter trio reaches page JS).
-    const combobox = exercise({ isCombobox: true });
-    assert.deepEqual(combobox.calls, ['keydown', 'keypress', 'keyup'], `${label}: combobox must commit via synthetic keys only`);
-    assert.equal(combobox.submitted, false, `${label}: combobox reports no native submit`);
+    const contenteditable = await exercise({ isContentEditable: true, keydownCancelled: true });
+    assert.deepEqual(contenteditable.calls, ['keydown:Enter', 'keypress:Enter', 'keyup:Enter'], `${label}: contenteditable must stay on the keyboard path`);
+    assert.deepEqual({ ...contenteditable.result }, { nativeSubmitAttempted: false, submissionOutcomeUnknown: true });
 
     // A page can cancel a submit event after observing it; that is not proof
     // that the consequential action reached the server.
-    const cancelledSubmit = exercise({ submitCancelled: true });
-    assert.deepEqual(cancelledSubmit.calls, ['keydown', 'keypress', 'keyup', 'requestSubmit'], `${label}: cancelled submit still has one native attempt`);
-    assert.equal(cancelledSubmit.submitted, false, `${label}: cancelled submit must not be reported as submitted`);
+    const cancelledSubmit = await exercise({ submitCancelled: true });
+    assert.deepEqual(cancelledSubmit.calls, ['requestSubmit'], `${label}: cancelled native submit must not dispatch Enter`);
+    assert.deepEqual({ ...cancelledSubmit.result }, { nativeSubmitAttempted: false, submissionOutcomeUnknown: true });
 
     // Invalid form: surface the silent requestSubmit abort.
-    const invalid = exercise({ checkValidity: () => false });
-    assert.deepEqual(invalid.calls, ['keydown', 'keypress', 'keyup'], `${label}: invalid form must not call requestSubmit`);
+    const invalid = await exercise({ checkValidity: () => false });
+    assert.deepEqual(invalid.calls, [], `${label}: invalid form must dispatch neither Enter nor requestSubmit`);
     assert.equal(invalid.failureResult?.submitted, false, `${label}: invalid form must fail with submitted:false`);
     assert.equal(invalid.failureResult?.invalid, true, `${label}: invalid form must flag invalid:true`);
   }

--- a/test/run.js
+++ b/test/run.js
@@ -55033,6 +55033,79 @@ test('set_field waits for reconciliation and verifies the complete value', () =>
   }
 });
 
+test('set_field submit dispatches Enter once and submits natively only when unhandled', () => {
+  for (const [label, rel] of [
+    ['chrome', 'src/chrome/src/content/content.js'],
+    ['firefox', 'src/firefox/src/content/content.js'],
+  ]) {
+    const source = fs.readFileSync(path.join(ROOT, rel), 'utf8');
+
+    // Pure boolean helper.
+    const helperStart = source.indexOf('function _setFieldUsesNativeSubmit(');
+    const helperEnd = source.indexOf('\n  }\n', helperStart) + 4;
+    assert.ok(helperStart >= 0 && helperEnd > helperStart, `${label}: submit helper should remain independently testable`);
+    const usesNativeSubmit = vm.runInNewContext(`(${source.slice(helperStart, helperEnd)})`);
+    const formWithSubmit = { requestSubmit() {} };
+    assert.equal(usesNativeSubmit(true, formWithSubmit), false, `${label}: combobox never uses native submit`);
+    assert.equal(usesNativeSubmit(false, formWithSubmit), true, `${label}: plain field in a form uses native submit`);
+    assert.equal(usesNativeSubmit(false, null), false, `${label}: form-less field does not use native submit`);
+    assert.equal(usesNativeSubmit(false, {}), false, `${label}: form without requestSubmit does not use native submit`);
+
+    // Behavioral slice of the submit block, run against stubs.
+    const blockStart = source.indexOf("const form = el.form || (el.closest && el.closest('form'));");
+    const blockEnd = source.indexOf('} catch {}', blockStart);
+    assert.ok(blockStart >= 0 && blockEnd > blockStart, `${label}: submit block not found`);
+    const block = source.slice(blockStart, blockEnd);
+    const runner = vm.runInNewContext(`(stubs) => {
+      const { dispatchKey, el, msg, failure, isCombobox, _setFieldUsesNativeSubmit, _consumeMessageRecipientDispatchBinding, ref_id, rect } = stubs;
+      let nativeSubmitAttempted = false;
+      ${block}
+      return nativeSubmitAttempted;
+    }`);
+
+    const exercise = ({ keydownCancelled, checkValidity = () => true, isCombobox = false }) => {
+      const calls = [];
+      const form = { requestSubmit: () => calls.push('requestSubmit'), checkValidity };
+      const el = { dispatchEvent: (ev) => (keydownCancelled && ev.type === 'keydown' ? false : true), form, closest: () => null };
+      const dispatchKey = (type) => { calls.push(type); return el.dispatchEvent({ type }); };
+      let failureResult = null;
+      const failure = (msg, data) => { failureResult = data; return { success: false, ...data }; };
+      const submitted = runner({
+        dispatchKey, el,
+        msg: { params: {} },
+        failure,
+        isCombobox,
+        _setFieldUsesNativeSubmit: usesNativeSubmit,
+        _consumeMessageRecipientDispatchBinding: () => ({ success: true }),
+        ref_id: 'ref_1',
+        rect: { x: 0, y: 0, w: 1, h: 1 },
+      });
+      return { calls, submitted, failureResult };
+    };
+
+    // Plain field + valid form + unhandled keydown: Enter trio + one submit.
+    const plain = exercise({});
+    assert.deepEqual(plain.calls, ['keydown', 'keypress', 'keyup', 'requestSubmit'], `${label}: plain field must dispatch Enter then submit natively once`);
+    assert.equal(plain.submitted, true, `${label}: native submit must be reported`);
+
+    // Page already handled Enter (keydown cancelled): no second submit.
+    const handled = exercise({ keydownCancelled: true });
+    assert.deepEqual(handled.calls, ['keydown', 'keypress', 'keyup'], `${label}: handled Enter must not double-submit`);
+    assert.equal(handled.submitted, false, `${label}: handled Enter reports no native submit`);
+
+    // Combobox: never native-submits (the Enter trio reaches page JS).
+    const combobox = exercise({ isCombobox: true });
+    assert.deepEqual(combobox.calls, ['keydown', 'keypress', 'keyup'], `${label}: combobox must commit via synthetic keys only`);
+    assert.equal(combobox.submitted, false, `${label}: combobox reports no native submit`);
+
+    // Invalid form: surface the silent requestSubmit abort.
+    const invalid = exercise({ checkValidity: () => false });
+    assert.deepEqual(invalid.calls, ['keydown', 'keypress', 'keyup'], `${label}: invalid form must not call requestSubmit`);
+    assert.equal(invalid.failureResult?.submitted, false, `${label}: invalid form must fail with submitted:false`);
+    assert.equal(invalid.failureResult?.invalid, true, `${label}: invalid form must flag invalid:true`);
+  }
+});
+
 test('type_ax shares settled exact verification and explicit recovery contract', () => {
   for (const [label, rel] of [
     ['chrome', 'src/chrome/src/content/content.js'],


### PR DESCRIPTION
## Summary

- `set_field({ submit: true })` on a regular (non-combobox) field now submits through **one** trusted path: `form.requestSubmit()`.
- The synthetic (untrusted) Enter dispatch is dropped for form-backed fields; it remains only as a fallback for form-less pages and for comboboxes (unchanged picker commit flow).

## Motivation

The old path dispatched synthetic `KeyboardEvent`s (never `isTrusted`, so never producing native default actions) **and then** called `form.requestSubmit()`:

- **Double submit:** on any page whose JS keydown listener submits on Enter (search boxes, composer/comment forms — extremely common), the page handler fires from the synthetic event *and* `requestSubmit()` fires a second native submit. On POST forms (login, checkout, send) this duplicates posts/orders/messages.
- The file itself documents the trust distinction for `press_keys` (content.js: "native browser default actions are only guaranteed for trusted events"), but this path still leaned on an untrusted Enter for submission semantics.

## Design

Introduced `_setFieldSubmitMode(isCombobox, form)` returning the single commit path:

- `combobox` → `synthetic-enter` (page JS commits the picker; submitting the enclosing form while a popup is open is usually wrong — preserved rationale)
- form present with `requestSubmit` → `requestSubmit` only (trusted native submission fires the form's JS handlers and the browser's own submit exactly once)
- form-less → `synthetic-enter` (the only mechanism that reaches JS-listener-only submit handlers)

## Testing

- `node test/run.js` — 1764 passed, 0 failed (1 new test, both builds)
- `npm run test:security` — 60/60 passed
- `npm run test:toolbar-guard` — 33 passed

New test covers the decision matrix (combobox / form / form-less) plus source-structure guards: the native branch contains no Enter dispatch, the fallback branch contains no `requestSubmit()`, and ArrowDown stays gated on `isCombobox`.

## Compatibility and risks

- Combobox behavior unchanged. Form-backed pages now submit exactly once instead of (possibly) twice.
- Not verified: a live-browser double-submit scenario — unit tests cover the extracted decision and the dispatched paths, not a real page (no E2E for content-script submit behavior in this repo).

## Scope

- Combobox "no submit at all when the page relies on native submission" was assessed as a deliberate design tradeoff (popup-open submission is usually wrong) and left unchanged.