### PR TITLE
fix(ui): render markdown tables

### DIFF
--- a/src/chrome/src/ui/history-text.js
+++ b/src/chrome/src/ui/history-text.js
@@ -19,6 +19,60 @@ const BLOCK_TAGS = new Set([
 
 const SKIPPED_TAGS = new Set(['SCRIPT', 'STYLE', 'TEMPLATE']);
 
+function elementChildren(node) {
+  return Array.from(node?.childNodes || []).filter((child) => child && child.nodeType === ELEMENT_NODE);
+}
+
+function tableRowsFromElement(table) {
+  const rows = [];
+  const visit = (node) => {
+    if (!node || node.nodeType !== ELEMENT_NODE) return;
+    if (String(node.tagName || '').toUpperCase() === 'TR') {
+      rows.push(node);
+      return;
+    }
+    for (const child of node.childNodes || []) visit(child);
+  };
+  visit(table);
+  return rows;
+}
+
+function tableRowCells(row) {
+  return elementChildren(row).filter((child) => {
+    const tag = String(child.tagName || '').toUpperCase();
+    return tag === 'TH' || tag === 'TD';
+  });
+}
+
+function markdownTableCellText(cell) {
+  return historyTextFromElement(cell, { markdown: true })
+    .replace(/\s+/g, ' ')
+    .trim()
+    .replace(/\|/g, '\\|');
+}
+
+function markdownTableFromElement(table) {
+  const rows = tableRowsFromElement(table);
+  if (!rows.length) return '';
+  const header = tableRowCells(rows[0]).map(markdownTableCellText);
+  if (!header.length) return '';
+  const lines = [
+    `| ${header.join(' | ')} |`,
+    `|${header.map(() => '---').join('|')}|`,
+  ];
+  for (const row of rows.slice(1)) {
+    const cells = tableRowCells(row).map(markdownTableCellText);
+    while (cells.length < header.length) cells.push('');
+    lines.push(`| ${cells.slice(0, header.length).join(' | ')} |`);
+  }
+  return lines.join('\n');
+}
+
+function tableElementFromNode(node) {
+  if (String(node?.tagName || '').toUpperCase() === 'TABLE') return node;
+  return elementChildren(node).find((child) => String(child.tagName || '').toUpperCase() === 'TABLE') || null;
+}
+
 export function historyTextFromElement(root, { markdown = true } = {}) {
   if (!root) return '';
   let output = '';
@@ -100,6 +154,15 @@ export function historyTextFromElement(root, { markdown = true } = {}) {
       if (href) output += '[';
       for (const child of Array.from(node.childNodes || [])) visit(child, false, inPre);
       if (href) output += `](${href})`;
+      return;
+    }
+    if (markdown && (tagName === 'TABLE' || node.classList?.contains?.('markdown-table-wrapper'))) {
+      const markdownTable = markdownTableFromElement(tableElementFromNode(node) || node);
+      if (markdownTable) {
+        ensureBreak();
+        output += markdownTable;
+        ensureBreak();
+      }
       return;
     }
 

--- a/src/chrome/src/ui/markdown-render.js
+++ b/src/chrome/src/ui/markdown-render.js
@@ -216,3 +216,73 @@ export function renderMarkdownHeadings(text) {
     }
   );
 }
+
+function splitMarkdownTableRow(line) {
+  let source = String(line || '').trim();
+  if (!source.includes('|')) return null;
+  if (source.startsWith('|')) source = source.slice(1);
+  // A trailing escaped pipe belongs to the cell instead of closing the row.
+  if (source.endsWith('|') && !source.endsWith('\\|')) source = source.slice(0, -1);
+
+  const cells = [];
+  let cell = '';
+  for (let i = 0; i < source.length; i += 1) {
+    const character = source[i];
+    if (character === '\\' && source[i + 1] === '|') {
+      cell += '|';
+      i += 1;
+    } else if (character === '|') {
+      cells.push(cell.trim());
+      cell = '';
+    } else {
+      cell += character;
+    }
+  }
+  cells.push(cell.trim());
+  return cells;
+}
+
+function markdownTableSeparator(cell) {
+  return /^:?-{3,}:?$/.test(cell);
+}
+
+function renderMarkdownTableRow(cells, tag) {
+  return `<tr>${cells.map((cell) => `<${tag}>${cell}</${tag}>`).join('')}</tr>`;
+}
+
+/** Convert GitHub-style pipe tables after the caller has escaped source HTML. */
+export function renderMarkdownTables(text) {
+  const lines = String(text == null ? '' : text).split(/\r?\n/);
+  const rendered = [];
+
+  for (let index = 0; index < lines.length;) {
+    const header = splitMarkdownTableRow(lines[index]);
+    const separator = splitMarkdownTableRow(lines[index + 1]);
+    const isTable = header?.length > 0
+      && separator?.length === header.length
+      && separator.every(markdownTableSeparator);
+    if (!isTable) {
+      rendered.push(lines[index]);
+      index += 1;
+      continue;
+    }
+
+    const body = [];
+    let next = index + 2;
+    while (next < lines.length) {
+      const row = splitMarkdownTableRow(lines[next]);
+      if (!row) break;
+      body.push(row.length < header.length
+        ? [...row, ...Array(header.length - row.length).fill('')]
+        : row.slice(0, header.length));
+      next += 1;
+    }
+
+    const headerRow = renderMarkdownTableRow(header, 'th');
+    const bodyRows = body.map((row) => renderMarkdownTableRow(row, 'td'));
+    rendered.push(`<div class="markdown-table-wrapper"><table><thead>${headerRow}</thead><tbody>${bodyRows.join('')}</tbody></table></div>`);
+    index = next;
+  }
+
+  return rendered.join('\n');
+}

--- a/src/chrome/src/ui/sidepanel.js
+++ b/src/chrome/src/ui/sidepanel.js
@@ -6,7 +6,7 @@
 import { t, getLocale, setLocale, LANGUAGES, applyDOMTranslations } from './i18n.js';
 import { CAPABILITY_LABEL } from '../agent/permission-gate.js';
 import { sanitizeMarkdownLinks } from './markdown-link.js';
-import { codeFenceLanguage, highlightCode, renderMarkdownHeadings } from './markdown-render.js';
+import { codeFenceLanguage, highlightCode, renderMarkdownHeadings, renderMarkdownTables } from './markdown-render.js';
 import { applyMode, loadMode, watch } from './theme.js';
 import { buildRecommendedActions, shouldShowRecommendedActions } from './recommended-actions.js';
 import { createContextMenuPromptHandler } from './context-menu-prompts.js';
@@ -11488,10 +11488,11 @@ function formatMarkdown(text, options = {}) {
     .replace(/</g, '&lt;')
     .replace(/>/g, '&gt;');
 
-  // 4. Block headings, inline formatting, markdown link sanitization, then
-  // newline → <br>. Code and inline-code placeholders were extracted above,
-  // so Markdown-looking source inside them is not interpreted here.
+  // 4. Block headings, tables, inline formatting, markdown link sanitization,
+  // then newline → <br>. Code and inline-code placeholders were extracted
+  // above, so Markdown-looking source inside them is not interpreted here.
   text = renderMarkdownHeadings(text);
+  text = renderMarkdownTables(text);
   text = text
     .replace(/\*\*(.+?)\*\*/g, '<strong>$1</strong>')
     .replace(/\*(.+?)\*/g, '<em>$1</em>');

--- a/src/chrome/src/ui/sidepanel.js
+++ b/src/chrome/src/ui/sidepanel.js
@@ -11488,11 +11488,13 @@ function formatMarkdown(text, options = {}) {
     .replace(/</g, '&lt;')
     .replace(/>/g, '&gt;');
 
-  // 4. Block headings, tables, inline formatting, markdown link sanitization,
-  // then newline → <br>. Code and inline-code placeholders were extracted
-  // above, so Markdown-looking source inside them is not interpreted here.
-  text = renderMarkdownHeadings(text);
+  // 4. Tables, then headings, inline formatting, markdown link sanitization,
+  // then newline → <br>. Headings swallow their trailing newline, so tables
+  // must run first or a table on the next line is glued onto the heading.
+  // Code and inline-code placeholders were extracted above, so
+  // Markdown-looking source inside them is not interpreted here.
   text = renderMarkdownTables(text);
+  text = renderMarkdownHeadings(text);
   text = text
     .replace(/\*\*(.+?)\*\*/g, '<strong>$1</strong>')
     .replace(/\*(.+?)\*/g, '<em>$1</em>');

--- a/src/chrome/styles/sidepanel.css
+++ b/src/chrome/styles/sidepanel.css
@@ -3176,6 +3176,31 @@ html[data-standalone="true"] #mode-toggle {
 .message-content h5,
 .message-content h6 { font-size: 13px; }
 
+.markdown-table-wrapper {
+  max-width: 100%;
+  margin: 8px 0;
+  overflow-x: auto;
+}
+
+.message-content table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 12px;
+}
+
+.message-content th,
+.message-content td {
+  padding: 5px 7px;
+  border: 1px solid var(--border);
+  text-align: left;
+  vertical-align: top;
+}
+
+.message-content th {
+  background: var(--overlay-bg);
+  font-weight: 600;
+}
+
 .message-content code {
   background: var(--overlay-bg);
   padding: 1px 4px;

--- a/src/firefox/src/ui/history-text.js
+++ b/src/firefox/src/ui/history-text.js
@@ -19,6 +19,60 @@ const BLOCK_TAGS = new Set([
 
 const SKIPPED_TAGS = new Set(['SCRIPT', 'STYLE', 'TEMPLATE']);
 
+function elementChildren(node) {
+  return Array.from(node?.childNodes || []).filter((child) => child && child.nodeType === ELEMENT_NODE);
+}
+
+function tableRowsFromElement(table) {
+  const rows = [];
+  const visit = (node) => {
+    if (!node || node.nodeType !== ELEMENT_NODE) return;
+    if (String(node.tagName || '').toUpperCase() === 'TR') {
+      rows.push(node);
+      return;
+    }
+    for (const child of node.childNodes || []) visit(child);
+  };
+  visit(table);
+  return rows;
+}
+
+function tableRowCells(row) {
+  return elementChildren(row).filter((child) => {
+    const tag = String(child.tagName || '').toUpperCase();
+    return tag === 'TH' || tag === 'TD';
+  });
+}
+
+function markdownTableCellText(cell) {
+  return historyTextFromElement(cell, { markdown: true })
+    .replace(/\s+/g, ' ')
+    .trim()
+    .replace(/\|/g, '\\|');
+}
+
+function markdownTableFromElement(table) {
+  const rows = tableRowsFromElement(table);
+  if (!rows.length) return '';
+  const header = tableRowCells(rows[0]).map(markdownTableCellText);
+  if (!header.length) return '';
+  const lines = [
+    `| ${header.join(' | ')} |`,
+    `|${header.map(() => '---').join('|')}|`,
+  ];
+  for (const row of rows.slice(1)) {
+    const cells = tableRowCells(row).map(markdownTableCellText);
+    while (cells.length < header.length) cells.push('');
+    lines.push(`| ${cells.slice(0, header.length).join(' | ')} |`);
+  }
+  return lines.join('\n');
+}
+
+function tableElementFromNode(node) {
+  if (String(node?.tagName || '').toUpperCase() === 'TABLE') return node;
+  return elementChildren(node).find((child) => String(child.tagName || '').toUpperCase() === 'TABLE') || null;
+}
+
 export function historyTextFromElement(root, { markdown = true } = {}) {
   if (!root) return '';
   let output = '';
@@ -100,6 +154,15 @@ export function historyTextFromElement(root, { markdown = true } = {}) {
       if (href) output += '[';
       for (const child of Array.from(node.childNodes || [])) visit(child, false, inPre);
       if (href) output += `](${href})`;
+      return;
+    }
+    if (markdown && (tagName === 'TABLE' || node.classList?.contains?.('markdown-table-wrapper'))) {
+      const markdownTable = markdownTableFromElement(tableElementFromNode(node) || node);
+      if (markdownTable) {
+        ensureBreak();
+        output += markdownTable;
+        ensureBreak();
+      }
       return;
     }
 

--- a/src/firefox/src/ui/markdown-render.js
+++ b/src/firefox/src/ui/markdown-render.js
@@ -216,3 +216,73 @@ export function renderMarkdownHeadings(text) {
     }
   );
 }
+
+function splitMarkdownTableRow(line) {
+  let source = String(line || '').trim();
+  if (!source.includes('|')) return null;
+  if (source.startsWith('|')) source = source.slice(1);
+  // A trailing escaped pipe belongs to the cell instead of closing the row.
+  if (source.endsWith('|') && !source.endsWith('\\|')) source = source.slice(0, -1);
+
+  const cells = [];
+  let cell = '';
+  for (let i = 0; i < source.length; i += 1) {
+    const character = source[i];
+    if (character === '\\' && source[i + 1] === '|') {
+      cell += '|';
+      i += 1;
+    } else if (character === '|') {
+      cells.push(cell.trim());
+      cell = '';
+    } else {
+      cell += character;
+    }
+  }
+  cells.push(cell.trim());
+  return cells;
+}
+
+function markdownTableSeparator(cell) {
+  return /^:?-{3,}:?$/.test(cell);
+}
+
+function renderMarkdownTableRow(cells, tag) {
+  return `<tr>${cells.map((cell) => `<${tag}>${cell}</${tag}>`).join('')}</tr>`;
+}
+
+/** Convert GitHub-style pipe tables after the caller has escaped source HTML. */
+export function renderMarkdownTables(text) {
+  const lines = String(text == null ? '' : text).split(/\r?\n/);
+  const rendered = [];
+
+  for (let index = 0; index < lines.length;) {
+    const header = splitMarkdownTableRow(lines[index]);
+    const separator = splitMarkdownTableRow(lines[index + 1]);
+    const isTable = header?.length > 0
+      && separator?.length === header.length
+      && separator.every(markdownTableSeparator);
+    if (!isTable) {
+      rendered.push(lines[index]);
+      index += 1;
+      continue;
+    }
+
+    const body = [];
+    let next = index + 2;
+    while (next < lines.length) {
+      const row = splitMarkdownTableRow(lines[next]);
+      if (!row) break;
+      body.push(row.length < header.length
+        ? [...row, ...Array(header.length - row.length).fill('')]
+        : row.slice(0, header.length));
+      next += 1;
+    }
+
+    const headerRow = renderMarkdownTableRow(header, 'th');
+    const bodyRows = body.map((row) => renderMarkdownTableRow(row, 'td'));
+    rendered.push(`<div class="markdown-table-wrapper"><table><thead>${headerRow}</thead><tbody>${bodyRows.join('')}</tbody></table></div>`);
+    index = next;
+  }
+
+  return rendered.join('\n');
+}

--- a/src/firefox/src/ui/sidepanel.js
+++ b/src/firefox/src/ui/sidepanel.js
@@ -11097,11 +11097,13 @@ function formatMarkdown(text, options = {}) {
     .replace(/</g, '&lt;')
     .replace(/>/g, '&gt;');
 
-  // 4. Block headings, tables, inline formatting, markdown link sanitization,
-  // then newline → <br>. Code and inline-code placeholders were extracted
-  // above, so Markdown-looking source inside them is not interpreted here.
-  text = renderMarkdownHeadings(text);
+  // 4. Tables, then headings, inline formatting, markdown link sanitization,
+  // then newline → <br>. Headings swallow their trailing newline, so tables
+  // must run first or a table on the next line is glued onto the heading.
+  // Code and inline-code placeholders were extracted above, so
+  // Markdown-looking source inside them is not interpreted here.
   text = renderMarkdownTables(text);
+  text = renderMarkdownHeadings(text);
   text = text
     .replace(/\*\*(.+?)\*\*/g, '<strong>$1</strong>')
     .replace(/\*(.+?)\*/g, '<em>$1</em>');

--- a/src/firefox/src/ui/sidepanel.js
+++ b/src/firefox/src/ui/sidepanel.js
@@ -6,7 +6,7 @@
 import { t, getLocale, setLocale, LANGUAGES, applyDOMTranslations } from './i18n.js';
 import { CAPABILITY_LABEL } from '../agent/permission-gate.js';
 import { sanitizeMarkdownLinks } from './markdown-link.js';
-import { codeFenceLanguage, highlightCode, renderMarkdownHeadings } from './markdown-render.js';
+import { codeFenceLanguage, highlightCode, renderMarkdownHeadings, renderMarkdownTables } from './markdown-render.js';
 import { applyMode, loadMode, watch } from './theme.js';
 import { buildRecommendedActions, shouldShowRecommendedActions } from './recommended-actions.js';
 import { createContextMenuPromptHandler } from './context-menu-prompts.js';
@@ -11097,10 +11097,11 @@ function formatMarkdown(text, options = {}) {
     .replace(/</g, '&lt;')
     .replace(/>/g, '&gt;');
 
-  // 4. Block headings, inline formatting, markdown link sanitization, then
-  // newline → <br>. Code and inline-code placeholders were extracted above,
-  // so Markdown-looking source inside them is not interpreted here.
+  // 4. Block headings, tables, inline formatting, markdown link sanitization,
+  // then newline → <br>. Code and inline-code placeholders were extracted
+  // above, so Markdown-looking source inside them is not interpreted here.
   text = renderMarkdownHeadings(text);
+  text = renderMarkdownTables(text);
   text = text
     .replace(/\*\*(.+?)\*\*/g, '<strong>$1</strong>')
     .replace(/\*(.+?)\*/g, '<em>$1</em>');

--- a/src/firefox/styles/sidepanel.css
+++ b/src/firefox/styles/sidepanel.css
@@ -3007,6 +3007,31 @@ html[data-standalone="true"] #mode-toggle {
 .message-content h5,
 .message-content h6 { font-size: 13px; }
 
+.markdown-table-wrapper {
+  max-width: 100%;
+  margin: 8px 0;
+  overflow-x: auto;
+}
+
+.message-content table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 12px;
+}
+
+.message-content th,
+.message-content td {
+  padding: 5px 7px;
+  border: 1px solid var(--border);
+  text-align: left;
+  vertical-align: top;
+}
+
+.message-content th {
+  background: var(--overlay-bg);
+  font-weight: 600;
+}
+
 .message-content code {
   background: var(--overlay-bg);
   padding: 1px 4px;

--- a/test/run.js
+++ b/test/run.js
@@ -394,7 +394,7 @@ const ChromeWebStoreReleaseFx = await import(
 const { sanitizeLink, sanitizeMarkdownLinks } = await import(
   'file://' + path.join(ROOT, 'src/chrome/src/ui/markdown-link.js').replace(/\\/g, '/')
 );
-const { codeFenceLanguage, highlightCode, renderMarkdownHeadings } = await import(
+const { codeFenceLanguage, highlightCode, renderMarkdownHeadings, renderMarkdownTables } = await import(
   'file://' + path.join(ROOT, 'src/chrome/src/ui/markdown-render.js').replace(/\\/g, '/')
 );
 const { renderSkillMarkdown } = await import(
@@ -531,7 +531,7 @@ const {
 const { sanitizeMarkdownLinks: sanitizeMarkdownLinksFx } = await import(
   'file://' + path.join(ROOT, 'src/firefox/src/ui/markdown-link.js').replace(/\\/g, '/')
 );
-const { codeFenceLanguage: codeFenceLanguageFx, highlightCode: highlightCodeFx, renderMarkdownHeadings: renderMarkdownHeadingsFx } = await import(
+const { codeFenceLanguage: codeFenceLanguageFx, highlightCode: highlightCodeFx, renderMarkdownHeadings: renderMarkdownHeadingsFx, renderMarkdownTables: renderMarkdownTablesFx } = await import(
   'file://' + path.join(ROOT, 'src/firefox/src/ui/markdown-render.js').replace(/\\/g, '/')
 );
 const { renderSkillMarkdown: renderSkillMarkdownFx } = await import(
@@ -13503,6 +13503,37 @@ test('ATX headings render as semantic headings and preserve inline Markdown', ()
   assert.equal(renderMarkdownHeadings('## C#\nText'), '<h2>C#</h2>Text');
 });
 
+test('pipe tables render as semantic tables instead of literal Markdown', () => {
+  const source = [
+    '| Aspect | multilingual-e5-small | BM25 |',
+    '|---|---|---|',
+    '| Retrieval type | Dense semantic retrieval | Sparse lexical retrieval |',
+    '| Exact keyword matching | Moderate | Excellent |',
+  ].join('\n');
+  const escaped = source.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+  const out = renderMarkdownTables(escaped);
+  assert.equal(
+    out,
+    '<div class="markdown-table-wrapper"><table><thead><tr><th>Aspect</th><th>multilingual-e5-small</th><th>BM25</th></tr></thead><tbody><tr><td>Retrieval type</td><td>Dense semantic retrieval</td><td>Sparse lexical retrieval</td></tr><tr><td>Exact keyword matching</td><td>Moderate</td><td>Excellent</td></tr></tbody></table></div>',
+  );
+  assert.doesNotMatch(out, /\| Aspect \|/);
+});
+
+test('pipe tables preserve inline-safe cell content and only match a valid separator', () => {
+  const table = '| Name | Value |\n|:---|---:|\n| `x` | &lt;safe&gt; |';
+  const out = renderMarkdownTables(table);
+  assert.match(out, /<th>Name<\/th><th>Value<\/th>/);
+  assert.match(out, /<td>`x`<\/td><td>&lt;safe&gt;<\/td>/);
+  assert.equal(renderMarkdownTables('| not a table |\n| still prose |'), '| not a table |\n| still prose |');
+});
+
+test('pipe tables keep rendering when a body row has missing or extra cells', () => {
+  const out = renderMarkdownTables('| A | B |\n|---|---|\n| one |\n| one | two | three |');
+  assert.match(out, /<td>one<\/td><td><\/td>/);
+  assert.match(out, /<td>one<\/td><td>two<\/td>/);
+  assert.doesNotMatch(out, /\| one \|/);
+});
+
 test('Chrome and Firefox Markdown rendering helpers stay in parity', () => {
   const samples = [
     ['const x = "<tag>";', 'javascript'],
@@ -13516,6 +13547,8 @@ test('Chrome and Firefox Markdown rendering helpers stay in parity', () => {
   const heading = '### **Option A**\nBody';
   assert.equal(renderMarkdownHeadingsFx(heading), renderMarkdownHeadings(heading));
   assert.equal(codeFenceLanguageFx('js title="example.js"'), codeFenceLanguage('js title="example.js"'));
+  const table = '| A | B |\n|---|---|\n| 1 | 2 |';
+  assert.equal(renderMarkdownTablesFx(table), renderMarkdownTables(table));
 });
 
 test('sidepanels wire highlighting and heading rendering into fenced Markdown', () => {
@@ -13525,10 +13558,12 @@ test('sidepanels wire highlighting and heading rendering into fenced Markdown', 
   ]) {
     const panel = fs.readFileSync(path.join(ROOT, panelRel), 'utf8');
     const css = fs.readFileSync(path.join(ROOT, cssRel), 'utf8');
-    assert.match(panel, /import \{ codeFenceLanguage, highlightCode, renderMarkdownHeadings \} from '\.\/markdown-render\.js';/, `${label}: renderer helpers should be imported`);
+    assert.match(panel, /import \{ codeFenceLanguage, highlightCode, renderMarkdownHeadings, renderMarkdownTables \} from '\.\/markdown-render\.js';/, `${label}: renderer helpers should be imported`);
     assert.match(panel, /const lang = codeFenceLanguage\(info\);/, `${label}: fenced code should tolerate metadata after its language token`);
     assert.match(panel, /const highlighted = enhance \? highlightCode\(block\.code, block\.lang\) : escapeHtml\(block\.code\);/, `${label}: completed fenced code should be highlighted by its language while live code stays lightweight`);
     assert.match(panel, /text = renderMarkdownHeadings\(text\);/, `${label}: ATX headings should be rendered`);
+    assert.match(panel, /text = renderMarkdownTables\(text\);/, `${label}: pipe tables should be rendered`);
+    assert.match(css, /\.message-content table \{[\s\S]*?border-collapse: collapse;/, `${label}: rendered tables should have readable borders`);
     assert.match(css, /\.syntax-keyword[\s\S]*?var\(--syntax-keyword\)/, `${label}: token colors should be styled`);
     assert.match(css, /\.syntax-variable \{ color: var\(--syntax-variable\); \}/, `${label}: variables should use their dedicated theme color`);
     assert.match(css, /\.message-content h3 \{ font-size: 14px; \}/, `${label}: level-three headings should be visually distinct`);

--- a/test/run.js
+++ b/test/run.js
@@ -13534,6 +13534,19 @@ test('pipe tables keep rendering when a body row has missing or extra cells', ()
   assert.doesNotMatch(out, /\| one \|/);
 });
 
+test('pipe tables still render when they follow an ATX heading with no blank line', () => {
+  const source = '## Comparison\n| A | B |\n|---|---|\n| 1 | 2 |';
+  const headingsFirst = renderMarkdownTables(renderMarkdownHeadings(source));
+  assert.match(headingsFirst, /<h2>Comparison<\/h2>/);
+  assert.doesNotMatch(headingsFirst, /<table>/, 'heading newline swallowing used to glue the header onto the h2');
+
+  const out = renderMarkdownHeadings(renderMarkdownTables(source));
+  assert.match(out, /<h2>Comparison<\/h2>/);
+  assert.match(out, /<table>/);
+  assert.match(out, /<td>1<\/td><td>2<\/td>/);
+  assert.doesNotMatch(out, /\| A \|/);
+});
+
 test('Chrome and Firefox Markdown rendering helpers stay in parity', () => {
   const samples = [
     ['const x = "<tag>";', 'javascript'],
@@ -13561,8 +13574,7 @@ test('sidepanels wire highlighting and heading rendering into fenced Markdown', 
     assert.match(panel, /import \{ codeFenceLanguage, highlightCode, renderMarkdownHeadings, renderMarkdownTables \} from '\.\/markdown-render\.js';/, `${label}: renderer helpers should be imported`);
     assert.match(panel, /const lang = codeFenceLanguage\(info\);/, `${label}: fenced code should tolerate metadata after its language token`);
     assert.match(panel, /const highlighted = enhance \? highlightCode\(block\.code, block\.lang\) : escapeHtml\(block\.code\);/, `${label}: completed fenced code should be highlighted by its language while live code stays lightweight`);
-    assert.match(panel, /text = renderMarkdownHeadings\(text\);/, `${label}: ATX headings should be rendered`);
-    assert.match(panel, /text = renderMarkdownTables\(text\);/, `${label}: pipe tables should be rendered`);
+    assert.match(panel, /text = renderMarkdownTables\(text\);\s*text = renderMarkdownHeadings\(text\);/, `${label}: pipe tables must render before headings swallow the following newline`);
     assert.match(css, /\.message-content table \{[\s\S]*?border-collapse: collapse;/, `${label}: rendered tables should have readable borders`);
     assert.match(css, /\.syntax-keyword[\s\S]*?var\(--syntax-keyword\)/, `${label}: token colors should be styled`);
     assert.match(css, /\.syntax-variable \{ color: var\(--syntax-variable\); \}/, `${label}: variables should use their dedicated theme color`);
@@ -30466,6 +30478,22 @@ test('chat history text serialization preserves rendered line structure', () => 
       serialize(renderedCodeFollowedByText),
       '```javascript\nline 1\n```\nClosing',
       `${label}: rendered code wrappers should preserve their language and use the source <br> as the only post-fence newline`,
+    );
+    const table = element(
+      'TABLE',
+      element('THEAD', element('TR', element('TH', textNode('Aspect')), element('TH', textNode('BM25')))),
+      element(
+        'TBODY',
+        element('TR', element('TD', textNode('Exact keyword matching')), element('TD', element('STRONG', textNode('Excellent')))),
+        element('TR', element('TD', textNode('A | B')), element('TD', textNode('kept'))),
+      ),
+    );
+    const wrappedTable = element('DIV', table);
+    wrappedTable.classList = { contains: (name) => name === 'markdown-table-wrapper' };
+    assert.equal(
+      serialize(wrappedTable).trim(),
+      '| Aspect | BM25 |\n|---|---|\n| Exact keyword matching | **Excellent** |\n| A \\| B | kept |',
+      `${label}: rendered pipe tables should round-trip as Markdown instead of flattened cells`,
     );
   }
 });


### PR DESCRIPTION
## Summary

- Render GitHub-style Markdown pipe tables as semantic HTML tables in the chat sidepanel.
- Mirror the renderer and styles across Chrome and Firefox.
- Add regression and parity coverage for issue #2838.

## Motivation

Responses containing a header row, separator row, and pipe-delimited data rows were displayed as literal Markdown instead of a table. This is the user-visible failure reported in [#2838](https://github.com/webbrain-one/webbrain/issues/2838).

## Design

- Add a dependency-free table parser to the existing Markdown renderer.
- Run it after HTML escaping and after fenced/inline code extraction, so untrusted cell text remains escaped and pipes inside code do not alter table structure.
- Accept valid separator rows, escaped pipes, and ragged body rows while keeping ordinary pipe text unchanged.
- Add responsive overflow handling and readable header/cell borders without changing provider, storage, or browser APIs.

## Testing

- `node test/run.js` — 1850 passed; 1 pre-existing failure for the missing tracked artifact `dist/webbrain-chrome-32.1.0.zip` in the Opera-safe license filename check.
- `node --check src/chrome/src/ui/markdown-render.js && node --check src/chrome/src/ui/sidepanel.js && node --check src/firefox/src/ui/markdown-render.js && node --check src/firefox/src/ui/sidepanel.js` — passed.
- `npm run test:toolbar-guard` — passed (33 tests).
- `npm run test:security` — passed (60/60 checks).
- Chrome unpacked extension check on `sidepanel.html` — passed; injected issue table rendered as one table with `overflow-x: auto`, and no page or console errors.

Firefox live browser verification was not available; Firefox parity is covered by the mirrored source and regression assertions.

## Compatibility and risks

- No public API, provider, storage, or data migration changes.
- Fenced code blocks and inline code remain protected by the existing placeholder extraction.
- The parser intentionally targets chat sidepanel rendering; standalone skill-preview table rendering is deferred.

## Scope

- Deferred support for tables in the separate skill-preview/history Markdown renderer.

Closes #2838