### PR TITLE
fix(anthropic): preserve thinking content across turns

### DIFF
--- a/src/chrome/src/agent/agent.js
+++ b/src/chrome/src/agent/agent.js
@@ -2109,8 +2109,49 @@ export class Agent extends LoopDetector {
     return result;
   }
 
+  _containsProviderReplayState(responseItems) {
+    return Array.isArray(responseItems)
+      && responseItems.some(item => item?.type === 'webbrain_provider_replay');
+  }
+
   _withResponseItems(message, responseItems, reasoningContent = '', provider = null) {
     if (Array.isArray(responseItems) && responseItems.length) {
+      const taggedItems = responseItems.filter(item => item?.type === 'webbrain_provider_replay');
+      if (taggedItems.length) {
+        const providerState = responseItems.length === 1 ? taggedItems[0] : null;
+        const providerName = String(provider?.name || '').trim().toLowerCase();
+        const model = String(provider?.model || provider?.config?.model || '').trim().toLowerCase();
+        const providerIdentity = provider?._reasoningReplayIdentity?.();
+        const replayToolIds = Array.isArray(providerState?.content)
+          ? providerState.content.filter(block => block?.type === 'tool_use').map(block => block.id)
+          : [];
+        const messageToolIds = Array.isArray(message?.tool_calls)
+          ? message.tool_calls.map(call => call?.id)
+          : [];
+        const toolCallsMatch = replayToolIds.length === messageToolIds.length
+          && replayToolIds.every((id, index) => id && id === messageToolIds[index]);
+        if (
+          !providerState
+          || providerState.version !== 1
+          || !Array.isArray(providerState.content)
+          || String(providerState.provider || '').trim().toLowerCase() !== providerName
+          || String(providerState.model || '').trim().toLowerCase() !== model
+          || providerState.providerIdentity !== providerIdentity
+          || !toolCallsMatch
+        ) {
+          return message;
+        }
+        return {
+          ...message,
+          _reasoning_replay: {
+            provider: providerName,
+            model,
+            providerState,
+            preserveAcrossTurns: true,
+            ...(messageToolIds.length ? { currentToolLoop: true } : {}),
+          },
+        };
+      }
       return { ...message, response_items: responseItems };
     }
     if (typeof reasoningContent !== 'string' || !reasoningContent) return message;
@@ -16265,6 +16306,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
     let totalChars = 0;
     let hasImage = false;
     for (const msg of messages) {
+      const messageStartChars = totalChars;
       if (Array.isArray(msg.content)) {
         for (const block of msg.content) {
           if (block && (block.type === 'image_url' || block.type === 'image')) {
@@ -16288,6 +16330,13 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
       if (msg.tool_calls) totalChars += JSON.stringify(msg.tool_calls).length;
       if (msg.response_items) totalChars += JSON.stringify(msg.response_items).length;
       if (typeof msg.reasoning_content === 'string') totalChars += msg.reasoning_content.length;
+      const replayContent = msg._reasoning_replay?.providerState?.content;
+      if (Array.isArray(replayContent)) {
+        // Anthropic sends the native content blocks instead of normalized
+        // content/tool_calls. Count the larger representation, never both.
+        const normalizedChars = totalChars - messageStartChars;
+        totalChars = messageStartChars + Math.max(normalizedChars, JSON.stringify(replayContent).length);
+      }
     }
     if (hasImage) totalChars += Agent.IMAGE_CHAR_COST;
     return totalChars;
@@ -25659,7 +25708,11 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
 
       // Fallback: if the LLM emitted tool calls as raw text instead of
       // using the structured tool_calls field, try to parse them out.
-      if ((!result.toolCalls || result.toolCalls.length === 0) && result.content) {
+      if (
+        (!result.toolCalls || result.toolCalls.length === 0)
+        && result.content
+        && !this._containsProviderReplayState(result.responseItems)
+      ) {
         const fallback = this._tryParseToolCallsFromText(result.content, allowedToolNames);
         if (fallback.length > 0) {
           this._logDebug({ type: 'llm_text_fallback_parse', step: steps, parsed: fallback.map(tc => tc.function.name) });
@@ -26435,7 +26488,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
         }
 
         // Fallback: parse tool calls from streamed text if structured calls are missing.
-        if (!hasToolCalls && fullText) {
+        if (!hasToolCalls && fullText && !this._containsProviderReplayState(responseItems)) {
           const fallback = this._tryParseToolCallsFromText(fullText, allowedToolNames);
           if (fallback.length > 0) {
             this._logDebug({ type: 'llm_text_fallback_parse', step: steps, parsed: fallback.map(tc => tc.function.name) });

--- a/src/chrome/src/agent/conversation-persistence.js
+++ b/src/chrome/src/agent/conversation-persistence.js
@@ -124,6 +124,32 @@ function reduceToBudget(messages, maxBytes, state) {
     state.compacted = true;
     out[index] = { ...message, content: `${message.content.slice(0, 3_900)}\n[content truncated for session recovery]` };
   }
+  // Signed provider state is opaque. If the snapshot is still oversized,
+  // remove whole replay/tool pairs instead of truncating a signature.
+  let droppedReplay = false;
+  for (let index = 0; index < out.length && byteLength(out) > maxBytes; index++) {
+    const message = out[index];
+    if (!message?._reasoning_replay?.providerState) continue;
+    const rest = { ...message };
+    delete rest._reasoning_replay;
+    delete rest.tool_calls;
+    out[index] = typeof rest.content !== 'string' || !rest.content.trim()
+      ? { ...rest, content: '[Provider reasoning omitted from session recovery.]' }
+      : rest;
+    state.compacted = true;
+    droppedReplay = true;
+  }
+  if (droppedReplay) {
+    const presentCallIds = new Set(out.flatMap(message => (
+      message?.role === 'assistant' && Array.isArray(message.tool_calls)
+        ? message.tool_calls.map(call => call?.id).filter(Boolean)
+        : []
+    )));
+    for (let index = out.length - 1; index >= 0; index--) {
+      const message = out[index];
+      if (message?.role === 'tool' && !presentCallIds.has(message.tool_call_id)) out.splice(index, 1);
+    }
+  }
   return out;
 }
 

--- a/src/chrome/src/providers/anthropic.js
+++ b/src/chrome/src/providers/anthropic.js
@@ -640,9 +640,7 @@ export class AnthropicProvider extends BaseLLMProvider {
           }
           const requiresReplay = sawThinking && sawToolUse;
           if (requiresReplay && !replayState) {
-            throw this._askStreamTerminalError(
-              'Anthropic stream ended with tool use but its signed thinking blocks were incomplete.',
-            );
+            console.warn('[anthropic] thinking+tool_use stream missing replay state; next turn will lose thinking context.');
           }
           yield {
             type: 'done',

--- a/src/chrome/src/providers/anthropic.js
+++ b/src/chrome/src/providers/anthropic.js
@@ -6,6 +6,9 @@ import {
   CLAUDE_CODE_SYSTEM_PREAMBLE,
 } from './oauth-claude.js';
 
+const ANTHROPIC_REPLAY_TYPE = 'webbrain_provider_replay';
+const ANTHROPIC_REPLAY_VERSION = 1;
+
 /**
  * Provider for Anthropic Claude API (native, not OpenAI-compatible).
  */
@@ -40,8 +43,40 @@ export class AnthropicProvider extends BaseLLMProvider {
     return `${String(this.baseUrl).replace(/\/+$/, '')}/v1/messages`;
   }
 
-  _prepareRequestBody(body, _options = {}, _stream = false) {
-    return body;
+  _prepareRequestBody(body, options = {}, _stream = false) {
+    const prepared = this._mergeConfiguredRequestBody(body, options);
+    const thinkingType = prepared.thinking?.type;
+    if (thinkingType === 'disabled') {
+      // A per-call disable must fully replace configured adaptive/manual fields.
+      prepared.thinking = { type: 'disabled' };
+    } else if (thinkingType === 'adaptive') {
+      delete prepared.thinking.budget_tokens;
+    }
+
+    const forcedToolChoice = ['any', 'tool'].includes(prepared.tool_choice?.type);
+    if (thinkingType === 'enabled' && forcedToolChoice) {
+      // Manual extended thinking rejects forced tool choice. Preserve the
+      // agent's explicit tool contract and disable thinking for this call.
+      delete prepared.thinking;
+    }
+
+    if (!this._supportsTemperatureParameter()) {
+      // Current Opus/Sonnet/Fable/Mythos models reject every non-default
+      // sampling override, even when thinking is omitted or disabled.
+      delete prepared.temperature;
+      delete prepared.top_p;
+      delete prepared.top_k;
+    } else if (prepared.thinking && prepared.thinking.type !== 'disabled') {
+      // Older models reject temperature/top_k while thinking is active and
+      // only accept top_p in the documented 0.95..1 range.
+      delete prepared.temperature;
+      delete prepared.top_k;
+      const topP = Number(prepared.top_p);
+      if (prepared.top_p != null && (!Number.isFinite(topP) || topP < 0.95 || topP > 1)) {
+        delete prepared.top_p;
+      }
+    }
+    return prepared;
   }
 
   _headers() {
@@ -77,6 +112,94 @@ export class AnthropicProvider extends BaseLLMProvider {
     return undefined;
   }
 
+  _reasoningReplayIdentity() {
+    const rawBaseUrl = String(this.baseUrl || '').trim().replace(/\/+$/, '');
+    let endpoint = rawBaseUrl;
+    try {
+      const url = new URL(rawBaseUrl);
+      url.username = '';
+      url.password = '';
+      url.search = '';
+      url.hash = '';
+      endpoint = url.toString().replace(/\/+$/, '');
+    } catch {}
+    return [
+      String(this.name || '').trim().toLowerCase(),
+      String(this.config._providerId || '').trim().toLowerCase(),
+      endpoint,
+      String(this.config.project || '').trim().toLowerCase(),
+      String(this.config.location || '').trim().toLowerCase(),
+    ].join('\n');
+  }
+
+  _isValidReplayContent(content) {
+    if (!Array.isArray(content) || content.length === 0) return false;
+    let hasThinking = false;
+    for (const block of content) {
+      if (!block || typeof block !== 'object' || typeof block.type !== 'string' || !block.type) {
+        return false;
+      }
+      if (block.type === 'thinking') {
+        if (typeof block.thinking !== 'string' || typeof block.signature !== 'string' || !block.signature) {
+          return false;
+        }
+        hasThinking = true;
+      } else if (block.type === 'redacted_thinking') {
+        if (typeof block.data !== 'string' || !block.data) return false;
+        hasThinking = true;
+      } else if (block.type === 'text') {
+        if (typeof block.text !== 'string') return false;
+      } else if (block.type === 'tool_use' && (
+        typeof block.id !== 'string'
+        || !block.id.trim()
+        || typeof block.name !== 'string'
+        || !block.name.trim()
+        || !block.input
+        || typeof block.input !== 'object'
+        || Array.isArray(block.input)
+      )) {
+        return false;
+      }
+    }
+    return hasThinking;
+  }
+
+  _replayState(content) {
+    if (!this._isValidReplayContent(content)) return null;
+    return {
+      type: ANTHROPIC_REPLAY_TYPE,
+      version: ANTHROPIC_REPLAY_VERSION,
+      provider: this.name,
+      model: this.model,
+      providerIdentity: this._reasoningReplayIdentity(),
+      content,
+    };
+  }
+
+  _replayContent(message) {
+    const state = message?._reasoning_replay?.providerState;
+    const replayToolIds = Array.isArray(state?.content)
+      ? state.content.filter(block => block?.type === 'tool_use').map(block => block.id)
+      : [];
+    const messageToolIds = Array.isArray(message?.tool_calls)
+      ? message.tool_calls.map(call => call?.id)
+      : [];
+    const toolCallsMatch = replayToolIds.length === messageToolIds.length
+      && replayToolIds.every((id, index) => id && id === messageToolIds[index]);
+    if (
+      state?.type !== ANTHROPIC_REPLAY_TYPE
+      || state.version !== ANTHROPIC_REPLAY_VERSION
+      || String(state.provider || '').trim().toLowerCase() !== String(this.name).trim().toLowerCase()
+      || String(state.model || '').trim().toLowerCase() !== String(this.model).trim().toLowerCase()
+      || state.providerIdentity !== this._reasoningReplayIdentity()
+      || !this._isValidReplayContent(state.content)
+      || !toolCallsMatch
+    ) {
+      return null;
+    }
+    return state.content;
+  }
+
   /**
    * Convert OpenAI-style messages to Anthropic format.
    * Extracts system message, converts tool_calls/tool results.
@@ -88,6 +211,14 @@ export class AnthropicProvider extends BaseLLMProvider {
     for (const msg of messages) {
       if (msg.role === 'system') {
         system += (system ? '\n\n' : '') + msg.content;
+        continue;
+      }
+
+      const replayContent = msg.role === 'assistant' ? this._replayContent(msg) : null;
+      if (replayContent) {
+        // Signatures and redacted blocks are opaque. Anthropic requires the
+        // complete original block sequence on subsequent tool/user turns.
+        converted.push({ role: 'assistant', content: replayContent });
         continue;
       }
 
@@ -237,13 +368,16 @@ export class AnthropicProvider extends BaseLLMProvider {
       throw new Error('Anthropic returned invalid JSON in chat response.');
     }
 
-    // Extract text content and tool use blocks
+    const responseContent = Array.isArray(data.content) ? data.content : [];
     let content = '';
+    let reasoningContent = '';
     let toolCalls = null;
 
-    for (const block of data.content || []) {
+    for (const block of responseContent) {
       if (block.type === 'text') {
         content += block.text || '';
+      } else if (block.type === 'thinking') {
+        reasoningContent += block.thinking || '';
       } else if (block.type === 'tool_use') {
         if (!toolCalls) toolCalls = [];
         toolCalls.push({
@@ -257,10 +391,19 @@ export class AnthropicProvider extends BaseLLMProvider {
       }
     }
 
+    const replayState = this._replayState(responseContent);
+    const requiresReplay = responseContent.some(block => block?.type === 'tool_use')
+      && responseContent.some(block => block?.type === 'thinking' || block?.type === 'redacted_thinking');
+    if (requiresReplay && !replayState) {
+      throw new Error('Anthropic returned tool use with incomplete signed thinking blocks.');
+    }
+
     return {
       content,
+      reasoningContent,
       toolCalls,
       usage: this._normalizeUsage(data.usage),
+      ...(replayState ? { responseItems: [replayState] } : {}),
       raw: data,
     };
   }
@@ -320,6 +463,10 @@ export class AnthropicProvider extends BaseLLMProvider {
     let sawUsage = false;
     let stopReason = '';
     const accumulatedUsage = {};
+    const streamedBlocks = new Map();
+    let replayValid = true;
+    let sawThinking = false;
+    let sawToolUse = false;
     const updateUsage = (usage) => {
       if (!usage || typeof usage !== 'object') return;
       sawUsage = true;
@@ -375,6 +522,7 @@ export class AnthropicProvider extends BaseLLMProvider {
         try {
           event = JSON.parse(payload);
         } catch (error) {
+          replayValid = false;
           if (this._supportsInteractiveAskStreaming()) {
             throw this._askStreamTransportError(
               `Anthropic stream returned malformed JSON (${error?.message || 'parse failed'}).`,
@@ -393,12 +541,68 @@ export class AnthropicProvider extends BaseLLMProvider {
           updateUsage(event.usage);
           if (event.delta?.stop_reason != null) stopReason = String(event.delta.stop_reason);
         } else if (event.type === 'content_block_delta') {
+          const record = streamedBlocks.get(event.index);
+          const deltaType = event.delta?.type;
+          if (!record || record.stopped) {
+            replayValid = false;
+          } else if (deltaType === 'thinking_delta' && record.block.type === 'thinking') {
+            record.block.thinking += String(event.delta.thinking || '');
+          } else if (deltaType === 'signature_delta' && record.block.type === 'thinking') {
+            record.block.signature += String(event.delta.signature || '');
+          } else if (deltaType === 'text_delta' && record.block.type === 'text') {
+            record.block.text += String(event.delta.text || '');
+          } else if (
+            deltaType === 'citations_delta'
+            && record.block.type === 'text'
+            && event.delta.citation
+            && typeof event.delta.citation === 'object'
+          ) {
+            if (!Array.isArray(record.block.citations)) record.block.citations = [];
+            record.block.citations.push(JSON.parse(JSON.stringify(event.delta.citation)));
+          } else if (deltaType === 'input_json_delta' && record.block.type === 'tool_use') {
+            record.inputJson += String(event.delta.partial_json || '');
+          } else {
+            replayValid = false;
+          }
           if (event.delta?.type === 'text_delta') {
             yield { type: 'text', content: event.delta.text };
+          } else if (event.delta?.type === 'thinking_delta') {
+            yield { type: 'reasoning', content: event.delta.thinking };
           } else if (event.delta?.type === 'input_json_delta') {
             yield { type: 'tool_call_delta', content: event.delta.partial_json };
           }
         } else if (event.type === 'content_block_start') {
+          const index = event.index;
+          const source = event.content_block;
+          if (source?.type === 'thinking' || source?.type === 'redacted_thinking') sawThinking = true;
+          if (source?.type === 'tool_use') sawToolUse = true;
+          if (
+            !Number.isInteger(index)
+            || index !== streamedBlocks.size
+            || streamedBlocks.has(index)
+            || !source
+            || typeof source !== 'object'
+            || typeof source.type !== 'string'
+            || !source.type
+          ) {
+            replayValid = false;
+          } else {
+            let block;
+            try {
+              block = JSON.parse(JSON.stringify(source));
+            } catch {
+              replayValid = false;
+            }
+            if (block) {
+              if (block.type === 'thinking') {
+                block.thinking = typeof block.thinking === 'string' ? block.thinking : '';
+                block.signature = typeof block.signature === 'string' ? block.signature : '';
+              } else if (block.type === 'text') {
+                block.text = typeof block.text === 'string' ? block.text : '';
+              }
+              streamedBlocks.set(index, { block, inputJson: '', stopped: false });
+            }
+          }
           if (event.content_block?.type === 'tool_use') {
             yield {
               type: 'tool_call_start',
@@ -408,13 +612,43 @@ export class AnthropicProvider extends BaseLLMProvider {
               },
             };
           }
+        } else if (event.type === 'content_block_stop') {
+          const record = streamedBlocks.get(event.index);
+          if (!record || record.stopped) {
+            replayValid = false;
+          } else {
+            record.stopped = true;
+            if (record.block.type === 'tool_use' && record.inputJson) {
+              try {
+                const input = JSON.parse(record.inputJson);
+                if (!input || typeof input !== 'object' || Array.isArray(input)) throw new Error('invalid tool input');
+                record.block.input = input;
+              } catch {
+                replayValid = false;
+              }
+            }
+          }
         } else if (event.type === 'message_stop') {
           const usage = usageChunk();
           if (usage) yield { type: 'usage', usage };
+          let replayState = null;
+          if (replayValid && [...streamedBlocks.values()].every(record => record.stopped)) {
+            const content = [...streamedBlocks.entries()]
+              .sort(([left], [right]) => left - right)
+              .map(([, record]) => record.block);
+            replayState = this._replayState(content);
+          }
+          const requiresReplay = sawThinking && sawToolUse;
+          if (requiresReplay && !replayState) {
+            throw this._askStreamTerminalError(
+              'Anthropic stream ended with tool use but its signed thinking blocks were incomplete.',
+            );
+          }
           yield {
             type: 'done',
             content: '',
             ...(stopReason ? { finishReason: stopReason } : {}),
+            ...(replayState ? { responseItems: [replayState] } : {}),
           };
           return;
         }
@@ -427,8 +661,9 @@ export class AnthropicProvider extends BaseLLMProvider {
 
   _supportsTemperatureParameter() {
     const model = String(this.model || '').toLowerCase();
-    if (/^claude-opus-4-(?:[7-9]|[1-9]\d)(?:$|[-_.])/.test(model)) return false;
-    if (/^claude-(?:sonnet|fable|mythos)-5(?:$|[-_.])/.test(model)) return false;
+    if (/^claude-opus-4-(?:[7-9]|[1-9]\d)(?:$|[-_.@])/.test(model)) return false;
+    if (/^claude-(?:opus|sonnet|fable|mythos)-5(?:$|[-_.@])/.test(model)) return false;
+    if (/^claude-mythos-preview(?:$|[-_.@])/.test(model)) return false;
     return true;
   }
 

--- a/src/chrome/src/providers/manager.js
+++ b/src/chrome/src/providers/manager.js
@@ -849,6 +849,9 @@ export class ProviderManager {
         'vertex_anthropic',
       ].includes(config.type),
     };
+    // Runtime-only identity for provider-specific conversation state. Keep it
+    // non-enumerable so it never leaks into storage, exports, or the settings UI.
+    Object.defineProperty(normalizedConfig, '_providerId', { value: String(id || '') });
     if (definitionId === 'ollama') {
       normalizedConfig.visionMode = OLLAMA_VISION_MODES.has(normalizedConfig.visionMode)
         ? normalizedConfig.visionMode

--- a/src/chrome/src/providers/vertex-anthropic.js
+++ b/src/chrome/src/providers/vertex-anthropic.js
@@ -52,8 +52,9 @@ export class VertexAnthropicProvider extends AnthropicProvider {
     return `https://${endpointHost}/v1/projects/${encodeURIComponent(project)}/locations/${encodeURIComponent(location)}/publishers/anthropic/models/${encodeURIComponent(this.model)}:${action}`;
   }
 
-  _prepareRequestBody(body, _options = {}, stream = false) {
-    const { model: _model, stream: _stream, ...payload } = body;
+  _prepareRequestBody(body, options = {}, stream = false) {
+    const prepared = super._prepareRequestBody(body, options, stream);
+    const { model: _model, stream: _stream, ...payload } = prepared;
     return {
       ...payload,
       anthropic_version: 'vertex-2023-10-16',

--- a/src/chrome/src/ui/settings.js
+++ b/src/chrome/src/ui/settings.js
@@ -2290,8 +2290,13 @@ function restoreProviderApiKeyWarnings() {
   }
 }
 
-function supportsProviderCompatibilitySettings(id, config = {}) {
+function supportsProviderCompatibilityControls(id, config = {}) {
   return id !== 'webbrain_cloud' && ['openai', 'llamacpp', 'azure_openai'].includes(config.type);
+}
+
+function supportsProviderCompatibilitySettings(id, config = {}) {
+  return supportsProviderCompatibilityControls(id, config)
+    || ['anthropic', 'anthropic_oauth', 'vertex_anthropic'].includes(config.type);
 }
 
 function providerExtraBodyText(value) {
@@ -2317,6 +2322,14 @@ function automaticTokenField(config) {
 }
 
 function compatibilitySummary(config) {
+  const extraCount = config.extraBody && typeof config.extraBody === 'object' && !Array.isArray(config.extraBody)
+    ? Object.keys(config.extraBody).length
+    : 0;
+  if (['anthropic', 'anthropic_oauth', 'vertex_anthropic'].includes(config.type)) {
+    return extraCount
+      ? t(extraCount === 1 ? 'st.providers.compat.summary_extra' : 'st.providers.compat.summary_extra_plural', { count: extraCount })
+      : t('st.providers.compat.provider_default');
+  }
   const compat = normalizeProviderCompatibility(config);
   const detected = detectedCompatibilityPreset(config);
   const preset = compat.preset === 'auto'
@@ -2329,9 +2342,6 @@ function compatibilitySummary(config) {
     ? prettyCompatibilityValue('system')
     : prettyCompatibilityValue(compat.systemPromptRole);
   const tokens = compat.maxTokensField === 'auto' ? automaticTokenField(config) : compat.maxTokensField;
-  const extraCount = config.extraBody && typeof config.extraBody === 'object' && !Array.isArray(config.extraBody)
-    ? Object.keys(config.extraBody).length
-    : 0;
   const extra = extraCount
     ? t(extraCount === 1 ? 'st.providers.compat.summary_extra' : 'st.providers.compat.summary_extra_plural', { count: extraCount })
     : '';
@@ -2372,6 +2382,7 @@ function refreshProviderCompatibilitySummary(id) {
 
 function renderProviderCompatibilitySettings(id, config) {
   if (!supportsProviderCompatibilitySettings(id, config)) return '';
+  const showCompatibilityControls = supportsProviderCompatibilityControls(id, config);
   const compat = normalizeProviderCompatibility(config);
   const extraBody = providerCompatibilityJsonDrafts.has(id)
     ? providerCompatibilityJsonDrafts.get(id)
@@ -2387,8 +2398,9 @@ function renderProviderCompatibilitySettings(id, config) {
         <span class="provider-compatibility-summary">${escapeHtml(compatibilitySummary(config))}</span>
       </summary>
       <div class="provider-compatibility-body">
-        <p>${escapeHtml(t('st.providers.compat.blurb'))}</p>
-        <div class="provider-compatibility-grid">
+        ${showCompatibilityControls ? `
+          <p>${escapeHtml(t('st.providers.compat.blurb'))}</p>
+          <div class="provider-compatibility-grid">
           <div class="field">
             <label>${escapeHtml(t('st.providers.compat.preset'))}</label>
             <select data-provider="${id}" data-key="compat.preset" data-type="select">
@@ -2413,7 +2425,8 @@ function renderProviderCompatibilitySettings(id, config) {
               ${options([['auto', valueLabel('auto')], ['max_tokens', 'max_tokens'], ['max_completion_tokens', 'max_completion_tokens']], compat.maxTokensField)}
             </select>
           </div>
-        </div>
+          </div>
+        ` : ''}
         <div class="field provider-compatibility-json">
           <label>${escapeHtml(t('st.providers.compat.extra_body'))}</label>
           <textarea data-provider="${id}" data-key="extraBody" data-type="json" spellcheck="false"

--- a/src/firefox/src/agent/agent.js
+++ b/src/firefox/src/agent/agent.js
@@ -2032,8 +2032,49 @@ export class Agent extends LoopDetector {
     return result;
   }
 
+  _containsProviderReplayState(responseItems) {
+    return Array.isArray(responseItems)
+      && responseItems.some(item => item?.type === 'webbrain_provider_replay');
+  }
+
   _withResponseItems(message, responseItems, reasoningContent = '', provider = null) {
     if (Array.isArray(responseItems) && responseItems.length) {
+      const taggedItems = responseItems.filter(item => item?.type === 'webbrain_provider_replay');
+      if (taggedItems.length) {
+        const providerState = responseItems.length === 1 ? taggedItems[0] : null;
+        const providerName = String(provider?.name || '').trim().toLowerCase();
+        const model = String(provider?.model || provider?.config?.model || '').trim().toLowerCase();
+        const providerIdentity = provider?._reasoningReplayIdentity?.();
+        const replayToolIds = Array.isArray(providerState?.content)
+          ? providerState.content.filter(block => block?.type === 'tool_use').map(block => block.id)
+          : [];
+        const messageToolIds = Array.isArray(message?.tool_calls)
+          ? message.tool_calls.map(call => call?.id)
+          : [];
+        const toolCallsMatch = replayToolIds.length === messageToolIds.length
+          && replayToolIds.every((id, index) => id && id === messageToolIds[index]);
+        if (
+          !providerState
+          || providerState.version !== 1
+          || !Array.isArray(providerState.content)
+          || String(providerState.provider || '').trim().toLowerCase() !== providerName
+          || String(providerState.model || '').trim().toLowerCase() !== model
+          || providerState.providerIdentity !== providerIdentity
+          || !toolCallsMatch
+        ) {
+          return message;
+        }
+        return {
+          ...message,
+          _reasoning_replay: {
+            provider: providerName,
+            model,
+            providerState,
+            preserveAcrossTurns: true,
+            ...(messageToolIds.length ? { currentToolLoop: true } : {}),
+          },
+        };
+      }
       return { ...message, response_items: responseItems };
     }
     if (typeof reasoningContent !== 'string' || !reasoningContent) return message;
@@ -14351,6 +14392,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
     let totalChars = 0;
     let hasImage = false;
     for (const msg of messages) {
+      const messageStartChars = totalChars;
       if (Array.isArray(msg.content)) {
         for (const block of msg.content) {
           if (block && (block.type === 'image_url' || block.type === 'image')) {
@@ -14374,6 +14416,13 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
       if (msg.tool_calls) totalChars += JSON.stringify(msg.tool_calls).length;
       if (msg.response_items) totalChars += JSON.stringify(msg.response_items).length;
       if (typeof msg.reasoning_content === 'string') totalChars += msg.reasoning_content.length;
+      const replayContent = msg._reasoning_replay?.providerState?.content;
+      if (Array.isArray(replayContent)) {
+        // Anthropic sends the native content blocks instead of normalized
+        // content/tool_calls. Count the larger representation, never both.
+        const normalizedChars = totalChars - messageStartChars;
+        totalChars = messageStartChars + Math.max(normalizedChars, JSON.stringify(replayContent).length);
+      }
     }
     if (hasImage) totalChars += Agent.IMAGE_CHAR_COST;
     return totalChars;
@@ -19816,7 +19865,11 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
 
       // Fallback: if the LLM emitted tool calls as raw text instead of
       // using the structured tool_calls field, try to parse them out.
-      if ((!result.toolCalls || result.toolCalls.length === 0) && result.content) {
+      if (
+        (!result.toolCalls || result.toolCalls.length === 0)
+        && result.content
+        && !this._containsProviderReplayState(result.responseItems)
+      ) {
         const fallback = this._tryParseToolCallsFromText(result.content, allowedToolNames);
         if (fallback.length > 0) {
           this._logDebug({ type: 'llm_text_fallback_parse', step: steps, parsed: fallback.map(tc => tc.function.name) });
@@ -20464,7 +20517,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
         fullText = Agent._stripReasoningTags(fullText);
 
         // Fallback: parse tool calls from streamed text if structured calls are missing.
-        if (!hasToolCalls && fullText) {
+        if (!hasToolCalls && fullText && !this._containsProviderReplayState(responseItems)) {
           const fallback = this._tryParseToolCallsFromText(fullText, allowedToolNames);
           if (fallback.length > 0) {
             this._logDebug({ type: 'llm_text_fallback_parse', step: steps, parsed: fallback.map(tc => tc.function.name) });

--- a/src/firefox/src/agent/conversation-persistence.js
+++ b/src/firefox/src/agent/conversation-persistence.js
@@ -124,6 +124,32 @@ function reduceToBudget(messages, maxBytes, state) {
     state.compacted = true;
     out[index] = { ...message, content: `${message.content.slice(0, 3_900)}\n[content truncated for session recovery]` };
   }
+  // Signed provider state is opaque. If the snapshot is still oversized,
+  // remove whole replay/tool pairs instead of truncating a signature.
+  let droppedReplay = false;
+  for (let index = 0; index < out.length && byteLength(out) > maxBytes; index++) {
+    const message = out[index];
+    if (!message?._reasoning_replay?.providerState) continue;
+    const rest = { ...message };
+    delete rest._reasoning_replay;
+    delete rest.tool_calls;
+    out[index] = typeof rest.content !== 'string' || !rest.content.trim()
+      ? { ...rest, content: '[Provider reasoning omitted from session recovery.]' }
+      : rest;
+    state.compacted = true;
+    droppedReplay = true;
+  }
+  if (droppedReplay) {
+    const presentCallIds = new Set(out.flatMap(message => (
+      message?.role === 'assistant' && Array.isArray(message.tool_calls)
+        ? message.tool_calls.map(call => call?.id).filter(Boolean)
+        : []
+    )));
+    for (let index = out.length - 1; index >= 0; index--) {
+      const message = out[index];
+      if (message?.role === 'tool' && !presentCallIds.has(message.tool_call_id)) out.splice(index, 1);
+    }
+  }
   return out;
 }
 

--- a/src/firefox/src/providers/anthropic.js
+++ b/src/firefox/src/providers/anthropic.js
@@ -638,9 +638,7 @@ export class AnthropicProvider extends BaseLLMProvider {
           }
           const requiresReplay = sawThinking && sawToolUse;
           if (requiresReplay && !replayState) {
-            throw this._askStreamTerminalError(
-              'Anthropic stream ended with tool use but its signed thinking blocks were incomplete.',
-            );
+            console.warn('[anthropic] thinking+tool_use stream missing replay state; next turn will lose thinking context.');
           }
           yield {
             type: 'done',

--- a/src/firefox/src/providers/anthropic.js
+++ b/src/firefox/src/providers/anthropic.js
@@ -6,6 +6,9 @@ import {
   CLAUDE_CODE_SYSTEM_PREAMBLE,
 } from './oauth-claude.js';
 
+const ANTHROPIC_REPLAY_TYPE = 'webbrain_provider_replay';
+const ANTHROPIC_REPLAY_VERSION = 1;
+
 /**
  * Provider for Anthropic Claude API (native, not OpenAI-compatible).
  */
@@ -39,8 +42,40 @@ export class AnthropicProvider extends BaseLLMProvider {
     return `${String(this.baseUrl).replace(/\/+$/, '')}/v1/messages`;
   }
 
-  _prepareRequestBody(body, _options = {}, _stream = false) {
-    return body;
+  _prepareRequestBody(body, options = {}, _stream = false) {
+    const prepared = this._mergeConfiguredRequestBody(body, options);
+    const thinkingType = prepared.thinking?.type;
+    if (thinkingType === 'disabled') {
+      // A per-call disable must fully replace configured adaptive/manual fields.
+      prepared.thinking = { type: 'disabled' };
+    } else if (thinkingType === 'adaptive') {
+      delete prepared.thinking.budget_tokens;
+    }
+
+    const forcedToolChoice = ['any', 'tool'].includes(prepared.tool_choice?.type);
+    if (thinkingType === 'enabled' && forcedToolChoice) {
+      // Manual extended thinking rejects forced tool choice. Preserve the
+      // agent's explicit tool contract and disable thinking for this call.
+      delete prepared.thinking;
+    }
+
+    if (!this._supportsTemperatureParameter()) {
+      // Current Opus/Sonnet/Fable/Mythos models reject every non-default
+      // sampling override, even when thinking is omitted or disabled.
+      delete prepared.temperature;
+      delete prepared.top_p;
+      delete prepared.top_k;
+    } else if (prepared.thinking && prepared.thinking.type !== 'disabled') {
+      // Older models reject temperature/top_k while thinking is active and
+      // only accept top_p in the documented 0.95..1 range.
+      delete prepared.temperature;
+      delete prepared.top_k;
+      const topP = Number(prepared.top_p);
+      if (prepared.top_p != null && (!Number.isFinite(topP) || topP < 0.95 || topP > 1)) {
+        delete prepared.top_p;
+      }
+    }
+    return prepared;
   }
 
   _headers() {
@@ -76,6 +111,94 @@ export class AnthropicProvider extends BaseLLMProvider {
     return undefined;
   }
 
+  _reasoningReplayIdentity() {
+    const rawBaseUrl = String(this.baseUrl || '').trim().replace(/\/+$/, '');
+    let endpoint = rawBaseUrl;
+    try {
+      const url = new URL(rawBaseUrl);
+      url.username = '';
+      url.password = '';
+      url.search = '';
+      url.hash = '';
+      endpoint = url.toString().replace(/\/+$/, '');
+    } catch {}
+    return [
+      String(this.name || '').trim().toLowerCase(),
+      String(this.config._providerId || '').trim().toLowerCase(),
+      endpoint,
+      String(this.config.project || '').trim().toLowerCase(),
+      String(this.config.location || '').trim().toLowerCase(),
+    ].join('\n');
+  }
+
+  _isValidReplayContent(content) {
+    if (!Array.isArray(content) || content.length === 0) return false;
+    let hasThinking = false;
+    for (const block of content) {
+      if (!block || typeof block !== 'object' || typeof block.type !== 'string' || !block.type) {
+        return false;
+      }
+      if (block.type === 'thinking') {
+        if (typeof block.thinking !== 'string' || typeof block.signature !== 'string' || !block.signature) {
+          return false;
+        }
+        hasThinking = true;
+      } else if (block.type === 'redacted_thinking') {
+        if (typeof block.data !== 'string' || !block.data) return false;
+        hasThinking = true;
+      } else if (block.type === 'text') {
+        if (typeof block.text !== 'string') return false;
+      } else if (block.type === 'tool_use' && (
+        typeof block.id !== 'string'
+        || !block.id.trim()
+        || typeof block.name !== 'string'
+        || !block.name.trim()
+        || !block.input
+        || typeof block.input !== 'object'
+        || Array.isArray(block.input)
+      )) {
+        return false;
+      }
+    }
+    return hasThinking;
+  }
+
+  _replayState(content) {
+    if (!this._isValidReplayContent(content)) return null;
+    return {
+      type: ANTHROPIC_REPLAY_TYPE,
+      version: ANTHROPIC_REPLAY_VERSION,
+      provider: this.name,
+      model: this.model,
+      providerIdentity: this._reasoningReplayIdentity(),
+      content,
+    };
+  }
+
+  _replayContent(message) {
+    const state = message?._reasoning_replay?.providerState;
+    const replayToolIds = Array.isArray(state?.content)
+      ? state.content.filter(block => block?.type === 'tool_use').map(block => block.id)
+      : [];
+    const messageToolIds = Array.isArray(message?.tool_calls)
+      ? message.tool_calls.map(call => call?.id)
+      : [];
+    const toolCallsMatch = replayToolIds.length === messageToolIds.length
+      && replayToolIds.every((id, index) => id && id === messageToolIds[index]);
+    if (
+      state?.type !== ANTHROPIC_REPLAY_TYPE
+      || state.version !== ANTHROPIC_REPLAY_VERSION
+      || String(state.provider || '').trim().toLowerCase() !== String(this.name).trim().toLowerCase()
+      || String(state.model || '').trim().toLowerCase() !== String(this.model).trim().toLowerCase()
+      || state.providerIdentity !== this._reasoningReplayIdentity()
+      || !this._isValidReplayContent(state.content)
+      || !toolCallsMatch
+    ) {
+      return null;
+    }
+    return state.content;
+  }
+
   /**
    * Convert OpenAI-style messages to Anthropic format.
    * Extracts system message, converts tool_calls/tool results.
@@ -87,6 +210,14 @@ export class AnthropicProvider extends BaseLLMProvider {
     for (const msg of messages) {
       if (msg.role === 'system') {
         system += (system ? '\n\n' : '') + msg.content;
+        continue;
+      }
+
+      const replayContent = msg.role === 'assistant' ? this._replayContent(msg) : null;
+      if (replayContent) {
+        // Signatures and redacted blocks are opaque. Anthropic requires the
+        // complete original block sequence on subsequent tool/user turns.
+        converted.push({ role: 'assistant', content: replayContent });
         continue;
       }
 
@@ -235,13 +366,16 @@ export class AnthropicProvider extends BaseLLMProvider {
       throw new Error('Anthropic returned invalid JSON in chat response.');
     }
 
-    // Extract text content and tool use blocks
+    const responseContent = Array.isArray(data.content) ? data.content : [];
     let content = '';
+    let reasoningContent = '';
     let toolCalls = null;
 
-    for (const block of data.content || []) {
+    for (const block of responseContent) {
       if (block.type === 'text') {
         content += block.text || '';
+      } else if (block.type === 'thinking') {
+        reasoningContent += block.thinking || '';
       } else if (block.type === 'tool_use') {
         if (!toolCalls) toolCalls = [];
         toolCalls.push({
@@ -255,10 +389,19 @@ export class AnthropicProvider extends BaseLLMProvider {
       }
     }
 
+    const replayState = this._replayState(responseContent);
+    const requiresReplay = responseContent.some(block => block?.type === 'tool_use')
+      && responseContent.some(block => block?.type === 'thinking' || block?.type === 'redacted_thinking');
+    if (requiresReplay && !replayState) {
+      throw new Error('Anthropic returned tool use with incomplete signed thinking blocks.');
+    }
+
     return {
       content,
+      reasoningContent,
       toolCalls,
       usage: this._normalizeUsage(data.usage),
+      ...(replayState ? { responseItems: [replayState] } : {}),
       raw: data,
     };
   }
@@ -318,6 +461,10 @@ export class AnthropicProvider extends BaseLLMProvider {
     let sawUsage = false;
     let stopReason = '';
     const accumulatedUsage = {};
+    const streamedBlocks = new Map();
+    let replayValid = true;
+    let sawThinking = false;
+    let sawToolUse = false;
     const updateUsage = (usage) => {
       if (!usage || typeof usage !== 'object') return;
       sawUsage = true;
@@ -373,6 +520,7 @@ export class AnthropicProvider extends BaseLLMProvider {
         try {
           event = JSON.parse(payload);
         } catch (error) {
+          replayValid = false;
           if (this._supportsInteractiveAskStreaming()) {
             throw this._askStreamTransportError(
               `Anthropic stream returned malformed JSON (${error?.message || 'parse failed'}).`,
@@ -391,12 +539,68 @@ export class AnthropicProvider extends BaseLLMProvider {
           updateUsage(event.usage);
           if (event.delta?.stop_reason != null) stopReason = String(event.delta.stop_reason);
         } else if (event.type === 'content_block_delta') {
+          const record = streamedBlocks.get(event.index);
+          const deltaType = event.delta?.type;
+          if (!record || record.stopped) {
+            replayValid = false;
+          } else if (deltaType === 'thinking_delta' && record.block.type === 'thinking') {
+            record.block.thinking += String(event.delta.thinking || '');
+          } else if (deltaType === 'signature_delta' && record.block.type === 'thinking') {
+            record.block.signature += String(event.delta.signature || '');
+          } else if (deltaType === 'text_delta' && record.block.type === 'text') {
+            record.block.text += String(event.delta.text || '');
+          } else if (
+            deltaType === 'citations_delta'
+            && record.block.type === 'text'
+            && event.delta.citation
+            && typeof event.delta.citation === 'object'
+          ) {
+            if (!Array.isArray(record.block.citations)) record.block.citations = [];
+            record.block.citations.push(JSON.parse(JSON.stringify(event.delta.citation)));
+          } else if (deltaType === 'input_json_delta' && record.block.type === 'tool_use') {
+            record.inputJson += String(event.delta.partial_json || '');
+          } else {
+            replayValid = false;
+          }
           if (event.delta?.type === 'text_delta') {
             yield { type: 'text', content: event.delta.text };
+          } else if (event.delta?.type === 'thinking_delta') {
+            yield { type: 'reasoning', content: event.delta.thinking };
           } else if (event.delta?.type === 'input_json_delta') {
             yield { type: 'tool_call_delta', content: event.delta.partial_json };
           }
         } else if (event.type === 'content_block_start') {
+          const index = event.index;
+          const source = event.content_block;
+          if (source?.type === 'thinking' || source?.type === 'redacted_thinking') sawThinking = true;
+          if (source?.type === 'tool_use') sawToolUse = true;
+          if (
+            !Number.isInteger(index)
+            || index !== streamedBlocks.size
+            || streamedBlocks.has(index)
+            || !source
+            || typeof source !== 'object'
+            || typeof source.type !== 'string'
+            || !source.type
+          ) {
+            replayValid = false;
+          } else {
+            let block;
+            try {
+              block = JSON.parse(JSON.stringify(source));
+            } catch {
+              replayValid = false;
+            }
+            if (block) {
+              if (block.type === 'thinking') {
+                block.thinking = typeof block.thinking === 'string' ? block.thinking : '';
+                block.signature = typeof block.signature === 'string' ? block.signature : '';
+              } else if (block.type === 'text') {
+                block.text = typeof block.text === 'string' ? block.text : '';
+              }
+              streamedBlocks.set(index, { block, inputJson: '', stopped: false });
+            }
+          }
           if (event.content_block?.type === 'tool_use') {
             yield {
               type: 'tool_call_start',
@@ -406,13 +610,43 @@ export class AnthropicProvider extends BaseLLMProvider {
               },
             };
           }
+        } else if (event.type === 'content_block_stop') {
+          const record = streamedBlocks.get(event.index);
+          if (!record || record.stopped) {
+            replayValid = false;
+          } else {
+            record.stopped = true;
+            if (record.block.type === 'tool_use' && record.inputJson) {
+              try {
+                const input = JSON.parse(record.inputJson);
+                if (!input || typeof input !== 'object' || Array.isArray(input)) throw new Error('invalid tool input');
+                record.block.input = input;
+              } catch {
+                replayValid = false;
+              }
+            }
+          }
         } else if (event.type === 'message_stop') {
           const usage = usageChunk();
           if (usage) yield { type: 'usage', usage };
+          let replayState = null;
+          if (replayValid && [...streamedBlocks.values()].every(record => record.stopped)) {
+            const content = [...streamedBlocks.entries()]
+              .sort(([left], [right]) => left - right)
+              .map(([, record]) => record.block);
+            replayState = this._replayState(content);
+          }
+          const requiresReplay = sawThinking && sawToolUse;
+          if (requiresReplay && !replayState) {
+            throw this._askStreamTerminalError(
+              'Anthropic stream ended with tool use but its signed thinking blocks were incomplete.',
+            );
+          }
           yield {
             type: 'done',
             content: '',
             ...(stopReason ? { finishReason: stopReason } : {}),
+            ...(replayState ? { responseItems: [replayState] } : {}),
           };
           return;
         }
@@ -425,8 +659,9 @@ export class AnthropicProvider extends BaseLLMProvider {
 
   _supportsTemperatureParameter() {
     const model = String(this.model || '').toLowerCase();
-    if (/^claude-opus-4-(?:[7-9]|[1-9]\d)(?:$|[-_.])/.test(model)) return false;
-    if (/^claude-(?:sonnet|fable|mythos)-5(?:$|[-_.])/.test(model)) return false;
+    if (/^claude-opus-4-(?:[7-9]|[1-9]\d)(?:$|[-_.@])/.test(model)) return false;
+    if (/^claude-(?:opus|sonnet|fable|mythos)-5(?:$|[-_.@])/.test(model)) return false;
+    if (/^claude-mythos-preview(?:$|[-_.@])/.test(model)) return false;
     return true;
   }
 

--- a/src/firefox/src/providers/manager.js
+++ b/src/firefox/src/providers/manager.js
@@ -794,6 +794,9 @@ export class ProviderManager {
         'vertex_anthropic',
       ].includes(config.type),
     };
+    // Runtime-only identity for provider-specific conversation state. Keep it
+    // non-enumerable so it never leaks into storage, exports, or the settings UI.
+    Object.defineProperty(normalizedConfig, '_providerId', { value: String(id || '') });
     if (definitionId === 'ollama') {
       normalizedConfig.visionMode = OLLAMA_VISION_MODES.has(normalizedConfig.visionMode)
         ? normalizedConfig.visionMode

--- a/src/firefox/src/providers/vertex-anthropic.js
+++ b/src/firefox/src/providers/vertex-anthropic.js
@@ -52,8 +52,9 @@ export class VertexAnthropicProvider extends AnthropicProvider {
     return `https://${endpointHost}/v1/projects/${encodeURIComponent(project)}/locations/${encodeURIComponent(location)}/publishers/anthropic/models/${encodeURIComponent(this.model)}:${action}`;
   }
 
-  _prepareRequestBody(body, _options = {}, stream = false) {
-    const { model: _model, stream: _stream, ...payload } = body;
+  _prepareRequestBody(body, options = {}, stream = false) {
+    const prepared = super._prepareRequestBody(body, options, stream);
+    const { model: _model, stream: _stream, ...payload } = prepared;
     return {
       ...payload,
       anthropic_version: 'vertex-2023-10-16',

--- a/src/firefox/src/ui/settings.js
+++ b/src/firefox/src/ui/settings.js
@@ -1917,8 +1917,13 @@ function restoreProviderApiKeyWarnings() {
   }
 }
 
-function supportsProviderCompatibilitySettings(id, config = {}) {
+function supportsProviderCompatibilityControls(id, config = {}) {
   return id !== 'webbrain_cloud' && ['openai', 'llamacpp', 'azure_openai'].includes(config.type);
+}
+
+function supportsProviderCompatibilitySettings(id, config = {}) {
+  return supportsProviderCompatibilityControls(id, config)
+    || ['anthropic', 'anthropic_oauth', 'vertex_anthropic'].includes(config.type);
 }
 
 function providerExtraBodyText(value) {
@@ -1944,6 +1949,14 @@ function automaticTokenField(config) {
 }
 
 function compatibilitySummary(config) {
+  const extraCount = config.extraBody && typeof config.extraBody === 'object' && !Array.isArray(config.extraBody)
+    ? Object.keys(config.extraBody).length
+    : 0;
+  if (['anthropic', 'anthropic_oauth', 'vertex_anthropic'].includes(config.type)) {
+    return extraCount
+      ? t(extraCount === 1 ? 'st.providers.compat.summary_extra' : 'st.providers.compat.summary_extra_plural', { count: extraCount })
+      : t('st.providers.compat.provider_default');
+  }
   const compat = normalizeProviderCompatibility(config);
   const detected = detectedCompatibilityPreset(config);
   const preset = compat.preset === 'auto'
@@ -1956,9 +1969,6 @@ function compatibilitySummary(config) {
     ? prettyCompatibilityValue('system')
     : prettyCompatibilityValue(compat.systemPromptRole);
   const tokens = compat.maxTokensField === 'auto' ? automaticTokenField(config) : compat.maxTokensField;
-  const extraCount = config.extraBody && typeof config.extraBody === 'object' && !Array.isArray(config.extraBody)
-    ? Object.keys(config.extraBody).length
-    : 0;
   const extra = extraCount
     ? t(extraCount === 1 ? 'st.providers.compat.summary_extra' : 'st.providers.compat.summary_extra_plural', { count: extraCount })
     : '';
@@ -1999,6 +2009,7 @@ function refreshProviderCompatibilitySummary(id) {
 
 function renderProviderCompatibilitySettings(id, config) {
   if (!supportsProviderCompatibilitySettings(id, config)) return '';
+  const showCompatibilityControls = supportsProviderCompatibilityControls(id, config);
   const compat = normalizeProviderCompatibility(config);
   const extraBody = providerCompatibilityJsonDrafts.has(id)
     ? providerCompatibilityJsonDrafts.get(id)
@@ -2014,8 +2025,9 @@ function renderProviderCompatibilitySettings(id, config) {
         <span class="provider-compatibility-summary">${escapeHtml(compatibilitySummary(config))}</span>
       </summary>
       <div class="provider-compatibility-body">
-        <p>${escapeHtml(t('st.providers.compat.blurb'))}</p>
-        <div class="provider-compatibility-grid">
+        ${showCompatibilityControls ? `
+          <p>${escapeHtml(t('st.providers.compat.blurb'))}</p>
+          <div class="provider-compatibility-grid">
           <div class="field">
             <label>${escapeHtml(t('st.providers.compat.preset'))}</label>
             <select data-provider="${id}" data-key="compat.preset" data-type="select">
@@ -2040,7 +2052,8 @@ function renderProviderCompatibilitySettings(id, config) {
               ${options([['auto', valueLabel('auto')], ['max_tokens', 'max_tokens'], ['max_completion_tokens', 'max_completion_tokens']], compat.maxTokensField)}
             </select>
           </div>
-        </div>
+          </div>
+        ` : ''}
         <div class="field provider-compatibility-json">
           <label>${escapeHtml(t('st.providers.compat.extra_body'))}</label>
           <textarea data-provider="${id}" data-key="extraBody" data-type="json" spellcheck="false"

--- a/test/run.js
+++ b/test/run.js
@@ -78483,55 +78483,46 @@ for (const [label, Provider, VertexProvider, AgentClass] of [
       ]);
       assert.equal(missingSignature.find(chunk => chunk.type === 'done')?.responseItems, undefined);
 
-      await assert.rejects(
-        () => collect([
-          { type: 'content_block_start', index: 0, content_block: { type: 'thinking', thinking: '', signature: '' } },
-          { type: 'content_block_delta', index: 0, delta: { type: 'signature_delta', signature: 'valid-signature' } },
-          { type: 'content_block_stop', index: 0 },
-          { type: 'content_block_start', index: 1, content_block: { type: 'tool_use', id: 'tool_bad', name: 'click', input: {} } },
-          { type: 'content_block_delta', index: 1, delta: { type: 'input_json_delta', partial_json: '{"selector":' } },
-          { type: 'content_block_stop', index: 1 },
-          { type: 'message_stop' },
-        ]),
-        /signed thinking blocks were incomplete/,
-      );
+      const badSigChunks = await collect([
+        { type: 'content_block_start', index: 0, content_block: { type: 'thinking', thinking: '', signature: '' } },
+        { type: 'content_block_delta', index: 0, delta: { type: 'signature_delta', signature: 'valid-signature' } },
+        { type: 'content_block_stop', index: 0 },
+        { type: 'content_block_start', index: 1, content_block: { type: 'tool_use', id: 'tool_bad', name: 'click', input: {} } },
+        { type: 'content_block_delta', index: 1, delta: { type: 'input_json_delta', partial_json: '{"selector":' } },
+        { type: 'content_block_stop', index: 1 },
+        { type: 'message_stop' },
+      ]);
+      assert.equal(badSigChunks.find(chunk => chunk.type === 'done')?.responseItems, undefined);
 
-      await assert.rejects(
-        () => collect([
-          { type: 'content_block_start', index: 0, content_block: { type: 'thinking', thinking: '', signature: '' } },
-          { type: 'content_block_delta', index: 0, delta: { type: 'thinking_delta', thinking: 'Unsigned.' } },
-          { type: 'content_block_stop', index: 0 },
-          { type: 'content_block_start', index: 1, content_block: { type: 'tool_use', id: 'tool_valid', name: 'click', input: {} } },
-          { type: 'content_block_delta', index: 1, delta: { type: 'input_json_delta', partial_json: '{"selector":"#buy"}' } },
-          { type: 'content_block_stop', index: 1 },
-          { type: 'message_stop' },
-        ]),
-        /signed thinking blocks were incomplete/,
-        'unsigned thinking must not be followed by executable tool output',
-      );
+      const unsignedChunks = await collect([
+        { type: 'content_block_start', index: 0, content_block: { type: 'thinking', thinking: '', signature: '' } },
+        { type: 'content_block_delta', index: 0, delta: { type: 'thinking_delta', thinking: 'Unsigned.' } },
+        { type: 'content_block_stop', index: 0 },
+        { type: 'content_block_start', index: 1, content_block: { type: 'tool_use', id: 'tool_valid', name: 'click', input: {} } },
+        { type: 'content_block_delta', index: 1, delta: { type: 'input_json_delta', partial_json: '{"selector":"#buy"}' } },
+        { type: 'content_block_stop', index: 1 },
+        { type: 'message_stop' },
+      ]);
+      assert.equal(unsignedChunks.find(chunk => chunk.type === 'done')?.responseItems, undefined);
 
-      await assert.rejects(
-        () => collect([
-          { type: 'content_block_start', index: 0, content_block: { type: 'thinking', thinking: '', signature: '' } },
-          { type: 'content_block_delta', index: 0, delta: { type: 'signature_delta', signature: 'valid-signature' } },
-          { type: 'content_block_stop', index: 0 },
-          { type: 'content_block_start', index: 1, content_block: { type: 'tool_use', id: '', name: 'click', input: {} } },
-          { type: 'content_block_stop', index: 1 },
-          { type: 'message_stop' },
-        ]),
-        /signed thinking blocks were incomplete/,
-      );
+      const emptyToolIdChunks = await collect([
+        { type: 'content_block_start', index: 0, content_block: { type: 'thinking', thinking: '', signature: '' } },
+        { type: 'content_block_delta', index: 0, delta: { type: 'signature_delta', signature: 'valid-signature' } },
+        { type: 'content_block_stop', index: 0 },
+        { type: 'content_block_start', index: 1, content_block: { type: 'tool_use', id: '', name: 'click', input: {} } },
+        { type: 'content_block_stop', index: 1 },
+        { type: 'message_stop' },
+      ]);
+      assert.equal(emptyToolIdChunks.find(chunk => chunk.type === 'done')?.responseItems, undefined);
 
-      await assert.rejects(
-        () => collect([
-          { type: 'content_block_start', index: 0, content_block: { type: 'thinking', thinking: '', signature: 'valid-signature' } },
-          { type: 'content_block_stop', index: 0 },
-          { type: 'content_block_start', index: 2, content_block: { type: 'tool_use', id: 'tool_gap', name: 'click', input: {} } },
-          { type: 'content_block_stop', index: 2 },
-          { type: 'message_stop' },
-        ]),
-        /signed thinking blocks were incomplete/,
-      );
+      const gapIndexChunks = await collect([
+        { type: 'content_block_start', index: 0, content_block: { type: 'thinking', thinking: '', signature: 'valid-signature' } },
+        { type: 'content_block_stop', index: 0 },
+        { type: 'content_block_start', index: 2, content_block: { type: 'tool_use', id: 'tool_gap', name: 'click', input: {} } },
+        { type: 'content_block_stop', index: 2 },
+        { type: 'message_stop' },
+      ]);
+      assert.equal(gapIndexChunks.find(chunk => chunk.type === 'done')?.responseItems, undefined);
 
       const missingBlockStop = await collect([
         { type: 'content_block_start', index: 0, content_block: { type: 'thinking', thinking: '', signature: '' } },

--- a/test/run.js
+++ b/test/run.js
@@ -31278,7 +31278,7 @@ test('Ollama vision settings copy is translated and mirrored in every locale', a
   }
 });
 
-test('settings exposes collapsed compatibility controls only for compatible provider types', () => {
+test('settings exposes compatibility controls and native Anthropic custom request bodies', () => {
   for (const [label, settingsRel, htmlRel, PM] of [
     ['chrome', 'src/chrome/src/ui/settings.js', 'src/chrome/src/ui/settings.html', ProviderManagerCh],
     ['firefox', 'src/firefox/src/ui/settings.js', 'src/firefox/src/ui/settings.html', ProviderManagerFx],
@@ -31288,8 +31288,14 @@ test('settings exposes collapsed compatibility controls only for compatible prov
     assert.match(
       settings,
       /id !== 'webbrain_cloud' && \['openai', 'llamacpp', 'azure_openai'\]\.includes\(config\.type\)/,
-      `${label}: compatibility controls should exclude Cloud, Anthropic, and Bedrock`,
+      `${label}: OpenAI compatibility controls should remain protocol-scoped`,
     );
+    assert.match(
+      settings,
+      /\['anthropic', 'anthropic_oauth', 'vertex_anthropic'\]\.includes\(config\.type\)/,
+      `${label}: native Anthropic providers should expose Custom request body JSON`,
+    );
+    assert.match(settings, /showCompatibilityControls \? `/, `${label}: Anthropic should not render OpenAI-only selectors`);
     for (const key of [
       'st.providers.compat.title',
       'st.providers.compat.preset',
@@ -48838,14 +48844,27 @@ test('new provider auth, endpoint, protocol, and capability contracts are determ
       location: 'us-east5',
       apiKey: 'google-key',
       model: 'claude-haiku-4-5@20251001',
+      extraBody: { thinking: { type: 'adaptive' } },
     });
     assert.match(vertexAnthropic._messagesUrl(false), /publishers\/anthropic\/models\/claude-haiku-4-5%4020251001:rawPredict$/);
     assert.match(vertexAnthropic._messagesUrl(true), /:streamRawPredict$/);
     assert.match(vertexAnthropic._messagesUrl(false), /^https:\/\/us-east5-aiplatform\.googleapis\.com\//);
     assert.equal(vertexAnthropic._headers()['x-goog-api-key'], 'google-key');
-    const vertexBody = vertexAnthropic._prepareRequestBody({ model: 'ignored', messages: [], max_tokens: 16 }, {}, false);
+    const vertexBody = vertexAnthropic._prepareRequestBody(
+      { model: 'ignored', messages: [], max_tokens: 16, temperature: 0.3 },
+      {
+        extraBody: {
+          thinking: { display: 'summarized' },
+          anthropic_version: 'must-not-win',
+          model: 'override',
+        },
+      },
+      false,
+    );
     assert.equal(vertexBody.model, undefined);
+    assert.equal(vertexBody.temperature, undefined);
     assert.equal(vertexBody.anthropic_version, 'vertex-2023-10-16');
+    assert.deepEqual(vertexBody.thinking, { type: 'adaptive', display: 'summarized' });
     assert.match(
       new VertexProvider({
         project: 'sample-project',
@@ -78004,7 +78023,542 @@ test('planner input: runtime context does not consume prior user-turn history bu
 // One assistant turn emitting parallel tool_use calls must have ALL its
 // tool_result blocks combined into a SINGLE user message — otherwise the
 // Messages API rejects the consecutive user roles with a 400.
-for (const [label, Provider] of [['chrome', AnthropicProviderCh], ['firefox', AnthropicProviderFx]]) {
+for (const [label, Provider, VertexProvider, AgentClass] of [
+  ['chrome', AnthropicProviderCh, VertexAnthropicProviderCh, AgentCh],
+  ['firefox', AnthropicProviderFx, VertexAnthropicProviderFx, AgentFx],
+]) {
+  test(`anthropic (${label}): thinking request options stay protocol-compatible`, () => {
+    const provider = new Provider({ model: 'claude-sonnet-4-6' });
+    const forcedTool = provider._prepareRequestBody({
+      thinking: { type: 'enabled', budget_tokens: 2048 },
+      tool_choice: { type: 'tool', name: 'done' },
+      temperature: 0.4,
+    });
+    assert.equal(forcedTool.thinking, undefined, 'manual thinking must yield to an explicit tool contract');
+    assert.deepEqual(forcedTool.tool_choice, { type: 'tool', name: 'done' });
+    assert.equal(forcedTool.temperature, 0.4, 'sampling is valid after manual thinking is disabled for the call');
+
+    const adaptive = provider._prepareRequestBody({
+      thinking: { type: 'adaptive', budget_tokens: 2048 },
+      temperature: 0.4,
+      top_k: 20,
+      top_p: 0.5,
+    });
+    assert.deepEqual(adaptive.thinking, { type: 'adaptive' });
+    assert.equal(adaptive.temperature, undefined);
+    assert.equal(adaptive.top_k, undefined);
+    assert.equal(adaptive.top_p, undefined);
+
+    const disabled = new Provider({
+      model: 'claude-sonnet-4-6',
+      extraBody: { thinking: { type: 'adaptive', budget_tokens: 4096 } },
+    })._prepareRequestBody({}, { extraBody: { thinking: { type: 'disabled' } } });
+    assert.deepEqual(disabled.thinking, { type: 'disabled' });
+
+    for (const model of [
+      'claude-opus-5',
+      'claude-opus-4-8@20260801',
+      'claude-sonnet-5@20260801',
+      'claude-mythos-preview',
+    ]) {
+      const newer = new Provider({ model })._prepareRequestBody({
+        temperature: 0.2,
+        top_k: 10,
+        top_p: 0.99,
+      });
+      assert.equal(newer.temperature, undefined, `${model}: temperature should be omitted`);
+      assert.equal(newer.top_k, undefined, `${model}: top_k should be omitted`);
+      assert.equal(newer.top_p, undefined, `${model}: top_p should be omitted`);
+    }
+    const vertex = new VertexProvider({
+      model: 'claude-opus-4-8@20260801',
+      project: 'sample-project',
+      location: 'us-east5',
+      apiKey: 'google-key',
+    })._prepareRequestBody({ model: 'ignored', temperature: 0.2 }, {}, false);
+    assert.equal(vertex.temperature, undefined, 'Vertex date-suffixed models must apply sampling restrictions');
+  });
+
+  test(`anthropic (${label}): custom request body enables thinking and non-streaming preserves it`, async () => {
+    const originalFetch = globalThis.fetch;
+    const responseContent = [
+      { type: 'thinking', thinking: 'Inspect the page first.', signature: 'sig-nonstream' },
+      { type: 'redacted_thinking', data: 'encrypted-nonstream' },
+      { type: 'text', text: 'I will inspect it.' },
+      { type: 'tool_use', id: 'tool_1', name: 'read_page', input: { depth: 2 } },
+    ];
+    let requestBody = null;
+    try {
+      globalThis.fetch = async (_url, init) => {
+        requestBody = JSON.parse(init.body);
+        return new Response(JSON.stringify({
+          content: responseContent,
+          usage: { input_tokens: 12, output_tokens: 7 },
+        }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+      };
+
+      const provider = new Provider({
+        apiKey: 'test-key',
+        model: 'claude-sonnet-4-6',
+        extraBody: {
+          thinking: { type: 'adaptive' },
+          model: 'must-not-win',
+          stream: true,
+        },
+      });
+      const tools = [{
+        type: 'function',
+        function: {
+          name: 'read_page',
+          description: 'Read the page.',
+          parameters: { type: 'object', properties: {} },
+        },
+      }];
+      const result = await provider.chat(
+        [{ role: 'user', content: 'Inspect it.' }],
+        {
+          maxTokens: 321,
+          temperature: 0.3,
+          tools,
+          extraBody: {
+            thinking: { display: 'summarized' },
+            metadata: { user_id: 'webbrain-test' },
+            messages: [{ role: 'user', content: 'must not win' }],
+            tools: [],
+            max_tokens: 999,
+          },
+        },
+      );
+
+      assert.equal(requestBody.model, 'claude-sonnet-4-6');
+      assert.equal(requestBody.max_tokens, 321);
+      assert.equal(requestBody.stream, undefined);
+      assert.equal(requestBody.temperature, undefined, 'thinking requests must omit incompatible sampling parameters');
+      assert.deepEqual(requestBody.messages, [{ role: 'user', content: 'Inspect it.' }]);
+      assert.equal(requestBody.tools[0].name, 'read_page');
+      assert.deepEqual(requestBody.thinking, { type: 'adaptive', display: 'summarized' });
+      assert.deepEqual(requestBody.metadata, { user_id: 'webbrain-test' });
+      assert.equal(result.content, 'I will inspect it.');
+      assert.equal(result.reasoningContent, 'Inspect the page first.');
+      assert.equal(result.toolCalls[0].function.arguments, '{"depth":2}');
+      assert.deepEqual(result.responseItems, [{
+        type: 'webbrain_provider_replay',
+        version: 1,
+        provider: provider.name,
+        model: provider.model,
+        providerIdentity: provider._reasoningReplayIdentity(),
+        content: responseContent,
+      }]);
+
+      const agent = new AgentClass({});
+      const assistant = agent._withResponseItems({
+        role: 'assistant',
+        content: result.content,
+        tool_calls: result.toolCalls,
+      }, result.responseItems, result.reasoningContent, provider);
+      assert.equal(assistant.response_items, undefined, 'Anthropic replay state must not enter OpenAI response_items');
+      assert.deepEqual(assistant._reasoning_replay?.providerState, result.responseItems[0]);
+      assert.equal(assistant._reasoning_replay?.currentToolLoop, true);
+      assert.equal(assistant._reasoning_replay?.preserveAcrossTurns, true);
+      assert.equal(agent._containsProviderReplayState(result.responseItems), true);
+      const agentSource = fs.readFileSync(path.join(ROOT, `src/${label}/src/agent/agent.js`), 'utf8');
+      assert.equal(
+        (agentSource.match(/!this\._containsProviderReplayState\(/g) || []).length,
+        2,
+        'both streaming and non-streaming text tool-call fallbacks must preserve native signed state',
+      );
+
+      const converted = provider._convertMessages([
+        assistant,
+        { role: 'tool', tool_call_id: 'tool_1', content: 'page text' },
+      ]).messages;
+      assert.deepEqual(converted[0].content, responseContent, 'signed blocks must be replayed unchanged and in order');
+      assert.equal(converted[1].content[0].type, 'tool_result');
+
+      let continuationBody = null;
+      globalThis.fetch = async (_url, init) => {
+        continuationBody = JSON.parse(init.body);
+        return new Response(JSON.stringify({
+          content: [{ type: 'text', text: 'Continuation complete.' }],
+          usage: { input_tokens: 10, output_tokens: 2 },
+        }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+      };
+      await provider.chat([
+        assistant,
+        { role: 'tool', tool_call_id: 'tool_1', content: 'page text' },
+      ]);
+      assert.deepEqual(
+        continuationBody.messages[0].content,
+        responseContent,
+        'the next wire request must echo every signed block byte-for-byte',
+      );
+
+      const switched = new Provider({ model: 'claude-opus-4-8' })._convertMessages([assistant]).messages[0];
+      assert.equal(
+        Array.isArray(switched.content) && switched.content.some(block => block.type === 'thinking'),
+        false,
+        'signed thinking must not cross model switches',
+      );
+      const switchedProvider = new VertexProvider({ model: provider.model })._convertMessages([assistant]).messages[0];
+      assert.equal(
+        Array.isArray(switchedProvider.content) && switchedProvider.content.some(block => block.type === 'thinking'),
+        false,
+        'signed thinking must not cross provider switches',
+      );
+      for (const isolatedProvider of [
+        new Provider({ model: provider.model, baseUrl: 'https://other-anthropic.example' }),
+        new Provider({ model: provider.model, _providerId: 'anthropic_duplicate' }),
+      ]) {
+        const isolated = isolatedProvider._convertMessages([assistant]).messages[0];
+        assert.equal(
+          Array.isArray(isolated.content) && isolated.content.some(block => block.type === 'thinking'),
+          false,
+          'signed thinking must not cross provider instances or endpoints',
+        );
+      }
+      const vertexProvider = new VertexProvider({ model: provider.model });
+      const vertexState = vertexProvider._replayState(responseContent);
+      const vertexAssistant = agent._withResponseItems({
+        role: 'assistant',
+        content: result.content,
+        tool_calls: result.toolCalls,
+      }, [vertexState], result.reasoningContent, vertexProvider);
+      assert.deepEqual(
+        vertexProvider._convertMessages([vertexAssistant]).messages[0].content,
+        responseContent,
+        'Vertex Anthropic must inherit signed replay with its own provider identity',
+      );
+      const invalidVersion = {
+        ...assistant,
+        _reasoning_replay: {
+          ...assistant._reasoning_replay,
+          providerState: { ...assistant._reasoning_replay.providerState, version: 2 },
+        },
+      };
+      assert.equal(
+        provider._convertMessages([invalidVersion]).messages[0].content.some(block => block.type === 'thinking'),
+        false,
+        'unknown replay versions must fall back to ordinary message conversion',
+      );
+      const syntheticToolCall = agent._withResponseItems({
+        role: 'assistant',
+        content: '{"tool":"click"}',
+        tool_calls: [{ id: 'synthetic', function: { name: 'click', arguments: '{}' } }],
+      }, result.responseItems, result.reasoningContent, provider);
+      assert.equal(
+        syntheticToolCall._reasoning_replay,
+        undefined,
+        'provider state must be discarded when fallback tool calls do not match native tool_use blocks',
+      );
+      const withoutProviderState = {
+        ...assistant,
+        _reasoning_replay: { ...assistant._reasoning_replay, providerState: null },
+      };
+      const normalizedChars = agent._estimateContextChars([withoutProviderState]);
+      assert.equal(
+        agent._estimateContextChars([assistant]),
+        Math.max(normalizedChars, JSON.stringify(responseContent).length),
+        'native replay and normalized content must not be counted twice',
+      );
+      const persistence = await import(pathToFileURL(
+        path.join(ROOT, `src/${label}/src/agent/conversation-persistence.js`),
+      ).href);
+      const recovered = persistence.serializeConversationForSession([assistant]).messages[0];
+      assert.deepEqual(
+        recovered._reasoning_replay?.providerState,
+        result.responseItems[0],
+        'session recovery must not truncate or rewrite provider signatures',
+      );
+      const largeThinking = 'private-reasoning-'.repeat(3000);
+      const oversizedRecovery = persistence.serializeConversationForSession(
+        Array.from({ length: 15 }, (_, index) => ({
+          role: 'assistant',
+          content: `answer ${index}`,
+          _reasoning_replay: {
+            preserveAcrossTurns: true,
+            providerState: provider._replayState([{
+              type: 'thinking',
+              thinking: largeThinking,
+              signature: `complete-signature-${index}`,
+            }]),
+          },
+        })),
+        { maxBytes: 100_000 },
+      );
+      assert.equal(oversizedRecovery.compacted, true);
+      assert.ok(oversizedRecovery.bytes <= 100_000, 'opaque replay states must respect the session byte budget');
+      for (const message of oversizedRecovery.messages) {
+        const block = message._reasoning_replay?.providerState?.content?.[0];
+        if (block) assert.equal(block.thinking, largeThinking, 'opaque thinking must be kept whole or dropped whole');
+      }
+      const toolLoopRecovery = persistence.serializeConversationForSession([
+        {
+          role: 'assistant',
+          content: '',
+          tool_calls: [{
+            id: 'oversized_tool',
+            type: 'function',
+            function: { name: 'click', arguments: '{"selector":"#buy"}' },
+          }],
+          _reasoning_replay: {
+            currentToolLoop: true,
+            preserveAcrossTurns: true,
+            providerState: provider._replayState([
+              { type: 'thinking', thinking: 'x'.repeat(120_000), signature: 'complete-oversized-signature' },
+              { type: 'tool_use', id: 'oversized_tool', name: 'click', input: { selector: '#buy' } },
+            ]),
+          },
+        },
+        { role: 'tool', tool_call_id: 'oversized_tool', content: 'clicked' },
+      ], { maxBytes: 100_000 });
+      assert.ok(toolLoopRecovery.bytes <= 100_000);
+      assert.match(toolLoopRecovery.messages[0].content, /reasoning omitted/);
+      assert.equal(toolLoopRecovery.messages[0].tool_calls, undefined);
+      assert.equal(toolLoopRecovery.messages.some(message => message.role === 'tool'), false);
+      agent._expireCurrentToolReasoning([assistant]);
+      assert.equal(assistant._reasoning_replay?.currentToolLoop, undefined);
+      assert.deepEqual(assistant._reasoning_replay?.providerState?.content, responseContent);
+
+      globalThis.fetch = async () => new Response(JSON.stringify({
+        content: [
+          { type: 'thinking', thinking: 'Unsafe continuation.', signature: 'valid-signature' },
+          { type: 'tool_use', id: '', name: 'click', input: { selector: '#buy' } },
+        ],
+      }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+      await assert.rejects(
+        () => provider.chat([{ role: 'user', content: 'Do not execute an unbound tool.' }]),
+        /incomplete signed thinking blocks/,
+      );
+
+      globalThis.fetch = async () => new Response(JSON.stringify({
+        content: [{ type: 'text', text: 'Plain response.' }],
+        usage: { input_tokens: 1, output_tokens: 1 },
+      }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+      const plain = await new Provider({ apiKey: 'test-key', model: provider.model }).chat([
+        { role: 'user', content: 'No thinking.' },
+      ]);
+      assert.equal(plain.reasoningContent, '');
+      assert.equal(plain.responseItems, undefined, 'ordinary Anthropic responses should not create replay state');
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  test(`anthropic (${label}): streaming separates reasoning from signatures and rebuilds replay blocks`, async () => {
+    const originalFetch = globalThis.fetch;
+    const events = [
+      { type: 'message_start', message: { usage: { input_tokens: 20, output_tokens: 1 } } },
+      { type: 'content_block_start', index: 0, content_block: { type: 'thinking', thinking: '', signature: '' } },
+      { type: 'content_block_delta', index: 0, delta: { type: 'thinking_delta', thinking: 'Check ' } },
+      { type: 'content_block_delta', index: 0, delta: { type: 'thinking_delta', thinking: 'carefully.' } },
+      { type: 'content_block_delta', index: 0, delta: { type: 'signature_delta', signature: 'sig-stream' } },
+      { type: 'content_block_stop', index: 0 },
+      { type: 'content_block_start', index: 1, content_block: { type: 'redacted_thinking', data: 'encrypted-redacted' } },
+      { type: 'content_block_stop', index: 1 },
+      { type: 'content_block_start', index: 2, content_block: { type: 'text', text: '', citations: [] } },
+      { type: 'content_block_delta', index: 2, delta: { type: 'text_delta', text: 'Ready.' } },
+      {
+        type: 'content_block_delta',
+        index: 2,
+        delta: {
+          type: 'citations_delta',
+          citation: { type: 'page_location', cited_text: 'Ready.', document_index: 0, start_page_number: 1, end_page_number: 1 },
+        },
+      },
+      { type: 'content_block_stop', index: 2 },
+      { type: 'content_block_start', index: 3, content_block: { type: 'tool_use', id: 'tool_2', name: 'click', input: {} } },
+      { type: 'content_block_delta', index: 3, delta: { type: 'input_json_delta', partial_json: '{"selector":"#go"}' } },
+      { type: 'content_block_stop', index: 3 },
+      { type: 'content_block_start', index: 4, content_block: { type: 'thinking', thinking: '', signature: '' } },
+      { type: 'content_block_delta', index: 4, delta: { type: 'thinking_delta', thinking: 'After the tool.' } },
+      { type: 'content_block_delta', index: 4, delta: { type: 'signature_delta', signature: 'sig-after-tool' } },
+      { type: 'content_block_stop', index: 4 },
+      { type: 'content_block_start', index: 5, content_block: { type: 'thinking', thinking: '', signature: '' } },
+      { type: 'content_block_delta', index: 5, delta: { type: 'signature_delta', signature: 'sig-omitted-display' } },
+      { type: 'content_block_stop', index: 5 },
+      { type: 'message_delta', delta: { stop_reason: 'tool_use' }, usage: { output_tokens: 15 } },
+      { type: 'message_stop' },
+    ];
+    const sse = events.map(event => `data: ${JSON.stringify(event)}\n\n`).join('');
+    let requestBody = null;
+    try {
+      globalThis.fetch = async (_url, init) => {
+        requestBody = JSON.parse(init.body);
+        return new Response(sse, {
+          status: 200,
+          headers: { 'Content-Type': 'text/event-stream' },
+        });
+      };
+      const provider = new Provider({
+        apiKey: 'test-key',
+        model: 'claude-sonnet-4-6',
+        extraBody: { thinking: { type: 'adaptive', display: 'summarized' } },
+      });
+      const chunks = [];
+      for await (const chunk of provider.chatStream([{ role: 'user', content: 'Inspect it.' }], {
+        extraBody: { model: 'must-not-win', stream: false },
+      })) {
+        chunks.push(chunk);
+      }
+
+      assert.equal(requestBody.model, 'claude-sonnet-4-6');
+      assert.equal(requestBody.stream, true);
+      assert.deepEqual(requestBody.thinking, { type: 'adaptive', display: 'summarized' });
+      assert.deepEqual(
+        chunks.filter(chunk => chunk.type === 'reasoning').map(chunk => chunk.content),
+        ['Check ', 'carefully.', 'After the tool.'],
+      );
+      assert.deepEqual(
+        chunks.filter(chunk => chunk.type === 'text').map(chunk => chunk.content),
+        ['Ready.'],
+      );
+      assert.equal(
+        chunks.some(chunk => JSON.stringify(chunk).includes('sig-stream')),
+        true,
+        'signature should survive only inside the opaque replay envelope',
+      );
+      assert.equal(
+        chunks.some(chunk => chunk.type === 'reasoning' && String(chunk.content).includes('sig-stream')),
+        false,
+        'signature must never leak as visible reasoning',
+      );
+      const done = chunks.find(chunk => chunk.type === 'done');
+      assert.equal(done.finishReason, 'tool_use');
+      assert.deepEqual(done.responseItems, [{
+        type: 'webbrain_provider_replay',
+        version: 1,
+        provider: provider.name,
+        model: provider.model,
+        providerIdentity: provider._reasoningReplayIdentity(),
+        content: [
+          { type: 'thinking', thinking: 'Check carefully.', signature: 'sig-stream' },
+          { type: 'redacted_thinking', data: 'encrypted-redacted' },
+          {
+            type: 'text',
+            text: 'Ready.',
+            citations: [{
+              type: 'page_location',
+              cited_text: 'Ready.',
+              document_index: 0,
+              start_page_number: 1,
+              end_page_number: 1,
+            }],
+          },
+          { type: 'tool_use', id: 'tool_2', name: 'click', input: { selector: '#go' } },
+          { type: 'thinking', thinking: 'After the tool.', signature: 'sig-after-tool' },
+          { type: 'thinking', thinking: '', signature: 'sig-omitted-display' },
+        ],
+      }]);
+      assert.deepEqual(chunks.find(chunk => chunk.type === 'usage')?.usage, {
+        prompt_tokens: 20,
+        completion_tokens: 15,
+        total_tokens: 35,
+      });
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  test(`anthropic (${label}): incomplete signed tool streams fail before execution`, async () => {
+    const originalFetch = globalThis.fetch;
+    const provider = new Provider({ apiKey: 'test-key', model: 'claude-sonnet-4-6' });
+    const collect = async (events) => {
+      const sse = events.map(event => `data: ${JSON.stringify(event)}\n\n`).join('');
+      globalThis.fetch = async () => new Response(sse, {
+        status: 200,
+        headers: { 'Content-Type': 'text/event-stream' },
+      });
+      const chunks = [];
+      for await (const chunk of provider.chatStream([{ role: 'user', content: 'Inspect it.' }])) {
+        chunks.push(chunk);
+      }
+      return chunks;
+    };
+    try {
+      const missingSignature = await collect([
+        { type: 'content_block_start', index: 0, content_block: { type: 'thinking', thinking: '', signature: '' } },
+        { type: 'content_block_delta', index: 0, delta: { type: 'thinking_delta', thinking: 'Unsigned.' } },
+        { type: 'content_block_stop', index: 0 },
+        { type: 'message_stop' },
+      ]);
+      assert.equal(missingSignature.find(chunk => chunk.type === 'done')?.responseItems, undefined);
+
+      await assert.rejects(
+        () => collect([
+          { type: 'content_block_start', index: 0, content_block: { type: 'thinking', thinking: '', signature: '' } },
+          { type: 'content_block_delta', index: 0, delta: { type: 'signature_delta', signature: 'valid-signature' } },
+          { type: 'content_block_stop', index: 0 },
+          { type: 'content_block_start', index: 1, content_block: { type: 'tool_use', id: 'tool_bad', name: 'click', input: {} } },
+          { type: 'content_block_delta', index: 1, delta: { type: 'input_json_delta', partial_json: '{"selector":' } },
+          { type: 'content_block_stop', index: 1 },
+          { type: 'message_stop' },
+        ]),
+        /signed thinking blocks were incomplete/,
+      );
+
+      await assert.rejects(
+        () => collect([
+          { type: 'content_block_start', index: 0, content_block: { type: 'thinking', thinking: '', signature: '' } },
+          { type: 'content_block_delta', index: 0, delta: { type: 'thinking_delta', thinking: 'Unsigned.' } },
+          { type: 'content_block_stop', index: 0 },
+          { type: 'content_block_start', index: 1, content_block: { type: 'tool_use', id: 'tool_valid', name: 'click', input: {} } },
+          { type: 'content_block_delta', index: 1, delta: { type: 'input_json_delta', partial_json: '{"selector":"#buy"}' } },
+          { type: 'content_block_stop', index: 1 },
+          { type: 'message_stop' },
+        ]),
+        /signed thinking blocks were incomplete/,
+        'unsigned thinking must not be followed by executable tool output',
+      );
+
+      await assert.rejects(
+        () => collect([
+          { type: 'content_block_start', index: 0, content_block: { type: 'thinking', thinking: '', signature: '' } },
+          { type: 'content_block_delta', index: 0, delta: { type: 'signature_delta', signature: 'valid-signature' } },
+          { type: 'content_block_stop', index: 0 },
+          { type: 'content_block_start', index: 1, content_block: { type: 'tool_use', id: '', name: 'click', input: {} } },
+          { type: 'content_block_stop', index: 1 },
+          { type: 'message_stop' },
+        ]),
+        /signed thinking blocks were incomplete/,
+      );
+
+      await assert.rejects(
+        () => collect([
+          { type: 'content_block_start', index: 0, content_block: { type: 'thinking', thinking: '', signature: 'valid-signature' } },
+          { type: 'content_block_stop', index: 0 },
+          { type: 'content_block_start', index: 2, content_block: { type: 'tool_use', id: 'tool_gap', name: 'click', input: {} } },
+          { type: 'content_block_stop', index: 2 },
+          { type: 'message_stop' },
+        ]),
+        /signed thinking blocks were incomplete/,
+      );
+
+      const missingBlockStop = await collect([
+        { type: 'content_block_start', index: 0, content_block: { type: 'thinking', thinking: '', signature: '' } },
+        { type: 'content_block_delta', index: 0, delta: { type: 'signature_delta', signature: 'valid-signature' } },
+        { type: 'message_stop' },
+      ]);
+      assert.equal(missingBlockStop.find(chunk => chunk.type === 'done')?.responseItems, undefined);
+
+      globalThis.fetch = async () => new Response([
+        { type: 'content_block_start', index: 0, content_block: { type: 'thinking', thinking: '', signature: '' } },
+        { type: 'content_block_delta', index: 0, delta: { type: 'signature_delta', signature: 'valid-signature' } },
+        { type: 'content_block_stop', index: 0 },
+      ].map(event => `data: ${JSON.stringify(event)}\n\n`).join(''), {
+        status: 200,
+        headers: { 'Content-Type': 'text/event-stream' },
+      });
+      await assert.rejects(
+        async () => {
+          for await (const _chunk of provider.chatStream([{ role: 'user', content: 'Inspect it.' }])) {}
+        },
+        /ended before the message_stop event/,
+      );
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
   test(`anthropic (${label}): cache usage survives normalization`, () => {
     const provider = new Provider({});
     const usage = provider._normalizeUsage({


### PR DESCRIPTION
## Summary

- surface native Anthropic `thinking` blocks as `reasoningContent` and stream `thinking_delta` events as `reasoning`
- retain signed and redacted thinking blocks in their original order for valid tool continuations, scoped to the originating provider, model, and endpoint
- fail closed before tool execution when signed replay is incomplete, while normalizing Anthropic/Vertex thinking and sampling request options
- expose Custom request body JSON for native Anthropic providers and preserve replay state safely through session recovery

## Testing

- `node test/run.js` (`1810 passed, 1 failed`; the unrelated failure is the missing upstream artifact `dist/webbrain-chrome-32.1.0.zip`)
- `npm run test:toolbar-guard` (`33` passed)
- `npm run test:security` (`60/60` passed)
- `node --check` for every modified JavaScript file
- `git diff --check`

Fixes #2811