### PR TITLE
fix(agent): verify same-URL history traversal

### DIFF
--- a/src/chrome/src/agent/agent.js
+++ b/src/chrome/src/agent/agent.js
@@ -19309,51 +19309,148 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
         if (blocked) return blocked;
       }
 
+      // A URL comparison alone cannot prove same-document history movement:
+      // SPAs may push several entries with an identical URL and keep their
+      // route solely in history.state. Listen before dispatch so those entries
+      // can be verified by the browser's navigation events.
+      let navigationTerminalResult = null;
+      let resolveNavigationTerminal;
+      let navigationLoadingObserved = false;
+      let historyDispatchArmed = false;
+      const navigationTerminal = new Promise(resolve => { resolveNavigationTerminal = resolve; });
+      const finishNavigationTerminal = (result) => {
+        if (navigationTerminalResult) return;
+        navigationTerminalResult = result;
+        resolveNavigationTerminal(result);
+      };
+      const waitForNavigationTerminal = (timeoutMs, timeoutType) => {
+        if (navigationTerminalResult) return Promise.resolve(navigationTerminalResult);
+        return new Promise(resolve => {
+          const timer = setTimeout(() => resolve({ type: timeoutType }), timeoutMs);
+          navigationTerminal.then(result => {
+            clearTimeout(timer);
+            resolve(result);
+          });
+        });
+      };
+      const listenerRecords = [];
+      const addNavigationListener = (event, listener) => {
+        if (!event?.addListener || !event?.removeListener) return;
+        try {
+          event.addListener(listener);
+          listenerRecords.push([event, listener]);
+        } catch {}
+      };
+      const isCurrentTopFrameNavigation = (details = {}) => {
+        return historyDispatchArmed && details.tabId === tabId && details.frameId === 0;
+      };
+      const observeNavigation = type => (details = {}) => {
+        if (!isCurrentTopFrameNavigation(details)) return;
+        // pushState/replaceState also emit onHistoryStateUpdated. Only an
+        // actual session-history traversal carries the forward_back qualifier.
+        if (!details.transitionQualifiers?.includes('forward_back')) return;
+        finishNavigationTerminal({ type: 'navigated', navigationType: type, url: details.url || '' });
+      };
+      addNavigationListener(chrome.webNavigation?.onHistoryStateUpdated, observeNavigation('history_state'));
+      addNavigationListener(chrome.webNavigation?.onCommitted, observeNavigation('committed'));
+      addNavigationListener(chrome.tabs?.onUpdated, (updatedTabId, changeInfo = {}) => {
+        if (!historyDispatchArmed || updatedTabId !== tabId) return;
+        if (changeInfo.status === 'loading') navigationLoadingObserved = true;
+      });
+      const removeNavigationListeners = () => {
+        for (const [event, listener] of listenerRecords.splice(0)) {
+          try { event.removeListener(listener); } catch {}
+        }
+      };
+
       // Drive history from the page's own context via scripting.executeScript
       // (the extension's injected function, NOT page eval) so it works even
       // where execute_js is CSP-blocked.
       let probe = null;
       let dispatched = false;
       try {
-        const delta = direction === 'back' ? -steps : steps;
-        dispatched = true;
-        const results = await chrome.scripting.executeScript({
-          target: { tabId },
-          args: [delta],
-          func: (d) => {
-            const before = location.href;
-            history.go(d);
-            return { before };
-          },
-        });
-        probe = results?.[0]?.result || null;
-      } catch (e) {
-        return { success: false, dispatched, error: `${name}: cannot navigate history on this page (${e.message}).` };
-      }
-      if (!probe) {
-        return { success: false, dispatched, error: `${name}: history navigation did not run on this page.` };
-      }
+        try {
+          const delta = direction === 'back' ? -steps : steps;
+          historyDispatchArmed = true;
+          dispatched = true;
+          const results = await chrome.scripting.executeScript({
+            target: { tabId },
+            args: [delta],
+            func: (d) => {
+              const before = location.href;
+              history.go(d);
+              return { before };
+            },
+          });
+          probe = results?.[0]?.result || null;
+        } catch (e) {
+          return { success: false, dispatched, error: `${name}: cannot navigate history on this page (${e.message}).` };
+        }
+        if (!probe) {
+          return { success: false, dispatched, error: `${name}: history navigation did not run on this page.` };
+        }
 
-      // history.go() commits asynchronously (including bfcache restores), so
-      // wait briefly, then confirm the URL actually changed. If it didn't,
-      // there was no entry in that direction — report failure rather than a
-      // misleading success the model would build on.
-      await new Promise(r => setTimeout(r, 1500));
-      let afterUrl = probe.before;
-      try {
-        const tab = await chrome.tabs.get(tabId);
-        if (tab?.url) afterUrl = tab.url;
-      } catch {}
+        // Preserve the existing 1.5s no-entry decision for idle tabs, while
+        // allowing a real cross-document traversal up to the navigate tool's
+        // 10s deadline when the tab reports that it is still loading.
+        let navigationWaitResult = await waitForNavigationTerminal(1500, 'probe_timeout');
+        if (navigationWaitResult.type === 'probe_timeout') {
+          let interimStatus = '';
+          try { interimStatus = (await chrome.tabs.get(tabId))?.status || ''; } catch {}
+          if (interimStatus === 'loading' || (!interimStatus && navigationLoadingObserved)) {
+            navigationWaitResult = await waitForNavigationTerminal(8500, 'deadline');
+          }
+        }
 
-      if (this._normalizeUrl(afterUrl) === this._normalizeUrl(probe.before)) {
+        let afterUrl = navigationWaitResult.url || probe.before;
+        let finalStatus = '';
+        try {
+          const tab = await chrome.tabs.get(tabId);
+          if (tab?.url) afterUrl = tab.url;
+          finalStatus = tab?.status || '';
+        } catch {}
+
+        const urlChanged = this._normalizeUrl(afterUrl) !== this._normalizeUrl(probe.before);
+        if (navigationWaitResult.type === 'navigated' || urlChanged) {
+          return {
+            success: true,
+            dispatched: true,
+            verified: true,
+            url: afterUrl,
+            previousUrl: probe.before,
+            direction,
+            steps,
+            ...(navigationWaitResult.navigationType ? { navigationType: navigationWaitResult.navigationType } : {}),
+          };
+        }
+
+        if (
+          navigationWaitResult.type === 'deadline'
+          && (finalStatus === 'loading' || (!finalStatus && navigationLoadingObserved))
+        ) {
+          return {
+            success: false,
+            dispatched: true,
+            navigationPending: true,
+            confirmationPossible: false,
+            recoveryRequired: 'wait_for_stable',
+            url: afterUrl,
+            previousUrl: probe.before,
+            direction,
+            steps,
+            error: `${name}: history navigation was dispatched and the tab is still loading. Call wait_for_stable, then inspect the current page.`,
+          };
+        }
+
         const dirWord = direction === 'back' ? 'earlier' : 'later';
         return {
           success: false,
           dispatched: true,
           error: `${name}: no ${dirWord} entry in this tab's history (the page did not change).`,
         };
+      } finally {
+        removeNavigationListeners();
       }
-      return { success: true, dispatched: true, url: afterUrl, previousUrl: probe.before, direction, steps };
     }
 
     if (name === 'new_tab') {

--- a/src/chrome/src/agent/tools.js
+++ b/src/chrome/src/agent/tools.js
@@ -375,7 +375,7 @@ export const AGENT_TOOLS = [
     type: 'function',
     function: {
       name: 'go_back',
-      description: 'Go back one entry in the current tab\'s session history, like the browser Back button. Use this for "go back" / "return to the previous page" rather than trying to run history.back() yourself (page scripts are CSP-blocked on many sites). Returns {success, url} on success, or {success:false, error} when there is no earlier entry or the page is internal (the URL is verified to actually change). Leaving a page with unsaved changes is blocked unless force:true.',
+      description: 'Go back one entry in the current tab\'s session history, like the browser Back button. Use this for "go back" / "return to the previous page" rather than trying to run history.back() yourself (page scripts are CSP-blocked on many sites). Returns {success, url} on success, or {success:false, error} when there is no earlier entry or the page is internal. Movement is verified from browser history events or a changed URL, including SPA entries whose URL stays identical. Leaving a page with unsaved changes is blocked unless force:true.',
       parameters: {
         type: 'object',
         properties: {
@@ -389,7 +389,7 @@ export const AGENT_TOOLS = [
     type: 'function',
     function: {
       name: 'go_forward',
-      description: 'Go forward one entry in the current tab\'s session history, like the browser Forward button — reverses a previous go_back. Returns {success, url} on success, or {success:false, error} when there is no later entry or the page is internal. Leaving a page with unsaved changes is blocked unless force:true.',
+      description: 'Go forward one entry in the current tab\'s session history, like the browser Forward button — reverses a previous go_back. Returns {success, url} on success, or {success:false, error} when there is no later entry or the page is internal. Movement is verified from browser history events or a changed URL, including SPA entries whose URL stays identical. Leaving a page with unsaved changes is blocked unless force:true.',
       parameters: {
         type: 'object',
         properties: {

--- a/src/firefox/src/agent/agent.js
+++ b/src/firefox/src/agent/agent.js
@@ -16775,49 +16775,146 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
         if (blocked) return blocked;
       }
 
+      // A URL comparison alone cannot prove same-document history movement:
+      // SPAs may push several entries with an identical URL and keep their
+      // route solely in history.state. Listen before dispatch so those entries
+      // can be verified by the browser's navigation events.
+      let navigationTerminalResult = null;
+      let resolveNavigationTerminal;
+      let navigationLoadingObserved = false;
+      let historyDispatchArmed = false;
+      const navigationTerminal = new Promise(resolve => { resolveNavigationTerminal = resolve; });
+      const finishNavigationTerminal = (result) => {
+        if (navigationTerminalResult) return;
+        navigationTerminalResult = result;
+        resolveNavigationTerminal(result);
+      };
+      const waitForNavigationTerminal = (timeoutMs, timeoutType) => {
+        if (navigationTerminalResult) return Promise.resolve(navigationTerminalResult);
+        return new Promise(resolve => {
+          const timer = setTimeout(() => resolve({ type: timeoutType }), timeoutMs);
+          navigationTerminal.then(result => {
+            clearTimeout(timer);
+            resolve(result);
+          });
+        });
+      };
+      const listenerRecords = [];
+      const addNavigationListener = (event, listener) => {
+        if (!event?.addListener || !event?.removeListener) return;
+        try {
+          event.addListener(listener);
+          listenerRecords.push([event, listener]);
+        } catch {}
+      };
+      const isCurrentTopFrameNavigation = (details = {}) => {
+        return historyDispatchArmed && details.tabId === tabId && details.frameId === 0;
+      };
+      const observeNavigation = type => (details = {}) => {
+        if (!isCurrentTopFrameNavigation(details)) return;
+        // pushState/replaceState also emit onHistoryStateUpdated. Only an
+        // actual session-history traversal carries the forward_back qualifier.
+        if (!details.transitionQualifiers?.includes('forward_back')) return;
+        finishNavigationTerminal({ type: 'navigated', navigationType: type, url: details.url || '' });
+      };
+      addNavigationListener(browser.webNavigation?.onHistoryStateUpdated, observeNavigation('history_state'));
+      addNavigationListener(browser.webNavigation?.onCommitted, observeNavigation('committed'));
+      addNavigationListener(browser.tabs?.onUpdated, (updatedTabId, changeInfo = {}) => {
+        if (!historyDispatchArmed || updatedTabId !== tabId) return;
+        if (changeInfo.status === 'loading') navigationLoadingObserved = true;
+      });
+      const removeNavigationListeners = () => {
+        for (const [event, listener] of listenerRecords.splice(0)) {
+          try { event.removeListener(listener); } catch {}
+        }
+      };
+
       // Drive history from the page context (CSP-safe; this is the extension's
       // injected code, not page eval).
       let probe = null;
       let dispatched = false;
       try {
-        const delta = direction === 'back' ? -steps : steps;
-        const code = `
-          (() => {
-            const before = location.href;
-            history.go(${delta});
-            return { before };
-          })()
-        `;
-        dispatched = true;
-        const results = await browser.tabs.executeScript(tabId, { code });
-        probe = (results && results[0]) || null;
-      } catch (e) {
-        return { success: false, dispatched, error: `${name}: cannot navigate history on this page (${e.message}).` };
-      }
-      if (!probe) {
-        return { success: false, dispatched, error: `${name}: history navigation did not run on this page.` };
-      }
+        try {
+          const delta = direction === 'back' ? -steps : steps;
+          const code = `
+            (() => {
+              const before = location.href;
+              history.go(${delta});
+              return { before };
+            })()
+          `;
+          historyDispatchArmed = true;
+          dispatched = true;
+          const results = await browser.tabs.executeScript(tabId, { code });
+          probe = (results && results[0]) || null;
+        } catch (e) {
+          return { success: false, dispatched, error: `${name}: cannot navigate history on this page (${e.message}).` };
+        }
+        if (!probe) {
+          return { success: false, dispatched, error: `${name}: history navigation did not run on this page.` };
+        }
 
-      // history.go() commits asynchronously (including bfcache restores), so
-      // wait briefly, then confirm the URL actually changed. If it didn't,
-      // there was no entry in that direction — report failure rather than a
-      // misleading success the model would build on.
-      await new Promise(r => setTimeout(r, 1500));
-      let afterUrl = probe.before;
-      try {
-        const tab = await browser.tabs.get(tabId);
-        if (tab?.url) afterUrl = tab.url;
-      } catch {}
+        // Preserve the existing 1.5s no-entry decision for idle tabs, while
+        // allowing a real cross-document traversal up to the navigate tool's
+        // 10s deadline when the tab reports that it is still loading.
+        let navigationWaitResult = await waitForNavigationTerminal(1500, 'probe_timeout');
+        if (navigationWaitResult.type === 'probe_timeout') {
+          let interimStatus = '';
+          try { interimStatus = (await browser.tabs.get(tabId))?.status || ''; } catch {}
+          if (interimStatus === 'loading' || (!interimStatus && navigationLoadingObserved)) {
+            navigationWaitResult = await waitForNavigationTerminal(8500, 'deadline');
+          }
+        }
 
-      if (this._normalizeUrl(afterUrl) === this._normalizeUrl(probe.before)) {
+        let afterUrl = navigationWaitResult.url || probe.before;
+        let finalStatus = '';
+        try {
+          const tab = await browser.tabs.get(tabId);
+          if (tab?.url) afterUrl = tab.url;
+          finalStatus = tab?.status || '';
+        } catch {}
+
+        const urlChanged = this._normalizeUrl(afterUrl) !== this._normalizeUrl(probe.before);
+        if (navigationWaitResult.type === 'navigated' || urlChanged) {
+          return {
+            success: true,
+            dispatched: true,
+            verified: true,
+            url: afterUrl,
+            previousUrl: probe.before,
+            direction,
+            steps,
+            ...(navigationWaitResult.navigationType ? { navigationType: navigationWaitResult.navigationType } : {}),
+          };
+        }
+
+        if (
+          navigationWaitResult.type === 'deadline'
+          && (finalStatus === 'loading' || (!finalStatus && navigationLoadingObserved))
+        ) {
+          return {
+            success: false,
+            dispatched: true,
+            navigationPending: true,
+            confirmationPossible: false,
+            recoveryRequired: 'wait_for_stable',
+            url: afterUrl,
+            previousUrl: probe.before,
+            direction,
+            steps,
+            error: `${name}: history navigation was dispatched and the tab is still loading. Call wait_for_stable, then inspect the current page.`,
+          };
+        }
+
         const dirWord = direction === 'back' ? 'earlier' : 'later';
         return {
           success: false,
           dispatched: true,
           error: `${name}: no ${dirWord} entry in this tab's history (the page did not change).`,
         };
+      } finally {
+        removeNavigationListeners();
       }
-      return { success: true, dispatched: true, url: afterUrl, previousUrl: probe.before, direction, steps };
     }
 
     if (name === 'new_tab') {

--- a/src/firefox/src/agent/tools.js
+++ b/src/firefox/src/agent/tools.js
@@ -375,7 +375,7 @@ export const AGENT_TOOLS = [
     type: 'function',
     function: {
       name: 'go_back',
-      description: 'Go back one entry in the current tab\'s session history, like the browser Back button. Use this for "go back" / "return to the previous page" rather than trying to run history.back() yourself (page scripts are CSP-blocked on many sites). Returns {success, url} on success, or {success:false, error} when there is no earlier entry or the page is internal (the URL is verified to actually change). Leaving a page with unsaved changes is blocked unless force:true.',
+      description: 'Go back one entry in the current tab\'s session history, like the browser Back button. Use this for "go back" / "return to the previous page" rather than trying to run history.back() yourself (page scripts are CSP-blocked on many sites). Returns {success, url} on success, or {success:false, error} when there is no earlier entry or the page is internal. Movement is verified from browser history events or a changed URL, including SPA entries whose URL stays identical. Leaving a page with unsaved changes is blocked unless force:true.',
       parameters: {
         type: 'object',
         properties: {
@@ -389,7 +389,7 @@ export const AGENT_TOOLS = [
     type: 'function',
     function: {
       name: 'go_forward',
-      description: 'Go forward one entry in the current tab\'s session history, like the browser Forward button — reverses a previous go_back. Returns {success, url} on success, or {success:false, error} when there is no later entry or the page is internal. Leaving a page with unsaved changes is blocked unless force:true.',
+      description: 'Go forward one entry in the current tab\'s session history, like the browser Forward button — reverses a previous go_back. Returns {success, url} on success, or {success:false, error} when there is no later entry or the page is internal. Movement is verified from browser history events or a changed URL, including SPA entries whose URL stays identical. Leaving a page with unsaved changes is blocked unless force:true.',
       parameters: {
         type: 'object',
         properties: {

--- a/test/run.js
+++ b/test/run.js
@@ -68837,6 +68837,220 @@ test('navigate rejects non-web schemes and contains browser API failures', async
   }
 });
 
+test('history tools verify same-URL SPA traversal from browser navigation events', async () => {
+  const originalChrome = globalThis.chrome;
+  const originalBrowser = globalThis.browser;
+  const originalSetTimeout = globalThis.setTimeout;
+  const tabId = 6410;
+  const sameUrl = 'https://app.example.test/workspace';
+
+  const createEvent = () => {
+    const listeners = new Set();
+    return {
+      addListener(listener) { listeners.add(listener); },
+      removeListener(listener) { listeners.delete(listener); },
+      emit(...args) {
+        for (const listener of [...listeners]) listener(...args);
+      },
+      get listenerCount() { return listeners.size; },
+    };
+  };
+
+  try {
+    // Keep the no-entry and pending branches deterministic without spending
+    // the production 1.5s/10s navigation budgets in the unit suite.
+    globalThis.setTimeout = (fn, delay, ...args) => {
+      return originalSetTimeout(fn, delay >= 8000 ? 20 : 0, ...args);
+    };
+
+    for (const [label, AgentClass] of [
+      ['chrome', AgentCh],
+      ['firefox', AgentFx],
+    ]) {
+      const events = {
+        history: createEvent(),
+        committed: createEvent(),
+        updated: createEvent(),
+      };
+      const allEvents = Object.values(events);
+      let currentUrl = sameUrl;
+      let status = 'complete';
+      let mode = 'same_history';
+      let expectedDelta = -1;
+
+      const runInjectedHistory = async (delta) => {
+        assert.equal(delta, expectedDelta, `${label}: history.go delta mismatch`);
+        const before = currentUrl;
+        if (mode === 'same_history') {
+          const now = Date.now();
+          // Ordinary History API updates lack forward_back and must not be
+          // mistaken for the traversal this tool dispatched. Qualified
+          // events from another tab or a child frame are unrelated too.
+          events.history.emit({ tabId, frameId: 0, url: sameUrl, timeStamp: now, transitionQualifiers: [] });
+          events.committed.emit({ tabId: tabId + 1, frameId: 0, url: sameUrl, timeStamp: now, transitionQualifiers: ['forward_back'] });
+          events.committed.emit({ tabId, frameId: 2, url: sameUrl, timeStamp: now, transitionQualifiers: ['forward_back'] });
+          events.history.emit({
+            tabId,
+            frameId: 0,
+            url: sameUrl,
+            timeStamp: now,
+            transitionQualifiers: ['forward_back'],
+          });
+        } else if (mode === 'unqualified_history') {
+          events.history.emit({
+            tabId,
+            frameId: 0,
+            url: sameUrl,
+            timeStamp: Date.now(),
+            transitionQualifiers: [],
+          });
+        } else if (mode === 'slow_commit') {
+          status = 'loading';
+          events.updated.emit(tabId, { status: 'loading' }, { id: tabId, url: currentUrl, status });
+          originalSetTimeout(() => {
+            status = 'complete';
+            events.committed.emit({
+              tabId,
+              frameId: 0,
+              url: sameUrl,
+              timeStamp: Date.now(),
+              transitionQualifiers: ['forward_back'],
+            });
+          }, 5);
+        } else if (mode === 'url_fallback') {
+          currentUrl = `${sameUrl}?entry=2`;
+        } else if (mode === 'loading') {
+          status = 'loading';
+          events.updated.emit(tabId, { status: 'loading' }, { id: tabId, url: currentUrl, status });
+        } else if (mode === 'throw') {
+          throw new Error(`${label}-injection-failed`);
+        }
+        return before;
+      };
+
+      const tabs = {
+        onUpdated: events.updated,
+        async get() {
+          return { id: tabId, url: currentUrl, status };
+        },
+      };
+      const api = {
+        webNavigation: {
+          onHistoryStateUpdated: events.history,
+          onCommitted: events.committed,
+        },
+        tabs,
+      };
+
+      if (label === 'chrome') {
+        delete globalThis.browser;
+        api.scripting = {
+          async executeScript({ args }) {
+            const before = await runInjectedHistory(args[0]);
+            return [{ result: { before } }];
+          },
+        };
+        globalThis.chrome = api;
+      } else {
+        delete globalThis.chrome;
+        tabs.executeScript = async (_tabId, { code }) => {
+          const match = /history\.go\((-?\d+)\)/.exec(code);
+          assert.ok(match, 'firefox: injected history.go call missing');
+          const before = await runInjectedHistory(Number(match[1]));
+          return [{ before }];
+        };
+        globalThis.browser = api;
+      }
+
+      const agent = new AgentClass({});
+      const assertListenersRemoved = (scenario) => {
+        assert.equal(
+          allEvents.reduce((sum, event) => sum + event.listenerCount, 0),
+          0,
+          `${label}: ${scenario} leaked a navigation listener`,
+        );
+      };
+
+      for (const [toolName, delta] of [['go_back', -2], ['go_forward', 2]]) {
+        currentUrl = sameUrl;
+        status = 'complete';
+        mode = 'same_history';
+        expectedDelta = delta;
+        const result = await agent.executeTool(tabId, toolName, { force: true, steps: 2 });
+        assert.equal(result.success, true, `${label}: ${toolName} rejected a same-URL SPA traversal`);
+        assert.equal(result.verified, true);
+        assert.equal(result.navigationType, 'history_state');
+        assert.equal(result.url, sameUrl);
+        assert.equal(result.previousUrl, sameUrl);
+        assert.equal(result.steps, 2);
+        assertListenersRemoved(`${toolName} same-URL success`);
+      }
+
+      mode = 'slow_commit';
+      expectedDelta = -1;
+      status = 'complete';
+      const slowCommit = await agent.executeTool(tabId, 'go_back', { force: true });
+      assert.equal(slowCommit.success, true, `${label}: a slow history commit should outlive the 1.5s probe`);
+      assert.equal(slowCommit.verified, true);
+      assert.equal(slowCommit.navigationType, 'committed');
+      assertListenersRemoved('slow commit');
+
+      mode = 'none';
+      const noEntry = await agent.executeTool(tabId, 'go_back', { force: true });
+      assert.equal(noEntry.success, false, `${label}: an idle same-URL tab should still report no history entry`);
+      assert.match(noEntry.error, /no earlier entry/);
+      assertListenersRemoved('no-entry failure');
+
+      mode = 'unqualified_history';
+      const unqualifiedHistory = await agent.executeTool(tabId, 'go_back', { force: true });
+      assert.equal(
+        unqualifiedHistory.success,
+        false,
+        `${label}: ordinary pushState/replaceState events must not verify history.go`,
+      );
+      assert.match(unqualifiedHistory.error, /no earlier entry/);
+      assertListenersRemoved('unqualified history event');
+
+      mode = 'url_fallback';
+      currentUrl = sameUrl;
+      const urlFallback = await agent.executeTool(tabId, 'go_back', { force: true });
+      assert.equal(urlFallback.success, true, `${label}: URL readback fallback regressed`);
+      assert.equal(urlFallback.verified, true);
+      assert.equal(urlFallback.url, `${sameUrl}?entry=2`);
+      assert.equal(urlFallback.navigationType, undefined);
+      assertListenersRemoved('URL fallback');
+
+      mode = 'loading';
+      currentUrl = sameUrl;
+      status = 'complete';
+      expectedDelta = 1;
+      const pending = await agent.executeTool(tabId, 'go_forward', { force: true });
+      assert.equal(pending.success, false, `${label}: loading traversal should not be called complete`);
+      assert.equal(pending.navigationPending, true);
+      assert.equal(pending.confirmationPossible, false);
+      assert.equal(pending.recoveryRequired, 'wait_for_stable');
+      assert.match(pending.error, /still loading/);
+      assertListenersRemoved('loading timeout');
+
+      mode = 'throw';
+      currentUrl = sameUrl;
+      status = 'complete';
+      expectedDelta = -1;
+      const injectionFailure = await agent.executeTool(tabId, 'go_back', { force: true });
+      assert.equal(injectionFailure.success, false);
+      assert.equal(injectionFailure.dispatched, true);
+      assert.match(injectionFailure.error, new RegExp(`${label}-injection-failed`));
+      assertListenersRemoved('injection error');
+    }
+  } finally {
+    globalThis.setTimeout = originalSetTimeout;
+    if (originalChrome === undefined) delete globalThis.chrome;
+    else globalThis.chrome = originalChrome;
+    if (originalBrowser === undefined) delete globalThis.browser;
+    else globalThis.browser = originalBrowser;
+  }
+});
+
 test('navigation host resolves relative / protocol-relative against current page', () => {
   const base = 'https://trusted.com/page';
   // protocol-relative → the host the browser will actually load, NOT current


### PR DESCRIPTION
## Summary

- verify `go_back` and `go_forward` with browser navigation events so SPA history entries remain valid when their URLs are identical
- register listeners before dispatch and require the target tab, top frame, and `forward_back` qualifier so ordinary `pushState` or `replaceState` updates cannot produce a false success
- preserve the changed-URL fallback; when a traversal is still loading after the existing 1.5 second probe, wait up to the 10 second navigation budget and return `navigationPending` if it remains unresolved
- mirror the implementation and tool descriptions across Chrome and Firefox

Fixes #2810.

## Browser evidence

Instrumented Chrome 151 behavior before implementing the fix:

- traversing between two entries with the exact same URL emits top-frame `onHistoryStateUpdated` with `transitionQualifiers: ["forward_back"]`
- ordinary `pushState` and `replaceState` updates emit no `forward_back` qualifier
- an out-of-range forward traversal emits no navigation event

Firefox was not installed locally. The Firefox mirror follows the same WebExtensions `forward_back` event contract, which is also covered by Gecko history-traversal source tests.

## Tests

- `node test/run.js`: **1802 passed, 1 failed**; the only failure is the existing release-artifact check because `dist/webbrain-chrome-32.1.0.zip` is absent while the tracked archives are still version 32.0.0
- `npm run test:toolbar-guard`: **33/33 passed**
- `npm run test:security`: **60/60 passed**
- syntax checks for all changed JavaScript files and `git diff --check`: passed

The new regression matrix covers Chrome and Firefox, back and forward traversal, exact same-URL success, qualifier/tab/frame filtering, slow commits, unchanged-URL no-entry behavior, the changed-URL fallback, bounded loading, and listener cleanup.