### PR TITLE
Add durable terminal runtime Cloud outbox

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ This changelog was generated from the repository Git history and release tags. V
 ## [33.0.8] - 2026-08-20
 
 ### Changed
+- Added a consent-gated, durable WebBrain Cloud terminal-runtime outbox so executed terminal tool results survive provider-trace export gaps and can be joined through stable de-identified references.
 - fix: resume vision downloads and organize settings
 - fix: require vision cache marker and isolate queued worker deadlines
 - fix: verify local vision cache and abort timed-out remote vision

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -566,6 +566,15 @@ copied nor fingerprinted in request events. Policy revisions are bumped when
 controlled prompt templates or tool-exposure rules change; private request
 content does not affect them.
 
+WebBrain Cloud runs also have a separate consent-gated terminal-runtime path.
+After an executed tool result is made durable in `chrome.storage.local`, a
+bounded `terminal_runtime` envelope is sent to the Cloud improvement endpoint.
+Transient failures remain in the outbox for the next Cloud run; acknowledged or
+non-retryable records are removed. This path does not depend on optional local
+IndexedDB tracing, is disabled for local/bring-your-own providers, and never
+blocks the visible answer on the network request. Chrome and Firefox use the
+same event and outbox schema.
+
 Each new trace run records the manifest version that created it. `/export`
 Markdown records the exporting version, `/export --traces` records both the
 exporting version and every turn's recording version, and Traces-page JSON adds

--- a/docs/privacy-and-data-flow.md
+++ b/docs/privacy-and-data-flow.md
@@ -111,6 +111,15 @@ sends the current preference, stable conversation id, and an allowlisted
 generation label with every WebBrain Cloud model request. It never attaches
 those collection fields to local or bring-your-own providers.
 
+For WebBrain Cloud only, an enabled Help Improve preference also allows the
+extension to retain one bounded terminal tool call/result and the final run
+status in a local durable outbox until the Cloud improvement endpoint
+acknowledges it. Delivery is retried on a later Cloud run after transient
+network/server failures. The outbox is not created for local or bring-your-own
+providers, and disabling Help Improve stops new terminal records; any older
+queued records are sent with the disabled preference so the server discards
+them and the client can remove them.
+
 Current clients explicitly send `X-WebBrain-Help-Improve: 1` or `0`. Older
 WebBrain Cloud clients that send neither the preference header nor a session id
 are treated as using the default-on setting. The Cloud service derives a
@@ -137,7 +146,10 @@ for WebBrain training.
 For eligible completed generations, MySQL is WebBrain's canonical store. The
 service strips media, compresses the request/response payload, encrypts it with
 AES-256-GCM, and stores it with an opaque HMAC session id. Interrupted streams
-and failed generations are not stored as improvement content. Eligible requests
+and failed generations are not stored as generation content. Separately,
+eligible terminal-runtime envelopes are de-identified, encrypted, and stored
+idempotently so evaluation can distinguish provider export gaps from actual
+execution outcomes. Eligible requests
 also use an isolated OpenRouter workspace with private Input & Output Logging
 enabled as a redundant review copy. OpenRouter documents a minimum retention of
 three months and says data may be retained longer unless deletion is requested.

--- a/src/chrome/README.md
+++ b/src/chrome/README.md
@@ -10,6 +10,7 @@ Open-source AI browser agent for Chrome, Microsoft Edge, and Firefox. Chat with 
 - **Multi-Step Agent** — Autonomous task execution with tool-use loops (configurable, default 130 steps)
 - **Continue from Limit** — When the agent hits the step limit, click Continue to keep going
 - **Multi-Provider LLM** — WebBrain Cloud plus local llama.cpp/Ollama/LM Studio/Jan/vLLM/SGLang/LocalAI and major direct cloud providers
+- **Reliable Cloud improvement traces** — when Help Improve WebBrain is enabled, terminal tool outcomes are durably queued and retried without delaying the visible answer
 - **Side Panel UI** — Clean chat interface that lives alongside your browsing
 - **Reading-first long replies** — Questions stay visible while answers grow, with controls to follow, jump to the latest content, or return to the question
 - **Per-Tab Conversations** — Each tab has its own chat history

--- a/src/chrome/src/agent/agent.js
+++ b/src/chrome/src/agent/agent.js
@@ -62,6 +62,7 @@ import {
   PDF_PASSTHROUGH_MAX_BYTES,
 } from './pdf-tools.js';
 import * as trace from '../trace/recorder.js';
+import { buildTerminalRuntimeEvent, enqueueCloudRuntimeEvent, flushCloudRuntimeOutbox } from '../trace/cloud-runtime-outbox.js';
 import { normalizeRuntimeTraceConfig } from '../trace/runtime-config.js';
 import { tracesToMarkdown } from './trace-export.js';
 import { solveCaptcha, detectCaptcha, injectToken, captchaParamError, captchaTypesMatch, captchaWebsiteUrl } from './captcha-solver.js';
@@ -10788,16 +10789,40 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
   }
 
   /**
-   * End a trace run and clear its currentRunId, tolerating recorder errors.
-   * No-op when runId is falsy. Shared by the streaming and non-streaming
-   * message paths so the teardown stays in one place. (#9)
+   * End local tracing and durably queue any opted-in Cloud terminal outcome.
+   * Cloud delivery remains active when optional local tracing is disabled.
+   * Shared by the streaming and non-streaming message paths. (#9)
    */
-  async _endTraceRun(tabId, runId, status, finalContent) {
-    if (!runId) return;
-    try {
-      await trace.endRun(runId, { status, finalContent });
-    } catch {}
-    this.currentRunId.delete(tabId);
+  async _endTraceRun(tabId, runId, status, finalContent, { provider = null, messages = null, mode = '' } = {}) {
+    if (String(provider?.config?.providerName || '').toLowerCase() === 'webbrain-cloud') {
+      try {
+        const sessionId = this.conversationIds.get(tabId) || null;
+        if (sessionId && provider?.config?.helpImproveWebBrain !== false) {
+          let extensionVersion = '';
+          try { extensionVersion = chrome.runtime.getManifest().version || ''; } catch {}
+          const item = buildTerminalRuntimeEvent({
+            runId,
+            status,
+            finalContent,
+            messages,
+            model: provider?.model,
+            mode,
+            browserTarget: 'chrome',
+            extensionVersion,
+          });
+          if (item) await enqueueCloudRuntimeEvent(sessionId, item);
+        }
+        // The durable write above is awaited; network delivery is deliberately
+        // detached from UI completion and retried by the next Cloud run.
+        void flushCloudRuntimeOutbox(provider);
+      } catch {}
+    }
+    if (runId) {
+      try {
+        await trace.endRun(runId, { status, finalContent });
+      } catch {}
+      this.currentRunId.delete(tabId);
+    }
   }
 
   /**
@@ -27143,6 +27168,10 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
     }
 
     const provider = this._activeProvider(tabId);
+    // Give previously queued terminal outcomes the whole duration of this run
+    // to upload; the current run is enqueued at finalization and may complete
+    // in the background or on the next Cloud run.
+    void flushCloudRuntimeOutbox(provider);
 
     if (typeof runOptions?.isDetachedStartCancelled === 'function'
         && runOptions.isDetachedStartCancelled()) {
@@ -28079,7 +28108,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
         lastTraceStep,
         this._traceTurnEndPayload(_traceStatus, traceFailureCode),
       );
-      await this._endTraceRun(tabId, runId, _traceStatus, finalResponse);
+      await this._endTraceRun(tabId, runId, _traceStatus, finalResponse, { provider, messages, mode });
     }
   }
 
@@ -28280,6 +28309,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
     }
 
     const provider = this._activeProvider(tabId);
+    void flushCloudRuntimeOutbox(provider);
 
     // Clear any stale abort flag before any LLM work. The planner gate makes a
     // paid LLM call and checks/consumes this flag, so a leftover flag from a
@@ -28929,7 +28959,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
         lastTraceStep,
         this._traceTurnEndPayload(_traceStatus, traceFailureCode),
       );
-      await this._endTraceRun(tabId, runId, _traceStatus, finalResponse);
+      await this._endTraceRun(tabId, runId, _traceStatus, finalResponse, { provider, messages, mode });
     }
   }
 }

--- a/src/chrome/src/providers/openai.js
+++ b/src/chrome/src/providers/openai.js
@@ -176,6 +176,33 @@ export class OpenAICompatibleProvider extends BaseLLMProvider {
     return headers;
   }
 
+  async sendRuntimeEvents(sessionId, events, { timeoutMs = 2500 } = {}) {
+    if (String(this.config.providerName || '').toLowerCase() !== 'webbrain-cloud') {
+      return { ok: false, retryable: false, status: 0 };
+    }
+    const controller = typeof AbortController === 'function' ? new AbortController() : null;
+    const timer = controller ? setTimeout(() => controller.abort(), Math.max(250, timeoutMs)) : null;
+    try {
+      const response = await fetchWithFallback(`${this.baseUrl}/improvement/runtime-events`, {
+        method: 'POST',
+        headers: this._headers(),
+        body: JSON.stringify({ session_id: String(sessionId || ''), events }),
+        ...(controller ? { signal: controller.signal } : {}),
+      });
+      if (response.ok) return { ok: true, retryable: false, status: response.status };
+      try { await response.text(); } catch {}
+      return {
+        ok: false,
+        retryable: response.status === 408 || response.status === 429 || response.status >= 500,
+        status: response.status,
+      };
+    } catch {
+      return { ok: false, retryable: true, status: 0 };
+    } finally {
+      if (timer != null) clearTimeout(timer);
+    }
+  }
+
   /**
    * Newer OpenAI models (gpt-5 and the o-series) reject `max_tokens` and any
    * non-default `temperature`, requiring `max_completion_tokens`. Detected by

--- a/src/chrome/src/trace/cloud-runtime-outbox.js
+++ b/src/chrome/src/trace/cloud-runtime-outbox.js
@@ -1,0 +1,176 @@
+import { makeEvent } from './event-model.js';
+
+const STORAGE_KEY = 'webbrainCloudRuntimeOutboxV1';
+const MAX_OUTBOX_EVENTS = 200;
+const MAX_FIELD_CHARS = 24_000;
+let storageQueue = Promise.resolve();
+let fallbackRunCounter = 0;
+
+function bounded(value, limit = MAX_FIELD_CHARS) {
+  const serialized = typeof value === 'string' ? value : JSON.stringify(value ?? null);
+  const text = typeof serialized === 'string' ? serialized : String(value ?? '');
+  if (text.length <= limit) return text;
+  return `${text.slice(0, limit)}\n[… ${text.length - limit} characters omitted]`;
+}
+
+function currentTurn(messages) {
+  const list = Array.isArray(messages) ? messages : [];
+  let start = 0;
+  for (let index = list.length - 1; index >= 0; index--) {
+    if (list[index]?.role === 'user') {
+      start = index + 1;
+      break;
+    }
+  }
+  return list.slice(start);
+}
+
+function parseResult(content) {
+  const text = typeof content === 'string' ? content : JSON.stringify(content ?? null);
+  const candidates = [text];
+  const firstBrace = text.indexOf('{');
+  const lastBrace = text.lastIndexOf('}');
+  if (firstBrace >= 0 && lastBrace > firstBrace) candidates.push(text.slice(firstBrace, lastBrace + 1));
+  for (const candidate of candidates) {
+    try {
+      const parsed = JSON.parse(candidate);
+      if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) return parsed;
+    } catch {}
+  }
+  return null;
+}
+
+function terminalTool(messages) {
+  const turn = currentTurn(messages);
+  const calls = new Map();
+  const results = [];
+  for (const message of turn) {
+    if (message?.role === 'assistant' && Array.isArray(message.tool_calls)) {
+      for (const call of message.tool_calls) {
+        if (call?.id) calls.set(call.id, call);
+      }
+    } else if (message?.role === 'tool' && message.tool_call_id) {
+      results.push(message);
+    }
+  }
+  if (!results.length) return null;
+  const paired = results.map(result => ({ result, call: calls.get(result.tool_call_id) })).filter(item => item.call);
+  const selected = [...paired].reverse().find(item => (
+    (item.call?.function?.name || item.call?.name) === 'done'
+  )) || paired.at(-1);
+  if (!selected) return null;
+  const call = selected.call;
+  const result = parseResult(selected.result.content);
+  const blocked = result?.blocked === true || result?.blockedDone === true;
+  const skipped = result?.skipped === true;
+  const failed = result?.success === false || (!blocked && typeof result?.error === 'string');
+  const status = blocked ? 'blocked' : skipped ? 'skipped' : failed ? 'failed' : 'succeeded';
+  return {
+    call_id: String(call.id),
+    name: String(call.function?.name || call.name || 'unknown_tool').slice(0, 128),
+    arguments: bounded(call.function?.arguments ?? call.arguments ?? '', 12_000),
+    result: bounded(selected.result.content, MAX_FIELD_CHARS),
+    status,
+    success: status === 'succeeded',
+  };
+}
+
+export function buildTerminalRuntimeEvent({
+  runId,
+  status,
+  finalContent,
+  messages,
+  model,
+  mode,
+  browserTarget,
+  extensionVersion,
+}) {
+  const tool = terminalTool(messages);
+  if (!tool) return null;
+  const generatedId = globalThis.crypto?.randomUUID?.()
+    || `${Date.now().toString(36)}_${(++fallbackRunCounter).toString(36)}`;
+  const effectiveRunId = String(runId || `cloud_${generatedId}`);
+  const event = makeEvent(effectiveRunId, 1, 'terminal_runtime', {
+    status: String(status || 'unknown').slice(0, 64),
+    final_content: bounded(finalContent || '', MAX_FIELD_CHARS),
+    terminal_tool: tool,
+    model: String(model || '').slice(0, 255),
+    mode: String(mode || '').slice(0, 32),
+    browser_target: String(browserTarget || '').slice(0, 32),
+    extension_version: String(extensionVersion || '').slice(0, 64),
+  });
+  if (!event) return null;
+  return {
+    event_id: `${effectiveRunId}:1:terminal_runtime`,
+    event,
+  };
+}
+
+async function readOutbox() {
+  const stored = await chrome.storage.local.get([STORAGE_KEY]);
+  return Array.isArray(stored?.[STORAGE_KEY]) ? stored[STORAGE_KEY] : [];
+}
+
+function updateOutbox(update) {
+  const next = storageQueue.catch(() => {}).then(async () => {
+    const current = await readOutbox();
+    const value = await update(current);
+    await chrome.storage.local.set({ [STORAGE_KEY]: value.slice(-MAX_OUTBOX_EVENTS) });
+    return value;
+  });
+  storageQueue = next;
+  return next;
+}
+
+export async function enqueueCloudRuntimeEvent(sessionId, item) {
+  const normalizedSessionId = String(sessionId || '').trim();
+  if (!normalizedSessionId || !item?.event_id || !item?.event) return false;
+  await updateOutbox(current => {
+    if (current.some(entry => entry?.event_id === item.event_id)) return current;
+    return [...current, {
+      session_id: normalizedSessionId,
+      event_id: item.event_id,
+      event: item.event,
+      queued_at: Date.now(),
+    }];
+  });
+  return true;
+}
+
+export async function flushCloudRuntimeOutbox(provider) {
+  if (String(provider?.config?.providerName || '').toLowerCase() !== 'webbrain-cloud') return 0;
+  if (typeof provider.sendRuntimeEvents !== 'function') return 0;
+  await storageQueue.catch(() => {});
+  let snapshot;
+  try { snapshot = await readOutbox(); } catch { return 0; }
+  if (!snapshot.length) return 0;
+  const groups = new Map();
+  for (const entry of snapshot) {
+    if (!groups.has(entry.session_id)) groups.set(entry.session_id, []);
+    groups.get(entry.session_id).push(entry);
+  }
+  const removeIds = new Set();
+  for (const [sessionId, entries] of groups) {
+    for (let index = 0; index < entries.length; index += 50) {
+      const batch = entries.slice(index, index + 50);
+      let result;
+      try {
+        result = await provider.sendRuntimeEvents(
+          sessionId,
+          batch.map(({ event_id, event }) => ({ event_id, event })),
+        );
+      } catch {
+        result = { ok: false, retryable: true };
+      }
+      if (result?.ok === true || result?.retryable === false) {
+        for (const entry of batch) removeIds.add(entry.event_id);
+      }
+    }
+  }
+  if (removeIds.size) {
+    await updateOutbox(current => current.filter(entry => !removeIds.has(entry?.event_id)));
+  }
+  return removeIds.size;
+}
+
+export const CLOUD_RUNTIME_OUTBOX_STORAGE_KEY = STORAGE_KEY;

--- a/src/chrome/src/trace/cloud-runtime-outbox.js
+++ b/src/chrome/src/trace/cloud-runtime-outbox.js
@@ -56,7 +56,8 @@ function terminalTool(messages) {
   if (!results.length) return null;
   const paired = results.map(result => ({ result, call: calls.get(result.tool_call_id) })).filter(item => item.call);
   const selected = [...paired].reverse().find(item => (
-    (item.call?.function?.name || item.call?.name) === 'done'
+    ['done', 'done_json'].includes(item.call?.function?.name || item.call?.name)
+    && parseResult(item.result.content)?.done === true
   )) || paired.at(-1);
   if (!selected) return null;
   const call = selected.call;
@@ -106,8 +107,18 @@ export function buildTerminalRuntimeEvent({
   };
 }
 
+function localStorageArea() {
+  const api = (typeof browser !== 'undefined' && browser?.storage)
+    ? browser
+    : ((typeof chrome !== 'undefined' && chrome?.storage) ? chrome : null);
+  if (!api?.storage?.local?.get || !api.storage.local.set) {
+    throw new Error('Extension local storage is unavailable');
+  }
+  return api.storage.local;
+}
+
 async function readOutbox() {
-  const stored = await chrome.storage.local.get([STORAGE_KEY]);
+  const stored = await localStorageArea().get([STORAGE_KEY]);
   return Array.isArray(stored?.[STORAGE_KEY]) ? stored[STORAGE_KEY] : [];
 }
 
@@ -115,7 +126,7 @@ function updateOutbox(update) {
   const next = storageQueue.catch(() => {}).then(async () => {
     const current = await readOutbox();
     const value = await update(current);
-    await chrome.storage.local.set({ [STORAGE_KEY]: value.slice(-MAX_OUTBOX_EVENTS) });
+    await localStorageArea().set({ [STORAGE_KEY]: value.slice(-MAX_OUTBOX_EVENTS) });
     return value;
   });
   storageQueue = next;

--- a/src/chrome/src/trace/event-model.js
+++ b/src/chrome/src/trace/event-model.js
@@ -35,6 +35,7 @@ export const EVENT_KINDS = Object.freeze([
   'note',
   'vision_sub_call',
   'vision_route',
+  'terminal_runtime',
 ]);
 
 // Kinds that readers may safely collapse. Empty today: the mechanism exists so

--- a/src/firefox/README.md
+++ b/src/firefox/README.md
@@ -10,6 +10,7 @@ Open-source AI browser agent for Chrome and Firefox. Chat with any web page, aut
 - **Multi-Step Agent** — Autonomous task execution with tool-use loops (configurable, default 130 steps)
 - **Continue from Limit** — When the agent hits the step limit, click Continue to keep going
 - **Multi-Provider LLM** — WebBrain Cloud plus local llama.cpp/Ollama/LM Studio/Jan/vLLM/SGLang/LocalAI and major direct cloud providers
+- **Reliable Cloud improvement traces** — when Help Improve WebBrain is enabled, terminal tool outcomes are durably queued and retried without delaying the visible answer
 - **Side Panel UI** — Clean chat interface that lives alongside your browsing
 - **Reading-first long replies** — Questions stay visible while answers grow, with controls to follow, jump to the latest content, or return to the question
 - **Per-Tab Conversations** — Each tab has its own chat history

--- a/src/firefox/src/agent/agent.js
+++ b/src/firefox/src/agent/agent.js
@@ -55,6 +55,7 @@ import {
   PDF_PASSTHROUGH_MAX_BYTES,
 } from './pdf-tools.js';
 import * as trace from '../trace/recorder.js';
+import { buildTerminalRuntimeEvent, enqueueCloudRuntimeEvent, flushCloudRuntimeOutbox } from '../trace/cloud-runtime-outbox.js';
 import { normalizeRuntimeTraceConfig } from '../trace/runtime-config.js';
 import { tracesToMarkdown } from './trace-export.js';
 import { solveCaptcha, detectCaptcha, injectToken, captchaParamError, captchaTypesMatch, captchaWebsiteUrl } from './captcha-solver.js';
@@ -8644,16 +8645,40 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
   }
 
   /**
-   * End a trace run and clear its currentRunId, tolerating recorder errors.
-   * No-op when runId is falsy. Shared by the streaming and non-streaming
-   * message paths so the teardown stays in one place. (#9)
+   * End local tracing and durably queue any opted-in Cloud terminal outcome.
+   * Cloud delivery remains active when optional local tracing is disabled.
+   * Shared by the streaming and non-streaming message paths. (#9)
    */
-  async _endTraceRun(tabId, runId, status, finalContent) {
-    if (!runId) return;
-    try {
-      await trace.endRun(runId, { status, finalContent });
-    } catch {}
-    this.currentRunId.delete(tabId);
+  async _endTraceRun(tabId, runId, status, finalContent, { provider = null, messages = null, mode = '' } = {}) {
+    if (String(provider?.config?.providerName || '').toLowerCase() === 'webbrain-cloud') {
+      try {
+        const sessionId = this.conversationIds.get(tabId) || null;
+        if (sessionId && provider?.config?.helpImproveWebBrain !== false) {
+          let extensionVersion = '';
+          try { extensionVersion = chrome.runtime.getManifest().version || ''; } catch {}
+          const item = buildTerminalRuntimeEvent({
+            runId,
+            status,
+            finalContent,
+            messages,
+            model: provider?.model,
+            mode,
+            browserTarget: 'firefox',
+            extensionVersion,
+          });
+          if (item) await enqueueCloudRuntimeEvent(sessionId, item);
+        }
+        // The durable write above is awaited; network delivery is deliberately
+        // detached from UI completion and retried by the next Cloud run.
+        void flushCloudRuntimeOutbox(provider);
+      } catch {}
+    }
+    if (runId) {
+      try {
+        await trace.endRun(runId, { status, finalContent });
+      } catch {}
+      this.currentRunId.delete(tabId);
+    }
   }
 
   /**
@@ -20775,6 +20800,10 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
     }
 
     const provider = this.providerManager.getActive();
+    // Give previously queued terminal outcomes the whole duration of this run
+    // to upload; the current run is enqueued at finalization and may complete
+    // in the background or on the next Cloud run.
+    void flushCloudRuntimeOutbox(provider);
 
     if (typeof runOptions?.isDetachedStartCancelled === 'function'
         && runOptions.isDetachedStartCancelled()) {
@@ -21584,7 +21613,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
         lastTraceStep,
         this._traceTurnEndPayload(_traceStatus, traceFailureCode),
       );
-      await this._endTraceRun(tabId, runId, _traceStatus, finalResponse);
+      await this._endTraceRun(tabId, runId, _traceStatus, finalResponse, { provider, messages, mode });
     }
   }
 
@@ -21747,6 +21776,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
     }
 
     const provider = this.providerManager.getActive();
+    void flushCloudRuntimeOutbox(provider);
 
     // Clear any stale abort flag before any LLM work. The planner gate makes a
     // paid LLM call and checks/consumes this flag, so a leftover flag from a
@@ -22281,7 +22311,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
         lastTraceStep,
         this._traceTurnEndPayload(_traceStatus, traceFailureCode),
       );
-      await this._endTraceRun(tabId, runId, _traceStatus, finalResponse);
+      await this._endTraceRun(tabId, runId, _traceStatus, finalResponse, { provider, messages, mode });
     }
   }
 }

--- a/src/firefox/src/providers/openai.js
+++ b/src/firefox/src/providers/openai.js
@@ -183,7 +183,7 @@ export class OpenAICompatibleProvider extends BaseLLMProvider {
     const controller = typeof AbortController === 'function' ? new AbortController() : null;
     const timer = controller ? setTimeout(() => controller.abort(), Math.max(250, timeoutMs)) : null;
     try {
-      const response = await fetchWithFallback(`${this.baseUrl}/improvement/runtime-events`, {
+      const response = await fetchWithTimeout(`${this.baseUrl}/improvement/runtime-events`, {
         method: 'POST',
         headers: this._headers(),
         body: JSON.stringify({ session_id: String(sessionId || ''), events }),

--- a/src/firefox/src/providers/openai.js
+++ b/src/firefox/src/providers/openai.js
@@ -176,6 +176,33 @@ export class OpenAICompatibleProvider extends BaseLLMProvider {
     return headers;
   }
 
+  async sendRuntimeEvents(sessionId, events, { timeoutMs = 2500 } = {}) {
+    if (String(this.config.providerName || '').toLowerCase() !== 'webbrain-cloud') {
+      return { ok: false, retryable: false, status: 0 };
+    }
+    const controller = typeof AbortController === 'function' ? new AbortController() : null;
+    const timer = controller ? setTimeout(() => controller.abort(), Math.max(250, timeoutMs)) : null;
+    try {
+      const response = await fetchWithFallback(`${this.baseUrl}/improvement/runtime-events`, {
+        method: 'POST',
+        headers: this._headers(),
+        body: JSON.stringify({ session_id: String(sessionId || ''), events }),
+        ...(controller ? { signal: controller.signal } : {}),
+      });
+      if (response.ok) return { ok: true, retryable: false, status: response.status };
+      try { await response.text(); } catch {}
+      return {
+        ok: false,
+        retryable: response.status === 408 || response.status === 429 || response.status >= 500,
+        status: response.status,
+      };
+    } catch {
+      return { ok: false, retryable: true, status: 0 };
+    } finally {
+      if (timer != null) clearTimeout(timer);
+    }
+  }
+
   /**
    * Newer OpenAI models (gpt-5 and the o-series) reject `max_tokens` and any
    * non-default `temperature`, requiring `max_completion_tokens`. Detected by

--- a/src/firefox/src/trace/cloud-runtime-outbox.js
+++ b/src/firefox/src/trace/cloud-runtime-outbox.js
@@ -1,0 +1,176 @@
+import { makeEvent } from './event-model.js';
+
+const STORAGE_KEY = 'webbrainCloudRuntimeOutboxV1';
+const MAX_OUTBOX_EVENTS = 200;
+const MAX_FIELD_CHARS = 24_000;
+let storageQueue = Promise.resolve();
+let fallbackRunCounter = 0;
+
+function bounded(value, limit = MAX_FIELD_CHARS) {
+  const serialized = typeof value === 'string' ? value : JSON.stringify(value ?? null);
+  const text = typeof serialized === 'string' ? serialized : String(value ?? '');
+  if (text.length <= limit) return text;
+  return `${text.slice(0, limit)}\n[… ${text.length - limit} characters omitted]`;
+}
+
+function currentTurn(messages) {
+  const list = Array.isArray(messages) ? messages : [];
+  let start = 0;
+  for (let index = list.length - 1; index >= 0; index--) {
+    if (list[index]?.role === 'user') {
+      start = index + 1;
+      break;
+    }
+  }
+  return list.slice(start);
+}
+
+function parseResult(content) {
+  const text = typeof content === 'string' ? content : JSON.stringify(content ?? null);
+  const candidates = [text];
+  const firstBrace = text.indexOf('{');
+  const lastBrace = text.lastIndexOf('}');
+  if (firstBrace >= 0 && lastBrace > firstBrace) candidates.push(text.slice(firstBrace, lastBrace + 1));
+  for (const candidate of candidates) {
+    try {
+      const parsed = JSON.parse(candidate);
+      if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) return parsed;
+    } catch {}
+  }
+  return null;
+}
+
+function terminalTool(messages) {
+  const turn = currentTurn(messages);
+  const calls = new Map();
+  const results = [];
+  for (const message of turn) {
+    if (message?.role === 'assistant' && Array.isArray(message.tool_calls)) {
+      for (const call of message.tool_calls) {
+        if (call?.id) calls.set(call.id, call);
+      }
+    } else if (message?.role === 'tool' && message.tool_call_id) {
+      results.push(message);
+    }
+  }
+  if (!results.length) return null;
+  const paired = results.map(result => ({ result, call: calls.get(result.tool_call_id) })).filter(item => item.call);
+  const selected = [...paired].reverse().find(item => (
+    (item.call?.function?.name || item.call?.name) === 'done'
+  )) || paired.at(-1);
+  if (!selected) return null;
+  const call = selected.call;
+  const result = parseResult(selected.result.content);
+  const blocked = result?.blocked === true || result?.blockedDone === true;
+  const skipped = result?.skipped === true;
+  const failed = result?.success === false || (!blocked && typeof result?.error === 'string');
+  const status = blocked ? 'blocked' : skipped ? 'skipped' : failed ? 'failed' : 'succeeded';
+  return {
+    call_id: String(call.id),
+    name: String(call.function?.name || call.name || 'unknown_tool').slice(0, 128),
+    arguments: bounded(call.function?.arguments ?? call.arguments ?? '', 12_000),
+    result: bounded(selected.result.content, MAX_FIELD_CHARS),
+    status,
+    success: status === 'succeeded',
+  };
+}
+
+export function buildTerminalRuntimeEvent({
+  runId,
+  status,
+  finalContent,
+  messages,
+  model,
+  mode,
+  browserTarget,
+  extensionVersion,
+}) {
+  const tool = terminalTool(messages);
+  if (!tool) return null;
+  const generatedId = globalThis.crypto?.randomUUID?.()
+    || `${Date.now().toString(36)}_${(++fallbackRunCounter).toString(36)}`;
+  const effectiveRunId = String(runId || `cloud_${generatedId}`);
+  const event = makeEvent(effectiveRunId, 1, 'terminal_runtime', {
+    status: String(status || 'unknown').slice(0, 64),
+    final_content: bounded(finalContent || '', MAX_FIELD_CHARS),
+    terminal_tool: tool,
+    model: String(model || '').slice(0, 255),
+    mode: String(mode || '').slice(0, 32),
+    browser_target: String(browserTarget || '').slice(0, 32),
+    extension_version: String(extensionVersion || '').slice(0, 64),
+  });
+  if (!event) return null;
+  return {
+    event_id: `${effectiveRunId}:1:terminal_runtime`,
+    event,
+  };
+}
+
+async function readOutbox() {
+  const stored = await chrome.storage.local.get([STORAGE_KEY]);
+  return Array.isArray(stored?.[STORAGE_KEY]) ? stored[STORAGE_KEY] : [];
+}
+
+function updateOutbox(update) {
+  const next = storageQueue.catch(() => {}).then(async () => {
+    const current = await readOutbox();
+    const value = await update(current);
+    await chrome.storage.local.set({ [STORAGE_KEY]: value.slice(-MAX_OUTBOX_EVENTS) });
+    return value;
+  });
+  storageQueue = next;
+  return next;
+}
+
+export async function enqueueCloudRuntimeEvent(sessionId, item) {
+  const normalizedSessionId = String(sessionId || '').trim();
+  if (!normalizedSessionId || !item?.event_id || !item?.event) return false;
+  await updateOutbox(current => {
+    if (current.some(entry => entry?.event_id === item.event_id)) return current;
+    return [...current, {
+      session_id: normalizedSessionId,
+      event_id: item.event_id,
+      event: item.event,
+      queued_at: Date.now(),
+    }];
+  });
+  return true;
+}
+
+export async function flushCloudRuntimeOutbox(provider) {
+  if (String(provider?.config?.providerName || '').toLowerCase() !== 'webbrain-cloud') return 0;
+  if (typeof provider.sendRuntimeEvents !== 'function') return 0;
+  await storageQueue.catch(() => {});
+  let snapshot;
+  try { snapshot = await readOutbox(); } catch { return 0; }
+  if (!snapshot.length) return 0;
+  const groups = new Map();
+  for (const entry of snapshot) {
+    if (!groups.has(entry.session_id)) groups.set(entry.session_id, []);
+    groups.get(entry.session_id).push(entry);
+  }
+  const removeIds = new Set();
+  for (const [sessionId, entries] of groups) {
+    for (let index = 0; index < entries.length; index += 50) {
+      const batch = entries.slice(index, index + 50);
+      let result;
+      try {
+        result = await provider.sendRuntimeEvents(
+          sessionId,
+          batch.map(({ event_id, event }) => ({ event_id, event })),
+        );
+      } catch {
+        result = { ok: false, retryable: true };
+      }
+      if (result?.ok === true || result?.retryable === false) {
+        for (const entry of batch) removeIds.add(entry.event_id);
+      }
+    }
+  }
+  if (removeIds.size) {
+    await updateOutbox(current => current.filter(entry => !removeIds.has(entry?.event_id)));
+  }
+  return removeIds.size;
+}
+
+export const CLOUD_RUNTIME_OUTBOX_STORAGE_KEY = STORAGE_KEY;

--- a/src/firefox/src/trace/cloud-runtime-outbox.js
+++ b/src/firefox/src/trace/cloud-runtime-outbox.js
@@ -56,7 +56,8 @@ function terminalTool(messages) {
   if (!results.length) return null;
   const paired = results.map(result => ({ result, call: calls.get(result.tool_call_id) })).filter(item => item.call);
   const selected = [...paired].reverse().find(item => (
-    (item.call?.function?.name || item.call?.name) === 'done'
+    ['done', 'done_json'].includes(item.call?.function?.name || item.call?.name)
+    && parseResult(item.result.content)?.done === true
   )) || paired.at(-1);
   if (!selected) return null;
   const call = selected.call;
@@ -106,8 +107,18 @@ export function buildTerminalRuntimeEvent({
   };
 }
 
+function localStorageArea() {
+  const api = (typeof browser !== 'undefined' && browser?.storage)
+    ? browser
+    : ((typeof chrome !== 'undefined' && chrome?.storage) ? chrome : null);
+  if (!api?.storage?.local?.get || !api.storage.local.set) {
+    throw new Error('Extension local storage is unavailable');
+  }
+  return api.storage.local;
+}
+
 async function readOutbox() {
-  const stored = await chrome.storage.local.get([STORAGE_KEY]);
+  const stored = await localStorageArea().get([STORAGE_KEY]);
   return Array.isArray(stored?.[STORAGE_KEY]) ? stored[STORAGE_KEY] : [];
 }
 
@@ -115,7 +126,7 @@ function updateOutbox(update) {
   const next = storageQueue.catch(() => {}).then(async () => {
     const current = await readOutbox();
     const value = await update(current);
-    await chrome.storage.local.set({ [STORAGE_KEY]: value.slice(-MAX_OUTBOX_EVENTS) });
+    await localStorageArea().set({ [STORAGE_KEY]: value.slice(-MAX_OUTBOX_EVENTS) });
     return value;
   });
   storageQueue = next;

--- a/src/firefox/src/trace/event-model.js
+++ b/src/firefox/src/trace/event-model.js
@@ -35,6 +35,7 @@ export const EVENT_KINDS = Object.freeze([
   'note',
   'vision_sub_call',
   'vision_route',
+  'terminal_runtime',
 ]);
 
 // Kinds that readers may safely collapse. Empty today: the mechanism exists so

--- a/test/run.js
+++ b/test/run.js
@@ -8198,6 +8198,60 @@ test('Cloud terminal runtime envelope pairs the terminal done call with its exec
   }
 });
 
+test('Cloud terminal runtime envelope prefers completed done_json over trailing skipped tools', () => {
+  const messages = [
+    { role: 'user', content: 'Return structured output' },
+    {
+      role: 'assistant',
+      tool_calls: [
+        { id: 'call_done_json', function: { name: 'done_json', arguments: '{"result":{"ok":true}}' } },
+        { id: 'call_trailing', function: { name: 'click', arguments: '{"ref_id":"e2"}' } },
+      ],
+    },
+    { role: 'tool', tool_call_id: 'call_done_json', content: '{"success":true,"done":true,"doneJson":true,"result":{"ok":true}}' },
+    { role: 'tool', tool_call_id: 'call_trailing', content: '{"success":false,"skipped":true}' },
+  ];
+  for (const [label, runtime] of [['chrome', CLOUD_RUNTIME_OUTBOX_CH], ['firefox', CLOUD_RUNTIME_OUTBOX_FX]]) {
+    const item = runtime.buildTerminalRuntimeEvent({
+      runId: `run-done-json-${label}`,
+      status: 'done',
+      finalContent: '{"ok":true}',
+      messages,
+      browserTarget: label,
+    });
+    assert.equal(item.event.data.terminal_tool.call_id, 'call_done_json', `${label}: trailing skipped tool replaced done_json`);
+    assert.equal(item.event.data.terminal_tool.name, 'done_json', `${label}: done_json was not treated as terminal`);
+    assert.equal(item.event.data.terminal_tool.status, 'succeeded');
+  }
+});
+
+test('Cloud terminal runtime envelope ignores blocked done attempts when later tools execute', () => {
+  const messages = [
+    { role: 'user', content: 'Complete the task' },
+    {
+      role: 'assistant',
+      tool_calls: [{ id: 'call_blocked_done', function: { name: 'done', arguments: '{"outcome":"success"}' } }],
+    },
+    { role: 'tool', tool_call_id: 'call_blocked_done', content: '{"success":false,"blockedDone":true}' },
+    {
+      role: 'assistant',
+      tool_calls: [{ id: 'call_recovery', function: { name: 'click', arguments: '{"ref_id":"e3"}' } }],
+    },
+    { role: 'tool', tool_call_id: 'call_recovery', content: '{"success":true}' },
+  ];
+  for (const [label, runtime] of [['chrome', CLOUD_RUNTIME_OUTBOX_CH], ['firefox', CLOUD_RUNTIME_OUTBOX_FX]]) {
+    const item = runtime.buildTerminalRuntimeEvent({
+      runId: `run-blocked-done-${label}`,
+      status: 'error',
+      finalContent: 'Stopped later',
+      messages,
+      browserTarget: label,
+    });
+    assert.equal(item.event.data.terminal_tool.call_id, 'call_recovery', `${label}: blocked done replaced later execution`);
+    assert.equal(item.event.data.terminal_tool.name, 'click');
+  }
+});
+
 test('Cloud terminal runtime outbox persists retryable failures and removes acknowledged events', async () => {
   const originalChrome = globalThis.chrome;
   const storage = {};
@@ -8245,6 +8299,51 @@ test('Cloud terminal runtime outbox persists retryable failures and removes ackn
   }
 });
 
+test('Firefox Cloud runtime outbox uses the promise-based browser storage namespace', async () => {
+  const originalBrowser = globalThis.browser;
+  const originalChrome = globalThis.chrome;
+  const storage = {};
+  let chromeCalls = 0;
+  globalThis.browser = {
+    storage: {
+      local: {
+        async get(keys) {
+          const key = Array.isArray(keys) ? keys[0] : keys;
+          return { [key]: storage[key] };
+        },
+        async set(values) { Object.assign(storage, values); },
+      },
+    },
+  };
+  globalThis.chrome = {
+    storage: {
+      local: {
+        get() { chromeCalls++; throw new Error('callback-only chrome namespace used'); },
+        set() { chromeCalls++; throw new Error('callback-only chrome namespace used'); },
+      },
+    },
+  };
+  try {
+    const item = {
+      event_id: 'run-firefox-storage:1:terminal_runtime',
+      event: { runId: 'run-firefox-storage', seq: 1, ts: 1, kind: 'terminal_runtime', data: {} },
+    };
+    assert.equal(await CLOUD_RUNTIME_OUTBOX_FX.enqueueCloudRuntimeEvent('conv-firefox', item), true);
+    assert.equal(storage[CLOUD_RUNTIME_OUTBOX_FX.CLOUD_RUNTIME_OUTBOX_STORAGE_KEY].length, 1);
+    assert.equal(await CLOUD_RUNTIME_OUTBOX_FX.flushCloudRuntimeOutbox({
+      config: { providerName: 'webbrain-cloud' },
+      async sendRuntimeEvents() { return { ok: true, retryable: false, status: 202 }; },
+    }), 1);
+    assert.equal(storage[CLOUD_RUNTIME_OUTBOX_FX.CLOUD_RUNTIME_OUTBOX_STORAGE_KEY].length, 0);
+    assert.equal(chromeCalls, 0, 'Firefox outbox touched the callback-based chrome namespace');
+  } finally {
+    if (originalBrowser === undefined) delete globalThis.browser;
+    else globalThis.browser = originalBrowser;
+    if (originalChrome === undefined) delete globalThis.chrome;
+    else globalThis.chrome = originalChrome;
+  }
+});
+
 test('Cloud terminal runtime outbox never overwrites queued data after a storage read failure', async () => {
   const originalChrome = globalThis.chrome;
   let writes = 0;
@@ -8268,6 +8367,40 @@ test('Cloud terminal runtime outbox never overwrites queued data after a storage
   } finally {
     if (originalChrome === undefined) delete globalThis.chrome;
     else globalThis.chrome = originalChrome;
+  }
+});
+
+test('Firefox Cloud runtime delivery uses its available fetch transport', async () => {
+  const originalBrowser = globalThis.browser;
+  const originalFetch = globalThis.fetch;
+  let request = null;
+  globalThis.browser = {
+    storage: {
+      local: { async get() { return {}; } },
+      onChanged: { addListener() {} },
+    },
+  };
+  globalThis.fetch = async (url, options) => {
+    request = { url, options };
+    return { ok: true, status: 202 };
+  };
+  try {
+    const provider = new OpenAIProviderFx({
+      providerName: 'webbrain-cloud',
+      baseUrl: 'https://cloud.example/v1',
+      deviceGuid: 'device-test',
+      helpImproveWebBrain: true,
+    });
+    const result = await provider.sendRuntimeEvents('conv-firefox', [{ event_id: 'event-1', event: {} }], { timeoutMs: 500 });
+    assert.deepEqual(result, { ok: true, retryable: false, status: 202 });
+    assert.equal(request?.url, 'https://cloud.example/v1/improvement/runtime-events');
+    assert.equal(request?.options?.method, 'POST');
+    assert.equal(JSON.parse(request?.options?.body || '{}').session_id, 'conv-firefox');
+  } finally {
+    if (originalBrowser === undefined) delete globalThis.browser;
+    else globalThis.browser = originalBrowser;
+    if (originalFetch === undefined) delete globalThis.fetch;
+    else globalThis.fetch = originalFetch;
   }
 });
 

--- a/test/run.js
+++ b/test/run.js
@@ -8106,6 +8106,8 @@ console.log('\ntrace event model');
 
 const EVENT_MODEL_CH = await import('file://' + path.join(ROOT, 'src/chrome/src/trace/event-model.js').replace(/\\/g, '/'));
 const EVENT_MODEL_FX = await import('file://' + path.join(ROOT, 'src/firefox/src/trace/event-model.js').replace(/\\/g, '/'));
+const CLOUD_RUNTIME_OUTBOX_CH = await import('file://' + path.join(ROOT, 'src/chrome/src/trace/cloud-runtime-outbox.js').replace(/\\/g, '/'));
+const CLOUD_RUNTIME_OUTBOX_FX = await import('file://' + path.join(ROOT, 'src/firefox/src/trace/cloud-runtime-outbox.js').replace(/\\/g, '/'));
 
 test('trace event model: catalog covers every kind the recorder writes', () => {
   const kinds = EVENT_MODEL_CH.EVENT_KINDS;
@@ -8166,6 +8168,121 @@ test('trace event model: mirrors are identical and browser-neutral', () => {
   assert.equal(EVENT_MODEL_CH.TRACE_FORMAT_VERSION, 1, 'first trace format version');
   assert.doesNotMatch(chromeSource, /chrome\./, 'event model must not depend on chrome APIs');
   assert.doesNotMatch(chromeSource, /indexedDB|storage\./, 'event model must not touch storage');
+});
+
+test('Cloud terminal runtime envelope pairs the terminal done call with its executed result', () => {
+  const messages = [
+    { role: 'user', content: 'Complete the task' },
+    {
+      role: 'assistant',
+      tool_calls: [{ id: 'call_done', function: { name: 'done', arguments: '{"outcome":"success","summary":"Complete"}' } }],
+    },
+    { role: 'tool', tool_call_id: 'call_done', content: '{"success":true,"done":true,"summary":"Complete"}' },
+  ];
+  for (const [label, runtime] of [['chrome', CLOUD_RUNTIME_OUTBOX_CH], ['firefox', CLOUD_RUNTIME_OUTBOX_FX]]) {
+    const item = runtime.buildTerminalRuntimeEvent({
+      runId: 'run-terminal',
+      status: 'done',
+      finalContent: 'Complete',
+      messages,
+      model: 'webbrain-cloud 1.0',
+      mode: 'act',
+      browserTarget: label,
+      extensionVersion: '27.2.0',
+    });
+    assert.equal(item.event_id, 'run-terminal:1:terminal_runtime');
+    assert.equal(item.event.kind, 'terminal_runtime');
+    assert.equal(item.event.data.terminal_tool.name, 'done');
+    assert.equal(item.event.data.terminal_tool.status, 'succeeded');
+    assert.match(item.event.data.terminal_tool.result, /"done":true/);
+  }
+});
+
+test('Cloud terminal runtime outbox persists retryable failures and removes acknowledged events', async () => {
+  const originalChrome = globalThis.chrome;
+  const storage = {};
+  globalThis.chrome = {
+    storage: {
+      local: {
+        async get(keys) {
+          const key = Array.isArray(keys) ? keys[0] : keys;
+          return { [key]: storage[key] };
+        },
+        async set(values) { Object.assign(storage, values); },
+      },
+    },
+  };
+  try {
+    const item = CLOUD_RUNTIME_OUTBOX_CH.buildTerminalRuntimeEvent({
+      runId: 'run-retry',
+      status: 'error',
+      finalContent: 'Failed visibly',
+      messages: [
+        { role: 'user', content: 'Try it' },
+        { role: 'assistant', tool_calls: [{ id: 'call_click', function: { name: 'click', arguments: '{"ref_id":"e1"}' } }] },
+        { role: 'tool', tool_call_id: 'call_click', content: '{"success":false,"error":"target missing"}' },
+      ],
+      browserTarget: 'chrome',
+    });
+    assert.equal(await CLOUD_RUNTIME_OUTBOX_CH.enqueueCloudRuntimeEvent('conv-1', item), true);
+    const provider = {
+      config: { providerName: 'webbrain-cloud' },
+      calls: 0,
+      async sendRuntimeEvents() {
+        this.calls++;
+        return this.calls === 1
+          ? { ok: false, retryable: true, status: 503 }
+          : { ok: true, retryable: false, status: 202 };
+      },
+    };
+    assert.equal(await CLOUD_RUNTIME_OUTBOX_CH.flushCloudRuntimeOutbox(provider), 0);
+    assert.equal(storage[CLOUD_RUNTIME_OUTBOX_CH.CLOUD_RUNTIME_OUTBOX_STORAGE_KEY].length, 1);
+    assert.equal(await CLOUD_RUNTIME_OUTBOX_CH.flushCloudRuntimeOutbox(provider), 1);
+    assert.equal(storage[CLOUD_RUNTIME_OUTBOX_CH.CLOUD_RUNTIME_OUTBOX_STORAGE_KEY].length, 0);
+  } finally {
+    if (originalChrome === undefined) delete globalThis.chrome;
+    else globalThis.chrome = originalChrome;
+  }
+});
+
+test('Cloud terminal runtime outbox never overwrites queued data after a storage read failure', async () => {
+  const originalChrome = globalThis.chrome;
+  let writes = 0;
+  globalThis.chrome = {
+    storage: {
+      local: {
+        async get() { throw new Error('storage unavailable'); },
+        async set() { writes++; },
+      },
+    },
+  };
+  try {
+    await assert.rejects(
+      CLOUD_RUNTIME_OUTBOX_CH.enqueueCloudRuntimeEvent('conv-fail', {
+        event_id: 'run-fail:1:terminal_runtime',
+        event: { runId: 'run-fail', seq: 1, ts: 1, kind: 'terminal_runtime', data: {} },
+      }),
+      /storage unavailable/,
+    );
+    assert.equal(writes, 0);
+  } finally {
+    if (originalChrome === undefined) delete globalThis.chrome;
+    else globalThis.chrome = originalChrome;
+  }
+});
+
+test('Cloud runtime delivery stays consent-gated and mirrored across both builds', () => {
+  const chromeOutbox = fs.readFileSync(path.join(ROOT, 'src/chrome/src/trace/cloud-runtime-outbox.js'), 'utf8');
+  const firefoxOutbox = fs.readFileSync(path.join(ROOT, 'src/firefox/src/trace/cloud-runtime-outbox.js'), 'utf8');
+  assert.equal(chromeOutbox, firefoxOutbox, 'Chrome/Firefox Cloud runtime outboxes drifted');
+  for (const browser of ['chrome', 'firefox']) {
+    const agent = fs.readFileSync(path.join(ROOT, `src/${browser}/src/agent/agent.js`), 'utf8');
+    const provider = fs.readFileSync(path.join(ROOT, `src/${browser}/src/providers/openai.js`), 'utf8');
+    assert.match(agent, /helpImproveWebBrain !== false[\s\S]*enqueueCloudRuntimeEvent/);
+    assert.match(agent, /void flushCloudRuntimeOutbox\(provider\)/);
+    assert.match(provider, /\/improvement\/runtime-events/);
+    assert.match(provider, /retryable: response\.status === 408 \|\| response\.status === 429 \|\| response\.status >= 500/);
+  }
 });
 
 test('trace recorder: writes go through the event model and stamp the format version', () => {


### PR DESCRIPTION
## Summary
- capture bounded terminal tool-call results at the end of WebBrain Cloud runs
- persist consent-gated runtime events in a Chrome/Firefox-parity local outbox
- retry delivery across service-worker restarts and future runs

## Validation
- node test/run.js (1978 passed)
- npm run test:security (60/60)
- Chrome/Firefox outbox parity verified
- git diff --check