### PR TITLE
fix(ui): show relative message timestamps

### DIFF
--- a/src/chrome/src/message-info.js
+++ b/src/chrome/src/message-info.js
@@ -9,6 +9,7 @@ function formatExactSentTime(createdAt, locale) {
       day: '2-digit',
       hour: '2-digit',
       minute: '2-digit',
+      second: '2-digit',
       hour12: false,
       timeZoneName: 'short',
     }).format(date);
@@ -18,7 +19,7 @@ function formatExactSentTime(createdAt, locale) {
     const offset = offsetMinutes === 0
       ? 'UTC'
       : `UTC${offsetMinutes > 0 ? '+' : '-'}${pad(Math.floor(Math.abs(offsetMinutes) / 60))}:${pad(Math.abs(offsetMinutes) % 60)}`;
-    return `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}, ${pad(date.getHours())}:${pad(date.getMinutes())} ${offset}`;
+    return `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}, ${pad(date.getHours())}:${pad(date.getMinutes())}:${pad(date.getSeconds())} ${offset}`;
   }
 }
 
@@ -26,30 +27,31 @@ function formatRelativeSentTime(createdAt, locale, now = Date.now()) {
   const value = Number(createdAt);
   if (!Number.isFinite(value) || value <= 0) return '';
   const units = [
-    ['second', 1000],
-    ['minute', 60 * 1000],
-    ['hour', 60 * 60 * 1000],
-    ['day', 24 * 60 * 60 * 1000],
+    { name: 'second', milliseconds: 1000 },
+    { name: 'minute', milliseconds: 60 * 1000 },
+    { name: 'hour', milliseconds: 60 * 60 * 1000 },
+    { name: 'day', milliseconds: 24 * 60 * 60 * 1000 },
   ];
   const current = Number(now);
   const elapsedMs = Number.isFinite(current) ? Math.max(0, current - value) : 0;
   const lastUnit = units[units.length - 1];
   let unit = lastUnit;
   for (let index = 0; index < units.length - 1; index += 1) {
-    if (elapsedMs < units[index + 1][1]) {
+    if (elapsedMs < units[index + 1].milliseconds) {
       unit = units[index];
       break;
     }
   }
-  const amount = Math.floor(elapsedMs / unit[1]);
+  const amount = Math.floor(elapsedMs / unit.milliseconds);
   try {
     return new Intl.RelativeTimeFormat(locale || undefined, {
       numeric: 'auto',
       style: 'long',
-    }).format(-amount, unit[0]);
+    }).format(-amount, unit.name);
   } catch {
+    // Keep timestamps usable when a browser lacks ICU data for the selected locale.
     if (amount === 0) return 'now';
-    return `${amount} ${unit[0]}${amount === 1 ? '' : 's'} ago`;
+    return `${amount} ${unit.name}${amount === 1 ? '' : 's'} ago`;
   }
 }
 

--- a/src/chrome/src/message-info.js
+++ b/src/chrome/src/message-info.js
@@ -45,7 +45,7 @@ function formatRelativeSentTime(createdAt, locale, now = Date.now()) {
   const amount = Math.floor(elapsedMs / unit.milliseconds);
   try {
     return new Intl.RelativeTimeFormat(locale || undefined, {
-      numeric: 'auto',
+      numeric: amount === 0 ? 'auto' : 'always',
       style: 'long',
     }).format(-amount, unit.name);
   } catch {

--- a/src/chrome/src/message-info.js
+++ b/src/chrome/src/message-info.js
@@ -1,4 +1,4 @@
-function formatSentTime(createdAt, locale) {
+function formatExactSentTime(createdAt, locale) {
   const value = Number(createdAt);
   if (!Number.isFinite(value) || value <= 0) return '';
   const date = new Date(value);
@@ -19,6 +19,37 @@ function formatSentTime(createdAt, locale) {
       ? 'UTC'
       : `UTC${offsetMinutes > 0 ? '+' : '-'}${pad(Math.floor(Math.abs(offsetMinutes) / 60))}:${pad(Math.abs(offsetMinutes) % 60)}`;
     return `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}, ${pad(date.getHours())}:${pad(date.getMinutes())} ${offset}`;
+  }
+}
+
+function formatRelativeSentTime(createdAt, locale, now = Date.now()) {
+  const value = Number(createdAt);
+  if (!Number.isFinite(value) || value <= 0) return '';
+  const units = [
+    ['second', 1000],
+    ['minute', 60 * 1000],
+    ['hour', 60 * 60 * 1000],
+    ['day', 24 * 60 * 60 * 1000],
+  ];
+  const current = Number(now);
+  const elapsedMs = Number.isFinite(current) ? Math.max(0, current - value) : 0;
+  const lastUnit = units[units.length - 1];
+  let unit = lastUnit;
+  for (let index = 0; index < units.length - 1; index += 1) {
+    if (elapsedMs < units[index + 1][1]) {
+      unit = units[index];
+      break;
+    }
+  }
+  const amount = Math.floor(elapsedMs / unit[1]);
+  try {
+    return new Intl.RelativeTimeFormat(locale || undefined, {
+      numeric: 'auto',
+      style: 'long',
+    }).format(-amount, unit[0]);
+  } catch {
+    if (amount === 0) return 'now';
+    return `${amount} ${unit[0]}${amount === 1 ? '' : 's'} ago`;
   }
 }
 
@@ -80,13 +111,14 @@ export function aggregateMessageCompletion(current, result, durationMs) {
   };
 }
 
-export function buildMessageInfoPills({ createdAt, completion = {}, verbose = false, locale } = {}) {
-  const time = formatSentTime(createdAt, locale);
+export function buildMessageInfoPills({ createdAt, completion = {}, verbose = false, locale, now = Date.now() } = {}) {
+  const time = formatRelativeSentTime(createdAt, locale, now);
   if (!time) return [];
   const pills = [{
     kind: 'sent',
     key: 'sp.message_info.sent',
     params: { time },
+    title: formatExactSentTime(createdAt, locale),
   }];
   if (!verbose) return pills;
   const outputTokens = firstPositiveInteger(completion.outputTokens);

--- a/src/chrome/src/ui/sidepanel.js
+++ b/src/chrome/src/ui/sidepanel.js
@@ -10639,10 +10639,9 @@ function renderMessageInfo(msgEl) {
   });
   row.replaceChildren(...pills.map((pill) => {
     const item = document.createElement('span');
-    item.className = pill.kind === 'sent'
-      ? 'message-info-item message-info-sent'
-      : `message-info-item message-info-pill message-info-${pill.kind}`;
+    item.className = `message-info-item message-info-pill message-info-${pill.kind}`;
     item.textContent = t(pill.key, pill.params);
+    if (pill.title) item.title = pill.title;
     return item;
   }));
   row.hidden = !msgEl.classList.contains('message-info-open') || pills.length === 0;

--- a/src/chrome/src/ui/sidepanel.js
+++ b/src/chrome/src/ui/sidepanel.js
@@ -10636,6 +10636,7 @@ function renderMessageInfo(msgEl) {
     completion: messageCompletionFromElement(msgEl),
     verbose: verboseMode,
     locale: getLocale(),
+    now: Number.isFinite(msgEl.__wbMessageInfoOpenedAt) ? msgEl.__wbMessageInfoOpenedAt : Date.now(),
   });
   row.replaceChildren(...pills.map((pill) => {
     const item = document.createElement('span');
@@ -10660,6 +10661,8 @@ function messageInfoClickHasTextSelection() {
 
 function toggleMessageInfo(msgEl) {
   const open = msgEl.classList.toggle('message-info-open');
+  if (open) msgEl.__wbMessageInfoOpenedAt = Date.now();
+  else delete msgEl.__wbMessageInfoOpenedAt;
   ensureMessageInfoElements(msgEl).toggle.setAttribute('aria-expanded', String(open));
   renderMessageInfo(msgEl);
   schedulePersist();
@@ -10672,7 +10675,10 @@ function bindMessageInfoToggle(msgEl) {
   msgEl.removeAttribute('aria-expanded');
   msgEl.removeAttribute('title');
   const { toggle } = ensureMessageInfoElements(msgEl);
-  if (msgEl.classList.contains('message-info-open')) renderMessageInfo(msgEl);
+  if (msgEl.classList.contains('message-info-open')) {
+    if (!Number.isFinite(msgEl.__wbMessageInfoOpenedAt)) msgEl.__wbMessageInfoOpenedAt = Date.now();
+    renderMessageInfo(msgEl);
+  }
   if (msgEl.__wbMessageInfoBound) return;
   msgEl.__wbMessageInfoBound = true;
   toggle.addEventListener('click', () => toggleMessageInfo(msgEl));

--- a/src/chrome/src/ui/sidepanel.js
+++ b/src/chrome/src/ui/sidepanel.js
@@ -10582,6 +10582,11 @@ function messageCompletionFromElement(msgEl) {
   };
 }
 
+function messageInfoOpenedAt(msgEl) {
+  const value = Number(msgEl?.dataset?.messageInfoOpenedAt);
+  return Number.isFinite(value) && value > 0 ? value : undefined;
+}
+
 let messageInfoRowId = 0;
 
 function ensureMessageInfoElements(msgEl) {
@@ -10636,7 +10641,7 @@ function renderMessageInfo(msgEl) {
     completion: messageCompletionFromElement(msgEl),
     verbose: verboseMode,
     locale: getLocale(),
-    now: Number.isFinite(msgEl.__wbMessageInfoOpenedAt) ? msgEl.__wbMessageInfoOpenedAt : Date.now(),
+    now: messageInfoOpenedAt(msgEl) ?? Date.now(),
   });
   row.replaceChildren(...pills.map((pill) => {
     const item = document.createElement('span');
@@ -10661,8 +10666,8 @@ function messageInfoClickHasTextSelection() {
 
 function toggleMessageInfo(msgEl) {
   const open = msgEl.classList.toggle('message-info-open');
-  if (open) msgEl.__wbMessageInfoOpenedAt = Date.now();
-  else delete msgEl.__wbMessageInfoOpenedAt;
+  if (open) msgEl.dataset.messageInfoOpenedAt = String(Date.now());
+  else delete msgEl.dataset.messageInfoOpenedAt;
   ensureMessageInfoElements(msgEl).toggle.setAttribute('aria-expanded', String(open));
   renderMessageInfo(msgEl);
   schedulePersist();
@@ -10676,7 +10681,7 @@ function bindMessageInfoToggle(msgEl) {
   msgEl.removeAttribute('title');
   const { toggle } = ensureMessageInfoElements(msgEl);
   if (msgEl.classList.contains('message-info-open')) {
-    if (!Number.isFinite(msgEl.__wbMessageInfoOpenedAt)) msgEl.__wbMessageInfoOpenedAt = Date.now();
+    if (!messageInfoOpenedAt(msgEl)) msgEl.dataset.messageInfoOpenedAt = String(Date.now());
     renderMessageInfo(msgEl);
   }
   if (msgEl.__wbMessageInfoBound) return;

--- a/src/chrome/styles/sidepanel.css
+++ b/src/chrome/styles/sidepanel.css
@@ -1555,12 +1555,19 @@ body {
   min-width: 0;
   margin: 0;
   padding: 0 4px;
-  overflow: hidden;
+  overflow-x: auto;
+  overflow-y: hidden;
+  scrollbar-width: none;
+  -ms-overflow-style: none;
   white-space: nowrap;
   color: var(--text-secondary);
   font-size: 10px;
   font-variant-numeric: tabular-nums;
   line-height: 1.35;
+}
+
+.message-info::-webkit-scrollbar {
+  display: none;
 }
 
 .message.user .message-info {

--- a/src/chrome/styles/sidepanel.css
+++ b/src/chrome/styles/sidepanel.css
@@ -1572,7 +1572,6 @@ body {
 
 .message.user .message-info {
   justify-content: flex-start;
-  margin-inline-start: auto;
 }
 
 .message-info[hidden] {

--- a/src/chrome/styles/sidepanel.css
+++ b/src/chrome/styles/sidepanel.css
@@ -1571,7 +1571,8 @@ body {
 }
 
 .message.user .message-info {
-  justify-content: flex-end;
+  justify-content: flex-start;
+  margin-inline-start: auto;
 }
 
 .message-info[hidden] {

--- a/src/firefox/src/message-info.js
+++ b/src/firefox/src/message-info.js
@@ -9,6 +9,7 @@ function formatExactSentTime(createdAt, locale) {
       day: '2-digit',
       hour: '2-digit',
       minute: '2-digit',
+      second: '2-digit',
       hour12: false,
       timeZoneName: 'short',
     }).format(date);
@@ -18,7 +19,7 @@ function formatExactSentTime(createdAt, locale) {
     const offset = offsetMinutes === 0
       ? 'UTC'
       : `UTC${offsetMinutes > 0 ? '+' : '-'}${pad(Math.floor(Math.abs(offsetMinutes) / 60))}:${pad(Math.abs(offsetMinutes) % 60)}`;
-    return `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}, ${pad(date.getHours())}:${pad(date.getMinutes())} ${offset}`;
+    return `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}, ${pad(date.getHours())}:${pad(date.getMinutes())}:${pad(date.getSeconds())} ${offset}`;
   }
 }
 
@@ -26,30 +27,31 @@ function formatRelativeSentTime(createdAt, locale, now = Date.now()) {
   const value = Number(createdAt);
   if (!Number.isFinite(value) || value <= 0) return '';
   const units = [
-    ['second', 1000],
-    ['minute', 60 * 1000],
-    ['hour', 60 * 60 * 1000],
-    ['day', 24 * 60 * 60 * 1000],
+    { name: 'second', milliseconds: 1000 },
+    { name: 'minute', milliseconds: 60 * 1000 },
+    { name: 'hour', milliseconds: 60 * 60 * 1000 },
+    { name: 'day', milliseconds: 24 * 60 * 60 * 1000 },
   ];
   const current = Number(now);
   const elapsedMs = Number.isFinite(current) ? Math.max(0, current - value) : 0;
   const lastUnit = units[units.length - 1];
   let unit = lastUnit;
   for (let index = 0; index < units.length - 1; index += 1) {
-    if (elapsedMs < units[index + 1][1]) {
+    if (elapsedMs < units[index + 1].milliseconds) {
       unit = units[index];
       break;
     }
   }
-  const amount = Math.floor(elapsedMs / unit[1]);
+  const amount = Math.floor(elapsedMs / unit.milliseconds);
   try {
     return new Intl.RelativeTimeFormat(locale || undefined, {
       numeric: 'auto',
       style: 'long',
-    }).format(-amount, unit[0]);
+    }).format(-amount, unit.name);
   } catch {
+    // Keep timestamps usable when a browser lacks ICU data for the selected locale.
     if (amount === 0) return 'now';
-    return `${amount} ${unit[0]}${amount === 1 ? '' : 's'} ago`;
+    return `${amount} ${unit.name}${amount === 1 ? '' : 's'} ago`;
   }
 }
 

--- a/src/firefox/src/message-info.js
+++ b/src/firefox/src/message-info.js
@@ -45,7 +45,7 @@ function formatRelativeSentTime(createdAt, locale, now = Date.now()) {
   const amount = Math.floor(elapsedMs / unit.milliseconds);
   try {
     return new Intl.RelativeTimeFormat(locale || undefined, {
-      numeric: 'auto',
+      numeric: amount === 0 ? 'auto' : 'always',
       style: 'long',
     }).format(-amount, unit.name);
   } catch {

--- a/src/firefox/src/message-info.js
+++ b/src/firefox/src/message-info.js
@@ -1,4 +1,4 @@
-function formatSentTime(createdAt, locale) {
+function formatExactSentTime(createdAt, locale) {
   const value = Number(createdAt);
   if (!Number.isFinite(value) || value <= 0) return '';
   const date = new Date(value);
@@ -19,6 +19,37 @@ function formatSentTime(createdAt, locale) {
       ? 'UTC'
       : `UTC${offsetMinutes > 0 ? '+' : '-'}${pad(Math.floor(Math.abs(offsetMinutes) / 60))}:${pad(Math.abs(offsetMinutes) % 60)}`;
     return `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}, ${pad(date.getHours())}:${pad(date.getMinutes())} ${offset}`;
+  }
+}
+
+function formatRelativeSentTime(createdAt, locale, now = Date.now()) {
+  const value = Number(createdAt);
+  if (!Number.isFinite(value) || value <= 0) return '';
+  const units = [
+    ['second', 1000],
+    ['minute', 60 * 1000],
+    ['hour', 60 * 60 * 1000],
+    ['day', 24 * 60 * 60 * 1000],
+  ];
+  const current = Number(now);
+  const elapsedMs = Number.isFinite(current) ? Math.max(0, current - value) : 0;
+  const lastUnit = units[units.length - 1];
+  let unit = lastUnit;
+  for (let index = 0; index < units.length - 1; index += 1) {
+    if (elapsedMs < units[index + 1][1]) {
+      unit = units[index];
+      break;
+    }
+  }
+  const amount = Math.floor(elapsedMs / unit[1]);
+  try {
+    return new Intl.RelativeTimeFormat(locale || undefined, {
+      numeric: 'auto',
+      style: 'long',
+    }).format(-amount, unit[0]);
+  } catch {
+    if (amount === 0) return 'now';
+    return `${amount} ${unit[0]}${amount === 1 ? '' : 's'} ago`;
   }
 }
 
@@ -80,13 +111,14 @@ export function aggregateMessageCompletion(current, result, durationMs) {
   };
 }
 
-export function buildMessageInfoPills({ createdAt, completion = {}, verbose = false, locale } = {}) {
-  const time = formatSentTime(createdAt, locale);
+export function buildMessageInfoPills({ createdAt, completion = {}, verbose = false, locale, now = Date.now() } = {}) {
+  const time = formatRelativeSentTime(createdAt, locale, now);
   if (!time) return [];
   const pills = [{
     kind: 'sent',
     key: 'sp.message_info.sent',
     params: { time },
+    title: formatExactSentTime(createdAt, locale),
   }];
   if (!verbose) return pills;
   const outputTokens = firstPositiveInteger(completion.outputTokens);

--- a/src/firefox/src/ui/sidepanel.js
+++ b/src/firefox/src/ui/sidepanel.js
@@ -10251,6 +10251,7 @@ function renderMessageInfo(msgEl) {
     completion: messageCompletionFromElement(msgEl),
     verbose: verboseMode,
     locale: getLocale(),
+    now: Number.isFinite(msgEl.__wbMessageInfoOpenedAt) ? msgEl.__wbMessageInfoOpenedAt : Date.now(),
   });
   row.replaceChildren(...pills.map((pill) => {
     const item = document.createElement('span');
@@ -10275,6 +10276,8 @@ function messageInfoClickHasTextSelection() {
 
 function toggleMessageInfo(msgEl) {
   const open = msgEl.classList.toggle('message-info-open');
+  if (open) msgEl.__wbMessageInfoOpenedAt = Date.now();
+  else delete msgEl.__wbMessageInfoOpenedAt;
   ensureMessageInfoElements(msgEl).toggle.setAttribute('aria-expanded', String(open));
   renderMessageInfo(msgEl);
   schedulePersist();
@@ -10287,7 +10290,10 @@ function bindMessageInfoToggle(msgEl) {
   msgEl.removeAttribute('aria-expanded');
   msgEl.removeAttribute('title');
   const { toggle } = ensureMessageInfoElements(msgEl);
-  if (msgEl.classList.contains('message-info-open')) renderMessageInfo(msgEl);
+  if (msgEl.classList.contains('message-info-open')) {
+    if (!Number.isFinite(msgEl.__wbMessageInfoOpenedAt)) msgEl.__wbMessageInfoOpenedAt = Date.now();
+    renderMessageInfo(msgEl);
+  }
   if (msgEl.__wbMessageInfoBound) return;
   msgEl.__wbMessageInfoBound = true;
   toggle.addEventListener('click', () => toggleMessageInfo(msgEl));

--- a/src/firefox/src/ui/sidepanel.js
+++ b/src/firefox/src/ui/sidepanel.js
@@ -10197,6 +10197,11 @@ function messageCompletionFromElement(msgEl) {
   };
 }
 
+function messageInfoOpenedAt(msgEl) {
+  const value = Number(msgEl?.dataset?.messageInfoOpenedAt);
+  return Number.isFinite(value) && value > 0 ? value : undefined;
+}
+
 let messageInfoRowId = 0;
 
 function ensureMessageInfoElements(msgEl) {
@@ -10251,7 +10256,7 @@ function renderMessageInfo(msgEl) {
     completion: messageCompletionFromElement(msgEl),
     verbose: verboseMode,
     locale: getLocale(),
-    now: Number.isFinite(msgEl.__wbMessageInfoOpenedAt) ? msgEl.__wbMessageInfoOpenedAt : Date.now(),
+    now: messageInfoOpenedAt(msgEl) ?? Date.now(),
   });
   row.replaceChildren(...pills.map((pill) => {
     const item = document.createElement('span');
@@ -10276,8 +10281,8 @@ function messageInfoClickHasTextSelection() {
 
 function toggleMessageInfo(msgEl) {
   const open = msgEl.classList.toggle('message-info-open');
-  if (open) msgEl.__wbMessageInfoOpenedAt = Date.now();
-  else delete msgEl.__wbMessageInfoOpenedAt;
+  if (open) msgEl.dataset.messageInfoOpenedAt = String(Date.now());
+  else delete msgEl.dataset.messageInfoOpenedAt;
   ensureMessageInfoElements(msgEl).toggle.setAttribute('aria-expanded', String(open));
   renderMessageInfo(msgEl);
   schedulePersist();
@@ -10291,7 +10296,7 @@ function bindMessageInfoToggle(msgEl) {
   msgEl.removeAttribute('title');
   const { toggle } = ensureMessageInfoElements(msgEl);
   if (msgEl.classList.contains('message-info-open')) {
-    if (!Number.isFinite(msgEl.__wbMessageInfoOpenedAt)) msgEl.__wbMessageInfoOpenedAt = Date.now();
+    if (!messageInfoOpenedAt(msgEl)) msgEl.dataset.messageInfoOpenedAt = String(Date.now());
     renderMessageInfo(msgEl);
   }
   if (msgEl.__wbMessageInfoBound) return;

--- a/src/firefox/src/ui/sidepanel.js
+++ b/src/firefox/src/ui/sidepanel.js
@@ -10254,10 +10254,9 @@ function renderMessageInfo(msgEl) {
   });
   row.replaceChildren(...pills.map((pill) => {
     const item = document.createElement('span');
-    item.className = pill.kind === 'sent'
-      ? 'message-info-item message-info-sent'
-      : `message-info-item message-info-pill message-info-${pill.kind}`;
+    item.className = `message-info-item message-info-pill message-info-${pill.kind}`;
     item.textContent = t(pill.key, pill.params);
+    if (pill.title) item.title = pill.title;
     return item;
   }));
   row.hidden = !msgEl.classList.contains('message-info-open') || pills.length === 0;

--- a/src/firefox/styles/sidepanel.css
+++ b/src/firefox/styles/sidepanel.css
@@ -1409,7 +1409,6 @@ body {
 
 .message.user .message-info {
   justify-content: flex-start;
-  margin-inline-start: auto;
 }
 
 .message-info[hidden] {

--- a/src/firefox/styles/sidepanel.css
+++ b/src/firefox/styles/sidepanel.css
@@ -1408,7 +1408,8 @@ body {
 }
 
 .message.user .message-info {
-  justify-content: flex-end;
+  justify-content: flex-start;
+  margin-inline-start: auto;
 }
 
 .message-info[hidden] {

--- a/src/firefox/styles/sidepanel.css
+++ b/src/firefox/styles/sidepanel.css
@@ -1392,12 +1392,19 @@ body {
   min-width: 0;
   margin: 0;
   padding: 0 4px;
-  overflow: hidden;
+  overflow-x: auto;
+  overflow-y: hidden;
+  scrollbar-width: none;
+  -ms-overflow-style: none;
   white-space: nowrap;
   color: var(--text-secondary);
   font-size: 10px;
   font-variant-numeric: tabular-nums;
   line-height: 1.35;
+}
+
+.message-info::-webkit-scrollbar {
+  display: none;
 }
 
 .message.user .message-info {

--- a/test/run.js
+++ b/test/run.js
@@ -90355,6 +90355,7 @@ function expectedMessageInfoTestTime() {
     day: '2-digit',
     hour: '2-digit',
     minute: '2-digit',
+    second: '2-digit',
     hour12: false,
     timeZone: MESSAGE_INFO_TEST_TIME_ZONE,
     timeZoneName: 'short',
@@ -90628,6 +90629,8 @@ test('message info toggles behaviorally through a semantic button, terminal repl
     assert.equal(msgEl.classList.contains('message-info-open'), false, `${label}: a bubble click should close keyboard-opened info`);
     msgEl.dispatch('click', { target: msgEl });
     assert.equal(msgEl.classList.contains('message-info-open'), true, `${label}: a second bubble click should reopen info`);
+    const openedAt = msgEl.__wbMessageInfoOpenedAt;
+    assert.ok(Number.isFinite(openedAt), `${label}: opening should capture one relative-time snapshot`);
     selectionCollapsed = false;
     msgEl.dispatch('click', { target: msgEl });
     assert.equal(msgEl.classList.contains('message-info-open'), true, `${label}: selecting answer text should not toggle message info`);
@@ -90642,6 +90645,7 @@ test('message info toggles behaviorally through a semantic button, terminal repl
       finishReason: 'stop',
     });
     assert.equal(messageCompletionFromElement(msgEl).finishReason, 'stop', `${label}: completion should reach the message datasets`);
+    assert.equal(msgEl.__wbMessageInfoOpenedAt, openedAt, `${label}: live completion updates should not advance the opened timestamp`);
     const finishPill = openRow.children.find((child) => child.className.includes('message-info-finish'));
     assert.ok(finishPill, `${label}: the finish-reason pill should render in verbose mode`);
 
@@ -90678,6 +90682,7 @@ test('message info toggles behaviorally through a semantic button, terminal repl
     // Keyboard-equivalent activation: the toggle button itself toggles.
     restoredToggle.dispatch('click', { target: restoredToggle });
     assert.equal(restored.classList.contains('message-info-open'), false, `${label}: the toggle button should close the row`);
+    assert.equal(restored.__wbMessageInfoOpenedAt, undefined, `${label}: closing should discard the relative-time snapshot`);
     assert.equal(restoredToggle.attributes['aria-expanded'], 'false', `${label}: the toggle should mirror the closed state`);
     assert.equal(restoredRow.hidden, true, `${label}: the row should hide when closed`);
 

--- a/test/run.js
+++ b/test/run.js
@@ -90539,6 +90539,11 @@ test('sidepanels reveal persisted message info while verbose gates completion de
     assert.match(css, /\.message-info::\-webkit-scrollbar \{[^}]*display: none;/, `${label}: message-info scrollbars should stay visually hidden`);
     assert.match(
       css,
+      /\.message\.user \.message-info \{[^}]*justify-content: flex-start;[^}]*margin-inline-start: auto;/,
+      `${label}: right-aligned user details should keep the scrollable content start reachable`,
+    );
+    assert.match(
+      css,
       /\.message-info-toggle \{[^}]*position: absolute;[^}]*inset: 0;[^}]*pointer-events: none;[^}]*\}[\s\S]*?\.message-info-toggle:focus-visible \{[^}]*outline:/,
       `${label}: the icon-free semantic toggle should cover the bubble and retain visible keyboard focus`,
     );
@@ -90629,7 +90634,7 @@ test('message info toggles behaviorally through a semantic button, terminal repl
     assert.equal(msgEl.classList.contains('message-info-open'), false, `${label}: a bubble click should close keyboard-opened info`);
     msgEl.dispatch('click', { target: msgEl });
     assert.equal(msgEl.classList.contains('message-info-open'), true, `${label}: a second bubble click should reopen info`);
-    const openedAt = msgEl.__wbMessageInfoOpenedAt;
+    const openedAt = Number(msgEl.dataset.messageInfoOpenedAt);
     assert.ok(Number.isFinite(openedAt), `${label}: opening should capture one relative-time snapshot`);
     selectionCollapsed = false;
     msgEl.dispatch('click', { target: msgEl });
@@ -90645,7 +90650,7 @@ test('message info toggles behaviorally through a semantic button, terminal repl
       finishReason: 'stop',
     });
     assert.equal(messageCompletionFromElement(msgEl).finishReason, 'stop', `${label}: completion should reach the message datasets`);
-    assert.equal(msgEl.__wbMessageInfoOpenedAt, openedAt, `${label}: live completion updates should not advance the opened timestamp`);
+    assert.equal(Number(msgEl.dataset.messageInfoOpenedAt), openedAt, `${label}: live completion updates should not advance the opened timestamp`);
     const finishPill = openRow.children.find((child) => child.className.includes('message-info-finish'));
     assert.ok(finishPill, `${label}: the finish-reason pill should render in verbose mode`);
 
@@ -90658,6 +90663,7 @@ test('message info toggles behaviorally through a semantic button, terminal repl
     // and retained metadata without inventing a sent time.
     const restored = fakeDomElement('message assistant');
     restored.dataset.messageCreatedAt = String(1734000123456);
+    restored.dataset.messageInfoOpenedAt = String(openedAt);
     restored.dataset.messageInputTokens = '1000';
     restored.dataset.messageOutputTokens = '600';
     restored.dataset.messageTotalTokens = '1600';
@@ -90670,6 +90676,7 @@ test('message info toggles behaviorally through a semantic button, terminal repl
     const restoredToggle = restored.children.find((child) => child.className === 'message-info-toggle');
     assert.ok(restoredToggle, `${label}: restored messages should regain a toggle button`);
     assert.equal(restoredToggle.attributes['aria-expanded'], 'true', `${label}: restored open state should be preserved`);
+    assert.equal(Number(restored.dataset.messageInfoOpenedAt), openedAt, `${label}: restored open state should retain its relative-time snapshot`);
     assert.equal(messageCreatedAt(restored), 1734000123456, `${label}: restored sent time should be retained`);
     const restoredRow = restoredBar.children.find((child) => child.className === 'message-info');
     assert.ok(restoredRow, `${label}: restored open rows should render`);
@@ -90682,7 +90689,7 @@ test('message info toggles behaviorally through a semantic button, terminal repl
     // Keyboard-equivalent activation: the toggle button itself toggles.
     restoredToggle.dispatch('click', { target: restoredToggle });
     assert.equal(restored.classList.contains('message-info-open'), false, `${label}: the toggle button should close the row`);
-    assert.equal(restored.__wbMessageInfoOpenedAt, undefined, `${label}: closing should discard the relative-time snapshot`);
+    assert.equal(restored.dataset.messageInfoOpenedAt, undefined, `${label}: closing should discard the relative-time snapshot`);
     assert.equal(restoredToggle.attributes['aria-expanded'], 'false', `${label}: the toggle should mirror the closed state`);
     assert.equal(restoredRow.hidden, true, `${label}: the row should hide when closed`);
 

--- a/test/run.js
+++ b/test/run.js
@@ -90413,7 +90413,10 @@ test('message info relative timestamps select stable units at each boundary', as
       [24 * 60 * 60 * 1000, -1, 'day'],
     ]) {
       const createdAt = now - offsetMs;
-      const expected = new Intl.RelativeTimeFormat('en-GB', { numeric: 'auto', style: 'long' })
+      const expected = new Intl.RelativeTimeFormat('en-GB', {
+        numeric: amount === 0 ? 'auto' : 'always',
+        style: 'long',
+      })
         .format(amount, unit);
       assert.equal(
         buildMessageInfoPills({ createdAt, locale: 'en-GB', now })[0].params.time,
@@ -90539,7 +90542,7 @@ test('sidepanels reveal persisted message info while verbose gates completion de
     assert.match(css, /\.message-info::\-webkit-scrollbar \{[^}]*display: none;/, `${label}: message-info scrollbars should stay visually hidden`);
     assert.match(
       css,
-      /\.message\.user \.message-info \{[^}]*justify-content: flex-start;[^}]*margin-inline-start: auto;/,
+      /\.message\.user \.message-info \{[^}]*justify-content: flex-start;/,
       `${label}: right-aligned user details should keep the scrollable content start reachable`,
     );
     assert.match(

--- a/test/run.js
+++ b/test/run.js
@@ -90334,6 +90334,7 @@ test('transcription runtime uses the Chrome offscreen fallback when direct fetch
 });
 
 const MESSAGE_INFO_TEST_DATE = Date.parse('2024-12-12T12:44:00Z');
+const MESSAGE_INFO_TEST_NOW = Date.parse('2024-12-12T12:45:30Z');
 const MESSAGE_INFO_TEST_TIME_ZONE = 'America/Los_Angeles';
 
 async function withProcessTimeZone(timeZone, callback) {
@@ -90360,7 +90361,12 @@ function expectedMessageInfoTestTime() {
   }).format(new Date(MESSAGE_INFO_TEST_DATE));
 }
 
-test('message info keeps normal mode limited to the system-timezone sent timestamp', async () => {
+function expectedMessageInfoRelativeTime() {
+  return new Intl.RelativeTimeFormat('en-GB', { numeric: 'auto', style: 'long' })
+    .format(-1, 'minute');
+}
+
+test('message info shows a click-time relative timestamp with an exact hover title', async () => {
   await withProcessTimeZone(MESSAGE_INFO_TEST_TIME_ZONE, async () => {
     for (const [label, rel] of [
       ['chrome', 'src/chrome/src/message-info.js'],
@@ -90376,15 +90382,55 @@ test('message info keeps normal mode limited to the system-timezone sent timesta
         },
         verbose: false,
         locale: 'en-GB',
+        now: MESSAGE_INFO_TEST_NOW,
       });
 
       assert.deepEqual(pills, [{
         kind: 'sent',
         key: 'sp.message_info.sent',
-        params: { time: expectedMessageInfoTestTime() },
-      }], `${label}: normal mode must use the system timezone without exposing token or provider details`);
+        params: { time: expectedMessageInfoRelativeTime() },
+        title: expectedMessageInfoTestTime(),
+      }], `${label}: normal mode should show relative time while keeping exact time for hover`);
     }
   });
+});
+
+test('message info relative timestamps select stable units at each boundary', async () => {
+  const now = Date.parse('2024-12-12T12:45:30Z');
+  for (const [label, rel] of [
+    ['chrome', 'src/chrome/src/message-info.js'],
+    ['firefox', 'src/firefox/src/message-info.js'],
+  ]) {
+    const { buildMessageInfoPills } = await import(pathToFileURL(path.join(ROOT, rel)).href);
+    for (const [offsetMs, amount, unit] of [
+      [0, 0, 'second'],
+      [59 * 1000, -59, 'second'],
+      [60 * 1000, -1, 'minute'],
+      [59 * 60 * 1000, -59, 'minute'],
+      [60 * 60 * 1000, -1, 'hour'],
+      [23 * 60 * 60 * 1000, -23, 'hour'],
+      [24 * 60 * 60 * 1000, -1, 'day'],
+    ]) {
+      const createdAt = now - offsetMs;
+      const expected = new Intl.RelativeTimeFormat('en-GB', { numeric: 'auto', style: 'long' })
+        .format(amount, unit);
+      assert.equal(
+        buildMessageInfoPills({ createdAt, locale: 'en-GB', now })[0].params.time,
+        expected,
+        `${label}: ${offsetMs}ms should use the ${unit} relative-time unit`,
+      );
+    }
+    assert.deepEqual(
+      buildMessageInfoPills({ createdAt: 'not-a-timestamp', locale: 'en-GB', now }),
+      [],
+      `${label}: invalid timestamps should remain unavailable`,
+    );
+    assert.equal(
+      buildMessageInfoPills({ createdAt: now + 60 * 1000, locale: 'en-GB', now })[0].params.time,
+      'now',
+      `${label}: future timestamps should not claim that a message was sent in the future`,
+    );
+  }
 });
 
 test('message info aggregates model calls into verbose completion pills', async () => {
@@ -90430,8 +90476,9 @@ test('message info aggregates model calls into verbose completion pills', async 
         completion,
         verbose: true,
         locale: 'en-GB',
+        now: MESSAGE_INFO_TEST_NOW,
       }), [
-        { kind: 'sent', key: 'sp.message_info.sent', params: { time: expectedMessageInfoTestTime() } },
+        { kind: 'sent', key: 'sp.message_info.sent', params: { time: expectedMessageInfoRelativeTime() }, title: expectedMessageInfoTestTime() },
         { kind: 'speed', key: 'sp.message_info.speed', params: { rate: '171.3' } },
         { kind: 'tokens', key: 'sp.message_info.tokens', params: { count: '1,295' } },
         { kind: 'duration', key: 'sp.message_info.duration', params: { seconds: '7.56' } },
@@ -90485,9 +90532,10 @@ test('sidepanels reveal persisted message info while verbose gates completion de
     );
     assert.match(
       css,
-      /\.message-info \{[^}]*flex-wrap: nowrap;[^}]*overflow: hidden;[^}]*white-space: nowrap;/,
-      `${label}: normal and verbose message info should stay on one clipped line`,
+      /\.message-info \{[^}]*flex-wrap: nowrap;[^}]*overflow-x: auto;[^}]*overflow-y: hidden;[^}]*scrollbar-width: none;[^}]*white-space: nowrap;/,
+      `${label}: normal and verbose message info should stay on one horizontally scrollable line`,
     );
+    assert.match(css, /\.message-info::\-webkit-scrollbar \{[^}]*display: none;/, `${label}: message-info scrollbars should stay visually hidden`);
     assert.match(
       css,
       /\.message-info-toggle \{[^}]*position: absolute;[^}]*inset: 0;[^}]*pointer-events: none;[^}]*\}[\s\S]*?\.message-info-toggle:focus-visible \{[^}]*outline:/,
@@ -90574,6 +90622,8 @@ test('message info toggles behaviorally through a semantic button, terminal repl
     assert.equal(openRow.id, toggle.attributes['aria-controls'], `${label}: the row id should match the toggle target`);
     const sentPill = openRow.children.find((child) => child.className.includes('message-info-sent'));
     assert.ok(sentPill, `${label}: the sent-time pill should render`);
+    assert.match(sentPill.className, /message-info-pill/, `${label}: sent time should use the same pill treatment as other details`);
+    assert.ok(sentPill.title, `${label}: sent time should expose the exact timestamp on hover`);
     msgEl.dispatch('click', { target: msgEl });
     assert.equal(msgEl.classList.contains('message-info-open'), false, `${label}: a bubble click should close keyboard-opened info`);
     msgEl.dispatch('click', { target: msgEl });


### PR DESCRIPTION
## Summary

- Show message sent time as a relative value such as `1 minute ago` or `2 hours ago`.
- Keep the exact timestamp available on hover.
- Keep the sent time in the same pill row and allow long rows to scroll without a visible scrollbar.

## Motivation

Issue #2847 asks for readable relative timestamps, exact hover details, consistent pill styling, and scrollable overflow in the chat message information row.

## Design

- `message-info.js` selects stable second, minute, hour, and day units with `Intl.RelativeTimeFormat`; zero elapsed time remains localized as `now`.
- The relative-time snapshot is captured when the info row opens and stored in the existing message HTML dataset so completion updates and sidepanel restores do not advance it unexpectedly.
- The exact localized timestamp includes seconds and timezone information in the sent pill `title`.
- Chrome and Firefox keep mirrored message-info logic and CSS. The row uses horizontal scrolling with hidden native scrollbars, and user-message rows start content at the scroll origin so the first pill remains reachable.

## Testing

- `npm test` — passed: 1893 unit checks and 60/60 security corpus checks.
- `node --check src/chrome/src/message-info.js src/firefox/src/message-info.js src/chrome/src/ui/sidepanel.js src/firefox/src/ui/sidepanel.js` — passed.
- `git diff --check` — passed.
- Chrome unpacked-extension smoke test on the real `chrome-extension://` sidepanel — relative sent text, exact hover title, pill class, computed overflow, and hidden scrollbar styles verified; console and page errors were empty.
- Firefox was covered by mirrored automated tests but not manually launched.

## Compatibility and risks

- No new dependencies, permissions, provider requests, or storage schema are introduced.
- The opened timestamp is an existing `data-*` message attribute and remains compatible with restored chat HTML.
- Relative text is frozen until the row is closed and reopened; the exact timestamp remains available on hover.

## Scope

- Calendar-aware month/year wording and a separate touch-accessible exact-time affordance are intentionally deferred.

Closes #2847