### PR TITLE
fix(ui): ignore stale list refreshes

### DIFF
--- a/src/chrome/src/ui/history.js
+++ b/src/chrome/src/ui/history.js
@@ -29,6 +29,7 @@ let allRecords = [];
 let allRuns = [];
 let selectedRecordId = null;
 let historyRecordRenderRequestId = 0;
+let historyRefreshRequestId = 0;
 
 function traceRunsForRecord(record) {
   if (!record?.conversationId) return [];
@@ -75,10 +76,12 @@ function clearFilter({ focus = false } = {}) {
 }
 
 async function refresh() {
+  const requestId = ++historyRefreshRequestId;
   const [records, runs] = await Promise.all([
     listChatHistoryRecords({ limit: 1000 }),
     listRuns({ limit: 1000 }).catch(() => []),
   ]);
+  if (requestId !== historyRefreshRequestId) return;
   allRecords = records;
   allRuns = runs;
   const selectedRecordStillExists = selectedRecordId && allRecords.some((record) => record.id === selectedRecordId);

--- a/src/chrome/src/ui/traces.js
+++ b/src/chrome/src/ui/traces.js
@@ -26,6 +26,7 @@ let compareMode = false;
 let compareIds = []; // length 0..2
 let timelineObjectUrls = new Set();
 let traceRenderRequestId = 0;
+let traceRefreshRequestId = 0;
 
 // conversationId → [runs, oldest first]. Rebuilt from allRuns on every refresh.
 let conversationMap = new Map();
@@ -64,7 +65,10 @@ function formatCost(value) {
 // ----- List -----------------------------------------------------------------
 
 async function refresh() {
-  allRuns = await listRuns({ limit: 500 });
+  const requestId = ++traceRefreshRequestId;
+  const runs = await listRuns({ limit: 500 });
+  if (requestId !== traceRefreshRequestId) return;
+  allRuns = runs;
   rebuildConversationMap();
   countPill.textContent = t(allRuns.length === 1 ? 'tr.run' : 'tr.runs', { n: allRuns.length });
   // Populate model filter.

--- a/src/firefox/src/ui/history.js
+++ b/src/firefox/src/ui/history.js
@@ -29,6 +29,7 @@ let allRecords = [];
 let allRuns = [];
 let selectedRecordId = null;
 let historyRecordRenderRequestId = 0;
+let historyRefreshRequestId = 0;
 
 function traceRunsForRecord(record) {
   if (!record?.conversationId) return [];
@@ -75,10 +76,12 @@ function clearFilter({ focus = false } = {}) {
 }
 
 async function refresh() {
+  const requestId = ++historyRefreshRequestId;
   const [records, runs] = await Promise.all([
     listChatHistoryRecords({ limit: 1000 }),
     listRuns({ limit: 1000 }).catch(() => []),
   ]);
+  if (requestId !== historyRefreshRequestId) return;
   allRecords = records;
   allRuns = runs;
   const selectedRecordStillExists = selectedRecordId && allRecords.some((record) => record.id === selectedRecordId);

--- a/src/firefox/src/ui/traces.js
+++ b/src/firefox/src/ui/traces.js
@@ -26,6 +26,7 @@ let compareMode = false;
 let compareIds = []; // length 0..2
 let timelineObjectUrls = new Set();
 let traceRenderRequestId = 0;
+let traceRefreshRequestId = 0;
 
 // conversationId → [runs, oldest first]. Rebuilt from allRuns on every refresh.
 let conversationMap = new Map();
@@ -64,7 +65,10 @@ function formatCost(value) {
 // ----- List -----------------------------------------------------------------
 
 async function refresh() {
-  allRuns = await listRuns({ limit: 500 });
+  const requestId = ++traceRefreshRequestId;
+  const runs = await listRuns({ limit: 500 });
+  if (requestId !== traceRefreshRequestId) return;
+  allRuns = runs;
   rebuildConversationMap();
   countPill.textContent = t(allRuns.length === 1 ? 'tr.run' : 'tr.runs', { n: allRuns.length });
   // Populate model filter.

--- a/test/run.js
+++ b/test/run.js
@@ -28974,6 +28974,104 @@ test('trace viewer drops stale async render completions', () => {
   }
 });
 
+test('history and trace pages ignore stale list refreshes', async () => {
+  function refreshSource(source, label) {
+    const match = source.match(/async function refresh\(\) \{[\s\S]*?\n\}/);
+    assert.ok(match, `${label}: refresh function missing`);
+    return match[0];
+  }
+
+  function historyHarness(source, recordReads, runReads) {
+    return Function('recordReads', 'runReads', `
+      let allRecords = [];
+      let allRuns = [];
+      let selectedRecordId = null;
+      let historyRefreshRequestId = 0;
+      let renderCount = 0;
+      const listChatHistoryRecords = () => recordReads.shift().promise;
+      const listRuns = () => runReads.shift().promise;
+      function renderEmpty() {}
+      function renderList() { renderCount += 1; }
+      function refreshButtons() {}
+      async function renderRecord() {}
+      ${refreshSource(source, 'history')}
+      return {
+        refresh,
+        snapshot: () => ({ allRecords, allRuns, renderCount }),
+      };
+    `)(recordReads, runReads);
+  }
+
+  function traceHarness(source, runReads) {
+    return Function('runReads', `
+      let allRuns = [];
+      let traceRefreshRequestId = 0;
+      let renderCount = 0;
+      const countPill = { textContent: '' };
+      const filterModel = { value: '', innerHTML: '' };
+      const listRuns = () => runReads.shift().promise;
+      const t = (_key, params) => String(params?.n ?? '');
+      const escapeHtml = String;
+      function rebuildConversationMap() {}
+      function renderList() { renderCount += 1; }
+      ${refreshSource(source, 'traces')}
+      return {
+        refresh,
+        snapshot: () => ({ allRuns, renderCount }),
+      };
+    `)(runReads);
+  }
+
+  for (const [label, prefix] of [
+    ['chrome', 'src/chrome'],
+    ['firefox', 'src/firefox'],
+  ]) {
+    const history = fs.readFileSync(path.join(ROOT, prefix, 'src/ui/history.js'), 'utf8');
+    assert.match(history, /let historyRefreshRequestId = 0;/, `${label}: history refreshes should be sequenced`);
+
+    const oldRecords = deferred();
+    const newRecords = deferred();
+    const oldHistoryRuns = deferred();
+    const newHistoryRuns = deferred();
+    const historyRuntime = historyHarness(
+      history,
+      [oldRecords, newRecords],
+      [oldHistoryRuns, newHistoryRuns],
+    );
+    const oldHistoryRefresh = historyRuntime.refresh();
+    const newHistoryRefresh = historyRuntime.refresh();
+    newRecords.resolve([]);
+    newHistoryRuns.resolve([]);
+    await newHistoryRefresh;
+    oldRecords.resolve([{ id: 'deleted-record' }]);
+    oldHistoryRuns.resolve([{ runId: 'deleted-run' }]);
+    await oldHistoryRefresh;
+    assert.deepEqual(
+      historyRuntime.snapshot(),
+      { allRecords: [], allRuns: [], renderCount: 1 },
+      `${label}: a late history read restored stale records`,
+    );
+
+    const traces = fs.readFileSync(path.join(ROOT, prefix, 'src/ui/traces.js'), 'utf8');
+    assert.match(traces, /let traceRefreshRequestId = 0;/, `${label}: trace refreshes should be sequenced`);
+
+    const oldTraceRuns = deferred();
+    const newTraceRuns = deferred();
+    const traceRuntime = traceHarness(traces, [oldTraceRuns, newTraceRuns]);
+    const oldTraceRefresh = traceRuntime.refresh();
+    const newTraceRefresh = traceRuntime.refresh();
+    newTraceRuns.resolve([]);
+    await newTraceRefresh;
+    oldTraceRuns.resolve([{ runId: 'deleted-run' }]);
+    await oldTraceRefresh;
+    assert.deepEqual(
+      traceRuntime.snapshot(),
+      { allRuns: [], renderCount: 1 },
+      `${label}: a late trace read restored stale runs`,
+    );
+  }
+});
+
 test('trace viewer escapes attribute data from stored trace records', () => {
   for (const [label, tracesRel] of [
     ['chrome', 'src/chrome/src/ui/traces.js'],


### PR DESCRIPTION
## Summary
- sequence concurrent History and Traces list refreshes
- ignore older reads before they mutate shared list state or rerender
- cover Chrome and Firefox with deterministic out-of-order Promise tests

## Why
Manual refresh, delete/clear, locale updates, and trace polling can overlap. A slower earlier read could otherwise replace a newer snapshot and briefly restore stale records or runs.

## Tests
- `node test/run.js` (1818 passed; the only failure is the existing artifact check because `dist/webbrain-chrome-32.1.0.zip` is absent from main)
- `npm run test:toolbar-guard` (33 passed)
- `npm run test:security` (60 passed)