### PR TITLE
feat(trace): session lineage fields (parentRunId/parentSessionId/delegationDepth) + runs index

### DIFF
--- a/src/chrome/src/trace/recorder.js
+++ b/src/chrome/src/trace/recorder.js
@@ -2,12 +2,13 @@ import { normalizeRuntimeTraceConfig } from './runtime-config.js';
 import { buildPromptTraceProvenance } from './prompt-provenance.js';
 import { formatErrorMessage } from '../error-format.js';
 import { TRACE_FORMAT_VERSION, makeEvent } from './event-model.js';
+import { normalizeRunHeader, effectiveDelegationDepth } from './run-header.js';
 
 /**
  * Trace recorder — writes per-run traces (LLM requests/responses, tool calls,
  * screenshots) into IndexedDB for later inspection and cross-model comparison.
  *
- * Schema (db `webbrain_traces`, v1):
+ * Schema (db `webbrain_traces`, v2):
  *   - runs       keyPath=runId                  // top-level run metadata
  *   - events     keyPath=[runId, seq]           // ordered event log
  *   - shots      keyPath=[runId, seq]           // screenshot Blobs
@@ -17,7 +18,7 @@ import { TRACE_FORMAT_VERSION, makeEvent } from './event-model.js';
  */
 
 const DB_NAME = 'webbrain_traces';
-const DB_VERSION = 1;
+const DB_VERSION = 2;
 
 let _dbPromise = null;
 function openDB() {
@@ -31,6 +32,19 @@ function openDB() {
         s.createIndex('startedAt', 'startedAt');
         s.createIndex('model', 'model');
         s.createIndex('providerId', 'providerId');
+      }
+      // v2: lineage lookup indexes. `conversationId` IS the session identity
+      // (grouping key for sibling runs); the index carries the semantic name
+      // so session-level queries read naturally. Records with null keys are
+      // skipped by IndexedDB, so old runs are simply absent from the index.
+      const runsStore = req.transaction ? req.transaction.objectStore('runs') : null;
+      if (runsStore) {
+        if (!runsStore.indexNames.contains('sessionId')) {
+          runsStore.createIndex('sessionId', 'conversationId');
+        }
+        if (!runsStore.indexNames.contains('parentRunId')) {
+          runsStore.createIndex('parentRunId', 'parentRunId');
+        }
       }
       if (!db.objectStoreNames.contains('events')) {
         const s = db.createObjectStore('events', { keyPath: ['runId', 'seq'] });
@@ -130,6 +144,7 @@ export async function startRun(meta = {}) {
   try {
     const db = await openDB();
     const runId = meta.runId || `run_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
+    const lineage = normalizeRunHeader(meta) || {};
     const record = {
       runId,
       // Stable per-conversation id so the Traces UI can group sibling runs
@@ -137,6 +152,11 @@ export async function startRun(meta = {}) {
       // map keyed by tabId. Older runs have null here — viewer treats those
       // as singletons.
       conversationId: meta.conversationId || null,
+      // Lineage: which run/session this run was derived from. Root runs keep
+      // null/0. Only allowlisted identifiers reach these fields (run-header.js).
+      parentRunId: (lineage && lineage.parentRunId) || null,
+      parentSessionId: (lineage && lineage.parentSessionId) || null,
+      delegationDepth: effectiveDelegationDepth(lineage),
       startedAt: Date.now(),
       endedAt: null,
       durationMs: null,

--- a/src/chrome/src/trace/run-header.js
+++ b/src/chrome/src/trace/run-header.js
@@ -1,0 +1,63 @@
+/**
+ * Trace run header — allowlisted normalization for the session-lineage fields
+ * stored on every run record by trace/recorder.js.
+ *
+ * Pure and browser-neutral so it can be unit-tested in test/run.js without a
+ * DOM or IndexedDB.
+ *
+ * `conversationId` is WebBrain's session identity (the Traces UI groups runs
+ * by it). On top of that, a run can name its parent run, the parent's session
+ * id, and its delegation depth — the chain that answers "which root run did
+ * this derived run come from" for cloud runs, workflow replays, and any future
+ * forked execution.
+ *
+ * These fields are identifiers and integers only; nothing content-bearing is
+ * accepted here. Bounds follow the runtime-config.js allowlist pattern so a
+ * caller can never smuggle credentials or message text into a trace via the
+ * lineage fields.
+ */
+
+const MAX_ID_LENGTH = 200;
+const MAX_DEPTH = 64;
+
+function safeId(value) {
+  const id = String(value || '').trim();
+  if (!id || id.length > MAX_ID_LENGTH) return null;
+  // Ids are opaque but printable; strip control characters so a malformed
+  // value can never corrupt an export or a query key.
+  if (/[\u0000-\u001f\u007f]/.test(id)) return null;
+  return id;
+}
+
+function safeDepth(value) {
+  const n = Number(value);
+  if (!Number.isInteger(n) || n < 0 || n > MAX_DEPTH) return null;
+  return n;
+}
+
+/**
+ * Normalize the lineage portion of a run header. Returns null when nothing
+ * valid is present, otherwise a partial object with only valid fields.
+ */
+export function normalizeRunHeader(meta) {
+  if (!meta || typeof meta !== 'object' || Array.isArray(meta)) return null;
+  const out = {};
+  const parentRunId = safeId(meta.parentRunId);
+  const parentSessionId = safeId(meta.parentSessionId);
+  const delegationDepth = safeDepth(meta.delegationDepth);
+  if (parentRunId) out.parentRunId = parentRunId;
+  if (parentSessionId) out.parentSessionId = parentSessionId;
+  if (delegationDepth != null) out.delegationDepth = delegationDepth;
+  return Object.keys(out).length ? out : null;
+}
+
+/**
+ * Resolve the run's own delegation depth: an explicit normalized depth wins;
+ * a run with a parent but no depth is a direct child (depth 1); everything
+ * else is a root run (depth 0).
+ */
+export function effectiveDelegationDepth(header) {
+  if (header && header.delegationDepth != null) return header.delegationDepth;
+  if (header && header.parentRunId) return 1;
+  return 0;
+}

--- a/src/firefox/src/trace/recorder.js
+++ b/src/firefox/src/trace/recorder.js
@@ -2,12 +2,13 @@ import { normalizeRuntimeTraceConfig } from './runtime-config.js';
 import { buildPromptTraceProvenance } from './prompt-provenance.js';
 import { formatErrorMessage } from '../error-format.js';
 import { TRACE_FORMAT_VERSION, makeEvent } from './event-model.js';
+import { normalizeRunHeader, effectiveDelegationDepth } from './run-header.js';
 
 /**
  * Trace recorder — writes per-run traces (LLM requests/responses, tool calls,
  * screenshots) into IndexedDB for later inspection and cross-model comparison.
  *
- * Schema (db `webbrain_traces`, v1):
+ * Schema (db `webbrain_traces`, v2):
  *   - runs       keyPath=runId                  // top-level run metadata
  *   - events     keyPath=[runId, seq]           // ordered event log
  *   - shots      keyPath=[runId, seq]           // screenshot Blobs
@@ -17,7 +18,7 @@ import { TRACE_FORMAT_VERSION, makeEvent } from './event-model.js';
  */
 
 const DB_NAME = 'webbrain_traces';
-const DB_VERSION = 1;
+const DB_VERSION = 2;
 
 let _dbPromise = null;
 function openDB() {
@@ -31,6 +32,19 @@ function openDB() {
         s.createIndex('startedAt', 'startedAt');
         s.createIndex('model', 'model');
         s.createIndex('providerId', 'providerId');
+      }
+      // v2: lineage lookup indexes. `conversationId` IS the session identity
+      // (grouping key for sibling runs); the index carries the semantic name
+      // so session-level queries read naturally. Records with null keys are
+      // skipped by IndexedDB, so old runs are simply absent from the index.
+      const runsStore = req.transaction ? req.transaction.objectStore('runs') : null;
+      if (runsStore) {
+        if (!runsStore.indexNames.contains('sessionId')) {
+          runsStore.createIndex('sessionId', 'conversationId');
+        }
+        if (!runsStore.indexNames.contains('parentRunId')) {
+          runsStore.createIndex('parentRunId', 'parentRunId');
+        }
       }
       if (!db.objectStoreNames.contains('events')) {
         const s = db.createObjectStore('events', { keyPath: ['runId', 'seq'] });
@@ -114,6 +128,7 @@ export async function startRun(meta) {
   try {
     const db = await openDB();
     const runId = meta.runId || `run_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
+    const lineage = normalizeRunHeader(meta) || {};
     const record = {
       runId,
       // Stable per-conversation id so the Traces UI can group sibling runs
@@ -121,6 +136,11 @@ export async function startRun(meta) {
       // map keyed by tabId. Older runs have null here — viewer treats those
       // as singletons.
       conversationId: meta.conversationId || null,
+      // Lineage: which run/session this run was derived from. Root runs keep
+      // null/0. Only allowlisted identifiers reach these fields (run-header.js).
+      parentRunId: (lineage && lineage.parentRunId) || null,
+      parentSessionId: (lineage && lineage.parentSessionId) || null,
+      delegationDepth: effectiveDelegationDepth(lineage),
       startedAt: Date.now(),
       endedAt: null,
       durationMs: null,

--- a/src/firefox/src/trace/run-header.js
+++ b/src/firefox/src/trace/run-header.js
@@ -1,0 +1,63 @@
+/**
+ * Trace run header — allowlisted normalization for the session-lineage fields
+ * stored on every run record by trace/recorder.js.
+ *
+ * Pure and browser-neutral so it can be unit-tested in test/run.js without a
+ * DOM or IndexedDB.
+ *
+ * `conversationId` is WebBrain's session identity (the Traces UI groups runs
+ * by it). On top of that, a run can name its parent run, the parent's session
+ * id, and its delegation depth — the chain that answers "which root run did
+ * this derived run come from" for cloud runs, workflow replays, and any future
+ * forked execution.
+ *
+ * These fields are identifiers and integers only; nothing content-bearing is
+ * accepted here. Bounds follow the runtime-config.js allowlist pattern so a
+ * caller can never smuggle credentials or message text into a trace via the
+ * lineage fields.
+ */
+
+const MAX_ID_LENGTH = 200;
+const MAX_DEPTH = 64;
+
+function safeId(value) {
+  const id = String(value || '').trim();
+  if (!id || id.length > MAX_ID_LENGTH) return null;
+  // Ids are opaque but printable; strip control characters so a malformed
+  // value can never corrupt an export or a query key.
+  if (/[\u0000-\u001f\u007f]/.test(id)) return null;
+  return id;
+}
+
+function safeDepth(value) {
+  const n = Number(value);
+  if (!Number.isInteger(n) || n < 0 || n > MAX_DEPTH) return null;
+  return n;
+}
+
+/**
+ * Normalize the lineage portion of a run header. Returns null when nothing
+ * valid is present, otherwise a partial object with only valid fields.
+ */
+export function normalizeRunHeader(meta) {
+  if (!meta || typeof meta !== 'object' || Array.isArray(meta)) return null;
+  const out = {};
+  const parentRunId = safeId(meta.parentRunId);
+  const parentSessionId = safeId(meta.parentSessionId);
+  const delegationDepth = safeDepth(meta.delegationDepth);
+  if (parentRunId) out.parentRunId = parentRunId;
+  if (parentSessionId) out.parentSessionId = parentSessionId;
+  if (delegationDepth != null) out.delegationDepth = delegationDepth;
+  return Object.keys(out).length ? out : null;
+}
+
+/**
+ * Resolve the run's own delegation depth: an explicit normalized depth wins;
+ * a run with a parent but no depth is a direct child (depth 1); everything
+ * else is a root run (depth 0).
+ */
+export function effectiveDelegationDepth(header) {
+  if (header && header.delegationDepth != null) return header.delegationDepth;
+  if (header && header.parentRunId) return 1;
+  return 0;
+}

--- a/test/run.js
+++ b/test/run.js
@@ -8819,6 +8819,62 @@ test('config transfer exports and restores Settings values including provider ke
   );
 });
 
+// trace run header — session lineage allowlist
+// ────────────────────────────────────────────────────────────────────────
+
+console.log('\ntrace run header');
+
+const RUN_HEADER_CH = await import('file://' + path.join(ROOT, 'src/chrome/src/trace/run-header.js').replace(/\\/g, '/'));
+const RUN_HEADER_FX = await import('file://' + path.join(ROOT, 'src/firefox/src/trace/run-header.js').replace(/\\/g, '/'));
+
+test('trace run header: normalizeRunHeader keeps only allowlisted lineage ids', () => {
+  const { normalizeRunHeader } = RUN_HEADER_CH;
+  assert.equal(normalizeRunHeader(null), null);
+  assert.equal(normalizeRunHeader([]), null);
+  assert.equal(normalizeRunHeader({}), null, 'empty header must be null');
+  const valid = normalizeRunHeader({ parentRunId: 'run_abc', parentSessionId: 'conv_1', delegationDepth: 3 });
+  assert.deepEqual(valid, { parentRunId: 'run_abc', parentSessionId: 'conv_1', delegationDepth: 3 });
+  assert.equal(normalizeRunHeader({ parentRunId: 'x'.repeat(201) }), null, 'over-long id must be rejected');
+  assert.deepEqual(normalizeRunHeader({ parentRunId: '  run_x  ' }), { parentRunId: 'run_x' }, 'ids should be trimmed');
+  assert.equal(normalizeRunHeader({ parentRunId: 'bad\u0000id' }), null, 'control characters must be rejected');
+  assert.equal(normalizeRunHeader({ delegationDepth: -1 }), null, 'negative depth must be rejected');
+  assert.equal(normalizeRunHeader({ delegationDepth: 3.5 }), null, 'fractional depth must be rejected');
+  assert.equal(normalizeRunHeader({ delegationDepth: 65 }), null, 'depth beyond the bound must be rejected');
+  assert.deepEqual(normalizeRunHeader({ parentSessionId: 'conv_9' }), { parentSessionId: 'conv_9' }, 'session id alone must survive');
+});
+
+test('trace run header: effectiveDelegationDepth resolves root/child/explicit', () => {
+  const { effectiveDelegationDepth, normalizeRunHeader } = RUN_HEADER_CH;
+  assert.equal(effectiveDelegationDepth(null), 0, 'no header is a root run');
+  assert.equal(effectiveDelegationDepth(normalizeRunHeader({})), 0, 'empty header is a root run');
+  assert.equal(effectiveDelegationDepth(normalizeRunHeader({ parentRunId: 'run_p' })), 1, 'parent without depth is a direct child');
+  assert.equal(effectiveDelegationDepth(normalizeRunHeader({ parentRunId: 'run_p', delegationDepth: 5 })), 5, 'explicit depth wins');
+  assert.equal(effectiveDelegationDepth(normalizeRunHeader({ parentSessionId: 'conv_x' })), 0, 'session id without parent run is a root run');
+});
+
+test('trace run header: mirrors are identical and browser-neutral', () => {
+  const chromeSource = fs.readFileSync(path.join(ROOT, 'src/chrome/src/trace/run-header.js'), 'utf8');
+  const firefoxSource = fs.readFileSync(path.join(ROOT, 'src/firefox/src/trace/run-header.js'), 'utf8');
+  assert.equal(chromeSource, firefoxSource, 'Chrome/Firefox run header drifted');
+  assert.equal(typeof RUN_HEADER_FX.normalizeRunHeader, 'function', 'Firefox run header missing exports');
+  assert.doesNotMatch(chromeSource, /chrome\./, 'run header must not depend on chrome APIs');
+  assert.doesNotMatch(chromeSource, /indexedDB|storage\./, 'run header must not touch storage');
+});
+
+test('trace recorder: DB v2 adds lineage indexes and startRun stores lineage fields', () => {
+  for (const browser of ['chrome', 'firefox']) {
+    const recorderSource = fs.readFileSync(path.join(ROOT, `src/${browser}/src/trace/recorder.js`), 'utf8');
+    assert.match(recorderSource, /const DB_VERSION = 2;/, `${browser}: trace DB did not move to v2`);
+    assert.match(recorderSource, /createIndex\('sessionId', 'conversationId'\)/, `${browser}: session index missing`);
+    assert.match(recorderSource, /createIndex\('parentRunId', 'parentRunId'\)/, `${browser}: parent index missing`);
+    assert.match(recorderSource, /indexNames\.contains\('sessionId'\)/, `${browser}: index creation is not idempotent`);
+    assert.match(recorderSource, /import \{ normalizeRunHeader, effectiveDelegationDepth \} from '\.\/run-header\.js';/, `${browser}: recorder does not import the run header`);
+    assert.match(recorderSource, /parentRunId: \(lineage && lineage\.parentRunId\) \|\| null,/, `${browser}: parentRunId not stored`);
+    assert.match(recorderSource, /parentSessionId: \(lineage && lineage\.parentSessionId\) \|\| null,/, `${browser}: parentSessionId not stored`);
+    assert.match(recorderSource, /delegationDepth: effectiveDelegationDepth\(lineage\),/, `${browser}: delegationDepth not resolved`);
+  }
+});
+
 test('trace recording remains opt-in by default', () => {
   for (const [label, prefix, configTransfer] of [
     ['chrome', 'src/chrome', ConfigTransferCh],


### PR DESCRIPTION
## Summary

- New browser-neutral module `trace/run-header.js` (Chrome + Firefox): allowlisted normalization of `parentRunId` / `parentSessionId` / `delegationDepth`.
- `startRun` stores the three lineage fields on every run record; `delegationDepth` resolves to an explicit value, else 1 for a run with a parent, else 0.
- Trace DB schema v1 → v2: idempotent `sessionId` (over `conversationId`) and `parentRunId` indexes for future session-level aggregation. No data migration.

## Motivation

Closes #2870.

WebBrain has natural fork scenarios with no data to support them: cloud runs (`cloud-runs.js`) and workflow replays (`replaySavedWorkflow`) produce independent runs, so "which browser run did this derived run come from" is unanswerable, and cost attribution cannot aggregate across a session and its derived runs. `conversationId` already groups sibling runs in the Traces UI; a parent chain extends that pattern to derived runs.

## Design

- **`conversationId` stays the session identity** — no new field name, avoiding three-way compatibility cost (UI / export / storage).
- Three new fields: `parentRunId`, `parentSessionId`, `delegationDepth` (old runs default to null/0 and are untouched).
- `normalizeRunHeader()` follows the existing `runtime-config.js` allowlist pattern: bounded string ids (≤200 chars, no control characters), bounded integer depth (0–64), trimmed. Nothing content-bearing can reach these fields.
- `effectiveDelegationDepth()`: explicit depth wins; a run with a parent but no depth is a direct child (1); everything else is a root (0).
- **DB v2**: `DB_VERSION 1→2`; `onupgradeneeded` creates the indexes idempotently (`indexNames.contains` guard). The `sessionId` index is keyed on `conversationId` (which IS the session identity) and carries the semantic name so session-level queries read naturally; IndexedDB skips records with null keys, so old runs are simply absent from the indexes. v1 data survives the upgrade byte-for-byte.

## Testing

- `node test/run.js` — passed, 1956 tests (4 new: normalization boundaries, depth resolution, mirror identity + browser-neutrality, recorder wiring)
- `node --check` on every touched file — passed

Skipped: unpacked-browser manual verification (no browser session available in this environment). The IndexedDB upgrade path is covered by source-level idempotency assertions; runtime IDB behavior in Chrome and Firefox is not manually exercised.

## Compatibility and risks

- v1 databases upgrade in place: only two new indexes are added; existing stores, records, and keys are untouched. Old runs (null lineage fields) are excluded from the new indexes automatically.
- The new fields are additive on the run record; existing readers (UI, exporters) ignore them.
- Risk: naming the session index `sessionId` while the field is `conversationId` — deliberate, documented in code, matching the issue design.

## Scope

Deliberately deferred: this PR is recorder-side support only. Plumbing `parentRunId` from the cloud-run and replay entry points is the next PR; session aggregation views/stats follow later.