### PR TITLE
feat(trace-export): add session-aware OTLP export compatibility

### DIFF
--- a/docs/export-and-workflow-formats.md
+++ b/docs/export-and-workflow-formats.md
@@ -103,10 +103,17 @@ npm run trace:otlp -- webbrain-trace-example.json \
   --output webbrain-trace-example.otlp.json
 ```
 
+For a legacy single-run input, the output retains the existing root span with
+model-call and tool child spans. A session bundle uses one trace per persisted
+session, one span per run, same-session `parentRunId` parent links, and span
+events for turn/step activity. Cross-session parents are represented as span
+links rather than parent spans.
+
 The output is an
 [OTLP/HTTP JSON](https://opentelemetry.io/docs/specs/otlp/#json-protobuf-encoding)
-`ExportTraceServiceRequest`. It contains one `invoke_agent WebBrain` root span,
-child model-call and `execute_tool` spans, and lightweight lifecycle events.
+`ExportTraceServiceRequest`. Legacy input contains one `invoke_agent WebBrain`
+root span, child model-call and `execute_tool` spans, and lightweight lifecycle
+events; session bundles contain one `invoke_agent` span per run.
 The mappings follow the current
 [OpenTelemetry GenAI semantic conventions](https://github.com/open-telemetry/semantic-conventions-genai/blob/main/docs/gen-ai/gen-ai-agent-spans.md),
 which are still marked development and may change.
@@ -133,6 +140,10 @@ npm run trace:otlp -- webbrain-trace-example.json \
   --output webbrain-trace-example.otlp.json \
   --include-content
 ```
+
+See [`trace-format-compatibility.md`](trace-format-compatibility.md) for the
+relationship between the storage version, run format version, and export
+schema, plus the reader obligations for unknown events and legacy records.
 
 This is a post-run conversion, not live OpenTelemetry instrumentation. Child
 span start times are reconstructed from the recorder's completion timestamp and

--- a/docs/trace-format-compatibility.md
+++ b/docs/trace-format-compatibility.md
@@ -15,8 +15,10 @@ WebBrain trace data has three independent version layers:
 ## Reader obligations
 
 Treat a missing or malformed `traceFormatVersion` as the legacy baseline. Keep
-missing optional fields harmless. Readers must not fail an entire export because
-one event kind is unknown:
+missing optional fields harmless. Reject a numeric `traceFormatVersion` newer
+than the latest version the reader supports instead of interpreting `seq` and
+`ts` with older semantics. Readers must not fail an entire export because one
+event kind is unknown:
 
 - the Traces UI shows a labeled placeholder with the raw event view;
 - machine-readable exporters preserve an unknown event as a generic record with

--- a/docs/trace-format-compatibility.md
+++ b/docs/trace-format-compatibility.md
@@ -1,0 +1,34 @@
+# Trace format compatibility
+
+WebBrain trace data has three independent version layers:
+
+- `DB_VERSION` describes IndexedDB object-store structure and changes only when
+  stores or indexes change.
+- `traceFormatVersion` describes the meaning of a persisted run and its event
+  log. New optional fields and new event kinds are additive and remain at the
+  current version. Bump this value only when an existing meaning changes, a
+  field becomes required, or `seq`/`ts` semantics change.
+- `schema` describes the JSON export envelope. `webbrain-trace/1` remains the
+  envelope for additive run and event changes. A new schema is reserved for a
+  container-shape or semantic break.
+
+## Reader obligations
+
+Treat a missing or malformed `traceFormatVersion` as the legacy baseline. Keep
+missing optional fields harmless. Readers must not fail an entire export because
+one event kind is unknown:
+
+- the Traces UI shows a labeled placeholder with the raw event view;
+- machine-readable exporters preserve an unknown event as a generic record with
+  its event kind;
+- the Markdown summary may omit unknown event details, but reports the count.
+
+Raw JSON re-export keeps the original fields. Compatibility handling does not
+perform destructive migration and does not change the default privacy policy.
+
+## Session bundles
+
+The existing single-run `webbrain-trace/1` shape remains valid. A session bundle
+may carry a `session` identity and a `runs` array containing `{ run, events }`
+entries. Session-aware consumers use persisted `conversationId`, `parentRunId`,
+and `parentSessionId` values; they do not infer lineage from in-memory state.

--- a/scripts/trace-to-otlp.mjs
+++ b/scripts/trace-to-otlp.mjs
@@ -2,6 +2,8 @@
 import { createHash } from 'node:crypto';
 import { readFileSync, writeFileSync } from 'node:fs';
 import { pathToFileURL } from 'node:url';
+import { isKnownKind } from '../src/chrome/src/trace/event-model.js';
+import { buildTraceLineageGroups } from '../src/chrome/src/trace/lineage.js';
 
 const WEBBRAIN_TRACE_SCHEMA = 'webbrain-trace/1';
 const CONTENT_LIMIT = 20_000;
@@ -22,6 +24,26 @@ function unixNano(milliseconds) {
 function stableHex(seed, length) {
   const value = createHash('sha256').update(String(seed)).digest('hex').slice(0, length);
   return /^0+$/.test(value) ? `${'0'.repeat(length - 1)}1` : value;
+}
+
+function normalizedId(value) {
+  return value == null ? '' : String(value).trim();
+}
+
+function normalizedFormatVersion(value) {
+  const version = Number(value);
+  return Number.isInteger(version) && version >= 0 ? version : 0;
+}
+
+function normalizedRun(run) {
+  return {
+    ...run,
+    traceFormatVersion: normalizedFormatVersion(run.traceFormatVersion),
+  };
+}
+
+function normalizedEvents(events) {
+  return events.filter((event) => event && typeof event === 'object');
 }
 
 function safeJson(value) {
@@ -90,9 +112,24 @@ function contentAttributes(run, includeContent) {
   ];
 }
 
+function genericEvent(event, includeContent, runStart) {
+  const data = event?.data || {};
+  return {
+    timeUnixNano: unixNano(eventTime(event, runStart)),
+    name: 'webbrain.unknown',
+    attributes: attributes([
+      ['webbrain.event.sequence', finiteNumber(event?.seq)],
+      ['webbrain.event.kind', String(event?.kind || 'unknown')],
+      ['webbrain.step', finiteNumber(data.step)],
+      ...(includeContent ? [['webbrain.event.data', boundedContent(data)]] : []),
+    ]),
+  };
+}
+
 function rootEvents(events, includeContent, runStart) {
   return events.flatMap((event) => {
     const data = event?.data || {};
+    if (!isKnownKind(event?.kind)) return [genericEvent(event, includeContent, runStart)];
     const base = [
       ['webbrain.event.sequence', finiteNumber(event?.seq)],
       ['webbrain.step', finiteNumber(data.step)],
@@ -181,9 +218,34 @@ function toolSpan(event, context, includeContent) {
   };
 }
 
-export function traceExportToOtlp(input, { includeContent = false } = {}) {
+function normalizeBundleEntry(entry, index) {
+  if (!entry?.run || typeof entry.run !== 'object' || Array.isArray(entry.run)) {
+    throw new Error(`Trace export bundle entry ${index} must contain a run object.`);
+  }
+  if (!Array.isArray(entry.events)) {
+    throw new Error(`Trace export bundle entry ${index} must contain an events array.`);
+  }
+  return { run: normalizedRun(entry.run), events: normalizedEvents(entry.events) };
+}
+
+export function normalizeTraceExport(input) {
   if (!input || input.schema !== WEBBRAIN_TRACE_SCHEMA) {
     throw new Error(`Expected a ${WEBBRAIN_TRACE_SCHEMA} export.`);
+  }
+  const exported = {
+    schema: input.schema,
+    exportedAt: finiteNumber(input.exportedAt),
+    exportedByWebBrainVersion: String(input.exportedByWebBrainVersion || ''),
+  };
+  if (Array.isArray(input.runs)) {
+    if (input.runs.length === 0) throw new Error('Trace export must contain a non-empty runs array.');
+    const runs = input.runs.map(normalizeBundleEntry);
+    return {
+      ...exported,
+      legacy: false,
+      sessionId: normalizedId(input.session?.sessionId),
+      runs,
+    };
   }
   if (!input.run || typeof input.run !== 'object' || Array.isArray(input.run)) {
     throw new Error('Trace export must contain a run object.');
@@ -191,13 +253,22 @@ export function traceExportToOtlp(input, { includeContent = false } = {}) {
   if (!Array.isArray(input.events)) {
     throw new Error('Trace export must contain an events array.');
   }
+  const run = normalizedRun(input.run);
+  return {
+    ...exported,
+    legacy: true,
+    sessionId: normalizedId(run.conversationId),
+    runs: [{ run, events: normalizedEvents(input.events) }],
+  };
+}
 
-  const run = input.run;
-  const events = [...input.events]
-    .filter((event) => event && typeof event === 'object')
-    .sort((a, b) => finiteNumber(a.seq) - finiteNumber(b.seq));
+function sortedEvents(events) {
+  return [...events].sort((a, b) => finiteNumber(a.seq) - finiteNumber(b.seq));
+}
+
+function runBounds(run, events, exportedAt) {
   const eventTimes = events.map((event) => finiteNumber(event.ts)).filter((time) => time > 0);
-  const fallbackStarts = [...eventTimes, finiteNumber(input.exportedAt)].filter((time) => time > 0);
+  const fallbackStarts = [...eventTimes, finiteNumber(exportedAt)].filter((time) => time > 0);
   const initialStart = finiteNumber(
     run.startedAt,
     fallbackStarts.length ? Math.min(...fallbackStarts) : 0,
@@ -212,6 +283,223 @@ export function traceExportToOtlp(input, { includeContent = false } = {}) {
     runStart + Math.max(0, finiteNumber(run.durationMs)),
     ...eventTimes,
   );
+  return { runStart, runEnd };
+}
+
+function sessionIdForRun(run, bundleSessionId, index) {
+  return normalizedId(run.conversationId)
+    || normalizedId(bundleSessionId)
+    || `run:${normalizedId(run.runId) || index}`;
+}
+
+function buildLineageRecords(bundle) {
+  const records = bundle.runs.map(({ run, events }, index) => {
+    const sessionId = sessionIdForRun(run, bundle.sessionId, index);
+    return {
+      index,
+      run: run.conversationId ? run : { ...run, conversationId: sessionId },
+      events: sortedEvents(events),
+      runId: normalizedId(run.runId),
+      sessionId,
+      parentRunId: normalizedId(run.parentRunId),
+      parentSessionId: normalizedId(run.parentSessionId),
+      lineageState: 'root',
+      parent: null,
+      crossSessionParent: null,
+      spanId: '',
+    };
+  });
+  const lineage = buildTraceLineageGroups(records.map(record => record.run));
+  const nodesByIndex = new Map(
+    lineage.groups.flatMap(group => group.nodes).map(node => [node.index, node]),
+  );
+  const nodesByKey = new Map(
+    lineage.groups.flatMap(group => group.nodes).map(node => [node.key, node]),
+  );
+  const byRunId = new Map();
+  for (const record of records) {
+    if (!record.runId) continue;
+    const matches = byRunId.get(record.runId) || [];
+    matches.push(record);
+    byRunId.set(record.runId, matches);
+  }
+  for (const record of records) {
+    const node = nodesByIndex.get(record.index);
+    record.lineageState = node?.lineageState || 'root';
+    if (node?.parentKey) record.parent = records[nodesByKey.get(node.parentKey)?.index];
+    if (record.lineageState === 'missing-parent'
+      && record.parentSessionId
+      && record.parentSessionId !== record.sessionId) {
+      record.lineageState = 'cross-session-parent';
+      record.crossSessionParent = { sessionId: record.parentSessionId, parent: null };
+    }
+    if (record.lineageState === 'cross-session-parent') {
+      const candidates = byRunId.get(record.parentRunId) || [];
+      if (candidates.length === 1) {
+        record.crossSessionParent = {
+          sessionId: record.parentSessionId || candidates[0].sessionId,
+          parent: candidates[0],
+        };
+      }
+    }
+  }
+  const counts = new Map();
+  for (const record of records) {
+    if (record.runId) counts.set(record.runId, (counts.get(record.runId) || 0) + 1);
+  }
+  const occurrences = new Map();
+  for (const record of records) {
+    const occurrence = occurrences.get(record.runId) || 0;
+    occurrences.set(record.runId, occurrence + 1);
+    const suffix = counts.get(record.runId) > 1 ? `:duplicate:${occurrence}` : '';
+    record.spanId = stableHex(`webbrain:run:${record.runId || record.index}${suffix}`, 16);
+  }
+  return records;
+}
+
+function bundleEvent(event, includeContent, runStart) {
+  const data = event?.data || {};
+  const kind = String(event?.kind || 'unknown');
+  const base = [
+    ['webbrain.event.sequence', finiteNumber(event?.seq)],
+    ['webbrain.event.kind', kind],
+    ['webbrain.step', finiteNumber(data.step)],
+  ];
+  let name = isKnownKind(kind) ? `webbrain.${kind}` : 'webbrain.unknown';
+  const extra = [];
+  if (kind === 'error') {
+    name = 'exception';
+    extra.push(['exception.type', data.phase ? `webbrain.${data.phase}` : 'webbrain.error']);
+    if (includeContent) extra.push(['exception.message', boundedContent(data.message)]);
+  } else if (kind === 'llm_response') {
+    extra.push(
+      ['gen_ai.request.model', data.model],
+      ['gen_ai.usage.input_tokens', data.usage?.prompt_tokens],
+      ['gen_ai.usage.output_tokens', data.usage?.completion_tokens],
+    );
+    if (includeContent) extra.push(['webbrain.llm.response.content', boundedContent(data.content)]);
+  } else if (kind === 'tool') {
+    const failed = failedToolResult(data.result);
+    extra.push(['gen_ai.tool.name', data.name], ...(failed ? [['error.type', 'tool_error']] : []));
+    if (includeContent) {
+      extra.push(
+        ['gen_ai.tool.call.arguments', boundedContent(data.args)],
+        ['gen_ai.tool.call.result', boundedContent(data.result)],
+      );
+    }
+  } else if (kind === 'streaming' || kind === 'note') {
+    extra.push(['webbrain.event.status', data.status], ['webbrain.event.reason', data.reason]);
+    if (includeContent && kind === 'note') extra.push(['webbrain.note', boundedContent(data.note)]);
+  }
+  if (!isKnownKind(kind) && includeContent) extra.push(['webbrain.event.data', boundedContent(data)]);
+  return {
+    timeUnixNano: unixNano(eventTime(event, runStart)),
+    name,
+    attributes: attributes([...base, ...extra]),
+  };
+}
+
+function bundleEvents(events, includeContent, runStart) {
+  return events.map((event) => bundleEvent(event, includeContent, runStart));
+}
+
+function lineageAttributes(record) {
+  return [
+    ['webbrain.trace.format.version', record.run.traceFormatVersion],
+    ['webbrain.parent.run.id', record.parentRunId],
+    ['webbrain.parent.session.id', record.parentSessionId],
+    ...(record.lineageState !== 'root' && record.lineageState !== 'attached'
+      ? [['webbrain.lineage.state', record.lineageState]]
+      : []),
+  ];
+}
+
+function sessionTraceId(sessionId) {
+  return stableHex(`webbrain:session:${sessionId}`, 32);
+}
+
+function bundleRunSpan(record, bundle, includeContent) {
+  const { runStart, runEnd } = runBounds(record.run, record.events, bundle.exportedAt);
+  const hasError = ['error', 'failed', 'loop_stopped'].includes(String(record.run.status || '').toLowerCase())
+    || record.events.some((event) => event.kind === 'error');
+  const span = {
+    traceId: sessionTraceId(record.sessionId),
+    spanId: record.spanId,
+    name: `invoke_agent ${record.run.runId || `run-${record.index}`}`,
+    kind: SPAN_KIND_INTERNAL,
+    startTimeUnixNano: unixNano(runStart),
+    endTimeUnixNano: unixNano(runEnd),
+    attributes: attributes([
+      ['gen_ai.operation.name', 'invoke_agent'],
+      ['gen_ai.agent.name', 'WebBrain'],
+      ['gen_ai.agent.version', record.run.webbrainVersion || bundle.exportedByWebBrainVersion],
+      ['gen_ai.provider.name', record.run.providerId],
+      ['gen_ai.request.model', record.run.model],
+      ['gen_ai.conversation.id', record.sessionId],
+      ['gen_ai.usage.input_tokens', record.run.totalInputTokens],
+      ['gen_ai.usage.output_tokens', record.run.totalOutputTokens],
+      ['webbrain.run.id', record.run.runId],
+      ['webbrain.run.status', record.run.status],
+      ...lineageAttributes(record),
+      ...contentAttributes(record.run, includeContent),
+    ]),
+    events: bundleEvents(record.events, includeContent, runStart),
+    ...(record.parent ? { parentSpanId: record.parent.spanId } : {}),
+    ...(hasError ? { status: { code: STATUS_CODE_ERROR } } : {}),
+  };
+  if (record.crossSessionParent) {
+    const { parent, sessionId } = record.crossSessionParent;
+    span.links = [{
+      traceId: sessionTraceId(sessionId),
+      spanId: parent?.spanId || stableHex(`webbrain:run:${record.parentRunId}`, 16),
+      attributes: attributes([
+        ['webbrain.parent.run.id', record.parentRunId],
+        ['webbrain.parent.session.id', sessionId],
+      ]),
+    }];
+  }
+  return span;
+}
+
+function sessionBundleToOtlp(bundle, includeContent) {
+  const records = buildLineageRecords(bundle);
+  const groups = new Map();
+  for (const record of records) {
+    const group = groups.get(record.sessionId) || [];
+    group.push(record);
+    groups.set(record.sessionId, group);
+  }
+  return {
+    resourceSpans: [...groups.entries()].sort(([a], [b]) => a.localeCompare(b)).map(([sessionId, sessionRecords]) => ({
+      resource: {
+        attributes: attributes([
+          ['service.name', 'webbrain'],
+          ['service.version', bundle.exportedByWebBrainVersion],
+          ['webbrain.session.id', sessionId],
+        ]),
+      },
+      scopeSpans: [{
+        scope: {
+          name: 'webbrain.trace-export',
+          ...(bundle.exportedByWebBrainVersion
+            ? { version: String(bundle.exportedByWebBrainVersion) }
+            : {}),
+        },
+        spans: sessionRecords
+          .sort((a, b) => (finiteNumber(a.run.startedAt) - finiteNumber(b.run.startedAt)) || a.runId.localeCompare(b.runId))
+          .map(record => bundleRunSpan(record, bundle, includeContent)),
+      }],
+    })),
+  };
+}
+
+export function traceExportToOtlp(input, { includeContent = false } = {}) {
+  const bundle = normalizeTraceExport(input);
+  if (!bundle.legacy) return sessionBundleToOtlp(bundle, includeContent);
+
+  const [{ run, events: rawEvents }] = bundle.runs;
+  const events = sortedEvents(rawEvents);
+  const { runStart, runEnd } = runBounds(run, events, bundle.exportedAt);
   const traceId = stableHex(`webbrain:${run.runId || runStart}`, 32);
   const rootSpanId = stableHex(`webbrain:${run.runId || runStart}:root`, 16);
   const context = { run, runStart, traceId, rootSpanId };

--- a/scripts/trace-to-otlp.mjs
+++ b/scripts/trace-to-otlp.mjs
@@ -2,7 +2,7 @@
 import { createHash } from 'node:crypto';
 import { readFileSync, writeFileSync } from 'node:fs';
 import { pathToFileURL } from 'node:url';
-import { isKnownKind } from '../src/chrome/src/trace/event-model.js';
+import { TRACE_FORMAT_VERSION, isKnownKind } from '../src/chrome/src/trace/event-model.js';
 import { buildTraceLineageGroups } from '../src/chrome/src/trace/lineage.js';
 
 const WEBBRAIN_TRACE_SCHEMA = 'webbrain-trace/1';
@@ -32,7 +32,13 @@ function normalizedId(value) {
 
 function normalizedFormatVersion(value) {
   const version = Number(value);
-  return Number.isInteger(version) && version >= 0 ? version : 0;
+  if (!Number.isInteger(version) || version < 0) return 0;
+  if (version > TRACE_FORMAT_VERSION) {
+    throw new Error(
+      `Unsupported trace format version ${version}; maximum supported version is ${TRACE_FORMAT_VERSION}.`,
+    );
+  }
+  return version;
 }
 
 function normalizedRun(run) {
@@ -297,7 +303,7 @@ function buildLineageRecords(bundle) {
     const sessionId = sessionIdForRun(run, bundle.sessionId, index);
     return {
       index,
-      run: run.conversationId ? run : { ...run, conversationId: sessionId },
+      run: { ...run, conversationId: sessionId },
       events: sortedEvents(events),
       runId: normalizedId(run.runId),
       sessionId,

--- a/test/run.js
+++ b/test/run.js
@@ -9036,6 +9036,15 @@ test('trace export compatibility: normalizes legacy and session bundle inputs', 
   assert.equal(bundle.sessionId, 'session-a');
   assert.equal(bundle.runs[0].run.traceFormatVersion, 0);
   assert.equal(bundle.runs[0].run.runId, 'run-a');
+
+  assert.throws(
+    () => normalizeTraceExport({
+      schema: 'webbrain-trace/1',
+      session: { sessionId: 'session-future' },
+      runs: [{ run: { runId: 'future-run', traceFormatVersion: 2 }, events: [] }],
+    }),
+    /Unsupported trace format version 2.*maximum supported version is 1/,
+  );
 });
 
 test('OTLP session bundles map runs to spans and steps to span events', () => {
@@ -9075,6 +9084,32 @@ test('OTLP session bundles map runs to spans and steps to span events', () => {
   assert.equal(child.kind, 1);
   assert.equal(child.events.length, 3);
   assert.deepEqual(child.events.map(event => event.name), ['webbrain.step_start', 'webbrain.llm_response', 'webbrain.tool']);
+});
+
+test('OTLP session bundles use their session ID for blank run conversation IDs', () => {
+  const payload = traceExportToOtlp({
+    schema: 'webbrain-trace/1',
+    session: { sessionId: 'session-a' },
+    runs: [
+      { run: { runId: 'root-run', conversationId: '   ' }, events: [] },
+      {
+        run: {
+          runId: 'child-run', conversationId: '\t', parentRunId: 'root-run',
+          parentSessionId: 'session-a',
+        },
+        events: [],
+      },
+    ],
+  });
+  const spans = payload.resourceSpans[0].scopeSpans[0].spans;
+  const root = spans.find(span => otlpAttributes(span.attributes)['webbrain.run.id'] === 'root-run');
+  const child = spans.find(span => otlpAttributes(span.attributes)['webbrain.run.id'] === 'child-run');
+  assert.ok(root);
+  assert.ok(child);
+  assert.equal(child.traceId, root.traceId);
+  assert.equal(child.parentSpanId, root.spanId);
+  assert.equal(child.links, undefined);
+  assert.equal(otlpAttributes(child.attributes)['gen_ai.conversation.id'], 'session-a');
 });
 
 test('OTLP session bundles preserve cross-session, missing, duplicate, and cyclic lineage', () => {
@@ -9133,6 +9168,7 @@ test('trace format compatibility policy documents the version layers and reader 
   assert.match(policy, /DB_VERSION/);
   assert.match(policy, /unknown event/i);
   assert.match(policy, /new optional fields/i);
+  assert.match(policy, /Reject a numeric `traceFormatVersion` newer/i);
 });
 
 test('OTLP trace converter CLI parsing keeps content opt-in and output explicit', () => {

--- a/test/run.js
+++ b/test/run.js
@@ -899,7 +899,7 @@ const {
 } = await import(
   'file://' + path.join(ROOT, 'scripts/build-zip.mjs').replace(/\\/g, '/')
 );
-const { traceExportToOtlp, parseTraceToOtlpArgs } = await import(
+const { normalizeTraceExport, traceExportToOtlp, parseTraceToOtlpArgs } = await import(
   'file://' + path.join(ROOT, 'scripts/trace-to-otlp.mjs').replace(/\\/g, '/')
 );
 
@@ -9013,6 +9013,126 @@ test('OTLP trace converter rejects other schemas and malformed records', () => {
   assert.equal(root.startTimeUnixNano, '1234000000');
   assert.equal(tool.startTimeUnixNano, '1234000000');
   assert.doesNotMatch(JSON.stringify(legacy), /stringValue\":\"(?:undefined|null)\"/);
+});
+
+test('trace export compatibility: normalizes legacy and session bundle inputs', () => {
+  const legacy = normalizeTraceExport({
+    schema: 'webbrain-trace/1',
+    run: { runId: 'legacy-run', traceFormatVersion: 'not-a-version' },
+    events: [],
+  });
+  assert.equal(legacy.legacy, true);
+  assert.equal(legacy.sessionId, '');
+  assert.equal(legacy.runs.length, 1);
+  assert.equal(legacy.runs[0].run.traceFormatVersion, 0);
+  assert.deepEqual(legacy.runs[0].events, []);
+
+  const bundle = normalizeTraceExport({
+    schema: 'webbrain-trace/1',
+    session: { sessionId: 'session-a' },
+    runs: [{ run: { runId: 'run-a', conversationId: 'session-a' }, events: [] }],
+  });
+  assert.equal(bundle.legacy, false);
+  assert.equal(bundle.sessionId, 'session-a');
+  assert.equal(bundle.runs[0].run.traceFormatVersion, 0);
+  assert.equal(bundle.runs[0].run.runId, 'run-a');
+});
+
+test('OTLP session bundles map runs to spans and steps to span events', () => {
+  const payload = traceExportToOtlp({
+    schema: 'webbrain-trace/1',
+    session: { sessionId: 'session-a' },
+    exportedAt: 1_800_000_000_000,
+    runs: [
+      {
+        run: {
+          runId: 'root-run', conversationId: 'session-a', startedAt: 1_800_000_000_000,
+          endedAt: 1_800_000_000_200, status: 'done', model: 'root-model',
+        },
+        events: [{ seq: 1, ts: 1_800_000_000_100, kind: 'turn_start', data: { step: 0 } }],
+      },
+      {
+        run: {
+          runId: 'child-run', conversationId: 'session-a', parentRunId: 'root-run',
+          startedAt: 1_800_000_000_300, endedAt: 1_800_000_000_700, status: 'done', model: 'child-model',
+        },
+        events: [
+          { seq: 1, ts: 1_800_000_000_400, kind: 'step_start', data: { step: 1 } },
+          { seq: 2, ts: 1_800_000_000_500, kind: 'llm_response', data: { step: 1, usage: { prompt_tokens: 3, completion_tokens: 2 } } },
+          { seq: 3, ts: 1_800_000_000_600, kind: 'tool', data: { step: 1, name: 'read_page', result: { success: true } } },
+        ],
+      },
+    ],
+  });
+  const spans = payload.resourceSpans.flatMap(resource => resource.scopeSpans.flatMap(scope => scope.spans));
+  assert.equal(spans.length, 2);
+  const root = spans.find(span => otlpAttributes(span.attributes)['webbrain.run.id'] === 'root-run');
+  const child = spans.find(span => otlpAttributes(span.attributes)['webbrain.run.id'] === 'child-run');
+  assert.ok(root);
+  assert.ok(child);
+  assert.equal(root.traceId, child.traceId);
+  assert.equal(child.parentSpanId, root.spanId);
+  assert.equal(child.kind, 1);
+  assert.equal(child.events.length, 3);
+  assert.deepEqual(child.events.map(event => event.name), ['webbrain.step_start', 'webbrain.llm_response', 'webbrain.tool']);
+});
+
+test('OTLP session bundles preserve cross-session, missing, duplicate, and cyclic lineage', () => {
+  const payload = traceExportToOtlp({
+    schema: 'webbrain-trace/1',
+    session: { sessionId: 'session-child' },
+    runs: [
+      { run: { runId: 'cross-child', conversationId: 'session-child', parentRunId: 'foreign', parentSessionId: 'session-parent' }, events: [] },
+      { run: { runId: 'missing-child', conversationId: 'session-child', parentRunId: 'not-loaded' }, events: [] },
+      { run: { runId: 'duplicate', conversationId: 'session-child' }, events: [] },
+      { run: { runId: 'duplicate', conversationId: 'session-child' }, events: [] },
+      { run: { runId: 'ambiguous-child', conversationId: 'session-child', parentRunId: 'duplicate' }, events: [] },
+      { run: { runId: 'cycle-a', conversationId: 'session-child', parentRunId: 'cycle-b' }, events: [] },
+      { run: { runId: 'cycle-b', conversationId: 'session-child', parentRunId: 'cycle-a' }, events: [] },
+    ],
+  });
+  const spans = payload.resourceSpans.flatMap(resource => resource.scopeSpans.flatMap(scope => scope.spans));
+  const spanFor = runId => spans.find(span => otlpAttributes(span.attributes)['webbrain.run.id'] === runId);
+  const spansFor = runId => spans.filter(span => otlpAttributes(span.attributes)['webbrain.run.id'] === runId);
+  assert.equal(spans.length, 7, 'session exporter dropped a persisted run');
+  const crossChild = spanFor('cross-child');
+  const crossAttrs = otlpAttributes(crossChild.attributes);
+  assert.equal(crossChild.parentSpanId, undefined);
+  assert.equal(crossChild.links.length, 1);
+  assert.notEqual(crossChild.links[0].traceId, crossChild.traceId);
+  assert.equal(otlpAttributes(crossChild.links[0].attributes)['webbrain.parent.run.id'], 'foreign');
+  assert.equal(crossAttrs['webbrain.lineage.state'], 'cross-session-parent');
+  assert.equal(otlpAttributes(spanFor('missing-child').attributes)['webbrain.lineage.state'], 'missing-parent');
+  assert.equal(otlpAttributes(spanFor('ambiguous-child').attributes)['webbrain.lineage.state'], 'ambiguous-parent');
+  assert.equal(otlpAttributes(spanFor('cycle-a').attributes)['webbrain.lineage.state'], 'cycle');
+  assert.equal(otlpAttributes(spanFor('cycle-b').attributes)['webbrain.lineage.state'], 'cycle');
+  const duplicateSpans = spansFor('duplicate');
+  assert.equal(duplicateSpans.length, 2);
+  assert.notEqual(duplicateSpans[0].spanId, duplicateSpans[1].spanId);
+});
+
+test('OTLP legacy output preserves unknown event kinds as generic events', () => {
+  const payload = traceExportToOtlp({
+    ...OTLP_TRACE_FIXTURE,
+    events: [
+      ...OTLP_TRACE_FIXTURE.events,
+      { runId: 'run_otlp_fixture', seq: 5, ts: 1_784_937_601_200, kind: 'future_kind', data: { secret: 'do not export by default' } },
+    ],
+  });
+  const root = payload.resourceSpans[0].scopeSpans[0].spans[0];
+  const unknown = root.events.find(event => otlpAttributes(event.attributes)['webbrain.event.kind'] === 'future_kind');
+  assert.ok(unknown);
+  assert.equal(unknown.name, 'webbrain.unknown');
+  assert.doesNotMatch(JSON.stringify(unknown), /do not export by default/);
+});
+
+test('trace format compatibility policy documents the version layers and reader obligations', () => {
+  const policy = fs.readFileSync(path.join(ROOT, 'docs/trace-format-compatibility.md'), 'utf8');
+  assert.match(policy, /webbrain-trace\/1/);
+  assert.match(policy, /traceFormatVersion/);
+  assert.match(policy, /DB_VERSION/);
+  assert.match(policy, /unknown event/i);
+  assert.match(policy, /new optional fields/i);
 });
 
 test('OTLP trace converter CLI parsing keeps content opt-in and output explicit', () => {


### PR DESCRIPTION
## Summary

Extends the post-run trace converter with a compatible session-aware OTLP export path and documents the trace versioning contract.

Closes #2908
Closes #2909

## Changes

- Adds a pure normalization seam for the existing single-run export and the optional `{ session, runs }` bundle shape.
- Keeps legacy single-run OTLP output unchanged, including its root span and model/tool child spans.
- Maps a session to one OTLP trace and each persisted run to one deterministic span.
- Resolves unique same-session `parentRunId` values to parent spans, represents cross-session parents as Span Links, and preserves missing, duplicate, and cyclic lineage with attributes.
- Keeps turn and step activity as span events and preserves the default content-free export behavior.
- Preserves unknown event kinds as generic OTLP events instead of silently dropping them.
- Documents the separate storage version, run format version, and export envelope version policies.

## Compatibility

The `webbrain-trace/1` envelope remains valid for additive fields and event kinds. Missing or malformed run format versions use the legacy baseline, while semantic changes, newly required fields, or changed sequence/timestamp meanings require an explicit version change. No storage migration or provider context propagation is included.

## Validation

- `node test/run.js` — 2037 passed, 0 failed
- `npm run test:toolbar-guard` — 33 passed
- `npm run test:security` — 60/60 checks passed
- `node scripts/benchmark-offline-relevance.mjs` — completed successfully
