### PR TITLE
fix(settings): ignore stale model list responses

### DIFF
--- a/src/chrome/src/ui/settings.js
+++ b/src/chrome/src/ui/settings.js
@@ -3375,28 +3375,37 @@ function clearProviderLoadedModels(id) {
   if (datalistEl) datalistEl.innerHTML = '';
 }
 
+const providerModelLoadGenerations = new Map();
+
 async function loadProviderModels(id) {
   let datalistEl = document.getElementById(`models-${id}`);
   if (!datalistEl) return;
+  const generation = (providerModelLoadGenerations.get(id) || 0) + 1;
+  providerModelLoadGenerations.set(id, generation);
+  const isCurrent = () => providerModelLoadGenerations.get(id) === generation;
   clearProviderLoadedModels(id);
   // Persist whatever the user has typed in baseUrl/model so the background
   // call uses the current values, not stale storage.
   try {
     await saveProvider(id, { showFlash: false, markConfigured: false });
   } catch (e) {
+    if (!isCurrent()) return;
     setProviderLoadModelsStatus(id, providerModelLoadErrorMessage(e.message), 'var(--danger, #c33)');
     return;
   }
 
+  if (!isCurrent()) return;
   setProviderLoadModelsStatus(id, t('st.providers.loading'));
   let res;
   try {
     res = await sendToBackground('list_provider_models', { providerId: id });
   } catch (e) {
+    if (!isCurrent()) return;
     setProviderLoadModelsStatus(id, providerModelLoadErrorMessage(e.message), 'var(--danger, #c33)');
     return;
   }
 
+  if (!isCurrent()) return;
   datalistEl = document.getElementById(`models-${id}`);
   if (!datalistEl) return;
   if (res?.ok) {

--- a/src/chrome/src/ui/settings.js
+++ b/src/chrome/src/ui/settings.js
@@ -3376,6 +3376,18 @@ function clearProviderLoadedModels(id) {
 }
 
 const providerModelLoadGenerations = new Map();
+const providerModelLoadSaveQueues = new Map();
+
+function queueProviderModelLoadSave(id, save) {
+  const previous = providerModelLoadSaveQueues.get(id) || Promise.resolve();
+  const queued = previous.catch(() => {}).then(save);
+  providerModelLoadSaveQueues.set(id, queued);
+  const clear = () => {
+    if (providerModelLoadSaveQueues.get(id) === queued) providerModelLoadSaveQueues.delete(id);
+  };
+  queued.then(clear, clear);
+  return queued;
+}
 
 async function loadProviderModels(id) {
   let datalistEl = document.getElementById(`models-${id}`);
@@ -3387,7 +3399,10 @@ async function loadProviderModels(id) {
   // Persist whatever the user has typed in baseUrl/model so the background
   // call uses the current values, not stale storage.
   try {
-    await saveProvider(id, { showFlash: false, markConfigured: false });
+    await queueProviderModelLoadSave(id, async () => {
+      if (!isCurrent()) return;
+      await saveProvider(id, { showFlash: false, markConfigured: false });
+    });
   } catch (e) {
     if (!isCurrent()) return;
     setProviderLoadModelsStatus(id, providerModelLoadErrorMessage(e.message), 'var(--danger, #c33)');

--- a/src/firefox/src/ui/settings.js
+++ b/src/firefox/src/ui/settings.js
@@ -2987,6 +2987,18 @@ function clearProviderLoadedModels(id) {
 }
 
 const providerModelLoadGenerations = new Map();
+const providerModelLoadSaveQueues = new Map();
+
+function queueProviderModelLoadSave(id, save) {
+  const previous = providerModelLoadSaveQueues.get(id) || Promise.resolve();
+  const queued = previous.catch(() => {}).then(save);
+  providerModelLoadSaveQueues.set(id, queued);
+  const clear = () => {
+    if (providerModelLoadSaveQueues.get(id) === queued) providerModelLoadSaveQueues.delete(id);
+  };
+  queued.then(clear, clear);
+  return queued;
+}
 
 async function loadProviderModels(id) {
   let datalistEl = document.getElementById(`models-${id}`);
@@ -2996,7 +3008,10 @@ async function loadProviderModels(id) {
   const isCurrent = () => providerModelLoadGenerations.get(id) === generation;
   clearProviderLoadedModels(id);
   try {
-    await saveProvider(id, { showFlash: false, markConfigured: false });
+    await queueProviderModelLoadSave(id, async () => {
+      if (!isCurrent()) return;
+      await saveProvider(id, { showFlash: false, markConfigured: false });
+    });
   } catch (e) {
     if (!isCurrent()) return;
     setProviderLoadModelsStatus(id, providerModelLoadErrorMessage(e.message), 'var(--danger, #c33)');

--- a/src/firefox/src/ui/settings.js
+++ b/src/firefox/src/ui/settings.js
@@ -2986,26 +2986,35 @@ function clearProviderLoadedModels(id) {
   if (datalistEl) datalistEl.innerHTML = '';
 }
 
+const providerModelLoadGenerations = new Map();
+
 async function loadProviderModels(id) {
   let datalistEl = document.getElementById(`models-${id}`);
   if (!datalistEl) return;
+  const generation = (providerModelLoadGenerations.get(id) || 0) + 1;
+  providerModelLoadGenerations.set(id, generation);
+  const isCurrent = () => providerModelLoadGenerations.get(id) === generation;
   clearProviderLoadedModels(id);
   try {
     await saveProvider(id, { showFlash: false, markConfigured: false });
   } catch (e) {
+    if (!isCurrent()) return;
     setProviderLoadModelsStatus(id, providerModelLoadErrorMessage(e.message), 'var(--danger, #c33)');
     return;
   }
 
+  if (!isCurrent()) return;
   setProviderLoadModelsStatus(id, t('st.providers.loading'));
   let res;
   try {
     res = await sendToBackground('list_provider_models', { providerId: id });
   } catch (e) {
+    if (!isCurrent()) return;
     setProviderLoadModelsStatus(id, providerModelLoadErrorMessage(e.message), 'var(--danger, #c33)');
     return;
   }
 
+  if (!isCurrent()) return;
   datalistEl = document.getElementById(`models-${id}`);
   if (!datalistEl) return;
   if (res?.ok) {

--- a/test/run.js
+++ b/test/run.js
@@ -36152,6 +36152,78 @@ test('provider model loading ignores an older response that finishes last', asyn
   }
 });
 
+test('provider model loading serializes overlapping saves so the newest settings persist last', async () => {
+  for (const [label, settingsRel] of [
+    ['chrome', 'src/chrome/src/ui/settings.js'],
+    ['firefox', 'src/firefox/src/ui/settings.js'],
+  ]) {
+    const source = fs.readFileSync(path.join(ROOT, settingsRel), 'utf8');
+    const start = source.indexOf('const providerModelLoadGenerations = new Map();');
+    const end = source.indexOf('\n}\n\nfunction setProviderTestResult', start);
+    assert.ok(start >= 0 && end > start, `${label}: provider model-load runtime missing`);
+
+    const datalistEl = { innerHTML: '' };
+    const optionsEl = { innerHTML: '' };
+    const loadedDialogEl = { open: false, querySelector: () => optionsEl };
+    const document = {
+      getElementById: id => id === 'models-vllm' ? datalistEl : null,
+      querySelector: selector => selector.includes('loaded-model-dialog') ? loadedDialogEl : null,
+    };
+    const saveResponses = [deferred(), deferred()];
+    const saveStarted = [deferred(), deferred()];
+    const savedBaseUrls = [];
+    let currentBaseUrl = 'http://old.test/v1';
+    let persistedBaseUrl = '';
+    let saveCount = 0;
+    let listRequestCount = 0;
+    const loadProviderModels = Function(
+      'document', 'clearProviderLoadedModels', 'saveProvider', 'setProviderLoadModelsStatus',
+      'providerModelLoadErrorMessage', 't', 'sendToBackground', 'applyProviderBaseUrl',
+      'applyProviderContextWindow', 'escapeHtml', 'openLoadedModelDialog',
+      `${source.slice(start, end + 2)}\nreturn loadProviderModels;`,
+    )(
+      document,
+      () => { datalistEl.innerHTML = ''; optionsEl.innerHTML = ''; loadedDialogEl.open = false; },
+      async () => {
+        const index = saveCount++;
+        const snapshot = currentBaseUrl;
+        savedBaseUrls.push(snapshot);
+        saveStarted[index].resolve();
+        await saveResponses[index].promise;
+        persistedBaseUrl = snapshot;
+      },
+      () => {},
+      value => String(value || ''),
+      key => key,
+      async command => {
+        assert.equal(command, 'list_provider_models', `${label}: unexpected background command`);
+        listRequestCount += 1;
+        return { ok: true, models: ['new-model'] };
+      },
+      () => {},
+      () => {},
+      value => String(value),
+      dialog => { dialog.open = true; },
+    );
+
+    const older = loadProviderModels('vllm');
+    await saveStarted[0].promise;
+    currentBaseUrl = 'http://new.test/v1';
+    const newer = loadProviderModels('vllm');
+    assert.equal(saveCount, 1, `${label}: overlapping provider saves were not serialized`);
+
+    saveResponses[0].resolve();
+    await saveStarted[1].promise;
+    saveResponses[1].resolve();
+    await Promise.all([older, newer]);
+
+    assert.deepEqual(savedBaseUrls, ['http://old.test/v1', 'http://new.test/v1'], `${label}: newest settings were not saved last`);
+    assert.equal(persistedBaseUrl, 'http://new.test/v1', `${label}: stale settings remained persisted`);
+    assert.equal(listRequestCount, 1, `${label}: stale load continued after its save completed`);
+    assert.match(datalistEl.innerHTML, /new-model/, `${label}: newest model list was not rendered`);
+  }
+});
+
 test('settings waits for immediate preference writes and theme persistence', () => {
   for (const [label, settingsRel] of [
     ['chrome', 'src/chrome/src/ui/settings.js'],

--- a/test/run.js
+++ b/test/run.js
@@ -36031,6 +36031,11 @@ test('settings async test controls surface rejected background results', () => {
       `${label}: model loading should clear stale model choices before saving or requesting new models`,
     );
     assert.match(
+      loadBody,
+      /const generation = \(providerModelLoadGenerations\.get\(id\) \|\| 0\) \+ 1;[\s\S]*?const isCurrent = \(\) => providerModelLoadGenerations\.get\(id\) === generation;[\s\S]*?await saveProvider[\s\S]*?if \(!isCurrent\(\)\) return;[\s\S]*?await sendToBackground\('list_provider_models'[\s\S]*?if \(!isCurrent\(\)\) return;/,
+      `${label}: stale model-load requests should stop before updating the current provider card`,
+    );
+    assert.match(
       settings,
       /const loadedModelsDialogHTML = canLoadModels[\s\S]*<dialog class="loaded-model-dialog" data-loaded-models-for="\$\{id\}"[\s\S]*class="loaded-model-options"[\s\S]*\$\{loadedModelsDialogHTML\}/,
       `${label}: local model loading should render a loaded-model dialog`,
@@ -36079,6 +36084,71 @@ test('settings async test controls surface rejected background results', () => {
         `${label}/${filename}: loaded-model selector copy should be localized`,
       );
     }
+  }
+});
+
+test('provider model loading ignores an older response that finishes last', async () => {
+  for (const [label, settingsRel] of [
+    ['chrome', 'src/chrome/src/ui/settings.js'],
+    ['firefox', 'src/firefox/src/ui/settings.js'],
+  ]) {
+    const source = fs.readFileSync(path.join(ROOT, settingsRel), 'utf8');
+    const start = source.indexOf('const providerModelLoadGenerations = new Map();');
+    const end = source.indexOf('\n}\n\nfunction setProviderTestResult', start);
+    assert.ok(start >= 0 && end > start, `${label}: provider model-load runtime missing`);
+
+    const datalistEl = { innerHTML: '' };
+    const optionsEl = { innerHTML: '' };
+    const loadedDialogEl = { open: false, querySelector: () => optionsEl };
+    const document = {
+      getElementById: id => id === 'models-vllm' ? datalistEl : null,
+      querySelector: selector => selector.includes('loaded-model-dialog') ? loadedDialogEl : null,
+    };
+    const responses = [deferred(), deferred()];
+    const requestStarted = [deferred(), deferred()];
+    const baseUrls = [];
+    const contextWindows = [];
+    const statuses = [];
+    let requestCount = 0;
+    const loadProviderModels = Function(
+      'document', 'clearProviderLoadedModels', 'saveProvider', 'setProviderLoadModelsStatus',
+      'providerModelLoadErrorMessage', 't', 'sendToBackground', 'applyProviderBaseUrl',
+      'applyProviderContextWindow', 'escapeHtml', 'openLoadedModelDialog',
+      `${source.slice(start, end + 2)}\nreturn loadProviderModels;`,
+    )(
+      document,
+      () => { datalistEl.innerHTML = ''; optionsEl.innerHTML = ''; loadedDialogEl.open = false; },
+      async () => {},
+      (_id, message) => { statuses.push(message); },
+      value => String(value || ''),
+      key => key,
+      async command => {
+        assert.equal(command, 'list_provider_models', `${label}: unexpected background command`);
+        const index = requestCount++;
+        requestStarted[index].resolve();
+        return await responses[index].promise;
+      },
+      (_id, value) => { baseUrls.push(value); },
+      (_id, value) => { contextWindows.push(value); },
+      value => String(value),
+      dialog => { dialog.open = true; },
+    );
+
+    const older = loadProviderModels('vllm');
+    await requestStarted[0].promise;
+    const newer = loadProviderModels('vllm');
+    await requestStarted[1].promise;
+    responses[1].resolve({ ok: true, models: ['new-model'], baseUrl: 'http://new.test/v1', contextWindow: 32768 });
+    await newer;
+    responses[0].resolve({ ok: true, models: ['old-model'], baseUrl: 'http://old.test/v1', contextWindow: 4096 });
+    await older;
+
+    assert.match(datalistEl.innerHTML, /new-model/, `${label}: newest model list was not rendered`);
+    assert.doesNotMatch(datalistEl.innerHTML, /old-model/, `${label}: stale model list replaced the newest response`);
+    assert.match(optionsEl.innerHTML, /new-model/, `${label}: newest model dialog options were not rendered`);
+    assert.deepEqual(baseUrls, ['http://new.test/v1'], `${label}: stale base URL was applied`);
+    assert.deepEqual(contextWindows, [32768], `${label}: stale context window was applied`);
+    assert.equal(statuses.at(-1), 'st.providers.models_loaded', `${label}: newest load status was not preserved`);
   }
 });
 


### PR DESCRIPTION
## Summary

- track model-load generations independently for each provider card
- stop superseded save, error, and model-list completions before they update the UI
- cover reversed response order against the real Chrome and Firefox settings functions

## Problem

A user can start loading models for endpoint A, change the provider settings to endpoint B, and load again. If B finishes first and A finishes later, the older A response currently overwrites the displayed model choices, repaired base URL, context window, and status for the newer B configuration.

## Testing

- `node test/run.js` (1895 passed, 0 failed)
- `npm run test:toolbar-guard` (33 passed)
- `npm run test:security` (60 checks passed)
- `node scripts/benchmark-offline-relevance.mjs`
- syntax and diff checks
- Chrome/Firefox model-load logic parity check