### PR TITLE
fix(settings): list built-in provider default models

### DIFF
--- a/src/chrome/src/ui/settings.js
+++ b/src/chrome/src/ui/settings.js
@@ -2663,7 +2663,7 @@ function renderProviders() {
       fields: [
         { key: 'apiKey', labelKey: 'st.provider.field.api_key', type: 'password', placeholder: 'AIza...' },
         { key: 'model', labelKey: 'st.provider.field.model', type: 'text', placeholder: 'gemini-3.1-pro',
-          suggestions: ['gemini-3.1-pro', 'gemini-3-flash', 'gemini-3.5-flash', 'gemini-3.1-flash-lite'] },
+          suggestions: ['gemini-3.1-pro', 'gemini-3.1-flash', 'gemini-3-flash', 'gemini-3.5-flash', 'gemini-3.1-flash-lite'] },
         { key: 'baseUrl', labelKey: 'st.provider.field.api_base_url', type: 'text', placeholder: 'https://generativelanguage.googleapis.com/v1beta/openai' },
         ...COST_ESTIMATE_FIELDS,
       ],
@@ -2683,7 +2683,7 @@ function renderProviders() {
       fields: [
         { key: 'apiKey', labelKey: 'st.provider.field.api_key', type: 'password', placeholder: 'API key' },
         { key: 'model', labelKey: 'st.provider.field.model', type: 'text', placeholder: 'mistral-medium-3.5',
-          suggestions: ['mistral-medium-3.5', 'mistral-small-4', 'codestral-25.08', 'devstral-medium'] },
+          suggestions: ['mistral-medium-3.5', 'mistral-large-latest', 'mistral-small-4', 'codestral-25.08', 'devstral-medium'] },
         { key: 'baseUrl', labelKey: 'st.provider.field.api_base_url', type: 'text', placeholder: 'https://api.mistral.ai/v1' },
         ...COST_ESTIMATE_FIELDS,
       ],
@@ -2710,7 +2710,7 @@ function renderProviders() {
       fields: [
         { key: 'apiKey', labelKey: 'st.provider.field.api_key', type: 'password', placeholder: 'nvapi-...' },
         { key: 'model', labelKey: 'st.provider.field.model', type: 'text', placeholder: 'nvidia/llama-3.3-nemotron-super-49b',
-          suggestions: ['nvidia/llama-3.3-nemotron-super-49b', 'nvidia/llama-3.1-nemotron-70b-instruct', 'nvidia/nemotron-nano-9b-v2', 'meta/llama-3.3-70b-instruct', 'deepseek-ai/deepseek-r1'] },
+          suggestions: ['nvidia/llama-3.3-nemotron-super-49b', 'nvidia/llama-3.1-nemotron-70b-instruct', 'nvidia/nemotron-nano-9b-v2', 'meta/llama-3.3-70b-instruct', 'meta/llama-3.1-8b-instruct', 'deepseek-ai/deepseek-r1'] },
         { key: 'baseUrl', labelKey: 'st.provider.field.api_base_url', type: 'text', placeholder: 'https://integrate.api.nvidia.com/v1' },
         ...COST_ESTIMATE_FIELDS,
       ],

--- a/src/firefox/src/ui/settings.js
+++ b/src/firefox/src/ui/settings.js
@@ -2290,7 +2290,7 @@ function renderProviders() {
       fields: [
         { key: 'apiKey', labelKey: 'st.provider.field.api_key', type: 'password', placeholder: 'AIza...' },
         { key: 'model', labelKey: 'st.provider.field.model', type: 'text', placeholder: 'gemini-3.1-pro',
-          suggestions: ['gemini-3.1-pro', 'gemini-3-flash', 'gemini-3.5-flash', 'gemini-3.1-flash-lite'] },
+          suggestions: ['gemini-3.1-pro', 'gemini-3.1-flash', 'gemini-3-flash', 'gemini-3.5-flash', 'gemini-3.1-flash-lite'] },
         { key: 'baseUrl', labelKey: 'st.provider.field.api_base_url', type: 'text', placeholder: 'https://generativelanguage.googleapis.com/v1beta/openai' },
         ...COST_ESTIMATE_FIELDS,
       ],
@@ -2310,7 +2310,7 @@ function renderProviders() {
       fields: [
         { key: 'apiKey', labelKey: 'st.provider.field.api_key', type: 'password', placeholder: 'API key' },
         { key: 'model', labelKey: 'st.provider.field.model', type: 'text', placeholder: 'mistral-medium-3.5',
-          suggestions: ['mistral-medium-3.5', 'mistral-small-4', 'codestral-25.08', 'devstral-medium'] },
+          suggestions: ['mistral-medium-3.5', 'mistral-large-latest', 'mistral-small-4', 'codestral-25.08', 'devstral-medium'] },
         { key: 'baseUrl', labelKey: 'st.provider.field.api_base_url', type: 'text', placeholder: 'https://api.mistral.ai/v1' },
         ...COST_ESTIMATE_FIELDS,
       ],
@@ -2337,7 +2337,7 @@ function renderProviders() {
       fields: [
         { key: 'apiKey', labelKey: 'st.provider.field.api_key', type: 'password', placeholder: 'nvapi-...' },
         { key: 'model', labelKey: 'st.provider.field.model', type: 'text', placeholder: 'nvidia/llama-3.3-nemotron-super-49b',
-          suggestions: ['nvidia/llama-3.3-nemotron-super-49b', 'nvidia/llama-3.1-nemotron-70b-instruct', 'nvidia/nemotron-nano-9b-v2', 'meta/llama-3.3-70b-instruct', 'deepseek-ai/deepseek-r1'] },
+          suggestions: ['nvidia/llama-3.3-nemotron-super-49b', 'nvidia/llama-3.1-nemotron-70b-instruct', 'nvidia/nemotron-nano-9b-v2', 'meta/llama-3.3-70b-instruct', 'meta/llama-3.1-8b-instruct', 'deepseek-ai/deepseek-r1'] },
         { key: 'baseUrl', labelKey: 'st.provider.field.api_base_url', type: 'text', placeholder: 'https://integrate.api.nvidia.com/v1' },
         ...COST_ESTIMATE_FIELDS,
       ],

--- a/test/run.js
+++ b/test/run.js
@@ -49028,6 +49028,46 @@ test('duplicate provider controls are wired through background and settings in b
   }
 });
 
+test('curated core provider model selectors include their built-in defaults', () => {
+  const expectedCuratedProviders = [
+    'alibaba', 'anthropic', 'cloudflare', 'deepseek', 'fireworks', 'gemini', 'groq',
+    'huggingface', 'kimi', 'minimax', 'mistral', 'nvidia', 'openai', 'openrouter',
+    'together', 'xai', 'z_ai',
+  ];
+
+  for (const [label, PM, settingsRel] of [
+    ['chrome', ProviderManagerCh, 'src/chrome/src/ui/settings.js'],
+    ['firefox', ProviderManagerFx, 'src/firefox/src/ui/settings.js'],
+  ]) {
+    const source = fs.readFileSync(path.join(ROOT, settingsRel), 'utf8');
+    const catalogMatch = source.match(/const providerConfigs = \{([\s\S]*?)^  \};\r?$/m);
+    assert.ok(catalogMatch, `${label}: provider config catalog was not found`);
+    const catalog = catalogMatch[1];
+    const blocks = [...catalog.matchAll(/^    ([a-z0-9_]+): \{([\s\S]*?)^    \},/gm)];
+    const defaults = new PM()._defaultConfigs();
+    const curatedProviderIds = [];
+
+    for (const [, id, body] of blocks) {
+      const modelField = body.match(/\{ key: 'model'[\s\S]*?suggestions: \[([\s\S]*?)\] \}/);
+      if (!modelField) continue;
+      curatedProviderIds.push(id);
+      const suggestions = [...modelField[1].matchAll(/'([^']+)'/g)].map(match => match[1]);
+      const defaultModel = defaults[id]?.model;
+      assert.ok(defaultModel, `${label}: curated provider ${id} has no built-in default model`);
+      assert.ok(
+        suggestions.includes(defaultModel),
+        `${label}: ${id} default model ${JSON.stringify(defaultModel)} is shown as Custom`,
+      );
+    }
+
+    assert.deepEqual(
+      curatedProviderIds.sort(),
+      expectedCuratedProviders,
+      `${label}: curated provider model selector coverage changed`,
+    );
+  }
+});
+
 test('_defaultConfigs: every entry carries an explicit category', () => {
   // Walk the actual default config table on each platform and assert
   // each entry has a category field. Catches "I added a provider but


### PR DESCRIPTION
## Summary

- add the existing Gemini, Mistral, and NVIDIA default model IDs to their curated Settings selectors
- prevent untouched built-in configurations from being presented as `Custom...` with an unnecessary text field
- add a Chrome/Firefox regression that checks all 17 curated core providers against their runtime defaults

## Testing

- `node test/run.js` (`1807 passed, 2 failed`; both failures are present on current `main`: the missing `dist/webbrain-chrome-32.1.0.zip` artifact and the stale Apocalypse Wikipedia callout visibility assertion)
- `npm run test:toolbar-guard` (`33` passed)
- `npm run test:security` (`60/60` passed)
- `node --check` for all modified JavaScript files
- `git diff --check`

Partially addresses #2816.