### PR TITLE
feat(trace): add step trajectory table

### DIFF
--- a/src/chrome/src/trace/trajectory.js
+++ b/src/chrome/src/trace/trajectory.js
@@ -70,18 +70,23 @@ function addError(row, data) {
   row.status = 'error';
 }
 
+// Only failure-shaped end payloads mark the row as errored. Every other end
+// payload closes its row as done because a recorded end event terminates the
+// step/run by definition; the agent emits terminal statuses that are not
+// enumerated here (scheduled_resume, read_scope_limited,
+// clarification_required, delivery-recovery fallbacks), and listing them
+// would only drift out of sync with agent.js.
+const FAILED_END_STATUSES = [
+  'error', 'loop_stopped', 'max_steps', 'cancelled', 'cost_limit',
+  'plan_only_output', 'incomplete_output', 'empty_output',
+  'placeholder_output', 'required_tool_missing', 'grounding_unavailable',
+  'captcha_manual_required',
+];
+
 function markEnd(row, data) {
-  const failedStatuses = [
-    'error', 'loop_stopped', 'max_steps', 'cancelled', 'cost_limit',
-    'plan_only_output', 'incomplete_output', 'empty_output',
-    'placeholder_output', 'required_tool_missing', 'grounding_unavailable',
-    'captcha_manual_required',
-  ];
-  const failed = data?.ok === false || failedStatuses.includes(data?.status);
+  const failed = data?.ok === false || FAILED_END_STATUSES.includes(data?.status);
   if (failed) row.status = 'error';
-  else if (data?.ok === true || data?.status === 'done') {
-    if (row.status !== 'error') row.status = 'done';
-  }
+  else if (row.status !== 'error') row.status = 'done';
   if (data?.code && failed) addUnique(row.errorCodes, data.code, MAX_ERRORS);
   if (data?.repaired === true) row.repaired = true;
 }

--- a/src/chrome/src/trace/trajectory.js
+++ b/src/chrome/src/trace/trajectory.js
@@ -1,0 +1,141 @@
+/**
+ * Build compact step rows from the trace event log.
+ *
+ * The Traces UI owns presentation; this browser-neutral module owns the
+ * durable event-to-step interpretation so Chrome, Firefox, and tests share
+ * one lifecycle contract. Missing lifecycle events remain `unknown` rather
+ * than being guessed from a response payload.
+ */
+
+const MAX_TOOL_NAMES = 8;
+const MAX_ERRORS = 8;
+
+function eventStep(event) {
+  if (event?.kind === 'turn_start' || event?.kind === 'turn_end') return null;
+  return Number.isInteger(event?.data?.step) ? event.data.step : null;
+}
+
+function eventTime(event) {
+  const value = Number(event?.ts);
+  return Number.isFinite(value) ? value : null;
+}
+
+function numeric(value) {
+  const number = Number(value);
+  return Number.isFinite(number) ? number : 0;
+}
+
+function ensureRow(rows, step) {
+  if (!rows.has(step)) {
+    rows.set(step, {
+      step,
+      status: 'unknown',
+      startedAt: null,
+      endedAt: null,
+      durationMs: null,
+      requestCount: 0,
+      responseCount: 0,
+      toolCount: 0,
+      subCallCount: 0,
+      errorCount: 0,
+      inputTokens: 0,
+      outputTokens: 0,
+      cost: 0,
+      llmLatencyMs: 0,
+      toolLatencyMs: 0,
+      toolNames: [],
+      errorCodes: [],
+      errors: [],
+      repaired: false,
+    });
+  }
+  return rows.get(step);
+}
+
+function addUnique(list, value, limit) {
+  if (!value || list.includes(value) || list.length >= limit) return;
+  list.push(value);
+}
+
+function addError(row, data) {
+  row.errorCount += 1;
+  addUnique(row.errorCodes, data?.code, MAX_ERRORS);
+  if (row.errors.length < MAX_ERRORS) {
+    row.errors.push({
+      code: data?.code || null,
+      phase: data?.phase || null,
+      message: data?.message || '',
+    });
+  }
+  row.status = 'error';
+}
+
+function markEnd(row, data) {
+  const failedStatuses = [
+    'error', 'loop_stopped', 'max_steps', 'cancelled', 'cost_limit',
+    'plan_only_output', 'incomplete_output', 'empty_output',
+    'placeholder_output', 'required_tool_missing', 'grounding_unavailable',
+    'captcha_manual_required',
+  ];
+  const failed = data?.ok === false || failedStatuses.includes(data?.status);
+  if (failed) row.status = 'error';
+  else if (data?.ok === true || data?.status === 'done') {
+    if (row.status !== 'error') row.status = 'done';
+  }
+  if (data?.code && failed) addUnique(row.errorCodes, data.code, MAX_ERRORS);
+  if (data?.repaired === true) row.repaired = true;
+}
+
+function finalizeRow(row) {
+  if (row.startedAt != null && row.endedAt != null) {
+    row.durationMs = Math.max(0, row.endedAt - row.startedAt);
+  }
+  return row;
+}
+
+export function buildTraceTrajectory(events) {
+  const rows = new Map();
+  const orderedEvents = (Array.isArray(events) ? events : [])
+    .map((event, index) => ({ event, index }))
+    .filter(({ event }) => event)
+    .sort((a, b) => {
+      const aSeq = Number(a.event.seq);
+      const bSeq = Number(b.event.seq);
+      if (Number.isFinite(aSeq) && Number.isFinite(bSeq)) return aSeq - bSeq;
+      if (Number.isFinite(aSeq)) return -1;
+      if (Number.isFinite(bSeq)) return 1;
+      return a.index - b.index;
+    });
+
+  for (const { event } of orderedEvents) {
+    const row = ensureRow(rows, eventStep(event));
+    const ts = eventTime(event);
+    if (event.kind === 'step_start' || event.kind === 'turn_start') {
+      if (row.startedAt == null && ts != null) row.startedAt = ts;
+      if (row.status === 'unknown') row.status = 'running';
+    }
+    if (event.kind === 'step_end' || event.kind === 'turn_end') {
+      if (ts != null) row.endedAt = ts;
+      markEnd(row, event.data);
+    }
+    if (event.kind === 'llm_request') row.requestCount += 1;
+    if (event.kind === 'llm_response') {
+      row.responseCount += 1;
+      const usage = event.data?.usage;
+      row.inputTokens += numeric(usage?.prompt_tokens);
+      row.outputTokens += numeric(usage?.completion_tokens);
+      row.cost += numeric(usage?.cost);
+      row.llmLatencyMs += Math.max(0, numeric(event.data?.latencyMs));
+    }
+    if (event.kind === 'tool') {
+      row.toolCount += 1;
+      row.toolLatencyMs += Math.max(0, numeric(event.data?.latencyMs));
+      addUnique(row.toolNames, event.data?.name, MAX_TOOL_NAMES);
+    }
+    if (event.kind === 'vision_sub_call') row.subCallCount += 1;
+    if (event.kind === 'error') addError(row, event.data);
+    if (event.data?.repaired === true) row.repaired = true;
+  }
+
+  return [...rows.values()].map(finalizeRow);
+}

--- a/src/chrome/src/ui/traces.html
+++ b/src/chrome/src/ui/traces.html
@@ -293,6 +293,76 @@
       font-family: ui-monospace, monospace;
     }
 
+    /* Step trajectory */
+    .trajectory {
+      margin: 14px 0;
+      border: 1px solid var(--border);
+      border-radius: 8px;
+      background: var(--bg2);
+      overflow: hidden;
+    }
+    .trajectory-heading {
+      padding: 9px 12px;
+      border-bottom: 1px solid var(--border);
+      color: var(--text);
+      font-size: 11px;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.04em;
+    }
+    .trajectory-scroll { overflow-x: auto; }
+    .trajectory-table {
+      width: 100%;
+      min-width: 620px;
+      border-collapse: collapse;
+      font-size: 11px;
+    }
+    .trajectory-table th,
+    .trajectory-table td {
+      padding: 8px 10px;
+      border-top: 1px solid var(--border);
+      text-align: left;
+      vertical-align: top;
+    }
+    .trajectory-table thead th {
+      border-top: 0;
+      color: var(--text3);
+      font-size: 10px;
+      font-weight: 500;
+      white-space: nowrap;
+    }
+    .trajectory-table tbody th { min-width: 220px; font-weight: 500; }
+    .trajectory-row.running { background: rgba(108,99,255,0.06); }
+    .trajectory-row.error { background: rgba(239,68,68,0.08); }
+    .trajectory-step,
+    .trajectory-status,
+    .trajectory-metric {
+      color: var(--text);
+      font-family: ui-monospace, SFMono-Regular, monospace;
+    }
+    .trajectory-activity {
+      margin-top: 3px;
+      color: var(--text2);
+      line-height: 1.45;
+      word-break: break-word;
+    }
+    .trajectory-errors { margin-top: 5px; }
+    .trajectory-errors summary {
+      cursor: pointer;
+      color: var(--error);
+      font-size: 10px;
+      user-select: none;
+    }
+    .trajectory-error-details {
+      margin-top: 4px;
+      color: var(--error);
+      font-size: 10px;
+      line-height: 1.4;
+      white-space: pre-wrap;
+      word-break: break-word;
+    }
+    .trajectory.compact { margin-top: 0; }
+
     /* Timeline */
     .timeline { display: flex; flex-direction: column; gap: 6px; }
     .event {

--- a/src/chrome/src/ui/traces.js
+++ b/src/chrome/src/ui/traces.js
@@ -8,6 +8,7 @@ import {
   deleteRun, clearAllRuns, repairStaleRuns,
 } from '../trace/recorder.js';
 import { isKnownKind, isIgnorableKind } from '../trace/event-model.js';
+import { buildTraceTrajectory } from '../trace/trajectory.js';
 import { sanitizeTraceExport } from '../agent/trace-export.js';
 import { t } from './i18n.js';
 import { escapeHtml, escapeAttr } from './utils.js';
@@ -261,6 +262,80 @@ function renderConversationPanel(run, compact) {
   `;
 }
 
+function formatTrajectoryDuration(durationMs) {
+  if (!Number.isFinite(durationMs)) return '—';
+  if (durationMs < 1000) return `${Math.round(durationMs)}ms`;
+  return `${(durationMs / 1000).toFixed(1)}s`;
+}
+
+function formatTrajectoryMetric(value) {
+  return value > 0 ? value.toLocaleString() : '—';
+}
+
+function renderTrajectoryActivity(row) {
+  const parts = [];
+  if (row.requestCount) parts.push(`${escapeHtml(t('tr.event.llm_request'))} ×${row.requestCount}`);
+  if (row.responseCount) parts.push(`${escapeHtml(t('tr.event.llm_response'))} ×${row.responseCount}`);
+  if (row.toolCount) {
+    const names = row.toolNames.length ? ` · ${row.toolNames.map(name => escapeHtml(name)).join(', ')}` : '';
+    parts.push(`🔧 ×${row.toolCount}${names}`);
+  }
+  if (row.subCallCount) parts.push(`${escapeHtml(t('tr.event.vision_sub_call'))} ×${row.subCallCount}`);
+  if (row.errorCount) parts.push(`${escapeHtml(t('tr.event.error_kind'))} ×${row.errorCount}`);
+  return parts.join(' · ') || '—';
+}
+
+function renderTrajectoryErrors(row) {
+  if (!row.errors.length && !row.errorCodes.length) return '';
+  const codes = row.errorCodes.length ? ` · ${row.errorCodes.map(code => escapeHtml(code)).join(', ')}` : '';
+  const details = row.errors.map((error) => {
+    const parts = [error.code, error.phase, error.message].filter(Boolean).map(escapeHtml);
+    return parts.join(' · ');
+  });
+  if (!details.length) details.push(row.errorCodes.map(code => escapeHtml(code)).join('\n'));
+  return `<details class="trajectory-errors"><summary>${escapeHtml(t('tr.event.error_kind'))}${codes}</summary><div class="trajectory-error-details">${details.join('\n')}</div></details>`;
+}
+
+function renderStepTrajectory(events, compact) {
+  const rows = buildTraceTrajectory(events);
+  if (!rows.length) return '';
+  const tableRows = rows.map((row) => {
+    const status = safeClassToken(row.status);
+    const stepLabel = row.step == null ? '—' : row.step;
+    const cost = formatCost(row.cost) || '—';
+    return `
+      <tr class="trajectory-row ${status}" data-step="${escapeAttr(row.step == null ? 'run' : row.step)}">
+        <th scope="row">
+          <span class="trajectory-step">${escapeHtml(stepLabel)}</span>
+          <div class="trajectory-activity">${renderTrajectoryActivity(row)}</div>
+          ${renderTrajectoryErrors(row)}
+        </th>
+        <td><span class="trajectory-status">${escapeHtml(row.status)}</span>${row.repaired ? ' ↻' : ''}</td>
+        <td class="trajectory-metric">${escapeHtml(formatTrajectoryDuration(row.durationMs))}</td>
+        <td class="trajectory-metric">${escapeHtml(formatTrajectoryMetric(row.inputTokens))}</td>
+        <td class="trajectory-metric">${escapeHtml(formatTrajectoryMetric(row.outputTokens))}</td>
+        <td class="trajectory-metric">${escapeHtml(cost)}</td>
+      </tr>`;
+  }).join('');
+  return `
+    <section class="trajectory${compact ? ' compact' : ''}" aria-label="${escapeAttr(t('tr.steps.label'))}">
+      <div class="trajectory-heading">${escapeHtml(t('tr.steps.label'))}</div>
+      <div class="trajectory-scroll">
+        <table class="trajectory-table">
+          <thead><tr>
+            <th scope="col">#</th>
+            <th scope="col">${escapeHtml(t('tr.status.label'))}</th>
+            <th scope="col">${escapeHtml(t('tr.duration.label'))}</th>
+            <th scope="col">${escapeHtml(t('tr.intokens.label'))}</th>
+            <th scope="col">${escapeHtml(t('tr.outtokens.label'))}</th>
+            <th scope="col">${escapeHtml(t('tr.cost.label'))}</th>
+          </tr></thead>
+          <tbody>${tableRows}</tbody>
+        </table>
+      </div>
+    </section>`;
+}
+
 async function buildRunView(run, events, compact, objectUrls = new Set()) {
   const header = `
     <div class="run-header">
@@ -289,7 +364,7 @@ async function buildRunView(run, events, compact, objectUrls = new Set()) {
     }
   }
   const items = events.map(ev => renderEvent(ev, shotCache, compact, objectUrls)).join('');
-  return `${header}<div class="timeline">${items}</div>`;
+  return `${header}${renderStepTrajectory(events, compact)}<div class="timeline">${items}</div>`;
 }
 
 function renderEvent(ev, shotCache, compact, objectUrls = new Set()) {

--- a/src/firefox/src/trace/trajectory.js
+++ b/src/firefox/src/trace/trajectory.js
@@ -70,18 +70,23 @@ function addError(row, data) {
   row.status = 'error';
 }
 
+// Only failure-shaped end payloads mark the row as errored. Every other end
+// payload closes its row as done because a recorded end event terminates the
+// step/run by definition; the agent emits terminal statuses that are not
+// enumerated here (scheduled_resume, read_scope_limited,
+// clarification_required, delivery-recovery fallbacks), and listing them
+// would only drift out of sync with agent.js.
+const FAILED_END_STATUSES = [
+  'error', 'loop_stopped', 'max_steps', 'cancelled', 'cost_limit',
+  'plan_only_output', 'incomplete_output', 'empty_output',
+  'placeholder_output', 'required_tool_missing', 'grounding_unavailable',
+  'captcha_manual_required',
+];
+
 function markEnd(row, data) {
-  const failedStatuses = [
-    'error', 'loop_stopped', 'max_steps', 'cancelled', 'cost_limit',
-    'plan_only_output', 'incomplete_output', 'empty_output',
-    'placeholder_output', 'required_tool_missing', 'grounding_unavailable',
-    'captcha_manual_required',
-  ];
-  const failed = data?.ok === false || failedStatuses.includes(data?.status);
+  const failed = data?.ok === false || FAILED_END_STATUSES.includes(data?.status);
   if (failed) row.status = 'error';
-  else if (data?.ok === true || data?.status === 'done') {
-    if (row.status !== 'error') row.status = 'done';
-  }
+  else if (row.status !== 'error') row.status = 'done';
   if (data?.code && failed) addUnique(row.errorCodes, data.code, MAX_ERRORS);
   if (data?.repaired === true) row.repaired = true;
 }

--- a/src/firefox/src/trace/trajectory.js
+++ b/src/firefox/src/trace/trajectory.js
@@ -1,0 +1,141 @@
+/**
+ * Build compact step rows from the trace event log.
+ *
+ * The Traces UI owns presentation; this browser-neutral module owns the
+ * durable event-to-step interpretation so Chrome, Firefox, and tests share
+ * one lifecycle contract. Missing lifecycle events remain `unknown` rather
+ * than being guessed from a response payload.
+ */
+
+const MAX_TOOL_NAMES = 8;
+const MAX_ERRORS = 8;
+
+function eventStep(event) {
+  if (event?.kind === 'turn_start' || event?.kind === 'turn_end') return null;
+  return Number.isInteger(event?.data?.step) ? event.data.step : null;
+}
+
+function eventTime(event) {
+  const value = Number(event?.ts);
+  return Number.isFinite(value) ? value : null;
+}
+
+function numeric(value) {
+  const number = Number(value);
+  return Number.isFinite(number) ? number : 0;
+}
+
+function ensureRow(rows, step) {
+  if (!rows.has(step)) {
+    rows.set(step, {
+      step,
+      status: 'unknown',
+      startedAt: null,
+      endedAt: null,
+      durationMs: null,
+      requestCount: 0,
+      responseCount: 0,
+      toolCount: 0,
+      subCallCount: 0,
+      errorCount: 0,
+      inputTokens: 0,
+      outputTokens: 0,
+      cost: 0,
+      llmLatencyMs: 0,
+      toolLatencyMs: 0,
+      toolNames: [],
+      errorCodes: [],
+      errors: [],
+      repaired: false,
+    });
+  }
+  return rows.get(step);
+}
+
+function addUnique(list, value, limit) {
+  if (!value || list.includes(value) || list.length >= limit) return;
+  list.push(value);
+}
+
+function addError(row, data) {
+  row.errorCount += 1;
+  addUnique(row.errorCodes, data?.code, MAX_ERRORS);
+  if (row.errors.length < MAX_ERRORS) {
+    row.errors.push({
+      code: data?.code || null,
+      phase: data?.phase || null,
+      message: data?.message || '',
+    });
+  }
+  row.status = 'error';
+}
+
+function markEnd(row, data) {
+  const failedStatuses = [
+    'error', 'loop_stopped', 'max_steps', 'cancelled', 'cost_limit',
+    'plan_only_output', 'incomplete_output', 'empty_output',
+    'placeholder_output', 'required_tool_missing', 'grounding_unavailable',
+    'captcha_manual_required',
+  ];
+  const failed = data?.ok === false || failedStatuses.includes(data?.status);
+  if (failed) row.status = 'error';
+  else if (data?.ok === true || data?.status === 'done') {
+    if (row.status !== 'error') row.status = 'done';
+  }
+  if (data?.code && failed) addUnique(row.errorCodes, data.code, MAX_ERRORS);
+  if (data?.repaired === true) row.repaired = true;
+}
+
+function finalizeRow(row) {
+  if (row.startedAt != null && row.endedAt != null) {
+    row.durationMs = Math.max(0, row.endedAt - row.startedAt);
+  }
+  return row;
+}
+
+export function buildTraceTrajectory(events) {
+  const rows = new Map();
+  const orderedEvents = (Array.isArray(events) ? events : [])
+    .map((event, index) => ({ event, index }))
+    .filter(({ event }) => event)
+    .sort((a, b) => {
+      const aSeq = Number(a.event.seq);
+      const bSeq = Number(b.event.seq);
+      if (Number.isFinite(aSeq) && Number.isFinite(bSeq)) return aSeq - bSeq;
+      if (Number.isFinite(aSeq)) return -1;
+      if (Number.isFinite(bSeq)) return 1;
+      return a.index - b.index;
+    });
+
+  for (const { event } of orderedEvents) {
+    const row = ensureRow(rows, eventStep(event));
+    const ts = eventTime(event);
+    if (event.kind === 'step_start' || event.kind === 'turn_start') {
+      if (row.startedAt == null && ts != null) row.startedAt = ts;
+      if (row.status === 'unknown') row.status = 'running';
+    }
+    if (event.kind === 'step_end' || event.kind === 'turn_end') {
+      if (ts != null) row.endedAt = ts;
+      markEnd(row, event.data);
+    }
+    if (event.kind === 'llm_request') row.requestCount += 1;
+    if (event.kind === 'llm_response') {
+      row.responseCount += 1;
+      const usage = event.data?.usage;
+      row.inputTokens += numeric(usage?.prompt_tokens);
+      row.outputTokens += numeric(usage?.completion_tokens);
+      row.cost += numeric(usage?.cost);
+      row.llmLatencyMs += Math.max(0, numeric(event.data?.latencyMs));
+    }
+    if (event.kind === 'tool') {
+      row.toolCount += 1;
+      row.toolLatencyMs += Math.max(0, numeric(event.data?.latencyMs));
+      addUnique(row.toolNames, event.data?.name, MAX_TOOL_NAMES);
+    }
+    if (event.kind === 'vision_sub_call') row.subCallCount += 1;
+    if (event.kind === 'error') addError(row, event.data);
+    if (event.data?.repaired === true) row.repaired = true;
+  }
+
+  return [...rows.values()].map(finalizeRow);
+}

--- a/src/firefox/src/ui/traces.html
+++ b/src/firefox/src/ui/traces.html
@@ -293,6 +293,76 @@
       font-family: ui-monospace, monospace;
     }
 
+    /* Step trajectory */
+    .trajectory {
+      margin: 14px 0;
+      border: 1px solid var(--border);
+      border-radius: 8px;
+      background: var(--bg2);
+      overflow: hidden;
+    }
+    .trajectory-heading {
+      padding: 9px 12px;
+      border-bottom: 1px solid var(--border);
+      color: var(--text);
+      font-size: 11px;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.04em;
+    }
+    .trajectory-scroll { overflow-x: auto; }
+    .trajectory-table {
+      width: 100%;
+      min-width: 620px;
+      border-collapse: collapse;
+      font-size: 11px;
+    }
+    .trajectory-table th,
+    .trajectory-table td {
+      padding: 8px 10px;
+      border-top: 1px solid var(--border);
+      text-align: left;
+      vertical-align: top;
+    }
+    .trajectory-table thead th {
+      border-top: 0;
+      color: var(--text3);
+      font-size: 10px;
+      font-weight: 500;
+      white-space: nowrap;
+    }
+    .trajectory-table tbody th { min-width: 220px; font-weight: 500; }
+    .trajectory-row.running { background: rgba(108,99,255,0.06); }
+    .trajectory-row.error { background: rgba(239,68,68,0.08); }
+    .trajectory-step,
+    .trajectory-status,
+    .trajectory-metric {
+      color: var(--text);
+      font-family: ui-monospace, SFMono-Regular, monospace;
+    }
+    .trajectory-activity {
+      margin-top: 3px;
+      color: var(--text2);
+      line-height: 1.45;
+      word-break: break-word;
+    }
+    .trajectory-errors { margin-top: 5px; }
+    .trajectory-errors summary {
+      cursor: pointer;
+      color: var(--error);
+      font-size: 10px;
+      user-select: none;
+    }
+    .trajectory-error-details {
+      margin-top: 4px;
+      color: var(--error);
+      font-size: 10px;
+      line-height: 1.4;
+      white-space: pre-wrap;
+      word-break: break-word;
+    }
+    .trajectory.compact { margin-top: 0; }
+
     /* Timeline */
     .timeline { display: flex; flex-direction: column; gap: 6px; }
     .event {

--- a/src/firefox/src/ui/traces.js
+++ b/src/firefox/src/ui/traces.js
@@ -8,6 +8,7 @@ import {
   deleteRun, clearAllRuns, repairStaleRuns,
 } from '../trace/recorder.js';
 import { isKnownKind, isIgnorableKind } from '../trace/event-model.js';
+import { buildTraceTrajectory } from '../trace/trajectory.js';
 import { sanitizeTraceExport } from '../agent/trace-export.js';
 import { t } from './i18n.js';
 import { escapeHtml, escapeAttr } from './utils.js';
@@ -261,6 +262,80 @@ function renderConversationPanel(run, compact) {
   `;
 }
 
+function formatTrajectoryDuration(durationMs) {
+  if (!Number.isFinite(durationMs)) return '—';
+  if (durationMs < 1000) return `${Math.round(durationMs)}ms`;
+  return `${(durationMs / 1000).toFixed(1)}s`;
+}
+
+function formatTrajectoryMetric(value) {
+  return value > 0 ? value.toLocaleString() : '—';
+}
+
+function renderTrajectoryActivity(row) {
+  const parts = [];
+  if (row.requestCount) parts.push(`${escapeHtml(t('tr.event.llm_request'))} ×${row.requestCount}`);
+  if (row.responseCount) parts.push(`${escapeHtml(t('tr.event.llm_response'))} ×${row.responseCount}`);
+  if (row.toolCount) {
+    const names = row.toolNames.length ? ` · ${row.toolNames.map(name => escapeHtml(name)).join(', ')}` : '';
+    parts.push(`🔧 ×${row.toolCount}${names}`);
+  }
+  if (row.subCallCount) parts.push(`${escapeHtml(t('tr.event.vision_sub_call'))} ×${row.subCallCount}`);
+  if (row.errorCount) parts.push(`${escapeHtml(t('tr.event.error_kind'))} ×${row.errorCount}`);
+  return parts.join(' · ') || '—';
+}
+
+function renderTrajectoryErrors(row) {
+  if (!row.errors.length && !row.errorCodes.length) return '';
+  const codes = row.errorCodes.length ? ` · ${row.errorCodes.map(code => escapeHtml(code)).join(', ')}` : '';
+  const details = row.errors.map((error) => {
+    const parts = [error.code, error.phase, error.message].filter(Boolean).map(escapeHtml);
+    return parts.join(' · ');
+  });
+  if (!details.length) details.push(row.errorCodes.map(code => escapeHtml(code)).join('\n'));
+  return `<details class="trajectory-errors"><summary>${escapeHtml(t('tr.event.error_kind'))}${codes}</summary><div class="trajectory-error-details">${details.join('\n')}</div></details>`;
+}
+
+function renderStepTrajectory(events, compact) {
+  const rows = buildTraceTrajectory(events);
+  if (!rows.length) return '';
+  const tableRows = rows.map((row) => {
+    const status = safeClassToken(row.status);
+    const stepLabel = row.step == null ? '—' : row.step;
+    const cost = formatCost(row.cost) || '—';
+    return `
+      <tr class="trajectory-row ${status}" data-step="${escapeAttr(row.step == null ? 'run' : row.step)}">
+        <th scope="row">
+          <span class="trajectory-step">${escapeHtml(stepLabel)}</span>
+          <div class="trajectory-activity">${renderTrajectoryActivity(row)}</div>
+          ${renderTrajectoryErrors(row)}
+        </th>
+        <td><span class="trajectory-status">${escapeHtml(row.status)}</span>${row.repaired ? ' ↻' : ''}</td>
+        <td class="trajectory-metric">${escapeHtml(formatTrajectoryDuration(row.durationMs))}</td>
+        <td class="trajectory-metric">${escapeHtml(formatTrajectoryMetric(row.inputTokens))}</td>
+        <td class="trajectory-metric">${escapeHtml(formatTrajectoryMetric(row.outputTokens))}</td>
+        <td class="trajectory-metric">${escapeHtml(cost)}</td>
+      </tr>`;
+  }).join('');
+  return `
+    <section class="trajectory${compact ? ' compact' : ''}" aria-label="${escapeAttr(t('tr.steps.label'))}">
+      <div class="trajectory-heading">${escapeHtml(t('tr.steps.label'))}</div>
+      <div class="trajectory-scroll">
+        <table class="trajectory-table">
+          <thead><tr>
+            <th scope="col">#</th>
+            <th scope="col">${escapeHtml(t('tr.status.label'))}</th>
+            <th scope="col">${escapeHtml(t('tr.duration.label'))}</th>
+            <th scope="col">${escapeHtml(t('tr.intokens.label'))}</th>
+            <th scope="col">${escapeHtml(t('tr.outtokens.label'))}</th>
+            <th scope="col">${escapeHtml(t('tr.cost.label'))}</th>
+          </tr></thead>
+          <tbody>${tableRows}</tbody>
+        </table>
+      </div>
+    </section>`;
+}
+
 async function buildRunView(run, events, compact, objectUrls = new Set()) {
   const header = `
     <div class="run-header">
@@ -289,7 +364,7 @@ async function buildRunView(run, events, compact, objectUrls = new Set()) {
     }
   }
   const items = events.map(ev => renderEvent(ev, shotCache, compact, objectUrls)).join('');
-  return `${header}<div class="timeline">${items}</div>`;
+  return `${header}${renderStepTrajectory(events, compact)}<div class="timeline">${items}</div>`;
 }
 
 function renderEvent(ev, shotCache, compact, objectUrls = new Set()) {

--- a/test/run.js
+++ b/test/run.js
@@ -9516,6 +9516,24 @@ test('trace trajectory: exposes lifecycle failure codes without requiring an err
   assert.deepEqual(rows[0].errors, []);
 });
 
+test('trace trajectory: closes run rows for unlisted terminal end statuses', () => {
+  for (const status of [
+    'scheduled_resume',
+    'read_scope_limited',
+    'clarification_required',
+    'chrome_protected_page_visual_fallback',
+    'partial',
+    'delivery_recovery_failed',
+  ]) {
+    const rows = TRACE_TRAJECTORY_CH.buildTraceTrajectory([
+      { seq: 1, ts: 10, kind: 'turn_start', data: {} },
+      { seq: 2, ts: 20, kind: 'llm_response', data: { step: 1, usage: { prompt_tokens: 5 } } },
+      { seq: 3, ts: 30, kind: 'turn_end', data: { status, reason: status } },
+    ]);
+    assert.equal(rows[0].status, 'done', `terminal turn_end status ${status} must not linger as running`);
+  }
+});
+
 test('trace UI: renders the trajectory rows before the detailed event timeline', () => {
   for (const browser of ['chrome', 'firefox']) {
     const traces = fs.readFileSync(path.join(ROOT, `src/${browser}/src/ui/traces.js`), 'utf8');

--- a/test/run.js
+++ b/test/run.js
@@ -8109,6 +8109,8 @@ const EVENT_MODEL_CH = await import('file://' + path.join(ROOT, 'src/chrome/src/
 const EVENT_MODEL_FX = await import('file://' + path.join(ROOT, 'src/firefox/src/trace/event-model.js').replace(/\\/g, '/'));
 const TRACE_REPAIR_CH = await import('file://' + path.join(ROOT, 'src/chrome/src/trace/repair.js').replace(/\\/g, '/'));
 const TRACE_REPAIR_FX = await import('file://' + path.join(ROOT, 'src/firefox/src/trace/repair.js').replace(/\\/g, '/'));
+const TRACE_TRAJECTORY_CH = await import('file://' + path.join(ROOT, 'src/chrome/src/trace/trajectory.js').replace(/\\/g, '/'));
+const TRACE_TRAJECTORY_FX = await import('file://' + path.join(ROOT, 'src/firefox/src/trace/trajectory.js').replace(/\\/g, '/'));
 const CLOUD_RUNTIME_OUTBOX_CH = await import('file://' + path.join(ROOT, 'src/chrome/src/trace/cloud-runtime-outbox.js').replace(/\\/g, '/'));
 const CLOUD_RUNTIME_OUTBOX_FX = await import('file://' + path.join(ROOT, 'src/firefox/src/trace/cloud-runtime-outbox.js').replace(/\\/g, '/'));
 
@@ -9426,6 +9428,104 @@ test('trace repair: recorder and browser entry points apply the repair transacti
     assert.match(background, /WB_TRACE_REPAIR_STALE_RUNS[\s\S]*?workflowTrace\.repairStaleRuns\(\)/, `${browser}: background does not answer the traces-page repair request`);
     assert.match(traces, /\(async \(\) => \{\s*await repairStaleRunsForPage\(\);\s*await refresh\(\);/, `${browser}: Traces page does not route its first repair through the background`);
     assert.match(traces, /WB_TRACE_REPAIR_STALE_RUNS[\s\S]*?return repairStaleRuns\(\)\.catch\(\(\) => \[\]\);/, `${browser}: Traces page lost its local fallback for when the background is unreachable`);
+  }
+});
+
+test('trace trajectory: groups step lifecycle metrics and failure evidence', () => {
+  const events = [
+    { seq: 1, ts: 100, kind: 'step_start', data: { step: 1 } },
+    { seq: 2, ts: 150, kind: 'llm_request', data: { step: 1, model: 'model-a' } },
+    { seq: 3, ts: 450, kind: 'llm_response', data: {
+      step: 1,
+      usage: { prompt_tokens: 10, completion_tokens: 4, cost: 0.12 },
+      latencyMs: 300,
+    } },
+    { seq: 4, ts: 500, kind: 'tool', data: {
+      step: 1, name: 'click', latencyMs: 50, result: { success: false },
+    } },
+    { seq: 5, ts: 600, kind: 'error', data: {
+      step: 1, phase: 'provider', message: 'transport failed', code: 'TRANSPORT',
+    } },
+    { seq: 6, ts: 700, kind: 'step_end', data: {
+      step: 1, ok: false, code: 'TRANSPORT', reason: 'error',
+    } },
+    { seq: 7, ts: 800, kind: 'step_start', data: { step: 2 } },
+    { seq: 8, ts: 900, kind: 'step_end', data: { step: 2, ok: true } },
+  ];
+  const rows = TRACE_TRAJECTORY_CH.buildTraceTrajectory(events);
+  const firefoxRows = TRACE_TRAJECTORY_FX.buildTraceTrajectory(events);
+
+  assert.deepEqual(rows.map((row) => row.step), [1, 2]);
+  assert.deepEqual(firefoxRows, rows, 'Chrome/Firefox trajectory aggregators must agree');
+  assert.deepEqual(rows[0], {
+    step: 1,
+    status: 'error',
+    startedAt: 100,
+    endedAt: 700,
+    durationMs: 600,
+    requestCount: 1,
+    responseCount: 1,
+    toolCount: 1,
+    subCallCount: 0,
+    errorCount: 1,
+    inputTokens: 10,
+    outputTokens: 4,
+    cost: 0.12,
+    llmLatencyMs: 300,
+    toolLatencyMs: 50,
+    toolNames: ['click'],
+    errorCodes: ['TRANSPORT'],
+    errors: [{ code: 'TRANSPORT', phase: 'provider', message: 'transport failed' }],
+    repaired: false,
+  });
+  assert.equal(rows[1].status, 'done');
+  assert.equal(rows[1].durationMs, 100);
+});
+
+test('trace trajectory: preserves run-level repair evidence and mirrors the browser modules', () => {
+  const rows = TRACE_TRAJECTORY_CH.buildTraceTrajectory([
+    { seq: 1, ts: 0, kind: 'turn_start', data: { step: 0 } },
+    { seq: 2, ts: 1, kind: 'error', data: {
+      step: null, phase: 'repair', message: 'interrupted', code: 'SERVICE_WORKER_EVICTED',
+    } },
+    { seq: 3, ts: 2, kind: 'turn_end', data: {
+      step: 0, status: 'error', reason: 'service_worker_eviction', code: 'SERVICE_WORKER_EVICTED', repaired: true,
+    } },
+  ]);
+  assert.equal(rows.length, 1, 'turn lifecycle and run-level evidence share one run row');
+  assert.equal(rows[0].step, null);
+  assert.equal(rows[0].status, 'error');
+  assert.equal(rows[0].durationMs, 2);
+  assert.deepEqual(rows[0].errorCodes, ['SERVICE_WORKER_EVICTED']);
+  assert.equal(rows[0].repaired, true);
+  assert.equal(
+    fs.readFileSync(path.join(ROOT, 'src/chrome/src/trace/trajectory.js'), 'utf8'),
+    fs.readFileSync(path.join(ROOT, 'src/firefox/src/trace/trajectory.js'), 'utf8'),
+    'Chrome/Firefox trajectory modules must remain mirrored',
+  );
+});
+
+test('trace trajectory: exposes lifecycle failure codes without requiring an error event', () => {
+  const rows = TRACE_TRAJECTORY_CH.buildTraceTrajectory([
+    { seq: 1, ts: 10, kind: 'step_start', data: { step: 3 } },
+    { seq: 2, ts: 20, kind: 'step_end', data: { step: 3, ok: false, code: 'COST_LIMIT' } },
+  ]);
+  assert.equal(rows[0].status, 'error');
+  assert.deepEqual(rows[0].errorCodes, ['COST_LIMIT']);
+  assert.equal(rows[0].errorCount, 0);
+  assert.deepEqual(rows[0].errors, []);
+});
+
+test('trace UI: renders the trajectory rows before the detailed event timeline', () => {
+  for (const browser of ['chrome', 'firefox']) {
+    const traces = fs.readFileSync(path.join(ROOT, `src/${browser}/src/ui/traces.js`), 'utf8');
+    const html = fs.readFileSync(path.join(ROOT, `src/${browser}/src/ui/traces.html`), 'utf8');
+    assert.match(traces, /import \{ buildTraceTrajectory \} from '\.\.\/trace\/trajectory\.js';/, `${browser}: Traces UI does not import the trajectory module`);
+    assert.match(traces, /function renderStepTrajectory\(events, compact\)/, `${browser}: trajectory renderer missing`);
+    assert.match(traces, /const rows = buildTraceTrajectory\(events\);/, `${browser}: UI does not build rows through the pure seam`);
+    assert.match(traces, /trajectory-table/, `${browser}: trajectory table class missing from renderer`);
+    assert.match(traces, /renderStepTrajectory\(events, compact\)/, `${browser}: run view does not render the trajectory before details`);
+    assert.match(html, /\.trajectory-table|\.trajectory-row/, `${browser}: trajectory table styles missing`);
   }
 });
 


### PR DESCRIPTION
## Summary

- Add a compact step summary to the Traces page above the existing detailed event timeline.
- Group durable trace events by actual step and run lifecycle, showing status, duration, token usage, cost, tool activity, vision sub-calls, error codes, and repair markers.
- Keep Chrome and Firefox behavior synchronized through a browser-neutral aggregation module.

Related changes: #2877, #2889.

## Implementation

- Add a pure `buildTraceTrajectory(events)` function for deterministic aggregation without changing the recorder schema or adding another IndexedDB projection.
- Represent turn lifecycle events in a run-level row so the lifecycle marker at step zero does not appear as a permanently running model step.
- Preserve older traces without lifecycle boundaries with an `unknown` status instead of guessing completion from response payloads.
- Keep the existing detailed timeline, compare mode, export behavior, lossless warning, and interrupted-run repair flow unchanged.
- Reuse existing localized labels and display only bounded aggregate/error evidence; raw request and tool payloads are not added to the new table.

## Testing

- `node test/run.js` — 1999 passed, 0 failed
- `npm run test:toolbar-guard` — 33 passed
- `npm run test:security` — 60/60 passed
- `node scripts/benchmark-offline-relevance.mjs` — completed successfully
- Node syntax checks and `git diff --check` — passed
- Manual Chrome unpacked-extension smoke test — Traces opened, Refresh worked, the step summary rendered before the timeline, and there were no console or page errors
- Firefox covered by mirrored source, parity tests, syntax checks, and the shared suite; manual Firefox verification was not run

## Compatibility

- The change is additive and reads the existing event log without changing stored event shapes.
- Existing trace exports and privacy warnings remain unchanged.
- The table remains bounded by the current trace viewer's normal run/event limits.
