### PR TITLE
Add hover tooltip on Edge card for Mac/Linux users

### DIFF
--- a/web/ar/index.html
+++ b/web/ar/index.html
@@ -2287,6 +2287,7 @@
       grid-template-columns: repeat(2, minmax(0, 1fr));
     }
     .download-card {
+      position: relative;
       background: var(--bg-card);
       border: 1px solid var(--border);
       border-radius: var(--radius);
@@ -2356,6 +2357,38 @@
       background: #2a2a2a;
       border-color: #6f6f6f;
       box-shadow: none;
+    }
+    .edge-unavailable-tip {
+      position: absolute;
+      top: -36px;
+      left: 50%;
+      transform: translateX(-50%);
+      background: #1a1a1a;
+      color: #e0e0e0;
+      font-size: 12px;
+      font-weight: 500;
+      line-height: 1;
+      padding: 7px 12px;
+      border-radius: 6px;
+      white-space: nowrap;
+      pointer-events: none;
+      opacity: 0;
+      transition: opacity 0.15s ease;
+      z-index: 10;
+      box-shadow: 0 2px 8px rgba(0,0,0,0.35);
+      border: 1px solid rgba(255,255,255,0.08);
+    }
+    .edge-unavailable-tip::after {
+      content: '';
+      position: absolute;
+      top: 100%;
+      left: 50%;
+      transform: translateX(-50%);
+      border: 5px solid transparent;
+      border-top-color: #1a1a1a;
+    }
+    .download-card-edge.is-disabled:hover .edge-unavailable-tip {
+      opacity: 1;
     }
     .download-row-current .download-card {
       padding: 38px 32px;
@@ -3782,6 +3815,7 @@
         </div>
       </div>
       <div class="download-card download-card-edge is-disabled" data-browser-card="edge" aria-disabled="true">
+        <div class="edge-unavailable-tip" data-edge-tip>Microsoft Edge does not work with Mac/Linux</div>
         <div class="browser-icon"><img src="/assets/browser-edge.svg" alt="" aria-hidden="true"></div>
         <h3>Microsoft Edge</h3>
         <p>Manifest V3 · Windows 10/11 · يتطلب Microsoft Edge على Windows.</p>

--- a/web/bn/index.html
+++ b/web/bn/index.html
@@ -2287,6 +2287,7 @@
       grid-template-columns: repeat(2, minmax(0, 1fr));
     }
     .download-card {
+      position: relative;
       background: var(--bg-card);
       border: 1px solid var(--border);
       border-radius: var(--radius);
@@ -2356,6 +2357,38 @@
       background: #2a2a2a;
       border-color: #6f6f6f;
       box-shadow: none;
+    }
+    .edge-unavailable-tip {
+      position: absolute;
+      top: -36px;
+      left: 50%;
+      transform: translateX(-50%);
+      background: #1a1a1a;
+      color: #e0e0e0;
+      font-size: 12px;
+      font-weight: 500;
+      line-height: 1;
+      padding: 7px 12px;
+      border-radius: 6px;
+      white-space: nowrap;
+      pointer-events: none;
+      opacity: 0;
+      transition: opacity 0.15s ease;
+      z-index: 10;
+      box-shadow: 0 2px 8px rgba(0,0,0,0.35);
+      border: 1px solid rgba(255,255,255,0.08);
+    }
+    .edge-unavailable-tip::after {
+      content: '';
+      position: absolute;
+      top: 100%;
+      left: 50%;
+      transform: translateX(-50%);
+      border: 5px solid transparent;
+      border-top-color: #1a1a1a;
+    }
+    .download-card-edge.is-disabled:hover .edge-unavailable-tip {
+      opacity: 1;
     }
     .download-row-current .download-card {
       padding: 38px 32px;
@@ -3782,6 +3815,7 @@
         </div>
       </div>
       <div class="download-card download-card-edge is-disabled" data-browser-card="edge" aria-disabled="true">
+        <div class="edge-unavailable-tip" data-edge-tip>Microsoft Edge does not work with Mac/Linux</div>
         <div class="browser-icon"><img src="/assets/browser-edge.svg" alt="" aria-hidden="true"></div>
         <h3>মাইক্রোসফট Edge</h3>
         <p>Manifest V3 · Windows 10/11 · Windows এ Microsoft Edge প্রয়োজন।</p>

--- a/web/build/template.html
+++ b/web/build/template.html
@@ -2240,6 +2240,7 @@
       grid-template-columns: repeat(2, minmax(0, 1fr));
     }
     .download-card {
+      position: relative;
       background: var(--bg-card);
       border: 1px solid var(--border);
       border-radius: var(--radius);
@@ -2309,6 +2310,38 @@
       background: #2a2a2a;
       border-color: #6f6f6f;
       box-shadow: none;
+    }
+    .edge-unavailable-tip {
+      position: absolute;
+      top: -36px;
+      left: 50%;
+      transform: translateX(-50%);
+      background: #1a1a1a;
+      color: #e0e0e0;
+      font-size: 12px;
+      font-weight: 500;
+      line-height: 1;
+      padding: 7px 12px;
+      border-radius: 6px;
+      white-space: nowrap;
+      pointer-events: none;
+      opacity: 0;
+      transition: opacity 0.15s ease;
+      z-index: 10;
+      box-shadow: 0 2px 8px rgba(0,0,0,0.35);
+      border: 1px solid rgba(255,255,255,0.08);
+    }
+    .edge-unavailable-tip::after {
+      content: '';
+      position: absolute;
+      top: 100%;
+      left: 50%;
+      transform: translateX(-50%);
+      border: 5px solid transparent;
+      border-top-color: #1a1a1a;
+    }
+    .download-card-edge.is-disabled:hover .edge-unavailable-tip {
+      opacity: 1;
     }
     .download-row-current .download-card {
       padding: 38px 32px;
@@ -3728,6 +3761,7 @@
         </div>
       </div>
       <div class="download-card download-card-edge is-disabled" data-browser-card="edge" aria-disabled="true">
+        <div class="edge-unavailable-tip" data-edge-tip>Microsoft Edge does not work with Mac/Linux</div>
         <div class="browser-icon"><img src="/assets/browser-edge.svg" alt="" aria-hidden="true"></div>
         <h3>{{t:download.edge.name}}</h3>
         <p>{{t-html:download.edge.desc_html}}</p>

--- a/web/de/index.html
+++ b/web/de/index.html
@@ -2287,6 +2287,7 @@
       grid-template-columns: repeat(2, minmax(0, 1fr));
     }
     .download-card {
+      position: relative;
       background: var(--bg-card);
       border: 1px solid var(--border);
       border-radius: var(--radius);
@@ -2356,6 +2357,38 @@
       background: #2a2a2a;
       border-color: #6f6f6f;
       box-shadow: none;
+    }
+    .edge-unavailable-tip {
+      position: absolute;
+      top: -36px;
+      left: 50%;
+      transform: translateX(-50%);
+      background: #1a1a1a;
+      color: #e0e0e0;
+      font-size: 12px;
+      font-weight: 500;
+      line-height: 1;
+      padding: 7px 12px;
+      border-radius: 6px;
+      white-space: nowrap;
+      pointer-events: none;
+      opacity: 0;
+      transition: opacity 0.15s ease;
+      z-index: 10;
+      box-shadow: 0 2px 8px rgba(0,0,0,0.35);
+      border: 1px solid rgba(255,255,255,0.08);
+    }
+    .edge-unavailable-tip::after {
+      content: '';
+      position: absolute;
+      top: 100%;
+      left: 50%;
+      transform: translateX(-50%);
+      border: 5px solid transparent;
+      border-top-color: #1a1a1a;
+    }
+    .download-card-edge.is-disabled:hover .edge-unavailable-tip {
+      opacity: 1;
     }
     .download-row-current .download-card {
       padding: 38px 32px;
@@ -3782,6 +3815,7 @@
         </div>
       </div>
       <div class="download-card download-card-edge is-disabled" data-browser-card="edge" aria-disabled="true">
+        <div class="edge-unavailable-tip" data-edge-tip>Microsoft Edge does not work with Mac/Linux</div>
         <div class="browser-icon"><img src="/assets/browser-edge.svg" alt="" aria-hidden="true"></div>
         <h3>Microsoft Edge</h3>
         <p>Manifest V3 · Windows 10/11 · Erfordert Microsoft Edge unter Windows.</p>

--- a/web/es/index.html
+++ b/web/es/index.html
@@ -2287,6 +2287,7 @@
       grid-template-columns: repeat(2, minmax(0, 1fr));
     }
     .download-card {
+      position: relative;
       background: var(--bg-card);
       border: 1px solid var(--border);
       border-radius: var(--radius);
@@ -2356,6 +2357,38 @@
       background: #2a2a2a;
       border-color: #6f6f6f;
       box-shadow: none;
+    }
+    .edge-unavailable-tip {
+      position: absolute;
+      top: -36px;
+      left: 50%;
+      transform: translateX(-50%);
+      background: #1a1a1a;
+      color: #e0e0e0;
+      font-size: 12px;
+      font-weight: 500;
+      line-height: 1;
+      padding: 7px 12px;
+      border-radius: 6px;
+      white-space: nowrap;
+      pointer-events: none;
+      opacity: 0;
+      transition: opacity 0.15s ease;
+      z-index: 10;
+      box-shadow: 0 2px 8px rgba(0,0,0,0.35);
+      border: 1px solid rgba(255,255,255,0.08);
+    }
+    .edge-unavailable-tip::after {
+      content: '';
+      position: absolute;
+      top: 100%;
+      left: 50%;
+      transform: translateX(-50%);
+      border: 5px solid transparent;
+      border-top-color: #1a1a1a;
+    }
+    .download-card-edge.is-disabled:hover .edge-unavailable-tip {
+      opacity: 1;
     }
     .download-row-current .download-card {
       padding: 38px 32px;
@@ -3782,6 +3815,7 @@
         </div>
       </div>
       <div class="download-card download-card-edge is-disabled" data-browser-card="edge" aria-disabled="true">
+        <div class="edge-unavailable-tip" data-edge-tip>Microsoft Edge does not work with Mac/Linux</div>
         <div class="browser-icon"><img src="/assets/browser-edge.svg" alt="" aria-hidden="true"></div>
         <h3>Microsoft Edge</h3>
         <p>Manifest V3 · Windows 10/11 · Requiere Microsoft Edge en Windows.</p>

--- a/web/fa/index.html
+++ b/web/fa/index.html
@@ -2287,6 +2287,7 @@
       grid-template-columns: repeat(2, minmax(0, 1fr));
     }
     .download-card {
+      position: relative;
       background: var(--bg-card);
       border: 1px solid var(--border);
       border-radius: var(--radius);
@@ -2356,6 +2357,38 @@
       background: #2a2a2a;
       border-color: #6f6f6f;
       box-shadow: none;
+    }
+    .edge-unavailable-tip {
+      position: absolute;
+      top: -36px;
+      left: 50%;
+      transform: translateX(-50%);
+      background: #1a1a1a;
+      color: #e0e0e0;
+      font-size: 12px;
+      font-weight: 500;
+      line-height: 1;
+      padding: 7px 12px;
+      border-radius: 6px;
+      white-space: nowrap;
+      pointer-events: none;
+      opacity: 0;
+      transition: opacity 0.15s ease;
+      z-index: 10;
+      box-shadow: 0 2px 8px rgba(0,0,0,0.35);
+      border: 1px solid rgba(255,255,255,0.08);
+    }
+    .edge-unavailable-tip::after {
+      content: '';
+      position: absolute;
+      top: 100%;
+      left: 50%;
+      transform: translateX(-50%);
+      border: 5px solid transparent;
+      border-top-color: #1a1a1a;
+    }
+    .download-card-edge.is-disabled:hover .edge-unavailable-tip {
+      opacity: 1;
     }
     .download-row-current .download-card {
       padding: 38px 32px;
@@ -3782,6 +3815,7 @@
         </div>
       </div>
       <div class="download-card download-card-edge is-disabled" data-browser-card="edge" aria-disabled="true">
+        <div class="edge-unavailable-tip" data-edge-tip>Microsoft Edge does not work with Mac/Linux</div>
         <div class="browser-icon"><img src="/assets/browser-edge.svg" alt="" aria-hidden="true"></div>
         <h3>مایکروسافت Edge</h3>
         <p>Manifest V3 · Windows 10/11 · به Microsoft Edge در ویندوز نیاز دارد.</p>

--- a/web/fr/index.html
+++ b/web/fr/index.html
@@ -2287,6 +2287,7 @@
       grid-template-columns: repeat(2, minmax(0, 1fr));
     }
     .download-card {
+      position: relative;
       background: var(--bg-card);
       border: 1px solid var(--border);
       border-radius: var(--radius);
@@ -2356,6 +2357,38 @@
       background: #2a2a2a;
       border-color: #6f6f6f;
       box-shadow: none;
+    }
+    .edge-unavailable-tip {
+      position: absolute;
+      top: -36px;
+      left: 50%;
+      transform: translateX(-50%);
+      background: #1a1a1a;
+      color: #e0e0e0;
+      font-size: 12px;
+      font-weight: 500;
+      line-height: 1;
+      padding: 7px 12px;
+      border-radius: 6px;
+      white-space: nowrap;
+      pointer-events: none;
+      opacity: 0;
+      transition: opacity 0.15s ease;
+      z-index: 10;
+      box-shadow: 0 2px 8px rgba(0,0,0,0.35);
+      border: 1px solid rgba(255,255,255,0.08);
+    }
+    .edge-unavailable-tip::after {
+      content: '';
+      position: absolute;
+      top: 100%;
+      left: 50%;
+      transform: translateX(-50%);
+      border: 5px solid transparent;
+      border-top-color: #1a1a1a;
+    }
+    .download-card-edge.is-disabled:hover .edge-unavailable-tip {
+      opacity: 1;
     }
     .download-row-current .download-card {
       padding: 38px 32px;
@@ -3782,6 +3815,7 @@
         </div>
       </div>
       <div class="download-card download-card-edge is-disabled" data-browser-card="edge" aria-disabled="true">
+        <div class="edge-unavailable-tip" data-edge-tip>Microsoft Edge does not work with Mac/Linux</div>
         <div class="browser-icon"><img src="/assets/browser-edge.svg" alt="" aria-hidden="true"></div>
         <h3>Microsoft Edge</h3>
         <p>Manifest V3 · Windows 10/11 · Nécessite Microsoft Edge sur Windows.</p>

--- a/web/he/index.html
+++ b/web/he/index.html
@@ -2287,6 +2287,7 @@
       grid-template-columns: repeat(2, minmax(0, 1fr));
     }
     .download-card {
+      position: relative;
       background: var(--bg-card);
       border: 1px solid var(--border);
       border-radius: var(--radius);
@@ -2356,6 +2357,38 @@
       background: #2a2a2a;
       border-color: #6f6f6f;
       box-shadow: none;
+    }
+    .edge-unavailable-tip {
+      position: absolute;
+      top: -36px;
+      left: 50%;
+      transform: translateX(-50%);
+      background: #1a1a1a;
+      color: #e0e0e0;
+      font-size: 12px;
+      font-weight: 500;
+      line-height: 1;
+      padding: 7px 12px;
+      border-radius: 6px;
+      white-space: nowrap;
+      pointer-events: none;
+      opacity: 0;
+      transition: opacity 0.15s ease;
+      z-index: 10;
+      box-shadow: 0 2px 8px rgba(0,0,0,0.35);
+      border: 1px solid rgba(255,255,255,0.08);
+    }
+    .edge-unavailable-tip::after {
+      content: '';
+      position: absolute;
+      top: 100%;
+      left: 50%;
+      transform: translateX(-50%);
+      border: 5px solid transparent;
+      border-top-color: #1a1a1a;
+    }
+    .download-card-edge.is-disabled:hover .edge-unavailable-tip {
+      opacity: 1;
     }
     .download-row-current .download-card {
       padding: 38px 32px;
@@ -3782,6 +3815,7 @@
         </div>
       </div>
       <div class="download-card download-card-edge is-disabled" data-browser-card="edge" aria-disabled="true">
+        <div class="edge-unavailable-tip" data-edge-tip>Microsoft Edge does not work with Mac/Linux</div>
         <div class="browser-icon"><img src="/assets/browser-edge.svg" alt="" aria-hidden="true"></div>
         <h3>Microsoft Edge</h3>
         <p>Manifest V3 · Windows 10/11 · דורש Microsoft Edge ב-Windows.</p>

--- a/web/hi/index.html
+++ b/web/hi/index.html
@@ -2287,6 +2287,7 @@
       grid-template-columns: repeat(2, minmax(0, 1fr));
     }
     .download-card {
+      position: relative;
       background: var(--bg-card);
       border: 1px solid var(--border);
       border-radius: var(--radius);
@@ -2356,6 +2357,38 @@
       background: #2a2a2a;
       border-color: #6f6f6f;
       box-shadow: none;
+    }
+    .edge-unavailable-tip {
+      position: absolute;
+      top: -36px;
+      left: 50%;
+      transform: translateX(-50%);
+      background: #1a1a1a;
+      color: #e0e0e0;
+      font-size: 12px;
+      font-weight: 500;
+      line-height: 1;
+      padding: 7px 12px;
+      border-radius: 6px;
+      white-space: nowrap;
+      pointer-events: none;
+      opacity: 0;
+      transition: opacity 0.15s ease;
+      z-index: 10;
+      box-shadow: 0 2px 8px rgba(0,0,0,0.35);
+      border: 1px solid rgba(255,255,255,0.08);
+    }
+    .edge-unavailable-tip::after {
+      content: '';
+      position: absolute;
+      top: 100%;
+      left: 50%;
+      transform: translateX(-50%);
+      border: 5px solid transparent;
+      border-top-color: #1a1a1a;
+    }
+    .download-card-edge.is-disabled:hover .edge-unavailable-tip {
+      opacity: 1;
     }
     .download-row-current .download-card {
       padding: 38px 32px;
@@ -3782,6 +3815,7 @@
         </div>
       </div>
       <div class="download-card download-card-edge is-disabled" data-browser-card="edge" aria-disabled="true">
+        <div class="edge-unavailable-tip" data-edge-tip>Microsoft Edge does not work with Mac/Linux</div>
         <div class="browser-icon"><img src="/assets/browser-edge.svg" alt="" aria-hidden="true"></div>
         <h3>माइक्रोसॉफ्ट Edge</h3>
         <p>मेनिफेस्ट V3 · विंडोज़ 10/11 · विंडोज़ पर Microsoft Edge की आवश्यकता है।</p>

--- a/web/id/index.html
+++ b/web/id/index.html
@@ -2287,6 +2287,7 @@
       grid-template-columns: repeat(2, minmax(0, 1fr));
     }
     .download-card {
+      position: relative;
       background: var(--bg-card);
       border: 1px solid var(--border);
       border-radius: var(--radius);
@@ -2356,6 +2357,38 @@
       background: #2a2a2a;
       border-color: #6f6f6f;
       box-shadow: none;
+    }
+    .edge-unavailable-tip {
+      position: absolute;
+      top: -36px;
+      left: 50%;
+      transform: translateX(-50%);
+      background: #1a1a1a;
+      color: #e0e0e0;
+      font-size: 12px;
+      font-weight: 500;
+      line-height: 1;
+      padding: 7px 12px;
+      border-radius: 6px;
+      white-space: nowrap;
+      pointer-events: none;
+      opacity: 0;
+      transition: opacity 0.15s ease;
+      z-index: 10;
+      box-shadow: 0 2px 8px rgba(0,0,0,0.35);
+      border: 1px solid rgba(255,255,255,0.08);
+    }
+    .edge-unavailable-tip::after {
+      content: '';
+      position: absolute;
+      top: 100%;
+      left: 50%;
+      transform: translateX(-50%);
+      border: 5px solid transparent;
+      border-top-color: #1a1a1a;
+    }
+    .download-card-edge.is-disabled:hover .edge-unavailable-tip {
+      opacity: 1;
     }
     .download-row-current .download-card {
       padding: 38px 32px;
@@ -3782,6 +3815,7 @@
         </div>
       </div>
       <div class="download-card download-card-edge is-disabled" data-browser-card="edge" aria-disabled="true">
+        <div class="edge-unavailable-tip" data-edge-tip>Microsoft Edge does not work with Mac/Linux</div>
         <div class="browser-icon"><img src="/assets/browser-edge.svg" alt="" aria-hidden="true"></div>
         <h3>Microsoft Edge</h3>
         <p>Manifest V3 · Windows 10/11 · Memerlukan Microsoft Edge di Windows.</p>

--- a/web/index.html
+++ b/web/index.html
@@ -2286,6 +2286,7 @@
       grid-template-columns: repeat(2, minmax(0, 1fr));
     }
     .download-card {
+      position: relative;
       background: var(--bg-card);
       border: 1px solid var(--border);
       border-radius: var(--radius);
@@ -2355,6 +2356,38 @@
       background: #2a2a2a;
       border-color: #6f6f6f;
       box-shadow: none;
+    }
+    .edge-unavailable-tip {
+      position: absolute;
+      top: -36px;
+      left: 50%;
+      transform: translateX(-50%);
+      background: #1a1a1a;
+      color: #e0e0e0;
+      font-size: 12px;
+      font-weight: 500;
+      line-height: 1;
+      padding: 7px 12px;
+      border-radius: 6px;
+      white-space: nowrap;
+      pointer-events: none;
+      opacity: 0;
+      transition: opacity 0.15s ease;
+      z-index: 10;
+      box-shadow: 0 2px 8px rgba(0,0,0,0.35);
+      border: 1px solid rgba(255,255,255,0.08);
+    }
+    .edge-unavailable-tip::after {
+      content: '';
+      position: absolute;
+      top: 100%;
+      left: 50%;
+      transform: translateX(-50%);
+      border: 5px solid transparent;
+      border-top-color: #1a1a1a;
+    }
+    .download-card-edge.is-disabled:hover .edge-unavailable-tip {
+      opacity: 1;
     }
     .download-row-current .download-card {
       padding: 38px 32px;
@@ -3781,6 +3814,7 @@
         </div>
       </div>
       <div class="download-card download-card-edge is-disabled" data-browser-card="edge" aria-disabled="true">
+        <div class="edge-unavailable-tip" data-edge-tip>Microsoft Edge does not work with Mac/Linux</div>
         <div class="browser-icon"><img src="/assets/browser-edge.svg" alt="" aria-hidden="true"></div>
         <h3>Microsoft Edge</h3>
         <p>Manifest V3 · Windows 10/11 · Requires Microsoft Edge on Windows.</p>

--- a/web/ja/index.html
+++ b/web/ja/index.html
@@ -2287,6 +2287,7 @@
       grid-template-columns: repeat(2, minmax(0, 1fr));
     }
     .download-card {
+      position: relative;
       background: var(--bg-card);
       border: 1px solid var(--border);
       border-radius: var(--radius);
@@ -2356,6 +2357,38 @@
       background: #2a2a2a;
       border-color: #6f6f6f;
       box-shadow: none;
+    }
+    .edge-unavailable-tip {
+      position: absolute;
+      top: -36px;
+      left: 50%;
+      transform: translateX(-50%);
+      background: #1a1a1a;
+      color: #e0e0e0;
+      font-size: 12px;
+      font-weight: 500;
+      line-height: 1;
+      padding: 7px 12px;
+      border-radius: 6px;
+      white-space: nowrap;
+      pointer-events: none;
+      opacity: 0;
+      transition: opacity 0.15s ease;
+      z-index: 10;
+      box-shadow: 0 2px 8px rgba(0,0,0,0.35);
+      border: 1px solid rgba(255,255,255,0.08);
+    }
+    .edge-unavailable-tip::after {
+      content: '';
+      position: absolute;
+      top: 100%;
+      left: 50%;
+      transform: translateX(-50%);
+      border: 5px solid transparent;
+      border-top-color: #1a1a1a;
+    }
+    .download-card-edge.is-disabled:hover .edge-unavailable-tip {
+      opacity: 1;
     }
     .download-row-current .download-card {
       padding: 38px 32px;
@@ -3782,6 +3815,7 @@
         </div>
       </div>
       <div class="download-card download-card-edge is-disabled" data-browser-card="edge" aria-disabled="true">
+        <div class="edge-unavailable-tip" data-edge-tip>Microsoft Edge does not work with Mac/Linux</div>
         <div class="browser-icon"><img src="/assets/browser-edge.svg" alt="" aria-hidden="true"></div>
         <h3>Microsoft Edge</h3>
         <p>Manifest V3 · Windows 10/11 · Windows の Microsoft Edge が必要。</p>

--- a/web/ko/index.html
+++ b/web/ko/index.html
@@ -2287,6 +2287,7 @@
       grid-template-columns: repeat(2, minmax(0, 1fr));
     }
     .download-card {
+      position: relative;
       background: var(--bg-card);
       border: 1px solid var(--border);
       border-radius: var(--radius);
@@ -2356,6 +2357,38 @@
       background: #2a2a2a;
       border-color: #6f6f6f;
       box-shadow: none;
+    }
+    .edge-unavailable-tip {
+      position: absolute;
+      top: -36px;
+      left: 50%;
+      transform: translateX(-50%);
+      background: #1a1a1a;
+      color: #e0e0e0;
+      font-size: 12px;
+      font-weight: 500;
+      line-height: 1;
+      padding: 7px 12px;
+      border-radius: 6px;
+      white-space: nowrap;
+      pointer-events: none;
+      opacity: 0;
+      transition: opacity 0.15s ease;
+      z-index: 10;
+      box-shadow: 0 2px 8px rgba(0,0,0,0.35);
+      border: 1px solid rgba(255,255,255,0.08);
+    }
+    .edge-unavailable-tip::after {
+      content: '';
+      position: absolute;
+      top: 100%;
+      left: 50%;
+      transform: translateX(-50%);
+      border: 5px solid transparent;
+      border-top-color: #1a1a1a;
+    }
+    .download-card-edge.is-disabled:hover .edge-unavailable-tip {
+      opacity: 1;
     }
     .download-row-current .download-card {
       padding: 38px 32px;
@@ -3782,6 +3815,7 @@
         </div>
       </div>
       <div class="download-card download-card-edge is-disabled" data-browser-card="edge" aria-disabled="true">
+        <div class="edge-unavailable-tip" data-edge-tip>Microsoft Edge does not work with Mac/Linux</div>
         <div class="browser-icon"><img src="/assets/browser-edge.svg" alt="" aria-hidden="true"></div>
         <h3>Microsoft Edge</h3>
         <p>Manifest V3 · Windows 10/11 · Windows의 Microsoft Edge가 필요합니다.</p>

--- a/web/ms/index.html
+++ b/web/ms/index.html
@@ -2287,6 +2287,7 @@
       grid-template-columns: repeat(2, minmax(0, 1fr));
     }
     .download-card {
+      position: relative;
       background: var(--bg-card);
       border: 1px solid var(--border);
       border-radius: var(--radius);
@@ -2356,6 +2357,38 @@
       background: #2a2a2a;
       border-color: #6f6f6f;
       box-shadow: none;
+    }
+    .edge-unavailable-tip {
+      position: absolute;
+      top: -36px;
+      left: 50%;
+      transform: translateX(-50%);
+      background: #1a1a1a;
+      color: #e0e0e0;
+      font-size: 12px;
+      font-weight: 500;
+      line-height: 1;
+      padding: 7px 12px;
+      border-radius: 6px;
+      white-space: nowrap;
+      pointer-events: none;
+      opacity: 0;
+      transition: opacity 0.15s ease;
+      z-index: 10;
+      box-shadow: 0 2px 8px rgba(0,0,0,0.35);
+      border: 1px solid rgba(255,255,255,0.08);
+    }
+    .edge-unavailable-tip::after {
+      content: '';
+      position: absolute;
+      top: 100%;
+      left: 50%;
+      transform: translateX(-50%);
+      border: 5px solid transparent;
+      border-top-color: #1a1a1a;
+    }
+    .download-card-edge.is-disabled:hover .edge-unavailable-tip {
+      opacity: 1;
     }
     .download-row-current .download-card {
       padding: 38px 32px;
@@ -3782,6 +3815,7 @@
         </div>
       </div>
       <div class="download-card download-card-edge is-disabled" data-browser-card="edge" aria-disabled="true">
+        <div class="edge-unavailable-tip" data-edge-tip>Microsoft Edge does not work with Mac/Linux</div>
         <div class="browser-icon"><img src="/assets/browser-edge.svg" alt="" aria-hidden="true"></div>
         <h3>Microsoft Edge</h3>
         <p>Manifest V3 · Windows 10/11 · Memerlukan Microsoft Edge pada Windows.</p>

--- a/web/nl/index.html
+++ b/web/nl/index.html
@@ -2287,6 +2287,7 @@
       grid-template-columns: repeat(2, minmax(0, 1fr));
     }
     .download-card {
+      position: relative;
       background: var(--bg-card);
       border: 1px solid var(--border);
       border-radius: var(--radius);
@@ -2356,6 +2357,38 @@
       background: #2a2a2a;
       border-color: #6f6f6f;
       box-shadow: none;
+    }
+    .edge-unavailable-tip {
+      position: absolute;
+      top: -36px;
+      left: 50%;
+      transform: translateX(-50%);
+      background: #1a1a1a;
+      color: #e0e0e0;
+      font-size: 12px;
+      font-weight: 500;
+      line-height: 1;
+      padding: 7px 12px;
+      border-radius: 6px;
+      white-space: nowrap;
+      pointer-events: none;
+      opacity: 0;
+      transition: opacity 0.15s ease;
+      z-index: 10;
+      box-shadow: 0 2px 8px rgba(0,0,0,0.35);
+      border: 1px solid rgba(255,255,255,0.08);
+    }
+    .edge-unavailable-tip::after {
+      content: '';
+      position: absolute;
+      top: 100%;
+      left: 50%;
+      transform: translateX(-50%);
+      border: 5px solid transparent;
+      border-top-color: #1a1a1a;
+    }
+    .download-card-edge.is-disabled:hover .edge-unavailable-tip {
+      opacity: 1;
     }
     .download-row-current .download-card {
       padding: 38px 32px;
@@ -3782,6 +3815,7 @@
         </div>
       </div>
       <div class="download-card download-card-edge is-disabled" data-browser-card="edge" aria-disabled="true">
+        <div class="edge-unavailable-tip" data-edge-tip>Microsoft Edge does not work with Mac/Linux</div>
         <div class="browser-icon"><img src="/assets/browser-edge.svg" alt="" aria-hidden="true"></div>
         <h3>Microsoft Edge</h3>
         <p>Manifest V3 · Windows 10/11 · Vereist Microsoft Edge op Windows.</p>

--- a/web/pt/index.html
+++ b/web/pt/index.html
@@ -2287,6 +2287,7 @@
       grid-template-columns: repeat(2, minmax(0, 1fr));
     }
     .download-card {
+      position: relative;
       background: var(--bg-card);
       border: 1px solid var(--border);
       border-radius: var(--radius);
@@ -2356,6 +2357,38 @@
       background: #2a2a2a;
       border-color: #6f6f6f;
       box-shadow: none;
+    }
+    .edge-unavailable-tip {
+      position: absolute;
+      top: -36px;
+      left: 50%;
+      transform: translateX(-50%);
+      background: #1a1a1a;
+      color: #e0e0e0;
+      font-size: 12px;
+      font-weight: 500;
+      line-height: 1;
+      padding: 7px 12px;
+      border-radius: 6px;
+      white-space: nowrap;
+      pointer-events: none;
+      opacity: 0;
+      transition: opacity 0.15s ease;
+      z-index: 10;
+      box-shadow: 0 2px 8px rgba(0,0,0,0.35);
+      border: 1px solid rgba(255,255,255,0.08);
+    }
+    .edge-unavailable-tip::after {
+      content: '';
+      position: absolute;
+      top: 100%;
+      left: 50%;
+      transform: translateX(-50%);
+      border: 5px solid transparent;
+      border-top-color: #1a1a1a;
+    }
+    .download-card-edge.is-disabled:hover .edge-unavailable-tip {
+      opacity: 1;
     }
     .download-row-current .download-card {
       padding: 38px 32px;
@@ -3782,6 +3815,7 @@
         </div>
       </div>
       <div class="download-card download-card-edge is-disabled" data-browser-card="edge" aria-disabled="true">
+        <div class="edge-unavailable-tip" data-edge-tip>Microsoft Edge does not work with Mac/Linux</div>
         <div class="browser-icon"><img src="/assets/browser-edge.svg" alt="" aria-hidden="true"></div>
         <h3>Microsoft Edge</h3>
         <p>Manifesto V3 · Windows 10/11 · Requer Microsoft Edge no Windows.</p>

--- a/web/ru/index.html
+++ b/web/ru/index.html
@@ -2287,6 +2287,7 @@
       grid-template-columns: repeat(2, minmax(0, 1fr));
     }
     .download-card {
+      position: relative;
       background: var(--bg-card);
       border: 1px solid var(--border);
       border-radius: var(--radius);
@@ -2356,6 +2357,38 @@
       background: #2a2a2a;
       border-color: #6f6f6f;
       box-shadow: none;
+    }
+    .edge-unavailable-tip {
+      position: absolute;
+      top: -36px;
+      left: 50%;
+      transform: translateX(-50%);
+      background: #1a1a1a;
+      color: #e0e0e0;
+      font-size: 12px;
+      font-weight: 500;
+      line-height: 1;
+      padding: 7px 12px;
+      border-radius: 6px;
+      white-space: nowrap;
+      pointer-events: none;
+      opacity: 0;
+      transition: opacity 0.15s ease;
+      z-index: 10;
+      box-shadow: 0 2px 8px rgba(0,0,0,0.35);
+      border: 1px solid rgba(255,255,255,0.08);
+    }
+    .edge-unavailable-tip::after {
+      content: '';
+      position: absolute;
+      top: 100%;
+      left: 50%;
+      transform: translateX(-50%);
+      border: 5px solid transparent;
+      border-top-color: #1a1a1a;
+    }
+    .download-card-edge.is-disabled:hover .edge-unavailable-tip {
+      opacity: 1;
     }
     .download-row-current .download-card {
       padding: 38px 32px;
@@ -3782,6 +3815,7 @@
         </div>
       </div>
       <div class="download-card download-card-edge is-disabled" data-browser-card="edge" aria-disabled="true">
+        <div class="edge-unavailable-tip" data-edge-tip>Microsoft Edge does not work with Mac/Linux</div>
         <div class="browser-icon"><img src="/assets/browser-edge.svg" alt="" aria-hidden="true"></div>
         <h3>Microsoft Edge</h3>
         <p>Manifest V3 · Windows 10/11 · Требуется Microsoft Edge в Windows.</p>

--- a/web/th/index.html
+++ b/web/th/index.html
@@ -2287,6 +2287,7 @@
       grid-template-columns: repeat(2, minmax(0, 1fr));
     }
     .download-card {
+      position: relative;
       background: var(--bg-card);
       border: 1px solid var(--border);
       border-radius: var(--radius);
@@ -2356,6 +2357,38 @@
       background: #2a2a2a;
       border-color: #6f6f6f;
       box-shadow: none;
+    }
+    .edge-unavailable-tip {
+      position: absolute;
+      top: -36px;
+      left: 50%;
+      transform: translateX(-50%);
+      background: #1a1a1a;
+      color: #e0e0e0;
+      font-size: 12px;
+      font-weight: 500;
+      line-height: 1;
+      padding: 7px 12px;
+      border-radius: 6px;
+      white-space: nowrap;
+      pointer-events: none;
+      opacity: 0;
+      transition: opacity 0.15s ease;
+      z-index: 10;
+      box-shadow: 0 2px 8px rgba(0,0,0,0.35);
+      border: 1px solid rgba(255,255,255,0.08);
+    }
+    .edge-unavailable-tip::after {
+      content: '';
+      position: absolute;
+      top: 100%;
+      left: 50%;
+      transform: translateX(-50%);
+      border: 5px solid transparent;
+      border-top-color: #1a1a1a;
+    }
+    .download-card-edge.is-disabled:hover .edge-unavailable-tip {
+      opacity: 1;
     }
     .download-row-current .download-card {
       padding: 38px 32px;
@@ -3782,6 +3815,7 @@
         </div>
       </div>
       <div class="download-card download-card-edge is-disabled" data-browser-card="edge" aria-disabled="true">
+        <div class="edge-unavailable-tip" data-edge-tip>Microsoft Edge does not work with Mac/Linux</div>
         <div class="browser-icon"><img src="/assets/browser-edge.svg" alt="" aria-hidden="true"></div>
         <h3>Microsoft Edge</h3>
         <p>Manifest V3 · Windows 10/11 · ต้องใช้ Microsoft Edge บน Windows</p>

--- a/web/tl/index.html
+++ b/web/tl/index.html
@@ -2287,6 +2287,7 @@
       grid-template-columns: repeat(2, minmax(0, 1fr));
     }
     .download-card {
+      position: relative;
       background: var(--bg-card);
       border: 1px solid var(--border);
       border-radius: var(--radius);
@@ -2356,6 +2357,38 @@
       background: #2a2a2a;
       border-color: #6f6f6f;
       box-shadow: none;
+    }
+    .edge-unavailable-tip {
+      position: absolute;
+      top: -36px;
+      left: 50%;
+      transform: translateX(-50%);
+      background: #1a1a1a;
+      color: #e0e0e0;
+      font-size: 12px;
+      font-weight: 500;
+      line-height: 1;
+      padding: 7px 12px;
+      border-radius: 6px;
+      white-space: nowrap;
+      pointer-events: none;
+      opacity: 0;
+      transition: opacity 0.15s ease;
+      z-index: 10;
+      box-shadow: 0 2px 8px rgba(0,0,0,0.35);
+      border: 1px solid rgba(255,255,255,0.08);
+    }
+    .edge-unavailable-tip::after {
+      content: '';
+      position: absolute;
+      top: 100%;
+      left: 50%;
+      transform: translateX(-50%);
+      border: 5px solid transparent;
+      border-top-color: #1a1a1a;
+    }
+    .download-card-edge.is-disabled:hover .edge-unavailable-tip {
+      opacity: 1;
     }
     .download-row-current .download-card {
       padding: 38px 32px;
@@ -3782,6 +3815,7 @@
         </div>
       </div>
       <div class="download-card download-card-edge is-disabled" data-browser-card="edge" aria-disabled="true">
+        <div class="edge-unavailable-tip" data-edge-tip>Microsoft Edge does not work with Mac/Linux</div>
         <div class="browser-icon"><img src="/assets/browser-edge.svg" alt="" aria-hidden="true"></div>
         <h3>Microsoft Edge</h3>
         <p>Manifest V3 · Windows 10/11 · Nangangailangan ng Microsoft Edge sa Windows.</p>

--- a/web/tr/index.html
+++ b/web/tr/index.html
@@ -2287,6 +2287,7 @@
       grid-template-columns: repeat(2, minmax(0, 1fr));
     }
     .download-card {
+      position: relative;
       background: var(--bg-card);
       border: 1px solid var(--border);
       border-radius: var(--radius);
@@ -2356,6 +2357,38 @@
       background: #2a2a2a;
       border-color: #6f6f6f;
       box-shadow: none;
+    }
+    .edge-unavailable-tip {
+      position: absolute;
+      top: -36px;
+      left: 50%;
+      transform: translateX(-50%);
+      background: #1a1a1a;
+      color: #e0e0e0;
+      font-size: 12px;
+      font-weight: 500;
+      line-height: 1;
+      padding: 7px 12px;
+      border-radius: 6px;
+      white-space: nowrap;
+      pointer-events: none;
+      opacity: 0;
+      transition: opacity 0.15s ease;
+      z-index: 10;
+      box-shadow: 0 2px 8px rgba(0,0,0,0.35);
+      border: 1px solid rgba(255,255,255,0.08);
+    }
+    .edge-unavailable-tip::after {
+      content: '';
+      position: absolute;
+      top: 100%;
+      left: 50%;
+      transform: translateX(-50%);
+      border: 5px solid transparent;
+      border-top-color: #1a1a1a;
+    }
+    .download-card-edge.is-disabled:hover .edge-unavailable-tip {
+      opacity: 1;
     }
     .download-row-current .download-card {
       padding: 38px 32px;
@@ -3782,6 +3815,7 @@
         </div>
       </div>
       <div class="download-card download-card-edge is-disabled" data-browser-card="edge" aria-disabled="true">
+        <div class="edge-unavailable-tip" data-edge-tip>Microsoft Edge does not work with Mac/Linux</div>
         <div class="browser-icon"><img src="/assets/browser-edge.svg" alt="" aria-hidden="true"></div>
         <h3>Microsoft Edge</h3>
         <p>Manifest V3 · Windows 10/11 · Windows üzerinde Microsoft Edge gerektirir.</p>

--- a/web/uk/index.html
+++ b/web/uk/index.html
@@ -2287,6 +2287,7 @@
       grid-template-columns: repeat(2, minmax(0, 1fr));
     }
     .download-card {
+      position: relative;
       background: var(--bg-card);
       border: 1px solid var(--border);
       border-radius: var(--radius);
@@ -2356,6 +2357,38 @@
       background: #2a2a2a;
       border-color: #6f6f6f;
       box-shadow: none;
+    }
+    .edge-unavailable-tip {
+      position: absolute;
+      top: -36px;
+      left: 50%;
+      transform: translateX(-50%);
+      background: #1a1a1a;
+      color: #e0e0e0;
+      font-size: 12px;
+      font-weight: 500;
+      line-height: 1;
+      padding: 7px 12px;
+      border-radius: 6px;
+      white-space: nowrap;
+      pointer-events: none;
+      opacity: 0;
+      transition: opacity 0.15s ease;
+      z-index: 10;
+      box-shadow: 0 2px 8px rgba(0,0,0,0.35);
+      border: 1px solid rgba(255,255,255,0.08);
+    }
+    .edge-unavailable-tip::after {
+      content: '';
+      position: absolute;
+      top: 100%;
+      left: 50%;
+      transform: translateX(-50%);
+      border: 5px solid transparent;
+      border-top-color: #1a1a1a;
+    }
+    .download-card-edge.is-disabled:hover .edge-unavailable-tip {
+      opacity: 1;
     }
     .download-row-current .download-card {
       padding: 38px 32px;
@@ -3782,6 +3815,7 @@
         </div>
       </div>
       <div class="download-card download-card-edge is-disabled" data-browser-card="edge" aria-disabled="true">
+        <div class="edge-unavailable-tip" data-edge-tip>Microsoft Edge does not work with Mac/Linux</div>
         <div class="browser-icon"><img src="/assets/browser-edge.svg" alt="" aria-hidden="true"></div>
         <h3>Microsoft Edge</h3>
         <p>Manifest V3 · Windows 10/11 · Потрібен Microsoft Edge у Windows.</p>

--- a/web/vi/index.html
+++ b/web/vi/index.html
@@ -2287,6 +2287,7 @@
       grid-template-columns: repeat(2, minmax(0, 1fr));
     }
     .download-card {
+      position: relative;
       background: var(--bg-card);
       border: 1px solid var(--border);
       border-radius: var(--radius);
@@ -2356,6 +2357,38 @@
       background: #2a2a2a;
       border-color: #6f6f6f;
       box-shadow: none;
+    }
+    .edge-unavailable-tip {
+      position: absolute;
+      top: -36px;
+      left: 50%;
+      transform: translateX(-50%);
+      background: #1a1a1a;
+      color: #e0e0e0;
+      font-size: 12px;
+      font-weight: 500;
+      line-height: 1;
+      padding: 7px 12px;
+      border-radius: 6px;
+      white-space: nowrap;
+      pointer-events: none;
+      opacity: 0;
+      transition: opacity 0.15s ease;
+      z-index: 10;
+      box-shadow: 0 2px 8px rgba(0,0,0,0.35);
+      border: 1px solid rgba(255,255,255,0.08);
+    }
+    .edge-unavailable-tip::after {
+      content: '';
+      position: absolute;
+      top: 100%;
+      left: 50%;
+      transform: translateX(-50%);
+      border: 5px solid transparent;
+      border-top-color: #1a1a1a;
+    }
+    .download-card-edge.is-disabled:hover .edge-unavailable-tip {
+      opacity: 1;
     }
     .download-row-current .download-card {
       padding: 38px 32px;
@@ -3782,6 +3815,7 @@
         </div>
       </div>
       <div class="download-card download-card-edge is-disabled" data-browser-card="edge" aria-disabled="true">
+        <div class="edge-unavailable-tip" data-edge-tip>Microsoft Edge does not work with Mac/Linux</div>
         <div class="browser-icon"><img src="/assets/browser-edge.svg" alt="" aria-hidden="true"></div>
         <h3>Microsoft Edge</h3>
         <p>Bản kê khai V3 · Windows 10/11 · Yêu cầu Microsoft Edge trên Windows.</p>

--- a/web/zh/index.html
+++ b/web/zh/index.html
@@ -2287,6 +2287,7 @@
       grid-template-columns: repeat(2, minmax(0, 1fr));
     }
     .download-card {
+      position: relative;
       background: var(--bg-card);
       border: 1px solid var(--border);
       border-radius: var(--radius);
@@ -2356,6 +2357,38 @@
       background: #2a2a2a;
       border-color: #6f6f6f;
       box-shadow: none;
+    }
+    .edge-unavailable-tip {
+      position: absolute;
+      top: -36px;
+      left: 50%;
+      transform: translateX(-50%);
+      background: #1a1a1a;
+      color: #e0e0e0;
+      font-size: 12px;
+      font-weight: 500;
+      line-height: 1;
+      padding: 7px 12px;
+      border-radius: 6px;
+      white-space: nowrap;
+      pointer-events: none;
+      opacity: 0;
+      transition: opacity 0.15s ease;
+      z-index: 10;
+      box-shadow: 0 2px 8px rgba(0,0,0,0.35);
+      border: 1px solid rgba(255,255,255,0.08);
+    }
+    .edge-unavailable-tip::after {
+      content: '';
+      position: absolute;
+      top: 100%;
+      left: 50%;
+      transform: translateX(-50%);
+      border: 5px solid transparent;
+      border-top-color: #1a1a1a;
+    }
+    .download-card-edge.is-disabled:hover .edge-unavailable-tip {
+      opacity: 1;
     }
     .download-row-current .download-card {
       padding: 38px 32px;
@@ -3782,6 +3815,7 @@
         </div>
       </div>
       <div class="download-card download-card-edge is-disabled" data-browser-card="edge" aria-disabled="true">
+        <div class="edge-unavailable-tip" data-edge-tip>Microsoft Edge does not work with Mac/Linux</div>
         <div class="browser-icon"><img src="/assets/browser-edge.svg" alt="" aria-hidden="true"></div>
         <h3>Microsoft Edge</h3>
         <p>Manifest V3 · Windows 10/11 · 需要 Windows 上的 Microsoft Edge。</p>


### PR DESCRIPTION
Shows 'Microsoft Edge does not work with Mac/Linux' popover when hovering the disabled Edge download card on non-Windows platforms.