### PR TITLE
fix(trace): repair runs interrupted by service-worker eviction

### DIFF
--- a/src/chrome/src/background.js
+++ b/src/chrome/src/background.js
@@ -112,6 +112,7 @@ import {
 const providerManager = new ProviderManager();
 const apocalypseController = createApocalypseController(chrome);
 const VISION_OFFSCREEN_URL = chrome.runtime.getURL('src/offscreen/offscreen.html');
+void workflowTrace.repairStaleRuns().catch(() => {});
 
 function normalizeVisionDownloadState(state) {
   return {

--- a/src/chrome/src/background.js
+++ b/src/chrome/src/background.js
@@ -112,7 +112,11 @@ import {
 const providerManager = new ProviderManager();
 const apocalypseController = createApocalypseController(chrome);
 const VISION_OFFSCREEN_URL = chrome.runtime.getURL('src/offscreen/offscreen.html');
-void workflowTrace.repairStaleRuns().catch(() => {});
+// The stale-run repair scan waits a beat after wake so a run resuming from
+// eviction registers its in-memory state first; the Traces page can also
+// request an immediate scan via WB_TRACE_REPAIR_STALE_RUNS.
+const TRACE_REPAIR_STARTUP_DELAY_MS = 15_000;
+setTimeout(() => { void workflowTrace.repairStaleRuns().catch(() => {}); }, TRACE_REPAIR_STARTUP_DELAY_MS);
 
 function normalizeVisionDownloadState(state) {
   return {
@@ -1485,6 +1489,16 @@ async function handleContextMenuAsk(info, tab) {
 
 chrome.contextMenus?.onClicked?.addListener?.((info, tab) => {
   handleContextMenuAsk(info, tab).catch(() => {});
+});
+
+// Only this instance knows which runs are live in memory, so it owns the
+// stale-run repair whenever it is reachable.
+chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
+  if (msg?.type !== 'WB_TRACE_REPAIR_STALE_RUNS') return;
+  workflowTrace.repairStaleRuns()
+    .then(repaired => sendResponse({ ok: true, repaired }))
+    .catch(error => sendResponse({ ok: false, error: error?.message || String(error) }));
+  return true;
 });
 
 chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {

--- a/src/chrome/src/trace/error-codes.js
+++ b/src/chrome/src/trace/error-codes.js
@@ -23,6 +23,7 @@ export const ERROR_CODES = Object.freeze([
   'TRANSPORT',
   'TOOL_TIMEOUT',
   'COST_LIMIT',
+  'SERVICE_WORKER_EVICTED',
   'UNKNOWN',
 ]);
 

--- a/src/chrome/src/trace/recorder.js
+++ b/src/chrome/src/trace/recorder.js
@@ -4,6 +4,11 @@ import { formatErrorMessage } from '../error-format.js';
 import { TRACE_FORMAT_VERSION, makeEvent } from './event-model.js';
 import { normalizeErrorCode } from './error-codes.js';
 import { normalizeRunHeader, effectiveDelegationDepth } from './run-header.js';
+import {
+  buildTraceRepairPlan,
+  isStaleRunningTrace,
+  TRACE_REPAIR_STALE_AFTER_MS,
+} from './repair.js';
 
 /**
  * Trace recorder — writes per-run traces (LLM requests/responses, tool calls,
@@ -135,6 +140,47 @@ async function _peekSeq(db, runId) {
     cursor.onerror = () => resolve(0);
   });
   return result;
+}
+
+function _repairRunInTransaction(db, runId, { now, staleAfterMs }) {
+  return new Promise((resolve, reject) => {
+    const transaction = tx(db, ['runs', 'events'], 'readwrite');
+    const runsStore = transaction.objectStore('runs');
+    const eventsStore = transaction.objectStore('events');
+    let run = null;
+    let events = null;
+    let pending = 2;
+    let repairedRunId = null;
+    let requestError = null;
+
+    const fail = (error) => {
+      requestError = error || new Error('trace repair request failed');
+      try { transaction.abort(); } catch {}
+    };
+    const apply = () => {
+      pending -= 1;
+      if (pending > 0 || requestError) return;
+      const plan = buildTraceRepairPlan(run, events, { now, staleAfterMs });
+      if (!plan) return;
+      for (const event of plan.events) eventsStore.put(event);
+      runsStore.put(plan.run);
+      repairedRunId = runId;
+    };
+
+    transaction.oncomplete = () => resolve(repairedRunId);
+    transaction.onerror = () => reject(requestError || transaction.error || new Error('trace repair failed'));
+    transaction.onabort = () => {
+      if (requestError) reject(requestError);
+      else if (!repairedRunId) resolve(null);
+    };
+
+    const runRequest = runsStore.get(runId);
+    runRequest.onsuccess = () => { run = runRequest.result || null; apply(); };
+    runRequest.onerror = () => fail(runRequest.error);
+    const eventsRequest = eventsStore.index('runId').getAll(IDBKeyRange.only(runId));
+    eventsRequest.onsuccess = () => { events = eventsRequest.result || []; apply(); };
+    eventsRequest.onerror = () => fail(eventsRequest.error);
+  });
 }
 
 function _newSeq(runId) {
@@ -495,6 +541,40 @@ export async function endRun(runId, { status = 'done', finalContent = null } = {
   } finally {
     _runState.delete(runId);
     _runWriteQueues.delete(runId);
+  }
+}
+
+/**
+ * Repair trace records left running after a service-worker eviction. Each run
+ * is re-read and updated in one transaction so a concurrent normal completion
+ * wins, and a second repair pass cannot append duplicate terminal events.
+ */
+export async function repairStaleRuns({
+  now = Date.now(),
+  staleAfterMs = TRACE_REPAIR_STALE_AFTER_MS,
+} = {}) {
+  if (typeof indexedDB === 'undefined') return [];
+  try {
+    const db = await openDB();
+    const candidates = await listRuns({ limit: Number.MAX_SAFE_INTEGER });
+    const repaired = [];
+    for (const candidate of candidates) {
+      if (!isStaleRunningTrace(candidate, { now, staleAfterMs })) continue;
+      // A live run in this service-worker instance is still owned by the
+      // agent. The durable marker handles races from another extension page.
+      if (_runState.has(candidate.runId)) continue;
+      await _flushRunWrites(candidate.runId);
+      try {
+        const repairedRunId = await _repairRunInTransaction(db, candidate.runId, { now, staleAfterMs });
+        if (repairedRunId) repaired.push(repairedRunId);
+      } catch (e) {
+        console.warn('[trace] stale-run repair failed:', e);
+      }
+    }
+    return repaired;
+  } catch (e) {
+    console.warn('[trace] stale-run scan failed:', e);
+    return [];
   }
 }
 

--- a/src/chrome/src/trace/recorder.js
+++ b/src/chrome/src/trace/recorder.js
@@ -7,6 +7,7 @@ import { normalizeRunHeader, effectiveDelegationDepth } from './run-header.js';
 import {
   buildTraceRepairPlan,
   isStaleRunningTrace,
+  normalizedThreshold,
   TRACE_REPAIR_STALE_AFTER_MS,
 } from './repair.js';
 
@@ -162,6 +163,9 @@ function _repairRunInTransaction(db, runId, { now, staleAfterMs }) {
       if (pending > 0 || requestError) return;
       const plan = buildTraceRepairPlan(run, events, { now, staleAfterMs });
       if (!plan) return;
+      // Last-instant liveness check: a run resumed between the candidate scan
+      // and this transaction has registered itself in memory again.
+      if (_runState.has(runId)) return;
       for (const event of plan.events) eventsStore.put(event);
       runsStore.put(plan.run);
       repairedRunId = runId;
@@ -549,14 +553,36 @@ export async function endRun(runId, { status = 'done', finalContent = null } = {
  * is re-read and updated in one transaction so a concurrent normal completion
  * wins, and a second repair pass cannot append duplicate terminal events.
  */
+async function _listStaleRunCandidates(db, cutoff) {
+  // Only runs old enough to be stale can qualify (last activity is never
+  // older than startedAt), so scan just that slice of the startedAt index
+  // instead of every run on record.
+  const out = [];
+  await new Promise((resolve, reject) => {
+    const idx = tx(db, ['runs'], 'readonly').objectStore('runs').index('startedAt');
+    const req = idx.openCursor(IDBKeyRange.upperBound(cutoff));
+    req.onsuccess = () => {
+      const c = req.result;
+      if (!c) return resolve();
+      const row = c.value;
+      if (row?.status === 'running' && !row.repairedBy) out.push(row);
+      c.continue();
+    };
+    req.onerror = () => reject(req.error || new Error('stale-run scan failed'));
+  });
+  return out;
+}
+
 export async function repairStaleRuns({
   now = Date.now(),
   staleAfterMs = TRACE_REPAIR_STALE_AFTER_MS,
 } = {}) {
   if (typeof indexedDB === 'undefined') return [];
+  if (!Number.isFinite(Number(now))) return [];
   try {
     const db = await openDB();
-    const candidates = await listRuns({ limit: Number.MAX_SAFE_INTEGER });
+    const cutoff = Number(now) - normalizedThreshold(staleAfterMs);
+    const candidates = await _listStaleRunCandidates(db, cutoff);
     const repaired = [];
     for (const candidate of candidates) {
       if (!isStaleRunningTrace(candidate, { now, staleAfterMs })) continue;

--- a/src/chrome/src/trace/repair.js
+++ b/src/chrome/src/trace/repair.js
@@ -41,12 +41,20 @@ function normalizedThreshold(value) {
   return Number.isFinite(Number(value)) ? Math.max(0, Number(value)) : TRACE_REPAIR_STALE_AFTER_MS;
 }
 
-export function isStaleRunningTrace(run, { now = Date.now(), staleAfterMs = TRACE_REPAIR_STALE_AFTER_MS } = {}) {
+export function isStaleRunningTrace(run, {
+  now = Date.now(),
+  staleAfterMs = TRACE_REPAIR_STALE_AFTER_MS,
+  events = [],
+} = {}) {
   if (!run || run.status !== 'running' || run.repairedBy) return false;
-  const startedAt = Number(run.startedAt);
   const currentTime = Number(now);
-  if (!Number.isFinite(startedAt) || !Number.isFinite(currentTime)) return false;
-  return currentTime - startedAt >= normalizedThreshold(staleAfterMs);
+  let lastActivityAt = Number(run.startedAt);
+  if (!Number.isFinite(lastActivityAt) || !Number.isFinite(currentTime)) return false;
+  for (const event of Array.isArray(events) ? events : []) {
+    const eventTime = Number(event?.ts);
+    if (Number.isFinite(eventTime)) lastActivityAt = Math.max(lastActivityAt, eventTime);
+  }
+  return currentTime - lastActivityAt >= normalizedThreshold(staleAfterMs);
 }
 
 /**
@@ -60,11 +68,11 @@ export function buildTraceRepairPlan(run, events, {
   now = Date.now(),
   staleAfterMs = TRACE_REPAIR_STALE_AFTER_MS,
 } = {}) {
-  if (!isStaleRunningTrace(run, { now, staleAfterMs })) return null;
   const orderedEvents = (Array.isArray(events) ? events : [])
     .filter(Boolean)
     .slice()
     .sort((a, b) => (Number(a.seq) || 0) - (Number(b.seq) || 0));
+  if (!isStaleRunningTrace(run, { now, staleAfterMs, events: orderedEvents })) return null;
   const lastSeq = orderedEvents.reduce((max, event) => Math.max(max, Number(event.seq) || 0), 0);
   const code = normalizeErrorCode(TRACE_REPAIR_ERROR_CODE);
   const repairedEvents = [];

--- a/src/chrome/src/trace/repair.js
+++ b/src/chrome/src/trace/repair.js
@@ -1,0 +1,116 @@
+import { makeEvent } from './event-model.js';
+import { normalizeErrorCode } from './error-codes.js';
+
+// A run can legitimately take a while, so repair only treats records older
+// than this conservative window as abandoned. Callers/tests may provide a
+// smaller explicit threshold when they need a deterministic boundary.
+export const TRACE_REPAIR_STALE_AFTER_MS = 10 * 60 * 1000;
+export const TRACE_REPAIR_MARKER = 'service-worker-eviction';
+export const TRACE_REPAIR_ERROR_CODE = 'SERVICE_WORKER_EVICTED';
+export const TRACE_REPAIR_REASON = 'service_worker_eviction';
+export const TRACE_REPAIR_MESSAGE = 'Trace run interrupted by service-worker eviction.';
+
+function repairEvent(runId, seq, kind, data, now) {
+  const event = makeEvent(runId, seq, kind, data);
+  return event ? { ...event, ts: now } : null;
+}
+
+function eventStep(event) {
+  return Number.isInteger(event?.data?.step) ? event.data.step : null;
+}
+
+function openSteps(events) {
+  const open = new Map();
+  for (const event of events) {
+    if (event?.kind === 'step_start') open.set(eventStep(event), eventStep(event));
+    if (event?.kind === 'step_end') open.delete(eventStep(event));
+  }
+  return [...open.values()].sort((a, b) => (a ?? 0) - (b ?? 0));
+}
+
+function openTurnStep(events) {
+  let step = null;
+  for (const event of events) {
+    if (event?.kind === 'turn_start') step = eventStep(event);
+    if (event?.kind === 'turn_end') step = null;
+  }
+  return step;
+}
+
+function normalizedThreshold(value) {
+  return Number.isFinite(Number(value)) ? Math.max(0, Number(value)) : TRACE_REPAIR_STALE_AFTER_MS;
+}
+
+export function isStaleRunningTrace(run, { now = Date.now(), staleAfterMs = TRACE_REPAIR_STALE_AFTER_MS } = {}) {
+  if (!run || run.status !== 'running' || run.repairedBy) return false;
+  const startedAt = Number(run.startedAt);
+  const currentTime = Number(now);
+  if (!Number.isFinite(startedAt) || !Number.isFinite(currentTime)) return false;
+  return currentTime - startedAt >= normalizedThreshold(staleAfterMs);
+}
+
+/**
+ * Build the durable repair mutation for one abandoned trace.
+ *
+ * This is deliberately pure: the recorder applies the returned event/run
+ * values in one IndexedDB transaction, while tests can prove the interruption
+ * semantics without a browser or a real IndexedDB implementation.
+ */
+export function buildTraceRepairPlan(run, events, {
+  now = Date.now(),
+  staleAfterMs = TRACE_REPAIR_STALE_AFTER_MS,
+} = {}) {
+  if (!isStaleRunningTrace(run, { now, staleAfterMs })) return null;
+  const orderedEvents = (Array.isArray(events) ? events : [])
+    .filter(Boolean)
+    .slice()
+    .sort((a, b) => (Number(a.seq) || 0) - (Number(b.seq) || 0));
+  const lastSeq = orderedEvents.reduce((max, event) => Math.max(max, Number(event.seq) || 0), 0);
+  const code = normalizeErrorCode(TRACE_REPAIR_ERROR_CODE);
+  const repairedEvents = [];
+  let nextSeq = lastSeq + 1;
+
+  for (const step of openSteps(orderedEvents)) {
+    repairedEvents.push(repairEvent(run.runId, nextSeq++, 'step_end', {
+      step,
+      ok: false,
+      reason: TRACE_REPAIR_REASON,
+      code,
+      repaired: true,
+    }, now));
+  }
+
+  repairedEvents.push(repairEvent(run.runId, nextSeq++, 'error', {
+    step: null,
+    phase: 'repair',
+    message: TRACE_REPAIR_MESSAGE,
+    code,
+  }, now));
+
+  const turnStep = openTurnStep(orderedEvents);
+  if (turnStep !== null) {
+    repairedEvents.push(repairEvent(run.runId, nextSeq, 'turn_end', {
+      step: turnStep,
+      status: 'error',
+      reason: TRACE_REPAIR_REASON,
+      code,
+      repaired: true,
+    }, now));
+  }
+
+  const maxStep = orderedEvents.reduce((max, event) => Math.max(max, eventStep(event) ?? 0), 0);
+  const startedAt = Number(run.startedAt);
+  return {
+    events: repairedEvents.filter(Boolean),
+    run: {
+      ...run,
+      endedAt: now,
+      durationMs: Math.max(0, now - startedAt),
+      status: 'error',
+      stepCount: Math.max(Number(run.stepCount) || 0, maxStep),
+      repairedBy: TRACE_REPAIR_MARKER,
+      repairedAt: now,
+      repairReason: TRACE_REPAIR_REASON,
+    },
+  };
+}

--- a/src/chrome/src/trace/repair.js
+++ b/src/chrome/src/trace/repair.js
@@ -37,7 +37,7 @@ function openTurnStep(events) {
   return step;
 }
 
-function normalizedThreshold(value) {
+export function normalizedThreshold(value) {
   return Number.isFinite(Number(value)) ? Math.max(0, Number(value)) : TRACE_REPAIR_STALE_AFTER_MS;
 }
 

--- a/src/chrome/src/ui/traces.js
+++ b/src/chrome/src/ui/traces.js
@@ -11,6 +11,8 @@ import { isKnownKind, isIgnorableKind } from '../trace/event-model.js';
 import { t } from './i18n.js';
 import { escapeHtml, escapeAttr } from './utils.js';
 
+const runtimeApi = globalThis.browser || globalThis.chrome;
+
 const listEl = document.getElementById('run-list');
 const mainPane = document.getElementById('main-pane');
 const emptyState = document.getElementById('empty-state');
@@ -645,10 +647,31 @@ document.addEventListener('visibilitychange', () => {
   else if (hasRunningJob()) scheduleAutoRefresh();
 });
 
+// Prefer letting the background own the stale-run scan: only its recorder
+// instance knows which runs are live in memory. If it cannot be reached,
+// nothing can be running anywhere, so a local pass is safe.
+async function repairStaleRunsForPage({ timeoutMs = 5_000 } = {}) {
+  let timer;
+  try {
+    if (runtimeApi?.runtime?.sendMessage) {
+      const response = await Promise.race([
+        runtimeApi.runtime.sendMessage({ type: 'WB_TRACE_REPAIR_STALE_RUNS' }),
+        new Promise((_resolve, reject) => {
+          timer = setTimeout(() => reject(new Error('trace repair roundtrip timed out')), timeoutMs);
+        }),
+      ]);
+      if (response?.ok) return Array.isArray(response.repaired) ? response.repaired : [];
+    }
+  } catch {} finally {
+    clearTimeout(timer);
+  }
+  return repairStaleRuns().catch(() => []);
+}
+
 // Initial load: always do one refresh so the list populates, then only keep
 // polling if the freshly-loaded data shows a live run.
 (async () => {
-  await repairStaleRuns().catch(() => []);
+  await repairStaleRunsForPage();
   await refresh();
   if (initialRunId && await ensureRunLoaded(initialRunId)) {
     selectedRunId = initialRunId;

--- a/src/chrome/src/ui/traces.js
+++ b/src/chrome/src/ui/traces.js
@@ -67,7 +67,6 @@ function formatCost(value) {
 
 async function refresh() {
   const requestId = ++traceRefreshRequestId;
-  if (typeof repairStaleRuns === 'function') await repairStaleRuns().catch(() => []);
   const runs = await listRuns({ limit: 500 });
   if (requestId !== traceRefreshRequestId) return;
   allRuns = runs;
@@ -649,6 +648,7 @@ document.addEventListener('visibilitychange', () => {
 // Initial load: always do one refresh so the list populates, then only keep
 // polling if the freshly-loaded data shows a live run.
 (async () => {
+  await repairStaleRuns().catch(() => []);
   await refresh();
   if (initialRunId && await ensureRunLoaded(initialRunId)) {
     selectedRunId = initialRunId;

--- a/src/chrome/src/ui/traces.js
+++ b/src/chrome/src/ui/traces.js
@@ -5,7 +5,7 @@
 
 import {
   listRuns, getRun, getRunEvents, getScreenshot,
-  deleteRun, clearAllRuns,
+  deleteRun, clearAllRuns, repairStaleRuns,
 } from '../trace/recorder.js';
 import { isKnownKind, isIgnorableKind } from '../trace/event-model.js';
 import { t } from './i18n.js';
@@ -67,6 +67,7 @@ function formatCost(value) {
 
 async function refresh() {
   const requestId = ++traceRefreshRequestId;
+  if (typeof repairStaleRuns === 'function') await repairStaleRuns().catch(() => []);
   const runs = await listRuns({ limit: 500 });
   if (requestId !== traceRefreshRequestId) return;
   allRuns = runs;

--- a/src/firefox/src/background.js
+++ b/src/firefox/src/background.js
@@ -100,7 +100,11 @@ import {
 const providerManager = new ProviderManager();
 const apocalypseController = createApocalypseController(browser);
 let emergencyDownloads = null;
-void workflowTrace.repairStaleRuns().catch(() => {});
+// The stale-run repair scan waits a beat after wake so a run resuming from
+// eviction registers its in-memory state first; the Traces page can also
+// request an immediate scan via WB_TRACE_REPAIR_STALE_RUNS.
+const TRACE_REPAIR_STARTUP_DELAY_MS = 15_000;
+setTimeout(() => { void workflowTrace.repairStaleRuns().catch(() => {}); }, TRACE_REPAIR_STARTUP_DELAY_MS);
 
 function emergencyDownloadController() {
   if (!emergencyDownloads) {
@@ -1260,6 +1264,16 @@ async function handleContextMenuAsk(info, tab) {
 
 getContextMenuApi()?.onClicked?.addListener?.((info, tab) => {
   handleContextMenuAsk(info, tab).catch(() => {});
+});
+
+// Only this instance knows which runs are live in memory, so it owns the
+// stale-run repair whenever it is reachable.
+browser.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
+  if (msg?.type !== 'WB_TRACE_REPAIR_STALE_RUNS') return;
+  workflowTrace.repairStaleRuns()
+    .then(repaired => sendResponse({ ok: true, repaired }))
+    .catch(error => sendResponse({ ok: false, error: error?.message || String(error) }));
+  return true;
 });
 
 browser.runtime.onMessage.addListener((msg, _sender, sendResponse) => {

--- a/src/firefox/src/background.js
+++ b/src/firefox/src/background.js
@@ -100,6 +100,7 @@ import {
 const providerManager = new ProviderManager();
 const apocalypseController = createApocalypseController(browser);
 let emergencyDownloads = null;
+void workflowTrace.repairStaleRuns().catch(() => {});
 
 function emergencyDownloadController() {
   if (!emergencyDownloads) {

--- a/src/firefox/src/trace/error-codes.js
+++ b/src/firefox/src/trace/error-codes.js
@@ -23,6 +23,7 @@ export const ERROR_CODES = Object.freeze([
   'TRANSPORT',
   'TOOL_TIMEOUT',
   'COST_LIMIT',
+  'SERVICE_WORKER_EVICTED',
   'UNKNOWN',
 ]);
 

--- a/src/firefox/src/trace/recorder.js
+++ b/src/firefox/src/trace/recorder.js
@@ -4,6 +4,11 @@ import { formatErrorMessage } from '../error-format.js';
 import { TRACE_FORMAT_VERSION, makeEvent } from './event-model.js';
 import { normalizeErrorCode } from './error-codes.js';
 import { normalizeRunHeader, effectiveDelegationDepth } from './run-header.js';
+import {
+  buildTraceRepairPlan,
+  isStaleRunningTrace,
+  TRACE_REPAIR_STALE_AFTER_MS,
+} from './repair.js';
 
 /**
  * Trace recorder — writes per-run traces (LLM requests/responses, tool calls,
@@ -120,6 +125,47 @@ async function _peekSeq(db, runId) {
     cursor.onerror = () => resolve(0);
   });
   return result;
+}
+
+function _repairRunInTransaction(db, runId, { now, staleAfterMs }) {
+  return new Promise((resolve, reject) => {
+    const transaction = tx(db, ['runs', 'events'], 'readwrite');
+    const runsStore = transaction.objectStore('runs');
+    const eventsStore = transaction.objectStore('events');
+    let run = null;
+    let events = null;
+    let pending = 2;
+    let repairedRunId = null;
+    let requestError = null;
+
+    const fail = (error) => {
+      requestError = error || new Error('trace repair request failed');
+      try { transaction.abort(); } catch {}
+    };
+    const apply = () => {
+      pending -= 1;
+      if (pending > 0 || requestError) return;
+      const plan = buildTraceRepairPlan(run, events, { now, staleAfterMs });
+      if (!plan) return;
+      for (const event of plan.events) eventsStore.put(event);
+      runsStore.put(plan.run);
+      repairedRunId = runId;
+    };
+
+    transaction.oncomplete = () => resolve(repairedRunId);
+    transaction.onerror = () => reject(requestError || transaction.error || new Error('trace repair failed'));
+    transaction.onabort = () => {
+      if (requestError) reject(requestError);
+      else if (!repairedRunId) resolve(null);
+    };
+
+    const runRequest = runsStore.get(runId);
+    runRequest.onsuccess = () => { run = runRequest.result || null; apply(); };
+    runRequest.onerror = () => fail(runRequest.error);
+    const eventsRequest = eventsStore.index('runId').getAll(IDBKeyRange.only(runId));
+    eventsRequest.onsuccess = () => { events = eventsRequest.result || []; apply(); };
+    eventsRequest.onerror = () => fail(eventsRequest.error);
+  });
 }
 
 function _newSeq(runId) {
@@ -477,6 +523,40 @@ export async function endRun(runId, { status = 'done', finalContent = null } = {
   } finally {
     _runState.delete(runId);
     _runWriteQueues.delete(runId);
+  }
+}
+
+/**
+ * Repair trace records left running after a service-worker eviction. Each run
+ * is re-read and updated in one transaction so a concurrent normal completion
+ * wins, and a second repair pass cannot append duplicate terminal events.
+ */
+export async function repairStaleRuns({
+  now = Date.now(),
+  staleAfterMs = TRACE_REPAIR_STALE_AFTER_MS,
+} = {}) {
+  if (typeof indexedDB === 'undefined') return [];
+  try {
+    const db = await openDB();
+    const candidates = await listRuns({ limit: Number.MAX_SAFE_INTEGER });
+    const repaired = [];
+    for (const candidate of candidates) {
+      if (!isStaleRunningTrace(candidate, { now, staleAfterMs })) continue;
+      // A live run in this background instance is still owned by the agent.
+      // The durable marker handles races from another extension page.
+      if (_runState.has(candidate.runId)) continue;
+      await _flushRunWrites(candidate.runId);
+      try {
+        const repairedRunId = await _repairRunInTransaction(db, candidate.runId, { now, staleAfterMs });
+        if (repairedRunId) repaired.push(repairedRunId);
+      } catch (e) {
+        console.warn('[trace] stale-run repair failed:', e);
+      }
+    }
+    return repaired;
+  } catch (e) {
+    console.warn('[trace] stale-run scan failed:', e);
+    return [];
   }
 }
 

--- a/src/firefox/src/trace/recorder.js
+++ b/src/firefox/src/trace/recorder.js
@@ -7,6 +7,7 @@ import { normalizeRunHeader, effectiveDelegationDepth } from './run-header.js';
 import {
   buildTraceRepairPlan,
   isStaleRunningTrace,
+  normalizedThreshold,
   TRACE_REPAIR_STALE_AFTER_MS,
 } from './repair.js';
 
@@ -147,6 +148,9 @@ function _repairRunInTransaction(db, runId, { now, staleAfterMs }) {
       if (pending > 0 || requestError) return;
       const plan = buildTraceRepairPlan(run, events, { now, staleAfterMs });
       if (!plan) return;
+      // Last-instant liveness check: a run resumed between the candidate scan
+      // and this transaction has registered itself in memory again.
+      if (_runState.has(runId)) return;
       for (const event of plan.events) eventsStore.put(event);
       runsStore.put(plan.run);
       repairedRunId = runId;
@@ -531,14 +535,36 @@ export async function endRun(runId, { status = 'done', finalContent = null } = {
  * is re-read and updated in one transaction so a concurrent normal completion
  * wins, and a second repair pass cannot append duplicate terminal events.
  */
+async function _listStaleRunCandidates(db, cutoff) {
+  // Only runs old enough to be stale can qualify (last activity is never
+  // older than startedAt), so scan just that slice of the startedAt index
+  // instead of every run on record.
+  const out = [];
+  await new Promise((resolve, reject) => {
+    const idx = tx(db, ['runs'], 'readonly').objectStore('runs').index('startedAt');
+    const req = idx.openCursor(IDBKeyRange.upperBound(cutoff));
+    req.onsuccess = () => {
+      const c = req.result;
+      if (!c) return resolve();
+      const row = c.value;
+      if (row?.status === 'running' && !row.repairedBy) out.push(row);
+      c.continue();
+    };
+    req.onerror = () => reject(req.error || new Error('stale-run scan failed'));
+  });
+  return out;
+}
+
 export async function repairStaleRuns({
   now = Date.now(),
   staleAfterMs = TRACE_REPAIR_STALE_AFTER_MS,
 } = {}) {
   if (typeof indexedDB === 'undefined') return [];
+  if (!Number.isFinite(Number(now))) return [];
   try {
     const db = await openDB();
-    const candidates = await listRuns({ limit: Number.MAX_SAFE_INTEGER });
+    const cutoff = Number(now) - normalizedThreshold(staleAfterMs);
+    const candidates = await _listStaleRunCandidates(db, cutoff);
     const repaired = [];
     for (const candidate of candidates) {
       if (!isStaleRunningTrace(candidate, { now, staleAfterMs })) continue;

--- a/src/firefox/src/trace/repair.js
+++ b/src/firefox/src/trace/repair.js
@@ -41,12 +41,20 @@ function normalizedThreshold(value) {
   return Number.isFinite(Number(value)) ? Math.max(0, Number(value)) : TRACE_REPAIR_STALE_AFTER_MS;
 }
 
-export function isStaleRunningTrace(run, { now = Date.now(), staleAfterMs = TRACE_REPAIR_STALE_AFTER_MS } = {}) {
+export function isStaleRunningTrace(run, {
+  now = Date.now(),
+  staleAfterMs = TRACE_REPAIR_STALE_AFTER_MS,
+  events = [],
+} = {}) {
   if (!run || run.status !== 'running' || run.repairedBy) return false;
-  const startedAt = Number(run.startedAt);
   const currentTime = Number(now);
-  if (!Number.isFinite(startedAt) || !Number.isFinite(currentTime)) return false;
-  return currentTime - startedAt >= normalizedThreshold(staleAfterMs);
+  let lastActivityAt = Number(run.startedAt);
+  if (!Number.isFinite(lastActivityAt) || !Number.isFinite(currentTime)) return false;
+  for (const event of Array.isArray(events) ? events : []) {
+    const eventTime = Number(event?.ts);
+    if (Number.isFinite(eventTime)) lastActivityAt = Math.max(lastActivityAt, eventTime);
+  }
+  return currentTime - lastActivityAt >= normalizedThreshold(staleAfterMs);
 }
 
 /**
@@ -60,11 +68,11 @@ export function buildTraceRepairPlan(run, events, {
   now = Date.now(),
   staleAfterMs = TRACE_REPAIR_STALE_AFTER_MS,
 } = {}) {
-  if (!isStaleRunningTrace(run, { now, staleAfterMs })) return null;
   const orderedEvents = (Array.isArray(events) ? events : [])
     .filter(Boolean)
     .slice()
     .sort((a, b) => (Number(a.seq) || 0) - (Number(b.seq) || 0));
+  if (!isStaleRunningTrace(run, { now, staleAfterMs, events: orderedEvents })) return null;
   const lastSeq = orderedEvents.reduce((max, event) => Math.max(max, Number(event.seq) || 0), 0);
   const code = normalizeErrorCode(TRACE_REPAIR_ERROR_CODE);
   const repairedEvents = [];

--- a/src/firefox/src/trace/repair.js
+++ b/src/firefox/src/trace/repair.js
@@ -1,0 +1,116 @@
+import { makeEvent } from './event-model.js';
+import { normalizeErrorCode } from './error-codes.js';
+
+// A run can legitimately take a while, so repair only treats records older
+// than this conservative window as abandoned. Callers/tests may provide a
+// smaller explicit threshold when they need a deterministic boundary.
+export const TRACE_REPAIR_STALE_AFTER_MS = 10 * 60 * 1000;
+export const TRACE_REPAIR_MARKER = 'service-worker-eviction';
+export const TRACE_REPAIR_ERROR_CODE = 'SERVICE_WORKER_EVICTED';
+export const TRACE_REPAIR_REASON = 'service_worker_eviction';
+export const TRACE_REPAIR_MESSAGE = 'Trace run interrupted by service-worker eviction.';
+
+function repairEvent(runId, seq, kind, data, now) {
+  const event = makeEvent(runId, seq, kind, data);
+  return event ? { ...event, ts: now } : null;
+}
+
+function eventStep(event) {
+  return Number.isInteger(event?.data?.step) ? event.data.step : null;
+}
+
+function openSteps(events) {
+  const open = new Map();
+  for (const event of events) {
+    if (event?.kind === 'step_start') open.set(eventStep(event), eventStep(event));
+    if (event?.kind === 'step_end') open.delete(eventStep(event));
+  }
+  return [...open.values()].sort((a, b) => (a ?? 0) - (b ?? 0));
+}
+
+function openTurnStep(events) {
+  let step = null;
+  for (const event of events) {
+    if (event?.kind === 'turn_start') step = eventStep(event);
+    if (event?.kind === 'turn_end') step = null;
+  }
+  return step;
+}
+
+function normalizedThreshold(value) {
+  return Number.isFinite(Number(value)) ? Math.max(0, Number(value)) : TRACE_REPAIR_STALE_AFTER_MS;
+}
+
+export function isStaleRunningTrace(run, { now = Date.now(), staleAfterMs = TRACE_REPAIR_STALE_AFTER_MS } = {}) {
+  if (!run || run.status !== 'running' || run.repairedBy) return false;
+  const startedAt = Number(run.startedAt);
+  const currentTime = Number(now);
+  if (!Number.isFinite(startedAt) || !Number.isFinite(currentTime)) return false;
+  return currentTime - startedAt >= normalizedThreshold(staleAfterMs);
+}
+
+/**
+ * Build the durable repair mutation for one abandoned trace.
+ *
+ * This is deliberately pure: the recorder applies the returned event/run
+ * values in one IndexedDB transaction, while tests can prove the interruption
+ * semantics without a browser or a real IndexedDB implementation.
+ */
+export function buildTraceRepairPlan(run, events, {
+  now = Date.now(),
+  staleAfterMs = TRACE_REPAIR_STALE_AFTER_MS,
+} = {}) {
+  if (!isStaleRunningTrace(run, { now, staleAfterMs })) return null;
+  const orderedEvents = (Array.isArray(events) ? events : [])
+    .filter(Boolean)
+    .slice()
+    .sort((a, b) => (Number(a.seq) || 0) - (Number(b.seq) || 0));
+  const lastSeq = orderedEvents.reduce((max, event) => Math.max(max, Number(event.seq) || 0), 0);
+  const code = normalizeErrorCode(TRACE_REPAIR_ERROR_CODE);
+  const repairedEvents = [];
+  let nextSeq = lastSeq + 1;
+
+  for (const step of openSteps(orderedEvents)) {
+    repairedEvents.push(repairEvent(run.runId, nextSeq++, 'step_end', {
+      step,
+      ok: false,
+      reason: TRACE_REPAIR_REASON,
+      code,
+      repaired: true,
+    }, now));
+  }
+
+  repairedEvents.push(repairEvent(run.runId, nextSeq++, 'error', {
+    step: null,
+    phase: 'repair',
+    message: TRACE_REPAIR_MESSAGE,
+    code,
+  }, now));
+
+  const turnStep = openTurnStep(orderedEvents);
+  if (turnStep !== null) {
+    repairedEvents.push(repairEvent(run.runId, nextSeq, 'turn_end', {
+      step: turnStep,
+      status: 'error',
+      reason: TRACE_REPAIR_REASON,
+      code,
+      repaired: true,
+    }, now));
+  }
+
+  const maxStep = orderedEvents.reduce((max, event) => Math.max(max, eventStep(event) ?? 0), 0);
+  const startedAt = Number(run.startedAt);
+  return {
+    events: repairedEvents.filter(Boolean),
+    run: {
+      ...run,
+      endedAt: now,
+      durationMs: Math.max(0, now - startedAt),
+      status: 'error',
+      stepCount: Math.max(Number(run.stepCount) || 0, maxStep),
+      repairedBy: TRACE_REPAIR_MARKER,
+      repairedAt: now,
+      repairReason: TRACE_REPAIR_REASON,
+    },
+  };
+}

--- a/src/firefox/src/trace/repair.js
+++ b/src/firefox/src/trace/repair.js
@@ -37,7 +37,7 @@ function openTurnStep(events) {
   return step;
 }
 
-function normalizedThreshold(value) {
+export function normalizedThreshold(value) {
   return Number.isFinite(Number(value)) ? Math.max(0, Number(value)) : TRACE_REPAIR_STALE_AFTER_MS;
 }
 

--- a/src/firefox/src/ui/traces.js
+++ b/src/firefox/src/ui/traces.js
@@ -11,6 +11,8 @@ import { isKnownKind, isIgnorableKind } from '../trace/event-model.js';
 import { t } from './i18n.js';
 import { escapeHtml, escapeAttr } from './utils.js';
 
+const runtimeApi = globalThis.browser || globalThis.chrome;
+
 const listEl = document.getElementById('run-list');
 const mainPane = document.getElementById('main-pane');
 const emptyState = document.getElementById('empty-state');
@@ -645,10 +647,31 @@ document.addEventListener('visibilitychange', () => {
   else if (hasRunningJob()) scheduleAutoRefresh();
 });
 
+// Prefer letting the background own the stale-run scan: only its recorder
+// instance knows which runs are live in memory. If it cannot be reached,
+// nothing can be running anywhere, so a local pass is safe.
+async function repairStaleRunsForPage({ timeoutMs = 5_000 } = {}) {
+  let timer;
+  try {
+    if (runtimeApi?.runtime?.sendMessage) {
+      const response = await Promise.race([
+        runtimeApi.runtime.sendMessage({ type: 'WB_TRACE_REPAIR_STALE_RUNS' }),
+        new Promise((_resolve, reject) => {
+          timer = setTimeout(() => reject(new Error('trace repair roundtrip timed out')), timeoutMs);
+        }),
+      ]);
+      if (response?.ok) return Array.isArray(response.repaired) ? response.repaired : [];
+    }
+  } catch {} finally {
+    clearTimeout(timer);
+  }
+  return repairStaleRuns().catch(() => []);
+}
+
 // Initial load: always do one refresh so the list populates, then only keep
 // polling if the freshly-loaded data shows a live run.
 (async () => {
-  await repairStaleRuns().catch(() => []);
+  await repairStaleRunsForPage();
   await refresh();
   if (initialRunId && await ensureRunLoaded(initialRunId)) {
     selectedRunId = initialRunId;

--- a/src/firefox/src/ui/traces.js
+++ b/src/firefox/src/ui/traces.js
@@ -67,7 +67,6 @@ function formatCost(value) {
 
 async function refresh() {
   const requestId = ++traceRefreshRequestId;
-  if (typeof repairStaleRuns === 'function') await repairStaleRuns().catch(() => []);
   const runs = await listRuns({ limit: 500 });
   if (requestId !== traceRefreshRequestId) return;
   allRuns = runs;
@@ -649,6 +648,7 @@ document.addEventListener('visibilitychange', () => {
 // Initial load: always do one refresh so the list populates, then only keep
 // polling if the freshly-loaded data shows a live run.
 (async () => {
+  await repairStaleRuns().catch(() => []);
   await refresh();
   if (initialRunId && await ensureRunLoaded(initialRunId)) {
     selectedRunId = initialRunId;

--- a/src/firefox/src/ui/traces.js
+++ b/src/firefox/src/ui/traces.js
@@ -5,7 +5,7 @@
 
 import {
   listRuns, getRun, getRunEvents, getScreenshot,
-  deleteRun, clearAllRuns,
+  deleteRun, clearAllRuns, repairStaleRuns,
 } from '../trace/recorder.js';
 import { isKnownKind, isIgnorableKind } from '../trace/event-model.js';
 import { t } from './i18n.js';
@@ -67,6 +67,7 @@ function formatCost(value) {
 
 async function refresh() {
   const requestId = ++traceRefreshRequestId;
+  if (typeof repairStaleRuns === 'function') await repairStaleRuns().catch(() => []);
   const runs = await listRuns({ limit: 500 });
   if (requestId !== traceRefreshRequestId) return;
   allRuns = runs;

--- a/test/run.js
+++ b/test/run.js
@@ -9254,8 +9254,14 @@ test('trace repair: recorder and browser entry points apply the repair transacti
     assert.match(recorder, /for \(const event of plan\.events\) eventsStore\.put\(event\);/, `${browser}: repair events are not persisted`);
     assert.match(recorder, /runsStore\.put\(plan\.run\);/, `${browser}: repaired run is not persisted`);
     assert.match(recorder, /export async function repairStaleRuns\(/, `${browser}: stale-run scan is not exported`);
-    assert.match(background, /void workflowTrace\.repairStaleRuns\(\)\.catch\(\(\) => \{\}\);/, `${browser}: background startup does not scan stale runs`);
-    assert.match(traces, /\(async \(\) => \{\s*await repairStaleRuns\(\)\.catch\(\(\) => \[\]\);\s*await refresh\(\);/, `${browser}: Traces page does not repair before its first list load`);
+    // Candidate scan must be bounded to the possibly-stale slice of history
+    // and re-check in-memory liveness at the last instant before writing.
+    assert.match(recorder, /index\('startedAt'\)[\s\S]*?openCursor\(IDBKeyRange\.upperBound\(cutoff\)\)/, `${browser}: stale-run scan must not walk the full runs store`);
+    assert.match(recorder, /if \(_runState\.has\(runId\)\) return;\n\s*for \(const event of plan\.events\)/, `${browser}: repair must re-check live runs before writing`);
+    assert.match(background, /setTimeout\(\(\) => \{ void workflowTrace\.repairStaleRuns\(\)\.catch\(\(\) => \{\}\); \}, TRACE_REPAIR_STARTUP_DELAY_MS\)/, `${browser}: background startup must defer the stale-run scan`);
+    assert.match(background, /WB_TRACE_REPAIR_STALE_RUNS[\s\S]*?workflowTrace\.repairStaleRuns\(\)/, `${browser}: background does not answer the traces-page repair request`);
+    assert.match(traces, /\(async \(\) => \{\s*await repairStaleRunsForPage\(\);\s*await refresh\(\);/, `${browser}: Traces page does not route its first repair through the background`);
+    assert.match(traces, /WB_TRACE_REPAIR_STALE_RUNS[\s\S]*?return repairStaleRuns\(\)\.catch\(\(\) => \[\]\);/, `${browser}: Traces page lost its local fallback for when the background is unreachable`);
   }
 });
 

--- a/test/run.js
+++ b/test/run.js
@@ -9211,6 +9211,7 @@ test('trace repair: stale interrupted runs receive one ordered terminal repair',
 
 test('trace repair: ignores recent and already repaired runs, with mirrored helpers', () => {
   const recent = { runId: 'recent', startedAt: 95_000, status: 'running' };
+  const activeLongRun = { runId: 'active_long', startedAt: 1_000, status: 'running' };
   const repaired = {
     runId: 'repaired',
     startedAt: 1_000,
@@ -9222,6 +9223,13 @@ test('trace repair: ignores recent and already repaired runs, with mirrored help
       repair.buildTraceRepairPlan(recent, [], { now: 100_000, staleAfterMs: 60_000 }),
       null,
       `${label}: recent runs must remain eligible for normal completion`,
+    );
+    assert.equal(
+      repair.buildTraceRepairPlan(activeLongRun, [
+        { runId: activeLongRun.runId, seq: 1, ts: 95_000, kind: 'step_start', data: { step: 1 } },
+      ], { now: 100_000, staleAfterMs: 60_000 }),
+      null,
+      `${label}: recent durable activity must protect a long-running active trace`,
     );
     assert.equal(
       repair.buildTraceRepairPlan(repaired, [], { now: 100_000, staleAfterMs: 60_000 }),

--- a/test/run.js
+++ b/test/run.js
@@ -9247,7 +9247,7 @@ test('trace repair: recorder and browser entry points apply the repair transacti
     assert.match(recorder, /runsStore\.put\(plan\.run\);/, `${browser}: repaired run is not persisted`);
     assert.match(recorder, /export async function repairStaleRuns\(/, `${browser}: stale-run scan is not exported`);
     assert.match(background, /void workflowTrace\.repairStaleRuns\(\)\.catch\(\(\) => \{\}\);/, `${browser}: background startup does not scan stale runs`);
-    assert.match(traces, /if \(typeof repairStaleRuns === 'function'\) await repairStaleRuns\(\)\.catch\(\(\) => \[\]\);/, `${browser}: Traces page does not start repair`);
+    assert.match(traces, /\(async \(\) => \{\s*await repairStaleRuns\(\)\.catch\(\(\) => \[\]\);\s*await refresh\(\);/, `${browser}: Traces page does not repair before its first list load`);
   }
 });
 

--- a/test/run.js
+++ b/test/run.js
@@ -8106,6 +8106,8 @@ console.log('\ntrace event model');
 
 const EVENT_MODEL_CH = await import('file://' + path.join(ROOT, 'src/chrome/src/trace/event-model.js').replace(/\\/g, '/'));
 const EVENT_MODEL_FX = await import('file://' + path.join(ROOT, 'src/firefox/src/trace/event-model.js').replace(/\\/g, '/'));
+const TRACE_REPAIR_CH = await import('file://' + path.join(ROOT, 'src/chrome/src/trace/repair.js').replace(/\\/g, '/'));
+const TRACE_REPAIR_FX = await import('file://' + path.join(ROOT, 'src/firefox/src/trace/repair.js').replace(/\\/g, '/'));
 const CLOUD_RUNTIME_OUTBOX_CH = await import('file://' + path.join(ROOT, 'src/chrome/src/trace/cloud-runtime-outbox.js').replace(/\\/g, '/'));
 const CLOUD_RUNTIME_OUTBOX_FX = await import('file://' + path.join(ROOT, 'src/firefox/src/trace/cloud-runtime-outbox.js').replace(/\\/g, '/'));
 
@@ -9144,6 +9146,7 @@ test('trace error codes: catalog is stable and normalizeErrorCode bounds the val
   assert.equal(normalizeErrorCode('NOT_A_CODE'), 'UNKNOWN', 'unknown code must normalize to UNKNOWN');
   assert.equal(normalizeErrorCode(null), 'UNKNOWN', 'null code must normalize to UNKNOWN');
   assert.equal(normalizeErrorCode(undefined), 'UNKNOWN', 'missing code must normalize to UNKNOWN');
+  assert.equal(isErrorCode('SERVICE_WORKER_EVICTED'), true, 'service-worker interruption needs a stable repair code');
   assert.deepEqual(ERROR_CODES_FX.ERROR_CODES, ERROR_CODES, 'Firefox code catalog drifted');
 });
 
@@ -9153,6 +9156,99 @@ test('trace error codes: mirrors are identical and browser-neutral', () => {
   assert.equal(chromeSource, firefoxSource, 'Chrome/Firefox error codes drifted');
   assert.doesNotMatch(chromeSource, /chrome\./, 'error codes must not depend on chrome APIs');
   assert.doesNotMatch(chromeSource, /indexedDB|storage\./, 'error codes must not touch storage');
+});
+
+test('trace repair: stale interrupted runs receive one ordered terminal repair', () => {
+  const run = {
+    runId: 'run_interrupted',
+    startedAt: 1_000,
+    status: 'running',
+    stepCount: 1,
+    finalContent: null,
+  };
+  const events = [
+    { runId: run.runId, seq: 1, kind: 'turn_start', data: { step: 0 } },
+    { runId: run.runId, seq: 2, kind: 'step_start', data: { step: 1 } },
+    { runId: run.runId, seq: 3, kind: 'llm_request', data: { step: 1 } },
+  ];
+  const plan = TRACE_REPAIR_CH.buildTraceRepairPlan(run, events, {
+    now: 100_000,
+    staleAfterMs: 60_000,
+  });
+
+  assert.ok(plan, 'an old running run must produce a repair plan');
+  assert.deepEqual(
+    plan.events.map((event) => [event.seq, event.kind]),
+    [[4, 'step_end'], [5, 'error'], [6, 'turn_end']],
+    'repair events must continue the existing sequence and close open lifecycle events',
+  );
+  assert.deepEqual(plan.events[0].data, {
+    step: 1,
+    ok: false,
+    reason: 'service_worker_eviction',
+    code: 'SERVICE_WORKER_EVICTED',
+    repaired: true,
+  });
+  assert.deepEqual(plan.events[1].data, {
+    step: null,
+    phase: 'repair',
+    message: 'Trace run interrupted by service-worker eviction.',
+    code: 'SERVICE_WORKER_EVICTED',
+  });
+  assert.deepEqual(plan.events[2].data, {
+    step: 0,
+    status: 'error',
+    reason: 'service_worker_eviction',
+    code: 'SERVICE_WORKER_EVICTED',
+    repaired: true,
+  });
+  assert.equal(plan.run.status, 'error', 'repaired run must no longer be running');
+  assert.equal(plan.run.endedAt, 100_000);
+  assert.equal(plan.run.durationMs, 99_000);
+  assert.equal(plan.run.repairedBy, 'service-worker-eviction');
+  assert.equal(plan.run.repairedAt, 100_000);
+});
+
+test('trace repair: ignores recent and already repaired runs, with mirrored helpers', () => {
+  const recent = { runId: 'recent', startedAt: 95_000, status: 'running' };
+  const repaired = {
+    runId: 'repaired',
+    startedAt: 1_000,
+    status: 'error',
+    repairedBy: 'service-worker-eviction',
+  };
+  for (const [label, repair] of [['chrome', TRACE_REPAIR_CH], ['firefox', TRACE_REPAIR_FX]]) {
+    assert.equal(
+      repair.buildTraceRepairPlan(recent, [], { now: 100_000, staleAfterMs: 60_000 }),
+      null,
+      `${label}: recent runs must remain eligible for normal completion`,
+    );
+    assert.equal(
+      repair.buildTraceRepairPlan(repaired, [], { now: 100_000, staleAfterMs: 60_000 }),
+      null,
+      `${label}: repaired runs must be idempotent`,
+    );
+  }
+  assert.equal(
+    fs.readFileSync(path.join(ROOT, 'src/chrome/src/trace/repair.js'), 'utf8'),
+    fs.readFileSync(path.join(ROOT, 'src/firefox/src/trace/repair.js'), 'utf8'),
+    'Chrome and Firefox repair helpers must remain mirrored',
+  );
+});
+
+test('trace repair: recorder and browser entry points apply the repair transaction', () => {
+  for (const browser of ['chrome', 'firefox']) {
+    const recorder = fs.readFileSync(path.join(ROOT, `src/${browser}/src/trace/recorder.js`), 'utf8');
+    const background = fs.readFileSync(path.join(ROOT, `src/${browser}/src/background.js`), 'utf8');
+    const traces = fs.readFileSync(path.join(ROOT, `src/${browser}/src/ui/traces.js`), 'utf8');
+    assert.match(recorder, /import \{[\s\S]*?buildTraceRepairPlan[\s\S]*?from '\.\/repair\.js';/, `${browser}: recorder repair import missing`);
+    assert.match(recorder, /const transaction = tx\(db, \['runs', 'events'\], 'readwrite'\)/, `${browser}: repair must share one atomic transaction`);
+    assert.match(recorder, /for \(const event of plan\.events\) eventsStore\.put\(event\);/, `${browser}: repair events are not persisted`);
+    assert.match(recorder, /runsStore\.put\(plan\.run\);/, `${browser}: repaired run is not persisted`);
+    assert.match(recorder, /export async function repairStaleRuns\(/, `${browser}: stale-run scan is not exported`);
+    assert.match(background, /void workflowTrace\.repairStaleRuns\(\)\.catch\(\(\) => \{\}\);/, `${browser}: background startup does not scan stale runs`);
+    assert.match(traces, /if \(typeof repairStaleRuns === 'function'\) await repairStaleRuns\(\)\.catch\(\(\) => \[\]\);/, `${browser}: Traces page does not start repair`);
+  }
 });
 
 test('agent trace error classification: _traceErrorCodeFor maps failures to stable codes', () => {


### PR DESCRIPTION
## Summary

- Repair stale trace runs left in `running` after a service-worker eviction.
- Append ordered, content-free structured interruption evidence and close any open step/turn lifecycle events.
- Apply the same behavior to Chrome and Firefox, from background startup and when the Traces page opens.

## Motivation

The recorder can persist a running run before the service worker is evicted, while the in-memory `endRun()` call is lost. The run then remains permanently `running`, even though its event sequence can still be recovered.

Closes #2888

## Design

- Scan durable runs with a conservative 10-minute stale threshold; recent runs remain untouched.
- Re-read each candidate and apply the repair plan in one `runs` + `events` IndexedDB transaction.
- Continue from the maximum durable event sequence, append `step_end`/`error`/`turn_end` evidence as applicable, and mark the run with `repairedBy` and `repairReason`.
- Reuse the existing event model and add the stable `SERVICE_WORKER_EVICTED` error code. No new event kind or trace schema migration is introduced.
- Keep Chrome and Firefox implementations mirrored.

## Testing

- `node test/run.js` — 1987 passed, 0 failed
- `npm run test:toolbar-guard` — 33 passed
- `npm run test:security` — 60/60 passed
- Node syntax checks for all touched JavaScript files — passed
- `node scripts/benchmark-offline-relevance.mjs` — completed successfully
- Manual Chrome unpacked-extension smoke test: extension loaded, Traces opened, Refresh clicked, no console/page errors

## Compatibility and risks

- Additive run metadata and error code only; existing completed traces are not modified.
- Default tracing behavior and privacy filtering are unchanged; repair events contain no user content.
- The 10-minute threshold intentionally protects recent runs, using the latest durable event timestamp as activity evidence. A run that stays completely quiet for longer than the threshold remains the intended repair candidate; the same service-worker instance is additionally protected by its in-memory active-run state.
- Firefox was covered by mirrored source, parity tests, syntax checks, and the shared unit suite; manual Firefox browser verification was not run.
