### PR TITLE
fix(apocalypse): validate resumed PDF ranges

### DIFF
--- a/src/chrome/src/agent/emergency-box.js
+++ b/src/chrome/src/agent/emergency-box.js
@@ -431,9 +431,45 @@ function safeResourceKey(value) {
   return `${key}.pdf`;
 }
 
-function contentRangeTotal(value) {
-  const match = String(value || '').match(/\/([0-9]+)$/);
-  return match ? Number(match[1]) : 0;
+function parseContentRange(value) {
+  const match = String(value || '').trim().match(/^bytes\s+([0-9]+)-([0-9]+)\/([0-9]+|\*)$/i);
+  if (!match) return null;
+  const start = Number(match[1]);
+  const end = Number(match[2]);
+  const total = match[3] === '*' ? null : Number(match[3]);
+  if (!Number.isSafeInteger(start) || !Number.isSafeInteger(end) || end < start) return null;
+  if (total !== null && (!Number.isSafeInteger(total) || total <= end)) return null;
+  return { start, end, total };
+}
+
+function normalizeIfRangeValidator(value) {
+  const normalized = String(value || '').trim();
+  if (/^"[^"\r\n]{0,252}"$/.test(normalized)) return normalized;
+  if (normalized.length <= 128 && Number.isFinite(Date.parse(normalized))) return normalized;
+  return '';
+}
+
+function responseIfRangeValidator(headers) {
+  return normalizeIfRangeValidator(headers?.get?.('etag'))
+    || normalizeIfRangeValidator(headers?.get?.('last-modified'));
+}
+
+function hasMismatchedIfRangeValidator(headers, validator) {
+  const isEntityTag = validator.startsWith('"');
+  const rawResponseValidator = String(headers?.get?.(isEntityTag ? 'etag' : 'last-modified') || '').trim();
+  if (!rawResponseValidator) return false;
+  const responseValidator = normalizeIfRangeValidator(rawResponseValidator);
+  if (!responseValidator) return true;
+  return isEntityTag
+    ? responseValidator !== validator
+    : Date.parse(responseValidator) !== Date.parse(validator);
+}
+
+function isCompleteContentRange(contentRange, start) {
+  return !!contentRange
+    && contentRange.start === start
+    && contentRange.total !== null
+    && contentRange.end + 1 === contentRange.total;
 }
 
 function normalizedRecord(resource, patch = {}) {
@@ -634,12 +670,25 @@ export async function downloadEmergencyResource(resource, options = {}) {
     ? existing.storageKey
     : '';
   let offset = await storage.size(storageKey);
+  const validatorMatchesStoredBytes = existing?.storageKey === storageKey
+    && existing?.url === resolved.url;
+  let committedIfRangeValidator = validatorMatchesStoredBytes
+    ? normalizeIfRangeValidator(existing?.ifRangeValidator)
+    : '';
+  if (offset > 0 && !committedIfRangeValidator) offset = 0;
+  let pendingIfRangeValidator = committedIfRangeValidator;
   let writer;
+  let response;
+  let reader;
+  let rollbackWriter = false;
+  let pendingRepresentationStarted = false;
   let lastPersistedAt = 0;
   const persist = async patch => {
     const record = normalizedRecord(resolved, {
       ...existing,
+      url: resolved.url,
       storageKey,
+      ifRangeValidator: committedIfRangeValidator,
       ...patch,
       updatedAt: Date.now(),
     });
@@ -650,21 +699,62 @@ export async function downloadEmergencyResource(resource, options = {}) {
 
   try {
     await persist({ status: 'downloading', error: '', bytesReceived: offset });
-    const headers = offset > 0 ? { Range: `bytes=${offset}-` } : undefined;
-    const response = await fetchImpl(resolved.url, { headers, signal });
-    if (!response.ok) throw new Error(`PDF download returned HTTP ${response.status}.`);
-    if (offset > 0 && response.status !== 206) offset = 0;
+    const headers = offset > 0
+      ? { Range: `bytes=${offset}-`, 'If-Range': committedIfRangeValidator }
+      : undefined;
+    const fetchResponse = async (requestHeaders, allowRangeNotSatisfiable = false) => {
+      const nextResponse = await fetchImpl(resolved.url, { headers: requestHeaders, signal });
+      if (!nextResponse.ok && !(allowRangeNotSatisfiable && nextResponse.status === 416)) {
+        try { await nextResponse.body?.cancel?.(); } catch { /* preserve the HTTP error */ }
+        throw new Error(`PDF download returned HTTP ${nextResponse.status}.`);
+      }
+      return nextResponse;
+    };
+    response = await fetchResponse(headers, offset > 0);
+    let contentRange = parseContentRange(response.headers?.get?.('content-range'));
+    if (offset > 0 && response.status !== 200 && (
+      response.status !== 206
+      || !isCompleteContentRange(contentRange, offset)
+      || hasMismatchedIfRangeValidator(response.headers, committedIfRangeValidator)
+    )) {
+      // An unusable range cannot be appended safely. Retry once without Range
+      // before opening the writer so the durable partial remains untouched.
+      try { await response.body?.cancel?.(); } catch { /* retry the full response */ }
+      response = await fetchResponse(undefined);
+      offset = 0;
+      contentRange = parseContentRange(response.headers?.get?.('content-range'));
+    } else if (offset > 0 && response.status === 200) {
+      offset = 0;
+    }
+    if (response.status !== 200 && response.status !== 206) {
+      try { await response.body?.cancel?.(); } catch { /* preserve the status error */ }
+      throw new Error(`PDF download returned unexpected HTTP ${response.status}.`);
+    }
+    if (response.status === 206 && !isCompleteContentRange(contentRange, offset)) {
+      try { await response.body?.cancel?.(); } catch { /* preserve the range error */ }
+      throw new Error('PDF download returned an incomplete or mismatched Content-Range.');
+    }
+    if (offset === 0) pendingIfRangeValidator = responseIfRangeValidator(response.headers);
+    const expectedTotalBytes = response.status === 206 ? contentRange?.total || 0 : 0;
     const contentLength = Number(response.headers?.get?.('content-length')) || 0;
-    const totalBytes = contentRangeTotal(response.headers?.get?.('content-range')) || (contentLength ? offset + contentLength : 0);
+    const totalBytes = expectedTotalBytes || (contentLength ? offset + contentLength : 0);
     writer = await storage.createWriter(storageKey);
-    if (offset === 0) await writer.truncate(0);
+    if (offset === 0) {
+      await writer.truncate(0);
+      pendingRepresentationStarted = true;
+    }
 
-    const reader = response.body?.getReader?.();
+    reader = response.body?.getReader?.();
     if (reader) {
       while (true) {
         const { done, value } = await reader.read();
         if (done) break;
         if (signal?.aborted) throw new DOMException('Download paused.', 'AbortError');
+        if (expectedTotalBytes && offset + value.byteLength > expectedTotalBytes) {
+          rollbackWriter = true;
+          try { await reader.cancel(); } catch { /* preserve the range error */ }
+          throw new Error('PDF download exceeded the declared Content-Range.');
+        }
         await writer.write(offset, value);
         offset += value.byteLength;
         const now = Date.now();
@@ -677,15 +767,30 @@ export async function downloadEmergencyResource(resource, options = {}) {
       }
     } else {
       const bytes = new Uint8Array(await response.arrayBuffer());
+      if (expectedTotalBytes && offset + bytes.byteLength > expectedTotalBytes) {
+        rollbackWriter = true;
+        throw new Error('PDF download exceeded the declared Content-Range.');
+      }
       await writer.write(offset, bytes);
       offset += bytes.byteLength;
     }
+    if (expectedTotalBytes && offset !== expectedTotalBytes) {
+      rollbackWriter = true;
+      throw new Error('PDF download size did not match the declared Content-Range.');
+    }
     await writer.close();
     writer = null;
+    committedIfRangeValidator = pendingIfRangeValidator;
 
     const file = await storage.open(storageKey);
+    if (expectedTotalBytes && file.size !== expectedTotalBytes) {
+      committedIfRangeValidator = '';
+      await storage.delete(storageKey).catch(() => {});
+      throw new Error('PDF download size did not match the declared Content-Range.');
+    }
     if ((await file.slice(0, 5).text()) !== '%PDF-') {
       await storage.delete(storageKey);
+      committedIfRangeValidator = '';
       throw new Error('The downloaded file is not a valid PDF.');
     }
     if (replacedStorageKey) await storage.delete(replacedStorageKey).catch(() => {});
@@ -697,14 +802,22 @@ export async function downloadEmergencyResource(resource, options = {}) {
       error: '',
     });
   } catch (error) {
+    try {
+      if (reader) await reader.cancel(error);
+      else await response?.body?.cancel?.(error);
+    } catch { /* preserve the download or storage error */ }
     if (writer) {
-      try {
-        // OPFS writable streams are atomic: aborting rolls the file back to its
-        // pre-download size. Commit successfully written chunks so a pause or
-        // transient network failure can resume from durable progress.
-        await writer.close();
-      } catch {
-        try { await writer.abort?.(error); } catch { /* preserve the original failure */ }
+      if (rollbackWriter) {
+        try { await writer.abort?.(error); } catch { /* never commit invalid range bytes */ }
+      } else {
+        try {
+          // Commit valid chunks so a pause or transient network failure can
+          // resume; integrity failures instead abort the atomic OPFS writer.
+          await writer.close();
+          if (pendingRepresentationStarted) committedIfRangeValidator = pendingIfRangeValidator;
+        } catch {
+          try { await writer.abort?.(error); } catch { /* preserve the original failure */ }
+        }
       }
       writer = null;
     }

--- a/src/firefox/src/agent/emergency-box.js
+++ b/src/firefox/src/agent/emergency-box.js
@@ -431,9 +431,45 @@ function safeResourceKey(value) {
   return `${key}.pdf`;
 }
 
-function contentRangeTotal(value) {
-  const match = String(value || '').match(/\/([0-9]+)$/);
-  return match ? Number(match[1]) : 0;
+function parseContentRange(value) {
+  const match = String(value || '').trim().match(/^bytes\s+([0-9]+)-([0-9]+)\/([0-9]+|\*)$/i);
+  if (!match) return null;
+  const start = Number(match[1]);
+  const end = Number(match[2]);
+  const total = match[3] === '*' ? null : Number(match[3]);
+  if (!Number.isSafeInteger(start) || !Number.isSafeInteger(end) || end < start) return null;
+  if (total !== null && (!Number.isSafeInteger(total) || total <= end)) return null;
+  return { start, end, total };
+}
+
+function normalizeIfRangeValidator(value) {
+  const normalized = String(value || '').trim();
+  if (/^"[^"\r\n]{0,252}"$/.test(normalized)) return normalized;
+  if (normalized.length <= 128 && Number.isFinite(Date.parse(normalized))) return normalized;
+  return '';
+}
+
+function responseIfRangeValidator(headers) {
+  return normalizeIfRangeValidator(headers?.get?.('etag'))
+    || normalizeIfRangeValidator(headers?.get?.('last-modified'));
+}
+
+function hasMismatchedIfRangeValidator(headers, validator) {
+  const isEntityTag = validator.startsWith('"');
+  const rawResponseValidator = String(headers?.get?.(isEntityTag ? 'etag' : 'last-modified') || '').trim();
+  if (!rawResponseValidator) return false;
+  const responseValidator = normalizeIfRangeValidator(rawResponseValidator);
+  if (!responseValidator) return true;
+  return isEntityTag
+    ? responseValidator !== validator
+    : Date.parse(responseValidator) !== Date.parse(validator);
+}
+
+function isCompleteContentRange(contentRange, start) {
+  return !!contentRange
+    && contentRange.start === start
+    && contentRange.total !== null
+    && contentRange.end + 1 === contentRange.total;
 }
 
 function normalizedRecord(resource, patch = {}) {
@@ -634,12 +670,25 @@ export async function downloadEmergencyResource(resource, options = {}) {
     ? existing.storageKey
     : '';
   let offset = await storage.size(storageKey);
+  const validatorMatchesStoredBytes = existing?.storageKey === storageKey
+    && existing?.url === resolved.url;
+  let committedIfRangeValidator = validatorMatchesStoredBytes
+    ? normalizeIfRangeValidator(existing?.ifRangeValidator)
+    : '';
+  if (offset > 0 && !committedIfRangeValidator) offset = 0;
+  let pendingIfRangeValidator = committedIfRangeValidator;
   let writer;
+  let response;
+  let reader;
+  let rollbackWriter = false;
+  let pendingRepresentationStarted = false;
   let lastPersistedAt = 0;
   const persist = async patch => {
     const record = normalizedRecord(resolved, {
       ...existing,
+      url: resolved.url,
       storageKey,
+      ifRangeValidator: committedIfRangeValidator,
       ...patch,
       updatedAt: Date.now(),
     });
@@ -650,21 +699,62 @@ export async function downloadEmergencyResource(resource, options = {}) {
 
   try {
     await persist({ status: 'downloading', error: '', bytesReceived: offset });
-    const headers = offset > 0 ? { Range: `bytes=${offset}-` } : undefined;
-    const response = await fetchImpl(resolved.url, { headers, signal });
-    if (!response.ok) throw new Error(`PDF download returned HTTP ${response.status}.`);
-    if (offset > 0 && response.status !== 206) offset = 0;
+    const headers = offset > 0
+      ? { Range: `bytes=${offset}-`, 'If-Range': committedIfRangeValidator }
+      : undefined;
+    const fetchResponse = async (requestHeaders, allowRangeNotSatisfiable = false) => {
+      const nextResponse = await fetchImpl(resolved.url, { headers: requestHeaders, signal });
+      if (!nextResponse.ok && !(allowRangeNotSatisfiable && nextResponse.status === 416)) {
+        try { await nextResponse.body?.cancel?.(); } catch { /* preserve the HTTP error */ }
+        throw new Error(`PDF download returned HTTP ${nextResponse.status}.`);
+      }
+      return nextResponse;
+    };
+    response = await fetchResponse(headers, offset > 0);
+    let contentRange = parseContentRange(response.headers?.get?.('content-range'));
+    if (offset > 0 && response.status !== 200 && (
+      response.status !== 206
+      || !isCompleteContentRange(contentRange, offset)
+      || hasMismatchedIfRangeValidator(response.headers, committedIfRangeValidator)
+    )) {
+      // An unusable range cannot be appended safely. Retry once without Range
+      // before opening the writer so the durable partial remains untouched.
+      try { await response.body?.cancel?.(); } catch { /* retry the full response */ }
+      response = await fetchResponse(undefined);
+      offset = 0;
+      contentRange = parseContentRange(response.headers?.get?.('content-range'));
+    } else if (offset > 0 && response.status === 200) {
+      offset = 0;
+    }
+    if (response.status !== 200 && response.status !== 206) {
+      try { await response.body?.cancel?.(); } catch { /* preserve the status error */ }
+      throw new Error(`PDF download returned unexpected HTTP ${response.status}.`);
+    }
+    if (response.status === 206 && !isCompleteContentRange(contentRange, offset)) {
+      try { await response.body?.cancel?.(); } catch { /* preserve the range error */ }
+      throw new Error('PDF download returned an incomplete or mismatched Content-Range.');
+    }
+    if (offset === 0) pendingIfRangeValidator = responseIfRangeValidator(response.headers);
+    const expectedTotalBytes = response.status === 206 ? contentRange?.total || 0 : 0;
     const contentLength = Number(response.headers?.get?.('content-length')) || 0;
-    const totalBytes = contentRangeTotal(response.headers?.get?.('content-range')) || (contentLength ? offset + contentLength : 0);
+    const totalBytes = expectedTotalBytes || (contentLength ? offset + contentLength : 0);
     writer = await storage.createWriter(storageKey);
-    if (offset === 0) await writer.truncate(0);
+    if (offset === 0) {
+      await writer.truncate(0);
+      pendingRepresentationStarted = true;
+    }
 
-    const reader = response.body?.getReader?.();
+    reader = response.body?.getReader?.();
     if (reader) {
       while (true) {
         const { done, value } = await reader.read();
         if (done) break;
         if (signal?.aborted) throw new DOMException('Download paused.', 'AbortError');
+        if (expectedTotalBytes && offset + value.byteLength > expectedTotalBytes) {
+          rollbackWriter = true;
+          try { await reader.cancel(); } catch { /* preserve the range error */ }
+          throw new Error('PDF download exceeded the declared Content-Range.');
+        }
         await writer.write(offset, value);
         offset += value.byteLength;
         const now = Date.now();
@@ -677,15 +767,30 @@ export async function downloadEmergencyResource(resource, options = {}) {
       }
     } else {
       const bytes = new Uint8Array(await response.arrayBuffer());
+      if (expectedTotalBytes && offset + bytes.byteLength > expectedTotalBytes) {
+        rollbackWriter = true;
+        throw new Error('PDF download exceeded the declared Content-Range.');
+      }
       await writer.write(offset, bytes);
       offset += bytes.byteLength;
     }
+    if (expectedTotalBytes && offset !== expectedTotalBytes) {
+      rollbackWriter = true;
+      throw new Error('PDF download size did not match the declared Content-Range.');
+    }
     await writer.close();
     writer = null;
+    committedIfRangeValidator = pendingIfRangeValidator;
 
     const file = await storage.open(storageKey);
+    if (expectedTotalBytes && file.size !== expectedTotalBytes) {
+      committedIfRangeValidator = '';
+      await storage.delete(storageKey).catch(() => {});
+      throw new Error('PDF download size did not match the declared Content-Range.');
+    }
     if ((await file.slice(0, 5).text()) !== '%PDF-') {
       await storage.delete(storageKey);
+      committedIfRangeValidator = '';
       throw new Error('The downloaded file is not a valid PDF.');
     }
     if (replacedStorageKey) await storage.delete(replacedStorageKey).catch(() => {});
@@ -697,14 +802,22 @@ export async function downloadEmergencyResource(resource, options = {}) {
       error: '',
     });
   } catch (error) {
+    try {
+      if (reader) await reader.cancel(error);
+      else await response?.body?.cancel?.(error);
+    } catch { /* preserve the download or storage error */ }
     if (writer) {
-      try {
-        // OPFS writable streams are atomic: aborting rolls the file back to its
-        // pre-download size. Commit successfully written chunks so a pause or
-        // transient network failure can resume from durable progress.
-        await writer.close();
-      } catch {
-        try { await writer.abort?.(error); } catch { /* preserve the original failure */ }
+      if (rollbackWriter) {
+        try { await writer.abort?.(error); } catch { /* never commit invalid range bytes */ }
+      } else {
+        try {
+          // Commit valid chunks so a pause or transient network failure can
+          // resume; integrity failures instead abort the atomic OPFS writer.
+          await writer.close();
+          if (pendingRepresentationStarted) committedIfRangeValidator = pendingIfRangeValidator;
+        } catch {
+          try { await writer.abort?.(error); } catch { /* preserve the original failure */ }
+        }
       }
       writer = null;
     }

--- a/test/run.js
+++ b/test/run.js
@@ -21892,6 +21892,11 @@ test('Emergency Box streams PDFs to resumable local storage and rejects non-PDF 
       bytes() { return new TextDecoder().decode(committed); },
     };
   }
+  const encoder = new TextEncoder();
+  const rangedResponse = (body, start, end, total) => new Response(body, {
+    status: 206,
+    headers: { 'content-range': `bytes ${start}-${end}/${total}` },
+  });
 
   for (const [label, runtime] of [['chrome', EmergencyBoxCh], ['firefox', EmergencyBoxFx]]) {
     const adapters = memoryAdapters();
@@ -21906,7 +21911,7 @@ test('Emergency Box streams PDFs to resumable local storage and rejects non-PDF 
     });
     assert.equal(ready.status, 'ready', `${label}: valid PDF did not become readable`);
     assert.equal(adapters.bytes(), pdf, `${label}: streamed PDF bytes were not preserved`);
-    assert.equal(ready.bytesReceived, new TextEncoder().encode(pdf).byteLength, `${label}: installed byte count is wrong`);
+    assert.equal(ready.bytesReceived, encoder.encode(pdf).byteLength, `${label}: installed byte count is wrong`);
 
     const invalid = memoryAdapters();
     await assert.rejects(
@@ -21919,6 +21924,223 @@ test('Emergency Box streams PDFs to resumable local storage and rejects non-PDF 
     );
     assert.equal(invalid.records.get('fixture-html')?.status, 'error', `${label}: invalid PDF failure was not actionable`);
     assert.equal(invalid.bytes(), '', `${label}: invalid PDF bytes were retained`);
+
+    const partialPdf = '%PDF-resumable-';
+    const tail = 'complete';
+    const partialBytes = encoder.encode(partialPdf).byteLength;
+    const completeBytes = partialBytes + encoder.encode(tail).byteLength;
+    const ifRangeValidator = '"fixture-v1"';
+    const resumableRecord = id => ({
+      id, storageKey: id, url: resource.url, ifRangeValidator,
+    });
+
+    const unvalidated = memoryAdapters(encoder.encode(partialPdf));
+    const unvalidatedHeaders = [];
+    const replacementPdf = '%PDF-restarted-complete';
+    const replacementBytes = encoder.encode(replacementPdf).byteLength;
+    await runtime.downloadEmergencyResource({ ...resource, id: 'fixture-unvalidated' }, {
+      ...unvalidated,
+      fetchImpl: async (_url, options) => {
+        unvalidatedHeaders.push(options.headers);
+        return new Response(replacementPdf, { status: 200, headers: { etag: '"fixture-v2"' } });
+      },
+    });
+    assert.deepEqual(unvalidatedHeaders, [undefined],
+      `${label}: an unvalidated partial was resumed without If-Range`);
+    assert.equal(unvalidated.bytes(), replacementPdf,
+      `${label}: an unvalidated partial was not replaced by the full response`);
+
+    const changedUrl = memoryAdapters(encoder.encode(partialPdf));
+    changedUrl.records.set('fixture-changed-url', {
+      ...resumableRecord('fixture-changed-url'),
+      url: 'https://old.example.test/fixture.pdf',
+    });
+    const changedUrlHeaders = [];
+    await runtime.downloadEmergencyResource({ ...resource, id: 'fixture-changed-url' }, {
+      ...changedUrl,
+      fetchImpl: async (_url, options) => {
+        changedUrlHeaders.push(options.headers);
+        return new Response(replacementPdf, { status: 200 });
+      },
+    });
+    assert.deepEqual(changedUrlHeaders, [undefined],
+      `${label}: a validator from another PDF URL authorized a range request`);
+    assert.equal(changedUrl.bytes(), replacementPdf,
+      `${label}: bytes from another PDF URL were retained`);
+
+    const resumed = memoryAdapters(encoder.encode(partialPdf));
+    resumed.records.set('fixture-resume', resumableRecord('fixture-resume'));
+    const resumeHeaders = [];
+    const resumedReady = await runtime.downloadEmergencyResource({ ...resource, id: 'fixture-resume' }, {
+      ...resumed,
+      fetchImpl: async (_url, options) => {
+        resumeHeaders.push(options.headers);
+        return rangedResponse(tail, partialBytes, completeBytes - 1, completeBytes);
+      },
+    });
+    assert.deepEqual(resumeHeaders, [{ Range: `bytes=${partialBytes}-`, 'If-Range': ifRangeValidator }],
+      `${label}: valid PDF resume did not bind its byte range to the original representation`);
+    assert.equal(resumed.bytes(), partialPdf + tail, `${label}: valid PDF range was not appended at its declared offset`);
+    assert.equal(resumedReady.status, 'ready', `${label}: valid PDF range did not become ready`);
+
+    const failedReplacement = memoryAdapters(encoder.encode(partialPdf));
+    failedReplacement.records.set('fixture-failed-replacement', resumableRecord('fixture-failed-replacement'));
+    let failedReplacementCancelled = false;
+    await assert.rejects(
+      runtime.downloadEmergencyResource({ ...resource, id: 'fixture-failed-replacement' }, {
+        ...failedReplacement,
+        storage: {
+          ...failedReplacement.storage,
+          async createWriter() { return {
+            async write() {},
+            async truncate() { throw new Error('fixture truncate failed'); },
+            async close() {},
+            async abort() {},
+          }; },
+        },
+        fetchImpl: async () => ({
+          ok: true,
+          status: 200,
+          headers: { get(name) { return name.toLowerCase() === 'etag' ? '"fixture-v2"' : null; } },
+          body: { async cancel() { failedReplacementCancelled = true; } },
+        }),
+      }),
+      /truncate failed/i,
+      `${label}: a failed full replacement did not surface its truncate error`,
+    );
+    assert.equal(failedReplacement.records.get('fixture-failed-replacement')?.ifRangeValidator, ifRangeValidator,
+      `${label}: a failed full replacement bound stale bytes to the new validator`);
+    assert.equal(failedReplacement.bytes(), partialPdf,
+      `${label}: a failed full replacement changed the durable partial`);
+    assert.equal(failedReplacementCancelled, true,
+      `${label}: a failed full replacement kept downloading after its storage error`);
+
+    const restarted = memoryAdapters(encoder.encode(partialPdf));
+    restarted.records.set('fixture-restart', resumableRecord('fixture-restart'));
+    const restartRanges = [];
+    const restartedReady = await runtime.downloadEmergencyResource({ ...resource, id: 'fixture-restart' }, {
+      ...restarted,
+      fetchImpl: async (_url, options) => {
+        restartRanges.push(options.headers?.Range || null);
+        if (restartRanges.length === 1) {
+          return new Response(tail, {
+            status: 206,
+            headers: {
+              'content-range': `bytes ${partialBytes}-${completeBytes - 1}/${completeBytes}`,
+              etag: 'W/"fixture-v2"',
+            },
+          });
+        }
+        return new Response(replacementPdf, { status: 200 });
+      },
+    });
+    assert.deepEqual(restartRanges, [`bytes=${partialBytes}-`, null],
+      `${label}: a PDF range with a changed validator was not retried without Range`);
+    assert.equal(restarted.bytes(), replacementPdf, `${label}: a changed PDF version was appended to stale bytes`);
+    assert.equal(restartedReady.status, 'ready', `${label}: full PDF retry did not become ready`);
+
+    const rejectedRetry = memoryAdapters(encoder.encode(partialPdf));
+    rejectedRetry.records.set('fixture-rejected-retry', resumableRecord('fixture-rejected-retry'));
+    let rejectedRequests = 0;
+    await assert.rejects(
+      runtime.downloadEmergencyResource({ ...resource, id: 'fixture-rejected-retry' }, {
+        ...rejectedRetry,
+        fetchImpl: async () => {
+          rejectedRequests += 1;
+          if (rejectedRequests === 1) {
+            return rangedResponse(replacementPdf, 0, replacementBytes - 1, replacementBytes);
+          }
+          return rangedResponse('misaligned', 1, 10, replacementBytes);
+        },
+      }),
+      /Content-Range/i,
+      `${label}: a second mismatched PDF range was accepted`,
+    );
+    assert.equal(rejectedRequests, 2, `${label}: mismatched PDF range retried more than once`);
+    assert.equal(rejectedRetry.bytes(), partialPdf, `${label}: rejected PDF ranges changed the durable partial`);
+    assert.equal(rejectedRetry.records.get('fixture-rejected-retry')?.status, 'error',
+      `${label}: rejected PDF range did not leave an actionable error`);
+
+    const shortRange = memoryAdapters(encoder.encode(partialPdf));
+    shortRange.records.set('fixture-short-range', resumableRecord('fixture-short-range'));
+    await assert.rejects(
+      runtime.downloadEmergencyResource({ ...resource, id: 'fixture-short-range' }, {
+        ...shortRange,
+        fetchImpl: async () => rangedResponse('short', partialBytes, completeBytes - 1, completeBytes),
+      }),
+      /size.*Content-Range/i,
+      `${label}: a truncated PDF range was marked ready`,
+    );
+    assert.equal(shortRange.records.get('fixture-short-range')?.status, 'error',
+      `${label}: truncated PDF range did not leave an actionable error`);
+    assert.equal(shortRange.bytes(), partialPdf,
+      `${label}: truncated PDF range changed the durable partial`);
+
+    const exhaustedRange = memoryAdapters(encoder.encode(partialPdf));
+    exhaustedRange.records.set('fixture-exhausted-range', resumableRecord('fixture-exhausted-range'));
+    const exhaustedRanges = [];
+    await runtime.downloadEmergencyResource({ ...resource, id: 'fixture-exhausted-range' }, {
+      ...exhaustedRange,
+      fetchImpl: async (_url, options) => {
+        exhaustedRanges.push(options.headers?.Range || null);
+        if (exhaustedRanges.length === 1) {
+          return new Response(null, {
+            status: 416,
+            headers: { 'content-range': `bytes */${partialBytes}` },
+          });
+        }
+        return new Response(replacementPdf, { status: 200 });
+      },
+    });
+    assert.deepEqual(exhaustedRanges, [`bytes=${partialBytes}-`, null],
+      `${label}: exhausted PDF range did not retry as a full download`);
+    assert.equal(exhaustedRange.bytes(), replacementPdf,
+      `${label}: exhausted PDF range did not recover with the full response`);
+
+    const unexpectedStatus = memoryAdapters(encoder.encode(partialPdf));
+    unexpectedStatus.records.set('fixture-unexpected-status', resumableRecord('fixture-unexpected-status'));
+    await assert.rejects(
+      runtime.downloadEmergencyResource({ ...resource, id: 'fixture-unexpected-status' }, {
+        ...unexpectedStatus,
+        fetchImpl: async () => new Response(null, { status: 204 }),
+      }),
+      /unexpected HTTP 204/i,
+      `${label}: an empty successful response was accepted as a PDF`,
+    );
+    assert.equal(unexpectedStatus.bytes(), partialPdf,
+      `${label}: an unexpected successful status erased the durable partial`);
+
+    const overlongRange = memoryAdapters(encoder.encode(partialPdf));
+    overlongRange.records.set('fixture-overlong-range', resumableRecord('fixture-overlong-range'));
+    let rangeReaderCancelled = false;
+    const overlongChunks = [encoder.encode('XXXX'), encoder.encode('far-too-long-tail')];
+    let overlongChunkIndex = 0;
+    await assert.rejects(
+      runtime.downloadEmergencyResource({ ...resource, id: 'fixture-overlong-range' }, {
+        ...overlongRange,
+        fetchImpl: async () => ({
+          ok: true,
+          status: 206,
+          headers: { get(name) {
+            return name.toLowerCase() === 'content-range'
+              ? `bytes ${partialBytes}-${completeBytes - 1}/${completeBytes}`
+              : null;
+          } },
+          body: { getReader() { return {
+            async read() {
+              if (overlongChunkIndex >= overlongChunks.length) return { done: true };
+              return { done: false, value: overlongChunks[overlongChunkIndex++] };
+            },
+            async cancel() { rangeReaderCancelled = true; },
+          }; } },
+        }),
+      }),
+      /exceeded.*Content-Range/i,
+      `${label}: an overlong PDF range was accepted`,
+    );
+    assert.equal(rangeReaderCancelled, true, `${label}: an overlong PDF response kept streaming`);
+    assert.equal(overlongRange.bytes(), partialPdf,
+      `${label}: an overlong PDF range changed the durable partial`);
   }
 });
 


### PR DESCRIPTION
## Summary

- validate `Content-Range` before appending a resumed Emergency Box PDF
- bind partial bytes to their source representation with `If-Range`, scoped to the same URL and storage key
- retry unusable ranges as a full download, cancel abandoned responses, and roll back protocol-invalid bytes

## Reproduction

With a local `%PDF-old-partial`, request `Range: bytes=16-` and return:

```
206 Content-Range: bytes 0-16/17
%PDF-new-complete
```

Current `main` appends the response to the old bytes and marks `%PDF-old-partial%PDF-new-complete` as `ready` because the combined file still begins with `%PDF-`. The same corruption occurs in Chrome and Firefox.

## Tests

- `node test/run.js` - 1817 passed; the one baseline failure requires the absent `dist/webbrain-{chrome,edge,firefox}-32.1.0.zip` release archives
- `npm run test:toolbar-guard` - 33 passed
- `npm run test:security` - 60/60 passed
- Chrome and Firefox `emergency-box.js` files are byte-identical