### PR TITLE
feat(trace): event model with run-level format version and tolerant read path

### DIFF
--- a/src/chrome/src/agent/trace-export.js
+++ b/src/chrome/src/agent/trace-export.js
@@ -18,9 +18,12 @@
  *   each with its ordered event list.
  */
 
+import { isKnownKind } from '../trace/event-model.js';
+
 const ARGS_LIMIT = 300;
 const RESULT_LIMIT = 600;
 const FOOTER = '_Screenshot pixels and vision descriptions are omitted here — see the Traces page for the complete record._';
+const UNKNOWN_EVENTS_NOTE = (n) => `_Note: ${n} unknown event(s) skipped._`;
 
 function oneLine(t) { return String(t ?? '').replace(/\s+/g, ' ').trim(); }
 function humanSize(n) { return n >= 1024 ? `${(n / 1024).toFixed(1)}kb` : `${n}b`; }
@@ -170,6 +173,7 @@ export function tracesToMarkdown(runsWithEvents, {
   if (exportVersion) md += `_Exported with WebBrain v${exportVersion}_\n\n`;
   let turnCount = 0;
   let toolCount = 0;
+  let unknownEventCount = 0;
 
   for (const entry of runs) {
     if (!entry || !entry.run) continue;
@@ -256,6 +260,10 @@ export function tracesToMarkdown(runsWithEvents, {
         md += `- 📚 ${renderLocalWikipediaRag(d.extra).replace(/^ · /, '')}\n`;
       } else if (ev.kind === 'note' && /screenshot|vision|attachment|visual/i.test(String(d.note || ''))) {
         md += `- ℹ️ ${oneLine(d.note)}\n`;
+      } else if (!isKnownKind(ev.kind)) {
+        // Unknown kinds are skipped (never rendered) but counted, so an
+        // exporter from a newer build cannot silently lose events.
+        unknownEventCount += 1;
       }
     }
     const finalContent = String(run.finalContent || '').trim();
@@ -269,6 +277,7 @@ export function tracesToMarkdown(runsWithEvents, {
     const line = oneLine(note);
     if (line) md += `_Note: ${line}_\n`;
   }
+  if (unknownEventCount > 0) md += `${UNKNOWN_EVENTS_NOTE(unknownEventCount)}\n`;
   md += `${FOOTER}\n`;
-  return { markdown: md, turnCount, toolCount };
+  return { markdown: md, turnCount, toolCount, unknownEventCount };
 }

--- a/src/chrome/src/trace/event-model.js
+++ b/src/chrome/src/trace/event-model.js
@@ -1,0 +1,95 @@
+/**
+ * Trace event model — the shared vocabulary and envelope for the per-run event
+ * log written by trace/recorder.js.
+ *
+ * Pure and browser-neutral so it can be unit-tested in test/run.js without a
+ * DOM or IndexedDB.
+ *
+ * The recorder stores events as {runId, seq, ts, kind, data}. This module owns:
+ *   - the authoritative list of known event kinds. The recorder, Traces UI,
+ *     and exporters consult it instead of maintaining their own lists, so a
+ *     new event type has one place to be declared;
+ *   - the run-level trace format version stamped on every new run record, so
+ *     a future schema change can detect old traces instead of misreading them;
+ *   - envelope construction with write-side validation: unknown kinds and
+ *     data that cannot survive a JSON round-trip are rejected here, so a
+ *     recording bug surfaces at write time rather than as a ghost event.
+ *
+ * Events are privacy-filtered at their recording call sites (see
+ * prompt-provenance.js); nothing in this module adds or requires content.
+ */
+
+export const TRACE_FORMAT_VERSION = 1;
+
+export const EVENT_KINDS = Object.freeze([
+  'llm_request',
+  'llm_response',
+  'tool',
+  'screenshot',
+  'error',
+  'streaming',
+  'note',
+  'vision_sub_call',
+  'vision_route',
+]);
+
+// Kinds that readers may safely collapse. Empty today: the mechanism exists so
+// a future "the UI can skip this" event type has a defined place instead of
+// each reader inventing its own skip list.
+export const IGNORABLE_KINDS = Object.freeze([]);
+
+const KNOWN_KINDS = new Set(EVENT_KINDS);
+
+export function isKnownKind(kind) {
+  return KNOWN_KINDS.has(kind);
+}
+
+export function isIgnorableKind(kind) {
+  return IGNORABLE_KINDS.includes(kind);
+}
+
+/**
+ * Build a writable event envelope. Returns null — never throws — when the
+ * event cannot be recorded: unknown kind, or data that JSON.stringify cannot
+ * represent. The recorder skips a null envelope with a warning so a recording
+ * bug can never break a run.
+ */
+export function makeEvent(runId, seq, kind, data) {
+  if (!isKnownKind(kind)) return null;
+  const payload = data == null ? null : data;
+  if (payload !== null) {
+    try {
+      JSON.stringify(payload);
+    } catch {
+      return null;
+    }
+  }
+  const ev = { runId, seq, ts: Date.now(), kind, data: payload };
+  if (isIgnorableKind(kind)) ev.ignorable = true;
+  return ev;
+}
+
+/**
+ * Read-side validation of an ordered event list: seq must be contiguous from
+ * 1 and kinds must be known. Tolerant by design — the caller decides what to
+ * do; the Traces UI keeps rendering unknown events rather than failing the
+ * whole run view.
+ *
+ * @returns {{ok: boolean, firstGap: number|null, unknownKinds: string[]}}
+ */
+export function validateEventLog(events) {
+  const list = Array.isArray(events) ? events : [];
+  let expected = 1;
+  const unknownKinds = [];
+  for (const ev of list) {
+    if (!ev) continue;
+    if (ev.seq === expected) expected += 1;
+    if (!isKnownKind(ev.kind) && !unknownKinds.includes(ev.kind)) unknownKinds.push(ev.kind);
+  }
+  const contiguous = expected - 1 === list.length;
+  return {
+    ok: contiguous && unknownKinds.length === 0,
+    firstGap: contiguous ? null : expected,
+    unknownKinds,
+  };
+}

--- a/src/chrome/src/trace/recorder.js
+++ b/src/chrome/src/trace/recorder.js
@@ -1,6 +1,7 @@
 import { normalizeRuntimeTraceConfig } from './runtime-config.js';
 import { buildPromptTraceProvenance } from './prompt-provenance.js';
 import { formatErrorMessage } from '../error-format.js';
+import { TRACE_FORMAT_VERSION, makeEvent } from './event-model.js';
 
 /**
  * Trace recorder — writes per-run traces (LLM requests/responses, tool calls,
@@ -144,6 +145,7 @@ export async function startRun(meta = {}) {
       providerId: meta.providerId || '',
       providerClass: meta.providerClass || '',
       webbrainVersion: meta.webbrainVersion || '',
+      traceFormatVersion: TRACE_FORMAT_VERSION,
       runtimeConfig: normalizeRuntimeTraceConfig(meta.runtimeConfig),
       userMessage: meta.userMessage || '',
       tabUrl: meta.tabUrl || '',
@@ -176,7 +178,13 @@ async function _appendEvent(runId, kind, data) {
       _runState.set(runId, { seq, forced: await isForcedTraceRun(runId) });
     }
     const seq = _newSeq(runId);
-    const ev = { runId, seq, ts: Date.now(), kind, data: data || null };
+    const ev = makeEvent(runId, seq, kind, data);
+    if (!ev) {
+      // Unknown kind or unserializable data: skip the write and surface the
+      // bug at recording time instead of storing a ghost event.
+      console.warn('[trace] dropped invalid event:', kind);
+      return null;
+    }
     await promisifyReq(tx(db, ['events']).objectStore('events').put(ev));
     return seq;
   } catch (e) {
@@ -267,9 +275,10 @@ export async function recordScreenshot(runId, step, dataUrl, caption = '') {
     await promisifyReq(tx(db, ['shots']).objectStore('shots').put(shot));
     // Also record a lightweight marker in the events log so the timeline
     // renders screenshots in order with everything else.
-    await promisifyReq(tx(db, ['events']).objectStore('events').put({
-      runId, seq, ts: shot.ts, kind: 'screenshot', data: { step, caption },
-    }));
+    const marker = makeEvent(runId, seq, 'screenshot', { step, caption });
+    if (marker) {
+      await promisifyReq(tx(db, ['events']).objectStore('events').put(marker));
+    }
     return seq;
   } catch (e) {
     console.warn('[trace] recordScreenshot failed:', e);

--- a/src/chrome/src/ui/traces.js
+++ b/src/chrome/src/ui/traces.js
@@ -7,6 +7,7 @@ import {
   listRuns, getRun, getRunEvents, getScreenshot,
   deleteRun, clearAllRuns,
 } from '../trace/recorder.js';
+import { isKnownKind, isIgnorableKind } from '../trace/event-model.js';
 import { t } from './i18n.js';
 import { escapeHtml, escapeAttr } from './utils.js';
 
@@ -285,6 +286,9 @@ async function buildRunView(run, events, compact, objectUrls = new Set()) {
 }
 
 function renderEvent(ev, shotCache, compact, objectUrls = new Set()) {
+  // Kind-level collapse for events recorded as ignorable. The catalog is
+  // empty today; the check keeps the behavior defined for future kinds.
+  if (isIgnorableKind(ev.kind)) return '';
   const ts = new Date(ev.ts).toLocaleTimeString();
   const stepBadge = ev.data?.step != null ? `<span class="step">${escapeHtml(t('tr.event.step', { step: ev.data.step }))}</span>` : '';
   switch (ev.kind) {
@@ -413,6 +417,16 @@ function renderEvent(ev, shotCache, compact, objectUrls = new Set()) {
           <div class="event note">
             <div class="event-head"><span class="kind">Local Wikipedia retrieval</span>${stepBadge}<span class="latency">${ts}</span></div>
             <span class="tool-args">On-device model request · ${queries} ${queries === 1 ? 'query' : 'queries'} · no network access</span>
+          </div>`;
+      }
+      if (!isKnownKind(ev.kind)) {
+        // Unknown kind from a newer build: keep the event visible instead of
+        // letting it vanish silently, but label it as unknown so the lack of
+        // rich rendering is obvious.
+        return `
+          <div class="event unknown">
+            <div class="event-head"><span class="kind">Unknown event · ${escapeHtml(ev.kind)}</span>${stepBadge}<span class="latency">${ts}</span></div>
+            <pre>${escapeHtml(JSON.stringify(ev.data, null, 2))}</pre>
           </div>`;
       }
       return `

--- a/src/firefox/src/agent/trace-export.js
+++ b/src/firefox/src/agent/trace-export.js
@@ -18,9 +18,12 @@
  *   each with its ordered event list.
  */
 
+import { isKnownKind } from '../trace/event-model.js';
+
 const ARGS_LIMIT = 300;
 const RESULT_LIMIT = 600;
 const FOOTER = '_Screenshot pixels and vision descriptions are omitted here — see the Traces page for the complete record._';
+const UNKNOWN_EVENTS_NOTE = (n) => `_Note: ${n} unknown event(s) skipped._`;
 
 function oneLine(t) { return String(t ?? '').replace(/\s+/g, ' ').trim(); }
 function humanSize(n) { return n >= 1024 ? `${(n / 1024).toFixed(1)}kb` : `${n}b`; }
@@ -170,6 +173,7 @@ export function tracesToMarkdown(runsWithEvents, {
   if (exportVersion) md += `_Exported with WebBrain v${exportVersion}_\n\n`;
   let turnCount = 0;
   let toolCount = 0;
+  let unknownEventCount = 0;
 
   for (const entry of runs) {
     if (!entry || !entry.run) continue;
@@ -256,6 +260,10 @@ export function tracesToMarkdown(runsWithEvents, {
         md += `- 📚 ${renderLocalWikipediaRag(d.extra).replace(/^ · /, '')}\n`;
       } else if (ev.kind === 'note' && /screenshot|vision|attachment|visual/i.test(String(d.note || ''))) {
         md += `- ℹ️ ${oneLine(d.note)}\n`;
+      } else if (!isKnownKind(ev.kind)) {
+        // Unknown kinds are skipped (never rendered) but counted, so an
+        // exporter from a newer build cannot silently lose events.
+        unknownEventCount += 1;
       }
     }
     const finalContent = String(run.finalContent || '').trim();
@@ -269,6 +277,7 @@ export function tracesToMarkdown(runsWithEvents, {
     const line = oneLine(note);
     if (line) md += `_Note: ${line}_\n`;
   }
+  if (unknownEventCount > 0) md += `${UNKNOWN_EVENTS_NOTE(unknownEventCount)}\n`;
   md += `${FOOTER}\n`;
-  return { markdown: md, turnCount, toolCount };
+  return { markdown: md, turnCount, toolCount, unknownEventCount };
 }

--- a/src/firefox/src/trace/event-model.js
+++ b/src/firefox/src/trace/event-model.js
@@ -1,0 +1,95 @@
+/**
+ * Trace event model — the shared vocabulary and envelope for the per-run event
+ * log written by trace/recorder.js.
+ *
+ * Pure and browser-neutral so it can be unit-tested in test/run.js without a
+ * DOM or IndexedDB.
+ *
+ * The recorder stores events as {runId, seq, ts, kind, data}. This module owns:
+ *   - the authoritative list of known event kinds. The recorder, Traces UI,
+ *     and exporters consult it instead of maintaining their own lists, so a
+ *     new event type has one place to be declared;
+ *   - the run-level trace format version stamped on every new run record, so
+ *     a future schema change can detect old traces instead of misreading them;
+ *   - envelope construction with write-side validation: unknown kinds and
+ *     data that cannot survive a JSON round-trip are rejected here, so a
+ *     recording bug surfaces at write time rather than as a ghost event.
+ *
+ * Events are privacy-filtered at their recording call sites (see
+ * prompt-provenance.js); nothing in this module adds or requires content.
+ */
+
+export const TRACE_FORMAT_VERSION = 1;
+
+export const EVENT_KINDS = Object.freeze([
+  'llm_request',
+  'llm_response',
+  'tool',
+  'screenshot',
+  'error',
+  'streaming',
+  'note',
+  'vision_sub_call',
+  'vision_route',
+]);
+
+// Kinds that readers may safely collapse. Empty today: the mechanism exists so
+// a future "the UI can skip this" event type has a defined place instead of
+// each reader inventing its own skip list.
+export const IGNORABLE_KINDS = Object.freeze([]);
+
+const KNOWN_KINDS = new Set(EVENT_KINDS);
+
+export function isKnownKind(kind) {
+  return KNOWN_KINDS.has(kind);
+}
+
+export function isIgnorableKind(kind) {
+  return IGNORABLE_KINDS.includes(kind);
+}
+
+/**
+ * Build a writable event envelope. Returns null — never throws — when the
+ * event cannot be recorded: unknown kind, or data that JSON.stringify cannot
+ * represent. The recorder skips a null envelope with a warning so a recording
+ * bug can never break a run.
+ */
+export function makeEvent(runId, seq, kind, data) {
+  if (!isKnownKind(kind)) return null;
+  const payload = data == null ? null : data;
+  if (payload !== null) {
+    try {
+      JSON.stringify(payload);
+    } catch {
+      return null;
+    }
+  }
+  const ev = { runId, seq, ts: Date.now(), kind, data: payload };
+  if (isIgnorableKind(kind)) ev.ignorable = true;
+  return ev;
+}
+
+/**
+ * Read-side validation of an ordered event list: seq must be contiguous from
+ * 1 and kinds must be known. Tolerant by design — the caller decides what to
+ * do; the Traces UI keeps rendering unknown events rather than failing the
+ * whole run view.
+ *
+ * @returns {{ok: boolean, firstGap: number|null, unknownKinds: string[]}}
+ */
+export function validateEventLog(events) {
+  const list = Array.isArray(events) ? events : [];
+  let expected = 1;
+  const unknownKinds = [];
+  for (const ev of list) {
+    if (!ev) continue;
+    if (ev.seq === expected) expected += 1;
+    if (!isKnownKind(ev.kind) && !unknownKinds.includes(ev.kind)) unknownKinds.push(ev.kind);
+  }
+  const contiguous = expected - 1 === list.length;
+  return {
+    ok: contiguous && unknownKinds.length === 0,
+    firstGap: contiguous ? null : expected,
+    unknownKinds,
+  };
+}

--- a/src/firefox/src/trace/recorder.js
+++ b/src/firefox/src/trace/recorder.js
@@ -1,6 +1,7 @@
 import { normalizeRuntimeTraceConfig } from './runtime-config.js';
 import { buildPromptTraceProvenance } from './prompt-provenance.js';
 import { formatErrorMessage } from '../error-format.js';
+import { TRACE_FORMAT_VERSION, makeEvent } from './event-model.js';
 
 /**
  * Trace recorder — writes per-run traces (LLM requests/responses, tool calls,
@@ -128,6 +129,7 @@ export async function startRun(meta) {
       providerId: meta.providerId || '',
       providerClass: meta.providerClass || '',
       webbrainVersion: meta.webbrainVersion || '',
+      traceFormatVersion: TRACE_FORMAT_VERSION,
       runtimeConfig: normalizeRuntimeTraceConfig(meta.runtimeConfig),
       userMessage: meta.userMessage || '',
       tabUrl: meta.tabUrl || '',
@@ -159,7 +161,13 @@ async function _appendEvent(runId, kind, data) {
       _runState.set(runId, { seq });
     }
     const seq = _newSeq(runId);
-    const ev = { runId, seq, ts: Date.now(), kind, data: data || null };
+    const ev = makeEvent(runId, seq, kind, data);
+    if (!ev) {
+      // Unknown kind or unserializable data: skip the write and surface the
+      // bug at recording time instead of storing a ghost event.
+      console.warn('[trace] dropped invalid event:', kind);
+      return null;
+    }
     await promisifyReq(tx(db, ['events']).objectStore('events').put(ev));
     return seq;
   } catch (e) {
@@ -250,9 +258,10 @@ export async function recordScreenshot(runId, step, dataUrl, caption = '') {
     await promisifyReq(tx(db, ['shots']).objectStore('shots').put(shot));
     // Also record a lightweight marker in the events log so the timeline
     // renders screenshots in order with everything else.
-    await promisifyReq(tx(db, ['events']).objectStore('events').put({
-      runId, seq, ts: shot.ts, kind: 'screenshot', data: { step, caption },
-    }));
+    const marker = makeEvent(runId, seq, 'screenshot', { step, caption });
+    if (marker) {
+      await promisifyReq(tx(db, ['events']).objectStore('events').put(marker));
+    }
     return seq;
   } catch (e) {
     console.warn('[trace] recordScreenshot failed:', e);

--- a/src/firefox/src/ui/traces.js
+++ b/src/firefox/src/ui/traces.js
@@ -7,6 +7,7 @@ import {
   listRuns, getRun, getRunEvents, getScreenshot,
   deleteRun, clearAllRuns,
 } from '../trace/recorder.js';
+import { isKnownKind, isIgnorableKind } from '../trace/event-model.js';
 import { t } from './i18n.js';
 import { escapeHtml, escapeAttr } from './utils.js';
 
@@ -285,6 +286,9 @@ async function buildRunView(run, events, compact, objectUrls = new Set()) {
 }
 
 function renderEvent(ev, shotCache, compact, objectUrls = new Set()) {
+  // Kind-level collapse for events recorded as ignorable. The catalog is
+  // empty today; the check keeps the behavior defined for future kinds.
+  if (isIgnorableKind(ev.kind)) return '';
   const ts = new Date(ev.ts).toLocaleTimeString();
   const stepBadge = ev.data?.step != null ? `<span class="step">${escapeHtml(t('tr.event.step', { step: ev.data.step }))}</span>` : '';
   switch (ev.kind) {
@@ -413,6 +417,16 @@ function renderEvent(ev, shotCache, compact, objectUrls = new Set()) {
           <div class="event note">
             <div class="event-head"><span class="kind">Local Wikipedia retrieval</span>${stepBadge}<span class="latency">${ts}</span></div>
             <span class="tool-args">On-device model request · ${queries} ${queries === 1 ? 'query' : 'queries'} · no network access</span>
+          </div>`;
+      }
+      if (!isKnownKind(ev.kind)) {
+        // Unknown kind from a newer build: keep the event visible instead of
+        // letting it vanish silently, but label it as unknown so the lack of
+        // rich rendering is obvious.
+        return `
+          <div class="event unknown">
+            <div class="event-head"><span class="kind">Unknown event · ${escapeHtml(ev.kind)}</span>${stepBadge}<span class="latency">${ts}</span></div>
+            <pre>${escapeHtml(JSON.stringify(ev.data, null, 2))}</pre>
           </div>`;
       }
       return `

--- a/test/run.js
+++ b/test/run.js
@@ -8099,6 +8099,112 @@ test('Ask and managed cloud classify communication read scope across languages',
   }
 });
 
+// trace event model — shared kind catalog and envelope validation
+// ────────────────────────────────────────────────────────────────────────
+
+console.log('\ntrace event model');
+
+const EVENT_MODEL_CH = await import('file://' + path.join(ROOT, 'src/chrome/src/trace/event-model.js').replace(/\\/g, '/'));
+const EVENT_MODEL_FX = await import('file://' + path.join(ROOT, 'src/firefox/src/trace/event-model.js').replace(/\\/g, '/'));
+
+test('trace event model: catalog covers every kind the recorder writes', () => {
+  const kinds = EVENT_MODEL_CH.EVENT_KINDS;
+  for (const kind of kinds) {
+    assert.equal(EVENT_MODEL_CH.isKnownKind(kind), true, `catalog entry ${kind} not recognized`);
+    assert.equal(EVENT_MODEL_CH.isIgnorableKind(kind), false, `catalog entry ${kind} should not be ignorable yet`);
+  }
+  assert.deepEqual(EVENT_MODEL_CH.IGNORABLE_KINDS, [], 'ignorable catalog should start empty');
+  for (const browser of ['chrome', 'firefox']) {
+    const recorderSource = fs.readFileSync(path.join(ROOT, `src/${browser}/src/trace/recorder.js`), 'utf8');
+    const used = [
+      ...[...recorderSource.matchAll(/_appendEvent\(runId, '([a-z_]+)'/g)].map(m => m[1]),
+      ...[...recorderSource.matchAll(/makeEvent\(runId, seq, '([a-z_]+)'/g)].map(m => m[1]),
+    ];
+    assert.ok(used.length >= 9, `${browser}: recorder event kinds not found (${used.length})`);
+    for (const kind of used) {
+      assert.ok(kinds.includes(kind), `${browser}: recorder uses uncatalogued kind '${kind}'`);
+    }
+  }
+});
+
+test('trace event model: makeEvent validates kinds and JSON round-trip', () => {
+  const { makeEvent } = EVENT_MODEL_CH;
+  const ev = makeEvent('run_x', 1, 'llm_request', { step: 0 });
+  assert.equal(ev.runId, 'run_x');
+  assert.equal(ev.seq, 1);
+  assert.equal(ev.kind, 'llm_request');
+  assert.deepEqual(ev.data, { step: 0 });
+  assert.equal(ev.ignorable, undefined, 'non-ignorable kinds must not carry the flag');
+  assert.equal(typeof ev.ts, 'number', 'envelope must carry a timestamp');
+  assert.equal(makeEvent('run_x', 2, 'not_a_kind', {}), null, 'unknown kind must be rejected');
+  const circular = {}; circular.self = circular;
+  assert.equal(makeEvent('run_x', 3, 'note', circular), null, 'unserializable data must be rejected');
+  assert.equal(makeEvent('run_x', 4, 'note', { big: 1n }), null, 'BigInt data must be rejected');
+  assert.deepEqual(makeEvent('run_x', 5, 'note', null).data, null, 'null data must be preserved as null');
+  assert.deepEqual(makeEvent('run_x', 6, 'note', undefined).data, null, 'undefined data must normalize to null');
+});
+
+test('trace event model: validateEventLog detects gaps and unknown kinds', () => {
+  const { validateEventLog } = EVENT_MODEL_CH;
+  assert.deepEqual(validateEventLog([]), { ok: true, firstGap: null, unknownKinds: [] }, 'empty log is valid');
+  assert.equal(validateEventLog([{ seq: 1, kind: 'note' }, { seq: 2, kind: 'error' }]).ok, true, 'contiguous log is valid');
+  const gap = validateEventLog([{ seq: 1, kind: 'note' }, { seq: 3, kind: 'note' }]);
+  assert.equal(gap.ok, false, 'gap must invalidate the log');
+  assert.equal(gap.firstGap, 2, 'first missing seq not reported');
+  const unknown = validateEventLog([{ seq: 1, kind: 'mystery' }]);
+  assert.equal(unknown.ok, false, 'unknown kind must invalidate the log');
+  assert.deepEqual(unknown.unknownKinds, ['mystery'], 'unknown kind not listed');
+  assert.equal(unknown.firstGap, null, 'unknown kinds must not count as gaps');
+});
+
+test('trace event model: mirrors are identical and browser-neutral', () => {
+  const chromeSource = fs.readFileSync(path.join(ROOT, 'src/chrome/src/trace/event-model.js'), 'utf8');
+  const firefoxSource = fs.readFileSync(path.join(ROOT, 'src/firefox/src/trace/event-model.js'), 'utf8');
+  assert.equal(chromeSource, firefoxSource, 'Chrome/Firefox event model drifted');
+  assert.deepEqual(EVENT_MODEL_FX.EVENT_KINDS, EVENT_MODEL_CH.EVENT_KINDS);
+  assert.equal(EVENT_MODEL_FX.TRACE_FORMAT_VERSION, EVENT_MODEL_CH.TRACE_FORMAT_VERSION);
+  assert.equal(EVENT_MODEL_CH.TRACE_FORMAT_VERSION, 1, 'first trace format version');
+  assert.doesNotMatch(chromeSource, /chrome\./, 'event model must not depend on chrome APIs');
+  assert.doesNotMatch(chromeSource, /indexedDB|storage\./, 'event model must not touch storage');
+});
+
+test('trace recorder: writes go through the event model and stamp the format version', () => {
+  for (const browser of ['chrome', 'firefox']) {
+    const recorderSource = fs.readFileSync(path.join(ROOT, `src/${browser}/src/trace/recorder.js`), 'utf8');
+    assert.match(recorderSource, /import \{ TRACE_FORMAT_VERSION, makeEvent \} from '\.\/event-model\.js';/, `${browser}: recorder does not import the event model`);
+    assert.match(recorderSource, /traceFormatVersion: TRACE_FORMAT_VERSION/, `${browser}: run record does not stamp the format version`);
+    assert.match(recorderSource, /const ev = makeEvent\(runId, seq, kind, data\);/, `${browser}: event writes bypass the envelope`);
+    assert.match(recorderSource, /dropped invalid event/, `${browser}: invalid-event drop is not surfaced`);
+    assert.match(recorderSource, /const marker = makeEvent\(runId, seq, 'screenshot'/, `${browser}: screenshot marker bypasses the envelope`);
+  }
+});
+
+test('trace export: unknown kinds are skipped and counted in both builds', () => {
+  const run = { runId: 'r1', userMessage: 'hello', status: 'done', webbrainVersion: '' };
+  const events = [
+    { runId: 'r1', seq: 1, ts: 1, kind: 'llm_request', data: { messageCount: 2, toolsCount: 0 } },
+    { runId: 'r1', seq: 2, ts: 2, kind: 'future_kind', data: { x: 1 } },
+  ];
+  for (const [label, serialize] of [['chrome', tracesToMarkdown], ['firefox', tracesToMarkdownFx]]) {
+    const { markdown, toolCount, unknownEventCount } = serialize([{ run, events }]);
+    assert.equal(toolCount, 0, `${label}: known tool count unaffected`);
+    assert.equal(unknownEventCount, 1, `${label}: unknown event not counted`);
+    assert.match(markdown, /1 unknown event\(s\) skipped/, `${label}: unknown skip note missing`);
+    assert.doesNotMatch(markdown, /future_kind/, `${label}: unknown event payload leaked into markdown`);
+  }
+  assert.equal(tracesToMarkdown([]).unknownEventCount, 0, 'empty export must report zero unknown events');
+});
+
+test('trace UI: unknown kinds render a placeholder instead of the generic note view', () => {
+  for (const browser of ['chrome', 'firefox']) {
+    const tracesSource = fs.readFileSync(path.join(ROOT, `src/${browser}/src/ui/traces.js`), 'utf8');
+    assert.match(tracesSource, /import \{ isKnownKind, isIgnorableKind \} from '\.\.\/trace\/event-model\.js';/, `${browser}: Traces UI does not consult the event model`);
+    assert.match(tracesSource, /Unknown event · \$\{escapeHtml\(ev\.kind\)\}/, `${browser}: unknown-kind placeholder missing`);
+    assert.match(tracesSource, /if \(!isKnownKind\(ev\.kind\)\)/, `${browser}: known-kind distinction missing`);
+    assert.match(tracesSource, /if \(isIgnorableKind\(ev\.kind\)\) return '';/, `${browser}: ignorable collapse missing`);
+  }
+});
+
 test('accessibility-tree schema and prompts preserve exact whole-document continuations', () => {
   const chromeSource = fs.readFileSync(path.join(ROOT, 'src/chrome/src/content/accessibility-tree.js'), 'utf8');
   const firefoxSource = fs.readFileSync(path.join(ROOT, 'src/firefox/src/content/accessibility-tree.js'), 'utf8');


### PR DESCRIPTION
## Summary

- New pure module `trace/event-model.js` (Chrome + Firefox): authoritative `EVENT_KINDS` catalog, `TRACE_FORMAT_VERSION`, and `makeEvent()` envelope construction with write-side validation.
- The recorder routes every event write through the model and stamps `traceFormatVersion: 1` on new run records.
- Tolerant read path: the Traces UI renders unknown kinds as an explicit "Unknown event" placeholder (and collapses ignorable kinds); the Markdown exporter skips unknown kinds and reports a count in the footer.

## Motivation

Closes #2869.

WebBrain's trace events were free-form `{runId, seq, ts, kind, data}` with three internal problems:

1. **No kind catalog** — event types were added incrementally over time but no single place defined the full set of valid kinds; a typo'd kind silently disappeared from the UI.
2. **No format version** — neither events nor runs carried a version, so the next required-field addition would make old traces unreadable with nothing to negotiate against. The project already handles legacy trace data ad-hoc (Traces UI tolerates `conversationId: null` runs, `trace-export.js` has legacy branches).
3. **No defined read-side policy** — UI and exporters had undefined behavior for unknown kinds: silent blank rendering, silently dropped data without counting.

## Design

- `EVENT_KINDS` covers all 9 existing kinds and is consulted by the recorder, the Traces UI, and the exporter, so a new event type has one declared home instead of per-reader lists.
- `IGNORABLE_KINDS` starts empty; the mechanism is in place so a future "safe to collapse" event type has a defined place. The UI honors the flag; nothing is ignorable today.
- `makeEvent()` returns `null` (never throws) for unknown kinds or data that cannot survive a JSON round-trip (circular, BigInt). The recorder skips a null envelope with a warning — a recording bug surfaces at write time and can never break a run. The screenshot timeline marker now goes through the same envelope path.
- Run records gain `traceFormatVersion: 1`; older runs without the field (= version 0) are untouched.
- Read side is deliberately tolerant rather than fail-closed: WebBrain has no log-rebuild semantics and must keep displaying existing traces. Unknown events are kept visible (explicit placeholder), never silently dropped, and exporters count them.
- `validateEventLog()` provides read-side tooling (seq contiguity + unknown-kind detection) for tests and future consumers.
- All new fields are content-free (version integer, kind names) — the privacy contract is unchanged.

## Testing

- `node test/run.js` — passed, 1959 tests (7 new: catalog coverage vs recorder usage, envelope validation, log validation, mirror identity + browser-neutrality, recorder wiring, exporter skip/count, UI placeholder)
- `npm run test:toolbar-guard` — passed (33 tests)
- `npm run test:security` — passed (60/60 checks)
- `node --check` on every touched file — passed

Skipped: unpacked-browser manual verification (no browser session available in this environment); both Chrome and Firefox builds are covered by the mirror-consistency tests instead. Untested browsers: Chrome, Firefox (runtime UI rendering of the new placeholder not manually exercised).

## Compatibility and risks

- Events keep the exact stored shape; only the screenshot marker's construction changed (same output shape, now validated).
- Old runs without `traceFormatVersion` remain fully readable; the version is informational today and becomes the negotiation point for future format changes.
- Risk: an unknown kind in an older trace now renders a labeled placeholder instead of the previous generic JSON view — a strictly clearer result, and only for kinds outside the catalog.

## Scope

Deliberately deferred (follow-ups, separate PRs): turn/step boundary events, session lineage fields, checkpoint/repair semantics, projections, OTLP association. This PR only establishes the event model foundation with no user-visible behavior change.

