### PR TITLE
feat(providers): support optional local API keys

### DIFF
--- a/src/chrome/src/providers/llamacpp.js
+++ b/src/chrome/src/providers/llamacpp.js
@@ -37,6 +37,12 @@ export class LlamaCppProvider extends BaseLLMProvider {
     return !!this.config.useCompactPrompt;
   }
 
+  _headers() {
+    const headers = { 'Content-Type': 'application/json' };
+    if (this.config.apiKey) headers.Authorization = `Bearer ${this.config.apiKey}`;
+    return headers;
+  }
+
   _buildRequestBody(messages, options = {}, stream = false) {
     const body = {
       messages: this._chatMessages(messages),
@@ -60,7 +66,7 @@ export class LlamaCppProvider extends BaseLLMProvider {
     try {
       res = await fetchWithFallback(url, {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+        headers: this._headers(),
         body: JSON.stringify(body),
       });
     } catch (e) {
@@ -96,7 +102,7 @@ export class LlamaCppProvider extends BaseLLMProvider {
     try {
       res = await fetchWithFallback(streamUrl, {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+        headers: this._headers(),
         body: JSON.stringify(body),
       });
     } catch (e) {

--- a/src/chrome/src/ui/settings.js
+++ b/src/chrome/src/ui/settings.js
@@ -2210,6 +2210,13 @@ const VISION_MODE_FIELD = {
   ],
 };
 const OLLAMA_VISION_MODE_FIELD = VISION_MODE_FIELD;
+const OPTIONAL_LOCAL_API_KEY_FIELD = {
+  key: 'apiKey',
+  labelKey: 'st.provider.field.api_key',
+  type: 'password',
+  placeholder: 'optional',
+  collapsed: true,
+};
 
 function providerDefinitionId(id, config = providersData[id]) {
   return String(config?.sourceProviderId || config?.duplicateOf || id || '');
@@ -2557,6 +2564,7 @@ function renderProviders() {
     llamacpp: {
       fields: [
         { key: 'baseUrl', labelKey: 'st.provider.field.server_url', type: 'text', placeholder: 'http://localhost:8080' },
+        OPTIONAL_LOCAL_API_KEY_FIELD,
         { key: 'model', labelKey: 'st.provider.field.model', type: 'text', placeholder: 'qwen/qwen3.5-9b' },
         CONTEXT_WINDOW_FIELD,
         VISION_MODE_FIELD,
@@ -2566,6 +2574,7 @@ function renderProviders() {
     ollama: {
       fields: [
         { key: 'baseUrl', labelKey: 'st.provider.field.server_url', type: 'text', placeholder: 'http://localhost:11434/v1' },
+        OPTIONAL_LOCAL_API_KEY_FIELD,
         { key: 'model', labelKey: 'st.provider.field.model', type: 'text', placeholder: 'qwen3.6:35b-a3b' },
         CONTEXT_WINDOW_FIELD,
         OLLAMA_VISION_MODE_FIELD,
@@ -2575,6 +2584,7 @@ function renderProviders() {
     lmstudio: {
       fields: [
         { key: 'baseUrl', labelKey: 'st.provider.field.server_url', type: 'text', placeholder: 'http://localhost:1234/v1' },
+        OPTIONAL_LOCAL_API_KEY_FIELD,
         { key: 'model', labelKey: 'st.provider.field.model_optional', type: 'text', placeholderKey: 'st.provider.field.model_loaded_hint' },
         CONTEXT_WINDOW_FIELD,
         VISION_MODE_FIELD,
@@ -2584,7 +2594,7 @@ function renderProviders() {
     jan: {
       fields: [
         { key: 'baseUrl', labelKey: 'st.provider.field.server_url', type: 'text', placeholder: 'http://localhost:1337/v1' },
-        { key: 'apiKey', labelKey: 'st.provider.field.api_key', type: 'password', placeholder: 'optional' },
+        OPTIONAL_LOCAL_API_KEY_FIELD,
         { key: 'model', labelKey: 'st.provider.field.model', type: 'text', placeholder: 'gemma-4-12b-qat' },
         CONTEXT_WINDOW_FIELD,
         { key: 'supportsVision', labelKey: 'st.provider.field.supports_vision', type: 'checkbox' },
@@ -2594,7 +2604,7 @@ function renderProviders() {
     vllm: {
       fields: [
         { key: 'baseUrl', labelKey: 'st.provider.field.server_url', type: 'text', placeholder: 'http://localhost:8000/v1' },
-        { key: 'apiKey', labelKey: 'st.provider.field.api_key', type: 'password', placeholder: 'optional' },
+        OPTIONAL_LOCAL_API_KEY_FIELD,
         { key: 'model', labelKey: 'st.provider.field.model', type: 'text', placeholder: 'gemma/gemma4-31b-qat' },
         CONTEXT_WINDOW_FIELD,
         { key: 'supportsVision', labelKey: 'st.provider.field.supports_vision', type: 'checkbox' },
@@ -2604,7 +2614,7 @@ function renderProviders() {
     sglang: {
       fields: [
         { key: 'baseUrl', labelKey: 'st.provider.field.server_url', type: 'text', placeholder: 'http://localhost:30000/v1' },
-        { key: 'apiKey', labelKey: 'st.provider.field.api_key', type: 'password', placeholder: 'optional' },
+        OPTIONAL_LOCAL_API_KEY_FIELD,
         { key: 'model', labelKey: 'st.provider.field.model', type: 'text', placeholder: 'gemma/gemma4-31b-qat' },
         CONTEXT_WINDOW_FIELD,
         { key: 'supportsVision', labelKey: 'st.provider.field.supports_vision', type: 'checkbox' },
@@ -2614,7 +2624,7 @@ function renderProviders() {
     localai: {
       fields: [
         { key: 'baseUrl', labelKey: 'st.provider.field.server_url', type: 'text', placeholder: 'http://localhost:8080/v1' },
-        { key: 'apiKey', labelKey: 'st.provider.field.api_key', type: 'password', placeholder: 'optional' },
+        OPTIONAL_LOCAL_API_KEY_FIELD,
         { key: 'model', labelKey: 'st.provider.field.model', type: 'text', placeholder: 'gpt-4' },
         CONTEXT_WINDOW_FIELD,
         VISION_MODE_FIELD,
@@ -2624,7 +2634,7 @@ function renderProviders() {
     gpt4all: {
       fields: [
         { key: 'baseUrl', labelKey: 'st.provider.field.server_url', type: 'text', placeholder: 'http://localhost:4891/v1' },
-        { key: 'apiKey', labelKey: 'st.provider.field.api_key', type: 'password', placeholder: 'optional' },
+        OPTIONAL_LOCAL_API_KEY_FIELD,
         { key: 'model', labelKey: 'st.provider.field.model', type: 'text', placeholder: 'loaded model' },
         CONTEXT_WINDOW_FIELD,
         { key: 'supportsVision', labelKey: 'st.provider.field.supports_vision', type: 'checkbox' },
@@ -2922,7 +2932,9 @@ function renderProviders() {
     visibleCount++;
 
     let fieldsHTML = '';
+    let collapsedFieldsHTML = '';
     for (const field of fieldDefs) {
+      let fieldHTML = '';
       const label = field.labelKey ? t(field.labelKey) : (field.label || field.key);
       const placeholder = field.placeholderKey ? t(field.placeholderKey) : (field.placeholder || '');
       if (field.type === 'select') {
@@ -2932,7 +2944,7 @@ function renderProviders() {
         const optionsHTML = field.options
           .map(o => `<option value="${escapeHtml(o.value)}"${o.value === current ? ' selected' : ''}>${escapeHtml(o.labelKey ? t(o.labelKey) : o.label)}</option>`)
           .join('');
-        fieldsHTML += `
+        fieldHTML += `
           <div class="field">
             <label>${escapeHtml(label)}</label>
             <select data-provider="${id}" data-key="${field.key}" data-type="select">${optionsHTML}</select>
@@ -2940,12 +2952,12 @@ function renderProviders() {
         `;
         if (VISION_UI_PROVIDER_IDS.has(definitionId) && field.key === 'visionMode') {
           const statusAttribute = definitionId === 'ollama' ? `data-ollama-vision-status="${id}"` : `data-vision-status="${id}"`;
-          fieldsHTML += `<div class="field-hint" ${statusAttribute}${current === 'auto' ? '' : ' hidden'} style="margin:-4px 0 10px;font-size:12px;color:var(--text2);">${escapeHtml(t(visionStatusKey(id, config)))}</div>`;
+          fieldHTML += `<div class="field-hint" ${statusAttribute}${current === 'auto' ? '' : ' hidden'} style="margin:-4px 0 10px;font-size:12px;color:var(--text2);">${escapeHtml(t(visionStatusKey(id, config)))}</div>`;
         }
       } else if (field.type === 'checkbox') {
         const isChecked = !!config[field.key];
         const checked = isChecked ? 'checked' : '';
-        fieldsHTML += `
+        fieldHTML += `
           <div class="field" style="display:flex;align-items:center;gap:8px;flex-direction:row;">
             <input type="checkbox" data-provider="${id}" data-key="${field.key}" data-type="checkbox" ${checked}
                    style="width:auto;cursor:pointer;">
@@ -2962,7 +2974,7 @@ function renderProviders() {
           .map(s => `<option value="${escapeHtml(s)}"${s === selectVal ? ' selected' : ''}>${escapeHtml(field.suggestionLabels?.[s] || s)}</option>`)
           .join('') +
           `<option value="__custom__"${isCustom ? ' selected' : ''}>${escapeHtml(t('st.provider.field.model_custom'))}</option>`;
-        fieldsHTML += `
+        fieldHTML += `
           <div class="field">
             <label>${escapeHtml(label)}</label>
             <select class="model-select" data-model-for="${id}">${optionsHTML}</select>
@@ -3002,7 +3014,7 @@ function renderProviders() {
         const minAttr = field.min != null ? ` min="${escapeHtml(field.min)}"` : '';
         const stepAttr = field.step != null ? ` step="${escapeHtml(field.step)}"` : '';
         const value = config[field.key] ?? '';
-        fieldsHTML += `
+        fieldHTML += `
           <div class="field">
             <label>${escapeHtml(label)}${apiKeyLink}</label>
             <input type="${field.type}" data-provider="${id}" data-key="${field.key}" data-type="${field.type}" ${listAttr}${minAttr}${stepAttr}
@@ -3013,6 +3025,19 @@ function renderProviders() {
           </div>
         `;
       }
+      if (field.collapsed) collapsedFieldsHTML += fieldHTML;
+      else fieldsHTML += fieldHTML;
+    }
+    if (collapsedFieldsHTML) {
+      fieldsHTML += `
+        <details class="provider-compatibility provider-local-auth">
+          <summary>
+            <span class="provider-compatibility-title">${escapeHtml(t('st.display.advanced'))}</span>
+            <span class="provider-compatibility-summary">${escapeHtml(t('st.provider.field.api_key'))}</span>
+          </summary>
+          <div class="provider-compatibility-body">${collapsedFieldsHTML}</div>
+        </details>
+      `;
     }
 
     const subscribeHref = id === 'webbrain_cloud' ? webbrainSubscribeUrl(config.deviceGuid) : '';

--- a/src/chrome/src/ui/settings.js
+++ b/src/chrome/src/ui/settings.js
@@ -2310,6 +2310,7 @@ const ZERO_ALLOWED_NUMBER_FIELDS = new Set([
   'outputCostPerMillionUsd',
 ]);
 const MIN_API_KEY_LENGTH = 12;
+const DUMMY_API_KEYS = new Set(['ollama', 'lm-studio']);
 
 function providerInputValue(input) {
   if (input.dataset.type === 'checkbox' || input.type === 'checkbox') {
@@ -2341,7 +2342,8 @@ function setProviderConfigValue(config, path, value) {
 function providerApiKeyWarning(id, config) {
   const input = document.querySelector(`input[data-provider="${id}"][data-key="apiKey"]`);
   if (!input) return '';
-  const apiKey = String(config.apiKey || '').trim();
+  const rawApiKey = String(config.apiKey || '').trim();
+  const apiKey = DUMMY_API_KEYS.has(rawApiKey) ? '' : rawApiKey;
   const keyIsOptional = providersData[id]?.category === 'local' && config.requiresApiKey !== true;
   const looksInvalid = apiKey ? apiKey.length < MIN_API_KEY_LENGTH : !keyIsOptional;
   input.setAttribute('aria-invalid', looksInvalid ? 'true' : 'false');

--- a/src/firefox/src/providers/llamacpp.js
+++ b/src/firefox/src/providers/llamacpp.js
@@ -37,6 +37,12 @@ export class LlamaCppProvider extends BaseLLMProvider {
     return !!this.config.useCompactPrompt;
   }
 
+  _headers() {
+    const headers = { 'Content-Type': 'application/json' };
+    if (this.config.apiKey) headers.Authorization = `Bearer ${this.config.apiKey}`;
+    return headers;
+  }
+
   _buildRequestBody(messages, options = {}, stream = false) {
     const body = {
       messages: this._chatMessages(messages),
@@ -60,7 +66,7 @@ export class LlamaCppProvider extends BaseLLMProvider {
     try {
       res = await fetchWithTimeout(url, {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+        headers: this._headers(),
         body: JSON.stringify(body),
       });
     } catch (e) {
@@ -96,7 +102,7 @@ export class LlamaCppProvider extends BaseLLMProvider {
     try {
       res = await fetchWithTimeout(streamUrl, {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+        headers: this._headers(),
         body: JSON.stringify(body),
       });
     } catch (e) {

--- a/src/firefox/src/ui/settings.js
+++ b/src/firefox/src/ui/settings.js
@@ -1812,6 +1812,13 @@ const VISION_MODE_FIELD = {
   ],
 };
 const OLLAMA_VISION_MODE_FIELD = VISION_MODE_FIELD;
+const OPTIONAL_LOCAL_API_KEY_FIELD = {
+  key: 'apiKey',
+  labelKey: 'st.provider.field.api_key',
+  type: 'password',
+  placeholder: 'optional',
+  collapsed: true,
+};
 
 function providerDefinitionId(id, config = providersData[id]) {
   return String(config?.sourceProviderId || config?.duplicateOf || id || '');
@@ -2159,6 +2166,7 @@ function renderProviders() {
     llamacpp: {
       fields: [
         { key: 'baseUrl', labelKey: 'st.provider.field.server_url', type: 'text', placeholder: 'http://localhost:8080' },
+        OPTIONAL_LOCAL_API_KEY_FIELD,
         { key: 'model', labelKey: 'st.provider.field.model', type: 'text', placeholder: 'qwen/qwen3.5-9b' },
         CONTEXT_WINDOW_FIELD,
         VISION_MODE_FIELD,
@@ -2168,6 +2176,7 @@ function renderProviders() {
     ollama: {
       fields: [
         { key: 'baseUrl', labelKey: 'st.provider.field.server_url', type: 'text', placeholder: 'http://localhost:11434/v1' },
+        OPTIONAL_LOCAL_API_KEY_FIELD,
         { key: 'model', labelKey: 'st.provider.field.model', type: 'text', placeholder: 'qwen3.6:35b-a3b' },
         CONTEXT_WINDOW_FIELD,
         OLLAMA_VISION_MODE_FIELD,
@@ -2177,6 +2186,7 @@ function renderProviders() {
     lmstudio: {
       fields: [
         { key: 'baseUrl', labelKey: 'st.provider.field.server_url', type: 'text', placeholder: 'http://localhost:1234/v1' },
+        OPTIONAL_LOCAL_API_KEY_FIELD,
         { key: 'model', labelKey: 'st.provider.field.model_optional', type: 'text', placeholderKey: 'st.provider.field.model_loaded_hint' },
         CONTEXT_WINDOW_FIELD,
         VISION_MODE_FIELD,
@@ -2186,7 +2196,7 @@ function renderProviders() {
     jan: {
       fields: [
         { key: 'baseUrl', labelKey: 'st.provider.field.server_url', type: 'text', placeholder: 'http://localhost:1337/v1' },
-        { key: 'apiKey', labelKey: 'st.provider.field.api_key', type: 'password', placeholder: 'optional' },
+        OPTIONAL_LOCAL_API_KEY_FIELD,
         { key: 'model', labelKey: 'st.provider.field.model', type: 'text', placeholder: 'gemma-4-12b-qat' },
         CONTEXT_WINDOW_FIELD,
         { key: 'supportsVision', labelKey: 'st.provider.field.supports_vision', type: 'checkbox' },
@@ -2196,7 +2206,7 @@ function renderProviders() {
     vllm: {
       fields: [
         { key: 'baseUrl', labelKey: 'st.provider.field.server_url', type: 'text', placeholder: 'http://localhost:8000/v1' },
-        { key: 'apiKey', labelKey: 'st.provider.field.api_key', type: 'password', placeholder: 'optional' },
+        OPTIONAL_LOCAL_API_KEY_FIELD,
         { key: 'model', labelKey: 'st.provider.field.model', type: 'text', placeholder: 'gemma/gemma4-31b-qat' },
         CONTEXT_WINDOW_FIELD,
         { key: 'supportsVision', labelKey: 'st.provider.field.supports_vision', type: 'checkbox' },
@@ -2206,7 +2216,7 @@ function renderProviders() {
     sglang: {
       fields: [
         { key: 'baseUrl', labelKey: 'st.provider.field.server_url', type: 'text', placeholder: 'http://localhost:30000/v1' },
-        { key: 'apiKey', labelKey: 'st.provider.field.api_key', type: 'password', placeholder: 'optional' },
+        OPTIONAL_LOCAL_API_KEY_FIELD,
         { key: 'model', labelKey: 'st.provider.field.model', type: 'text', placeholder: 'gemma/gemma4-31b-qat' },
         CONTEXT_WINDOW_FIELD,
         { key: 'supportsVision', labelKey: 'st.provider.field.supports_vision', type: 'checkbox' },
@@ -2216,7 +2226,7 @@ function renderProviders() {
     localai: {
       fields: [
         { key: 'baseUrl', labelKey: 'st.provider.field.server_url', type: 'text', placeholder: 'http://localhost:8080/v1' },
-        { key: 'apiKey', labelKey: 'st.provider.field.api_key', type: 'password', placeholder: 'optional' },
+        OPTIONAL_LOCAL_API_KEY_FIELD,
         { key: 'model', labelKey: 'st.provider.field.model', type: 'text', placeholder: 'gpt-4' },
         CONTEXT_WINDOW_FIELD,
         VISION_MODE_FIELD,
@@ -2226,7 +2236,7 @@ function renderProviders() {
     gpt4all: {
       fields: [
         { key: 'baseUrl', labelKey: 'st.provider.field.server_url', type: 'text', placeholder: 'http://localhost:4891/v1' },
-        { key: 'apiKey', labelKey: 'st.provider.field.api_key', type: 'password', placeholder: 'optional' },
+        OPTIONAL_LOCAL_API_KEY_FIELD,
         { key: 'model', labelKey: 'st.provider.field.model', type: 'text', placeholder: 'loaded model' },
         CONTEXT_WINDOW_FIELD,
         { key: 'supportsVision', labelKey: 'st.provider.field.supports_vision', type: 'checkbox' },
@@ -2519,7 +2529,9 @@ function renderProviders() {
     visibleCount++;
 
     let fieldsHTML = '';
+    let collapsedFieldsHTML = '';
     for (const field of fieldDefs) {
+      let fieldHTML = '';
       const label = field.labelKey ? t(field.labelKey) : (field.label || field.key);
       const placeholder = field.placeholderKey ? t(field.placeholderKey) : (field.placeholder || '');
       if (field.type === 'select') {
@@ -2529,7 +2541,7 @@ function renderProviders() {
         const optionsHTML = field.options
           .map(o => `<option value="${escapeHtml(o.value)}"${o.value === current ? ' selected' : ''}>${escapeHtml(o.labelKey ? t(o.labelKey) : o.label)}</option>`)
           .join('');
-        fieldsHTML += `
+        fieldHTML += `
           <div class="field">
             <label>${escapeHtml(label)}</label>
             <select data-provider="${id}" data-key="${field.key}" data-type="select">${optionsHTML}</select>
@@ -2537,12 +2549,12 @@ function renderProviders() {
         `;
         if (VISION_UI_PROVIDER_IDS.has(definitionId) && field.key === 'visionMode') {
           const statusAttribute = definitionId === 'ollama' ? `data-ollama-vision-status="${id}"` : `data-vision-status="${id}"`;
-          fieldsHTML += `<div class="field-hint" ${statusAttribute}${current === 'auto' ? '' : ' hidden'} style="margin:-4px 0 10px;font-size:12px;color:var(--text2);">${escapeHtml(t(visionStatusKey(id, config)))}</div>`;
+          fieldHTML += `<div class="field-hint" ${statusAttribute}${current === 'auto' ? '' : ' hidden'} style="margin:-4px 0 10px;font-size:12px;color:var(--text2);">${escapeHtml(t(visionStatusKey(id, config)))}</div>`;
         }
       } else if (field.type === 'checkbox') {
         const isChecked = !!config[field.key];
         const checked = isChecked ? 'checked' : '';
-        fieldsHTML += `
+        fieldHTML += `
           <div class="field" style="display:flex;align-items:center;gap:8px;flex-direction:row;">
             <input type="checkbox" data-provider="${id}" data-key="${field.key}" data-type="checkbox" ${checked}
                    style="width:auto;cursor:pointer;">
@@ -2559,7 +2571,7 @@ function renderProviders() {
           .map(s => `<option value="${escapeHtml(s)}"${s === selectVal ? ' selected' : ''}>${escapeHtml(s)}</option>`)
           .join('') +
           `<option value="__custom__"${isCustom ? ' selected' : ''}>${escapeHtml(t('st.provider.field.model_custom'))}</option>`;
-        fieldsHTML += `
+        fieldHTML += `
           <div class="field">
             <label>${escapeHtml(label)}</label>
             <select class="model-select" data-model-for="${id}">${optionsHTML}</select>
@@ -2599,7 +2611,7 @@ function renderProviders() {
         const minAttr = field.min != null ? ` min="${escapeHtml(field.min)}"` : '';
         const stepAttr = field.step != null ? ` step="${escapeHtml(field.step)}"` : '';
         const value = config[field.key] ?? '';
-        fieldsHTML += `
+        fieldHTML += `
           <div class="field">
             <label>${escapeHtml(label)}${apiKeyLink}</label>
             <input type="${field.type}" data-provider="${id}" data-key="${field.key}" data-type="${field.type}" ${listAttr}${minAttr}${stepAttr}
@@ -2610,6 +2622,19 @@ function renderProviders() {
           </div>
         `;
       }
+      if (field.collapsed) collapsedFieldsHTML += fieldHTML;
+      else fieldsHTML += fieldHTML;
+    }
+    if (collapsedFieldsHTML) {
+      fieldsHTML += `
+        <details class="provider-compatibility provider-local-auth">
+          <summary>
+            <span class="provider-compatibility-title">${escapeHtml(t('st.display.advanced'))}</span>
+            <span class="provider-compatibility-summary">${escapeHtml(t('st.provider.field.api_key'))}</span>
+          </summary>
+          <div class="provider-compatibility-body">${collapsedFieldsHTML}</div>
+        </details>
+      `;
     }
 
     const subscribeHref = id === 'webbrain_cloud' ? webbrainSubscribeUrl(config.deviceGuid) : '';

--- a/src/firefox/src/ui/settings.js
+++ b/src/firefox/src/ui/settings.js
@@ -1912,6 +1912,7 @@ const ZERO_ALLOWED_NUMBER_FIELDS = new Set([
   'outputCostPerMillionUsd',
 ]);
 const MIN_API_KEY_LENGTH = 12;
+const DUMMY_API_KEYS = new Set(['ollama', 'lm-studio']);
 
 function providerInputValue(input) {
   if (input.dataset.type === 'checkbox' || input.type === 'checkbox') {
@@ -1943,7 +1944,8 @@ function setProviderConfigValue(config, path, value) {
 function providerApiKeyWarning(id, config) {
   const input = document.querySelector(`input[data-provider="${id}"][data-key="apiKey"]`);
   if (!input) return '';
-  const apiKey = String(config.apiKey || '').trim();
+  const rawApiKey = String(config.apiKey || '').trim();
+  const apiKey = DUMMY_API_KEYS.has(rawApiKey) ? '' : rawApiKey;
   const keyIsOptional = providersData[id]?.category === 'local' && config.requiresApiKey !== true;
   const looksInvalid = apiKey ? apiKey.length < MIN_API_KEY_LENGTH : !keyIsOptional;
   input.setAttribute('aria-invalid', looksInvalid ? 'true' : 'false');

--- a/test/run.js
+++ b/test/run.js
@@ -39462,6 +39462,42 @@ test('settings provider save and test status updates are DOM-safe', () => {
   }
 });
 
+test('local provider API keys stay available in a collapsed advanced section', () => {
+  for (const [label, settingsRel] of [
+    ['chrome', 'src/chrome/src/ui/settings.js'],
+    ['firefox', 'src/firefox/src/ui/settings.js'],
+  ]) {
+    const settings = fs.readFileSync(path.join(ROOT, settingsRel), 'utf8');
+
+    assert.match(
+      settings,
+      /const OPTIONAL_LOCAL_API_KEY_FIELD = \{[\s\S]*?key: 'apiKey',[\s\S]*?collapsed: true,[\s\S]*?\};/,
+      `${label}: local providers should share one optional authentication field`,
+    );
+    for (const id of ['llamacpp', 'ollama', 'lmstudio', 'jan', 'vllm', 'sglang', 'localai', 'gpt4all']) {
+      const start = settings.indexOf(`${id}: {`);
+      assert.notEqual(start, -1, `${label}: ${id} settings missing`);
+      const end = settings.indexOf('\n    },', start);
+      assert.ok(
+        settings.slice(start, end).includes('OPTIONAL_LOCAL_API_KEY_FIELD'),
+        `${label}: ${id} should expose optional authentication`,
+      );
+    }
+    assert.match(
+      settings,
+      /<details class="provider-compatibility provider-local-auth">[\s\S]*?st\.display\.advanced[\s\S]*?st\.provider\.field\.api_key[\s\S]*?\$\{collapsedFieldsHTML\}[\s\S]*?<\/details>/,
+      `${label}: optional local authentication should render closed by default`,
+    );
+    const proxyStart = settings.indexOf('local_openai_proxy: {');
+    const proxyEnd = settings.indexOf('\n    },', proxyStart);
+    assert.doesNotMatch(
+      settings.slice(proxyStart, proxyEnd),
+      /OPTIONAL_LOCAL_API_KEY_FIELD/,
+      `${label}: the required proxy API key must remain visible`,
+    );
+  }
+});
+
 test('settings warns on missing or short API keys and shows the Ollama localhost FAQ', () => {
   for (const [label, settingsRel, htmlRel, localeRel] of [
     ['chrome', 'src/chrome/src/ui/settings.js', 'src/chrome/src/ui/settings.html', 'src/chrome/src/ui/locales/en.js'],
@@ -60827,6 +60863,43 @@ test('OpenAI-compatible Ask providers consume text, tool, usage, and DONE fixtur
           { type: 'usage', usage: { prompt_tokens: 5, completion_tokens: 3, total_tokens: 8 } },
           { type: 'done', content: '', finishReason: 'tool_calls' },
         ], `${label}/${id}: compatible stream fixture mismatch`);
+      }
+    }
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test('llama.cpp sends configured API keys on chat and streaming requests', async () => {
+  const originalFetch = globalThis.fetch;
+  try {
+    for (const Provider of [LlamaCppProviderCh, LlamaCppProviderFx]) {
+      const requests = [];
+      const provider = new Provider({
+        baseUrl: 'http://localhost:8080',
+        model: 'local-model',
+        apiKey: 'local-secret-key',
+      });
+      globalThis.fetch = async (_url, options) => {
+        requests.push(options);
+        const body = JSON.parse(options.body);
+        if (body.stream) {
+          return new Response([
+            `data: ${JSON.stringify({ choices: [{ delta: { content: 'ok' } }] })}\n\n`,
+            'data: [DONE]\n\n',
+          ].join(''), { status: 200, headers: { 'Content-Type': 'text/event-stream' } });
+        }
+        return new Response(JSON.stringify({
+          choices: [{ message: { content: 'ok' } }],
+        }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+      };
+
+      await provider.chat([{ role: 'user', content: 'hello' }]);
+      for await (const _chunk of provider.chatStream([{ role: 'user', content: 'hello' }])) {}
+
+      assert.equal(requests.length, 2);
+      for (const request of requests) {
+        assert.equal(request.headers.Authorization, 'Bearer local-secret-key');
       }
     }
   } finally {

--- a/test/run.js
+++ b/test/run.js
@@ -39511,6 +39511,11 @@ test('settings warns on missing or short API keys and shows the Ollama localhost
     assert.match(settings, /const MIN_API_KEY_LENGTH = 12;/, `${label}: conservative API-key minimum missing`);
     assert.match(
       settings,
+      /const DUMMY_API_KEYS = new Set\(\['ollama', 'lm-studio'\]\);[\s\S]*?DUMMY_API_KEYS\.has\(rawApiKey\) \? '' : rawApiKey/,
+      `${label}: seeded local sentinel keys should be treated as empty instead of invalid`,
+    );
+    assert.match(
+      settings,
       /function providerApiKeyWarning\(id, config\) \{[\s\S]*?data-key="apiKey"[\s\S]*?const keyIsOptional = providersData\[id\]\?\.category === 'local' && config\.requiresApiKey !== true;[\s\S]*?apiKey\.length < MIN_API_KEY_LENGTH[\s\S]*?aria-invalid[\s\S]*?st\.providers\.api_key_warning/,
       `${label}: API-key warning should allow ordinary empty local auth while enforcing authenticated local proxies`,
     );


### PR DESCRIPTION
## Summary

- expose API-key configuration for llama.cpp, Ollama, LM Studio, and the other optional-auth local providers
- keep optional local authentication inside a collapsed Advanced section while leaving the required Local Proxy key visible
- send configured Bearer credentials from llama.cpp chat and streaming requests
- mirror the settings and provider changes across Chrome and Firefox

Closes #2896

## Verification

- `node --check` on all four changed runtime files
- `node test/run.js`: 2023/2025 pass, including the new Chrome/Firefox UI and request-header regressions; the two remaining failures are pre-existing release-artifact checks (`CHANGELOG.md` latest entry is 33.1.1 while `package.json` is 33.1.5, and `dist/webbrain-chrome-33.1.5.zip` is absent)
- `node scripts/benchmark-offline-relevance.mjs`
- `npm run test:security`: 60/60 checks pass
- `git diff --check`