### PR TITLE
fix(oauth): deduplicate subscription token refreshes

### DIFF
--- a/src/chrome/src/providers/oauth-subscriptions.js
+++ b/src/chrome/src/providers/oauth-subscriptions.js
@@ -103,6 +103,8 @@ async function tokenError(label, res) {
  */
 function makeOAuthClient(def) {
   const STORAGE_KEY = def.storageKey;
+  // Refresh tokens may rotate, so concurrent callers must share one request.
+  let _inflightRefresh = null;
 
   function redirectUri() {
     return def.redirect || `https://${chrome.runtime.id}.chromiumapp.org/`;
@@ -213,7 +215,16 @@ function makeOAuthClient(def) {
     return tokens;
   }
 
-  async function refresh() {
+  function refresh() {
+    if (!_inflightRefresh) {
+      _inflightRefresh = _doRefresh().finally(() => {
+        _inflightRefresh = null;
+      });
+    }
+    return _inflightRefresh;
+  }
+
+  async function _doRefresh() {
     const stored = await chrome.storage.local.get([STORAGE_KEY]);
     const tokens = stored[STORAGE_KEY];
     if (!tokens?.refreshToken) throw new Error(`${def.label}: no refresh token on file — sign in first.`);

--- a/src/firefox/src/providers/oauth-subscriptions.js
+++ b/src/firefox/src/providers/oauth-subscriptions.js
@@ -103,6 +103,8 @@ async function tokenError(label, res) {
  */
 function makeOAuthClient(def) {
   const STORAGE_KEY = def.storageKey;
+  // Refresh tokens may rotate, so concurrent callers must share one request.
+  let _inflightRefresh = null;
 
   function redirectUri() {
     return def.redirect || `https://${browser.runtime.id}.chromiumapp.org/`;
@@ -213,7 +215,16 @@ function makeOAuthClient(def) {
     return tokens;
   }
 
-  async function refresh() {
+  function refresh() {
+    if (!_inflightRefresh) {
+      _inflightRefresh = _doRefresh().finally(() => {
+        _inflightRefresh = null;
+      });
+    }
+    return _inflightRefresh;
+  }
+
+  async function _doRefresh() {
     const stored = await browser.storage.local.get([STORAGE_KEY]);
     const tokens = stored[STORAGE_KEY];
     if (!tokens?.refreshToken) throw new Error(`${def.label}: no refresh token on file — sign in first.`);

--- a/test/run.js
+++ b/test/run.js
@@ -885,6 +885,12 @@ const { ProviderManager: ProviderManagerCh } = await import(
 const { ProviderManager: ProviderManagerFx } = await import(
   'file://' + path.join(ROOT, 'src/firefox/src/providers/manager.js').replace(/\\/g, '/')
 );
+const { refreshSubscription: refreshSubscriptionCh } = await import(
+  'file://' + path.join(ROOT, 'src/chrome/src/providers/oauth-subscriptions.js').replace(/\\/g, '/')
+);
+const { refreshSubscription: refreshSubscriptionFx } = await import(
+  'file://' + path.join(ROOT, 'src/firefox/src/providers/oauth-subscriptions.js').replace(/\\/g, '/')
+);
 const {
   WebGPUProvider,
   WebGPUVisionProvider,
@@ -50958,6 +50964,103 @@ test('WebGPU worker replays text tool history and applies model-specific generat
     else globalThis.__holdWebgpuTextGeneration = previousHoldTextGeneration;
     if (previousReleaseTextGeneration === undefined) delete globalThis.__releaseWebgpuTextGeneration;
     else globalThis.__releaseWebgpuTextGeneration = previousReleaseTextGeneration;
+  }
+});
+
+test('subscription OAuth refreshes share in-flight work and retry after failures', async () => {
+  const originalChrome = globalThis.chrome;
+  const originalBrowser = globalThis.browser;
+  const originalFetch = globalThis.fetch;
+  const storageKey = 'chromeWebStoreOauthTokens';
+
+  try {
+    for (const [label, apiName, refreshSubscription] of [
+      ['chrome', 'chrome', refreshSubscriptionCh],
+      ['firefox', 'browser', refreshSubscriptionFx],
+    ]) {
+      const oldTokens = {
+        accessToken: 'old-access',
+        refreshToken: 'old-refresh',
+        clientId: 'client-id',
+        expiresAt: 0,
+      };
+      const stored = { [storageKey]: { ...oldTokens } };
+      const local = {
+        async get(keys) {
+          const result = {};
+          for (const key of Array.isArray(keys) ? keys : [keys]) {
+            if (Object.hasOwn(stored, key)) result[key] = stored[key];
+          }
+          return result;
+        },
+        async set(values) {
+          Object.assign(stored, values);
+        },
+        async remove(keys) {
+          for (const key of Array.isArray(keys) ? keys : [keys]) delete stored[key];
+        },
+      };
+      globalThis[apiName] = { storage: { local } };
+
+      const responseGate = deferred();
+      const requestStarted = deferred();
+      let fetchCalls = 0;
+      globalThis.fetch = () => {
+        fetchCalls += 1;
+        requestStarted.resolve();
+        return responseGate.promise;
+      };
+
+      const firstRefresh = refreshSubscription('chrome_web_store');
+      const secondRefresh = refreshSubscription('chrome_web_store');
+      await requestStarted.promise;
+      await waitMicrotasks();
+      assert.equal(fetchCalls, 1, `${label}: concurrent refreshes reached the token endpoint more than once`);
+
+      responseGate.resolve({
+        ok: true,
+        status: 200,
+        async json() {
+          return { access_token: 'new-access', refresh_token: 'new-refresh', expires_in: 3600 };
+        },
+      });
+      const [firstTokens, secondTokens] = await Promise.all([firstRefresh, secondRefresh]);
+      assert.deepEqual(secondTokens, firstTokens, `${label}: concurrent callers received different token results`);
+      assert.equal(stored[storageKey]?.accessToken, 'new-access', `${label}: refreshed access token was not persisted`);
+      assert.equal(stored[storageKey]?.refreshToken, 'new-refresh', `${label}: rotated refresh token was not preserved`);
+
+      stored[storageKey] = { ...oldTokens };
+      let retryCalls = 0;
+      globalThis.fetch = async () => {
+        retryCalls += 1;
+        if (retryCalls === 1) return { ok: false, status: 400 };
+        return {
+          ok: true,
+          status: 200,
+          async json() {
+            return { access_token: 'retry-access', refresh_token: 'retry-refresh', expires_in: 3600 };
+          },
+        };
+      };
+
+      await assert.rejects(
+        refreshSubscription('chrome_web_store'),
+        /refresh token rejected/,
+        `${label}: hard refresh failure was not surfaced`,
+      );
+      assert.equal(stored[storageKey], undefined, `${label}: rejected credentials were not removed`);
+      stored[storageKey] = { ...oldTokens };
+      const retryTokens = await refreshSubscription('chrome_web_store');
+      assert.equal(retryCalls, 2, `${label}: failed in-flight refresh blocked a later retry`);
+      assert.equal(retryTokens.accessToken, 'retry-access', `${label}: retry did not return fresh credentials`);
+    }
+  } finally {
+    if (originalChrome === undefined) delete globalThis.chrome;
+    else globalThis.chrome = originalChrome;
+    if (originalBrowser === undefined) delete globalThis.browser;
+    else globalThis.browser = originalBrowser;
+    if (originalFetch === undefined) delete globalThis.fetch;
+    else globalThis.fetch = originalFetch;
   }
 });
 


### PR DESCRIPTION
## Summary

- share one in-flight token refresh per subscription OAuth client
- prevent concurrent callers from reusing the same rotating refresh token
- clear the in-flight state after success or failure so later refreshes can retry
- cover Chrome and Firefox with production-module behavior tests

## Problem

Concurrent refresh calls could both read the same stored refresh token. When the provider rotates refresh tokens, the first request succeeds and stores the replacement, while the second request can fail with HTTP 400 and remove the newly stored credentials. This spuriously signs the user out.

## Testing

- `node test/run.js` (1895 passed, 0 failed)
- `npm run test:toolbar-guard` (33 passed)
- `npm run test:security` (60 checks passed)
- `node scripts/benchmark-offline-relevance.mjs`
- `node --check` on both changed production modules and `test/run.js`
- `git diff --check`
- Chrome/Firefox source parity check

## AI assistance

OpenAI Codex (GPT-5) assisted with implementation, tests, and review.