### PR TITLE
feat(trace): export conversation trace bundles

### DIFF
--- a/docs/export-and-workflow-formats.md
+++ b/docs/export-and-workflow-formats.md
@@ -87,7 +87,10 @@ changing the `webbrain-trace/1` schema:
 Lossless entries are redacted with the same credential-key safeguards as
 standalone JSON exports. Standalone exports keep the original `run` and
 `events` fields for existing consumers; session bundles use `session` and
-`runs` instead.
+`runs` instead. Before downloading a session bundle, the Traces page confirms
+the number of included runs and warns when any run uses the sensitive debug
+tier. A session export fails instead of silently producing a partial bundle if
+its run or event records cannot be read.
 
 ### Convert a trace to ATIF v1.7
 
@@ -106,6 +109,11 @@ trajectory to standard output:
 node scripts/trace-to-atif.mjs trace.json trajectory.json
 node scripts/trace-to-atif.mjs trace.json -
 ```
+
+Standalone exports remain one ATIF trajectory keyed by the run ID. Session
+bundles become one multi-turn ATIF trajectory keyed by the session ID; runs are
+ordered chronologically, step numbers stay contiguous, and each step records
+its source run in `extra.webbrain_run_id`.
 
 The converter maps user and agent messages, tool calls and observations, token
 metrics, errors, model metadata, and final content. It does not upload data.

--- a/docs/export-and-workflow-formats.md
+++ b/docs/export-and-workflow-formats.md
@@ -9,7 +9,7 @@ workflow. These files have different privacy and compatibility properties.
 | `/export --traces` | `webbrain-traces-<timestamp>.md` | Recorded tool-chain Markdown | Yes. It can contain user prompts, model output, tool arguments, URLs, and results. Raw system prompts are not embedded. |
 | `/export --config` | `webbrain-config-<timestamp>.json` | `webbrain-config/1` | **Yes. It is plaintext and can contain API keys, profile data, and user memory.** |
 | `/workflow --export <id>` | `<name>.webbrain-workflow.json` | `webbrain-workflow/1` | Review before sharing. Runtime values are omitted, but saved targets and URL scopes remain. |
-| Traces page **Export JSON** | `webbrain-trace-<model>-<run-id>.json` | `webbrain-trace/1` | Yes. It contains the raw recorded run and may include screenshots. |
+| Traces page **Export JSON** | `webbrain-trace-<model>-<run-id>.json` or `webbrain-session-<session-id>.json` | `webbrain-trace/1` | Yes. It contains one recorded run or a session bundle and may include screenshots. |
 
 All exports are created locally by the browser. Exporting a file does not upload
 it.
@@ -49,7 +49,8 @@ Screenshots, vision sub-calls, and internal trace notes are omitted from this
 Markdown format. The export may be marked partial or truncated when the browser
 cannot retrieve the complete recorded chain.
 
-The Traces page offers a separate JSON export for one selected run:
+The Traces page offers a separate JSON export for one selected run. Standalone
+runs retain the legacy shape:
 
 ```json
 {
@@ -65,6 +66,28 @@ The Traces page offers a separate JSON export for one selected run:
 Screenshot events can include `screenshot_base64` or `screenshot_dataUrl`.
 Consumers should check `schema`, tolerate additional fields, and avoid relying
 on undocumented event internals.
+
+When the selected run belongs to a conversation, the same action exports the
+indexed conversation runs as one session bundle. Each entry keeps its own run
+metadata and event list so parent-run lineage can be reconstructed without
+changing the `webbrain-trace/1` schema:
+
+```json
+{
+  "schema": "webbrain-trace/1",
+  "session": { "sessionId": "conversation-7" },
+  "runs": [
+    { "run": {}, "events": [] }
+  ],
+  "exportedAt": 1784937600000,
+  "exportedByWebBrainVersion": "25.8.5"
+}
+```
+
+Lossless entries are redacted with the same credential-key safeguards as
+standalone JSON exports. Standalone exports keep the original `run` and
+`events` fields for existing consumers; session bundles use `session` and
+`runs` instead.
 
 ### Convert a trace to ATIF v1.7
 

--- a/scripts/trace-to-atif.mjs
+++ b/scripts/trace-to-atif.mjs
@@ -109,6 +109,7 @@ export function webbrainTraceToAtif(input) {
   if (input.schema !== SOURCE_SCHEMA) {
     throw new TypeError(`Expected schema "${SOURCE_SCHEMA}".`);
   }
+  if (Array.isArray(input.runs)) return webbrainTraceBundleToAtif(input);
   if (!isObject(input.run)) throw new TypeError('WebBrain trace run must be an object.');
   if (!Array.isArray(input.events)) throw new TypeError('WebBrain trace events must be an array.');
   if (typeof input.run.runId !== 'string' || !input.run.runId.trim()) {
@@ -322,6 +323,145 @@ export function webbrainTraceToAtif(input) {
     steps,
     final_metrics: finalMetrics,
     extra: rootExtra,
+  };
+}
+
+function uniqueValues(values) {
+  return [...new Set(values.filter(value => value != null && value !== ''))];
+}
+
+function summedMetric(trajectories, key) {
+  const values = trajectories
+    .map(({ trajectory }) => finiteNumber(trajectory.final_metrics?.[key]))
+    .filter(value => value !== undefined);
+  return values.length ? values.reduce((total, value) => total + value, 0) : undefined;
+}
+
+function appendBundleSteps(target, trajectory, runId, allocatedToolCallIds) {
+  for (const sourceStep of trajectory.steps) {
+    const remappedCallIds = new Map();
+    const step = {
+      ...sourceStep,
+      step_id: target.length + 1,
+      extra: {
+        ...(sourceStep.extra || {}),
+        webbrain_run_id: runId,
+      },
+    };
+    if (Array.isArray(sourceStep.tool_calls)) {
+      step.tool_calls = sourceStep.tool_calls.map((call) => {
+        const originalId = String(call.tool_call_id || 'webbrain-call');
+        let toolCallId = originalId;
+        if (allocatedToolCallIds.has(toolCallId)) {
+          const stem = `${originalId}-${runId}`;
+          toolCallId = stem;
+          let suffix = 2;
+          while (allocatedToolCallIds.has(toolCallId)) {
+            toolCallId = `${stem}-${suffix}`;
+            suffix += 1;
+          }
+          remappedCallIds.set(originalId, toolCallId);
+        }
+        allocatedToolCallIds.add(toolCallId);
+        return { ...call, tool_call_id: toolCallId };
+      });
+    }
+    if (sourceStep.observation) {
+      step.observation = {
+        ...sourceStep.observation,
+        results: Array.isArray(sourceStep.observation.results)
+          ? sourceStep.observation.results.map((result) => ({
+              ...result,
+              ...(result.source_call_id && remappedCallIds.has(result.source_call_id)
+                ? { source_call_id: remappedCallIds.get(result.source_call_id) }
+                : {}),
+            }))
+          : sourceStep.observation.results,
+      };
+    }
+    target.push(step);
+  }
+}
+
+function webbrainTraceBundleToAtif(input) {
+  const sessionId = isObject(input.session) && typeof input.session.sessionId === 'string'
+    ? input.session.sessionId.trim()
+    : '';
+  if (!sessionId) {
+    throw new TypeError('WebBrain trace bundle session.sessionId must be a non-empty string.');
+  }
+  if (input.runs.length === 0) {
+    throw new TypeError('WebBrain trace bundle runs must be a non-empty array.');
+  }
+
+  const entries = input.runs.map((entry, index) => {
+    if (!isObject(entry)) {
+      throw new TypeError(`WebBrain trace bundle entry ${index} must be an object.`);
+    }
+    return entry;
+  }).sort((left, right) => {
+    const timeDelta = (finiteNumber(left.run?.startedAt) ?? 0)
+      - (finiteNumber(right.run?.startedAt) ?? 0);
+    if (timeDelta !== 0) return timeDelta;
+    return String(left.run?.runId || '').localeCompare(String(right.run?.runId || ''));
+  });
+
+  const trajectories = entries.map((entry) => ({
+    runId: String(entry.run?.runId || '').trim(),
+    trajectory: webbrainTraceToAtif({
+      schema: input.schema,
+      exportedAt: input.exportedAt,
+      exportedByWebBrainVersion: input.exportedByWebBrainVersion,
+      run: entry.run,
+      events: entry.events,
+    }),
+  }));
+  const steps = [];
+  const allocatedToolCallIds = new Set();
+  for (const { runId, trajectory } of trajectories) {
+    appendBundleSteps(steps, trajectory, runId, allocatedToolCallIds);
+  }
+
+  const models = uniqueValues(trajectories.map(({ trajectory }) => trajectory.agent.model_name));
+  const providerIds = uniqueValues(trajectories.map(({ trajectory }) => trajectory.agent.extra?.provider_id));
+  const providerClasses = uniqueValues(trajectories.map(({ trajectory }) => trajectory.agent.extra?.provider_class));
+  const modes = uniqueValues(trajectories.map(({ trajectory }) => trajectory.agent.extra?.mode));
+  const agentExtra = compactObject({
+    webbrain_run_count: trajectories.length,
+    provider_id: providerIds.length === 1 ? providerIds[0] : undefined,
+    provider_class: providerClasses.length === 1 ? providerClasses[0] : undefined,
+    mode: modes.length === 1 ? modes[0] : undefined,
+  });
+  const version = String(
+    input.exportedByWebBrainVersion || trajectories[0].trajectory.agent.version || 'unknown',
+  );
+
+  return {
+    schema_version: ATIF_SCHEMA_VERSION,
+    session_id: sessionId,
+    trajectory_id: sessionId,
+    agent: compactObject({
+      name: 'webbrain',
+      version,
+      model_name: models.length === 1 ? models[0] : undefined,
+      extra: agentExtra,
+    }),
+    steps,
+    final_metrics: compactObject({
+      total_prompt_tokens: summedMetric(trajectories, 'total_prompt_tokens'),
+      total_completion_tokens: summedMetric(trajectories, 'total_completion_tokens'),
+      total_steps: steps.length,
+    }),
+    extra: compactObject({
+      source_schema: SOURCE_SCHEMA,
+      source_exported_at: timestamp(input.exportedAt),
+      source_exported_by_webbrain_version: input.exportedByWebBrainVersion
+        ? String(input.exportedByWebBrainVersion)
+        : undefined,
+      source_session_id: sessionId,
+      source_run_count: trajectories.length,
+      source_run_ids: trajectories.map(({ runId }) => runId),
+    }),
   };
 }
 

--- a/src/chrome/src/agent/trace-export.js
+++ b/src/chrome/src/agent/trace-export.js
@@ -55,7 +55,17 @@ function redactExportValue(value, key = '') {
 }
 
 export function sanitizeTraceExport(payload) {
-  return payload?.run?.lossless === true ? redactExportValue(payload) : payload;
+  if (payload?.run?.lossless === true) return redactExportValue(payload);
+  if (!Array.isArray(payload?.runs)) return payload;
+
+  let changed = false;
+  const runs = payload.runs.map((entry) => {
+    if (entry?.run?.lossless !== true) return entry;
+    changed = true;
+    return redactExportValue(entry);
+  });
+
+  return changed ? { ...payload, runs } : payload;
 }
 
 // Lossless requests carry the full message/tool shape. Render a bounded,

--- a/src/chrome/src/trace/export-contract.js
+++ b/src/chrome/src/trace/export-contract.js
@@ -1,0 +1,45 @@
+/**
+ * Build the versioned JSON envelope used by the Traces page.
+ *
+ * A standalone export keeps the original { run, events } shape. When a
+ * session ID is supplied, the same schema carries { session, runs } so
+ * consumers can preserve session-level lineage without guessing whether a
+ * single record was exported.
+ */
+
+export const TRACE_EXPORT_SCHEMA = 'webbrain-trace/1';
+
+function normalizeEntries(entries) {
+  if (!Array.isArray(entries)) return [];
+  return entries.map((entry) => ({
+    run: entry?.run && typeof entry.run === 'object' ? entry.run : {},
+    events: Array.isArray(entry?.events) ? entry.events : [],
+  }));
+}
+
+export function buildTraceExportPayload(
+  entries,
+  { sessionId = '', exportedAt = Date.now(), exportedByWebBrainVersion = '' } = {},
+) {
+  const normalized = normalizeEntries(entries);
+  const common = {
+    schema: TRACE_EXPORT_SCHEMA,
+    exportedAt,
+    exportedByWebBrainVersion,
+  };
+
+  if (sessionId) {
+    return {
+      ...common,
+      session: { sessionId },
+      runs: normalized,
+    };
+  }
+
+  const first = normalized[0] || { run: {}, events: [] };
+  return {
+    ...common,
+    run: first.run,
+    events: first.events,
+  };
+}

--- a/src/chrome/src/ui/traces.js
+++ b/src/chrome/src/ui/traces.js
@@ -309,6 +309,13 @@ async function renderRun(runId) {
     replaceTimelineObjectUrls(new Set());
     return;
   }
+  const exportButton = document.getElementById('btn-export');
+  const exportSessionId = typeof run.conversationId === 'string'
+    ? run.conversationId.trim()
+    : '';
+  exportButton.title = exportSessionId
+    ? `${t('tr.btn.export')} · ${t('tr.conversation.label')}`
+    : t('tr.btn.export.title');
   const events = await getRunEvents(runId).catch(() => []);
   if (!isCurrentRunRender(requestId, runId)) return;
   const objectUrls = new Set();
@@ -740,7 +747,7 @@ document.getElementById('btn-compare').addEventListener('click', () => {
 });
 
 async function loadTraceExportEntry(run) {
-  const events = await getRunEvents(run.runId).catch(() => []);
+  const events = await getRunEvents(run.runId);
   // Resolve screenshot blobs to base64 for portability.
   for (const ev of events) {
     if (ev.kind === 'screenshot') {
@@ -757,43 +764,69 @@ async function loadTraceExportEntry(run) {
   return { run, events };
 }
 
+function traceExportConfirmation(exportRuns) {
+  const sensitiveRunCount = exportRuns.filter(run => run?.lossless === true).length;
+  const lines = [
+    t('tr.btn.export'),
+    `${t('tr.conversation.label')} · ${t(exportRuns.length === 1 ? 'tr.run' : 'tr.runs', { n: exportRuns.length })}`,
+  ];
+  if (sensitiveRunCount > 0) {
+    lines.push(
+      '',
+      `${t('tr.lossless.badge')} · ${t(sensitiveRunCount === 1 ? 'tr.run' : 'tr.runs', { n: sensitiveRunCount })}`,
+      t('tr.lossless.warning'),
+    );
+  }
+  return lines.join('\n');
+}
+
 document.getElementById('btn-export').addEventListener('click', async () => {
   if (!selectedRunId) return alert(t('tr.select_first'));
   const runId = selectedRunId;
-  const run = await getRun(runId);
-  if (!run) return alert(t('tr.select_first'));
-  const sessionId = typeof run.conversationId === 'string' ? run.conversationId.trim() : '';
-  const sessionRuns = sessionId
-    ? await listRuns({ conversationId: run.conversationId }).catch(() => [])
-    : [];
-  const exportRuns = [];
-  const seenRunIds = new Set();
-  for (const candidate of [...sessionRuns, run]) {
-    if (!candidate?.runId || seenRunIds.has(candidate.runId)) continue;
-    seenRunIds.add(candidate.runId);
-    exportRuns.push(candidate);
-  }
-  const entries = [];
-  for (const exportRun of exportRuns) entries.push(await loadTraceExportEntry(exportRun));
-  const isSession = Boolean(sessionId);
-  const payload = buildTraceExportPayload(entries, {
-    sessionId,
-    exportedAt: Date.now(),
-    exportedByWebBrainVersion: chrome.runtime.getManifest().version || '',
-  });
-  const blob = new Blob([JSON.stringify(sanitizeTraceExport(payload), null, 2)], { type: 'application/json' });
-  const url = URL.createObjectURL(blob);
-  const a = document.createElement('a');
-  a.href = url;
-  a.download = isSession
-    ? `webbrain-session-${safeFilenamePart(sessionId, 'session')}.json`
-    : `webbrain-trace-${run.model || 'unknown'}-${run.runId}.json`;
-  document.body.appendChild(a);
   try {
-    a.click();
-  } finally {
-    a.remove();
-    setTimeout(() => URL.revokeObjectURL(url), 7000);
+    const run = await getRun(runId);
+    if (!run) return alert(t('tr.select_first'));
+    const sessionId = typeof run.conversationId === 'string' ? run.conversationId.trim() : '';
+    const sessionRuns = sessionId
+      ? await listRuns({ limit: Number.MAX_SAFE_INTEGER, conversationId: sessionId })
+      : [];
+    const exportRuns = [];
+    const seenRunIds = new Set();
+    for (const candidate of [...sessionRuns, run]) {
+      if (!candidate?.runId || seenRunIds.has(candidate.runId)) continue;
+      seenRunIds.add(candidate.runId);
+      exportRuns.push(candidate);
+    }
+    exportRuns.sort((left, right) => (
+      ((left.startedAt || 0) - (right.startedAt || 0))
+      || String(left.runId).localeCompare(String(right.runId))
+    ));
+    const isSession = Boolean(sessionId);
+    if (isSession && !confirm(traceExportConfirmation(exportRuns))) return;
+    const entries = [];
+    for (const exportRun of exportRuns) entries.push(await loadTraceExportEntry(exportRun));
+    const payload = buildTraceExportPayload(entries, {
+      sessionId,
+      exportedAt: Date.now(),
+      exportedByWebBrainVersion: chrome.runtime.getManifest().version || '',
+    });
+    const blob = new Blob([JSON.stringify(sanitizeTraceExport(payload), null, 2)], { type: 'application/json' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = isSession
+      ? `webbrain-session-${safeFilenamePart(sessionId, 'session')}.json`
+      : `webbrain-trace-${run.model || 'unknown'}-${run.runId}.json`;
+    document.body.appendChild(a);
+    try {
+      a.click();
+    } finally {
+      a.remove();
+      setTimeout(() => URL.revokeObjectURL(url), 7000);
+    }
+  } catch (error) {
+    console.error('[traces] export failed:', error);
+    alert(`${t('tr.btn.export')}: ${error?.message || error}`);
   }
 });
 

--- a/src/chrome/src/ui/traces.js
+++ b/src/chrome/src/ui/traces.js
@@ -11,6 +11,7 @@ import { isKnownKind, isIgnorableKind } from '../trace/event-model.js';
 import { buildTraceTrajectory } from '../trace/trajectory.js';
 import { aggregateTraceRuns } from '../trace/stats.js';
 import { buildTraceLineageGroups } from '../trace/lineage.js';
+import { buildTraceExportPayload } from '../trace/export-contract.js';
 import { sanitizeTraceExport } from '../agent/trace-export.js';
 import { t } from './i18n.js';
 import { escapeHtml, escapeAttr } from './utils.js';
@@ -738,36 +739,55 @@ document.getElementById('btn-compare').addEventListener('click', () => {
   renderList();
 });
 
+async function loadTraceExportEntry(run) {
+  const events = await getRunEvents(run.runId).catch(() => []);
+  // Resolve screenshot blobs to base64 for portability.
+  for (const ev of events) {
+    if (ev.kind === 'screenshot') {
+      const shot = await getScreenshot(run.runId, ev.seq);
+      if (shot?.blob) {
+        ev.data = ev.data || {};
+        ev.data.screenshot_base64 = await blobToBase64(shot.blob);
+      } else if (shot?.dataUrl) {
+        ev.data = ev.data || {};
+        ev.data.screenshot_dataUrl = shot.dataUrl;
+      }
+    }
+  }
+  return { run, events };
+}
+
 document.getElementById('btn-export').addEventListener('click', async () => {
   if (!selectedRunId) return alert(t('tr.select_first'));
   const runId = selectedRunId;
   const run = await getRun(runId);
   if (!run) return alert(t('tr.select_first'));
-  const events = await getRunEvents(runId).catch(() => []);
-  // Resolve screenshot blobs to base64 for portability.
-  for (const ev of events) {
-    if (ev.kind === 'screenshot') {
-      const shot = await getScreenshot(runId, ev.seq);
-      if (shot?.blob) {
-        ev.data = ev.data || {};
-        ev.data.screenshot_base64 = await blobToBase64(shot.blob);
-      } else if (shot?.dataUrl) {
-        ev.data.screenshot_dataUrl = shot.dataUrl;
-      }
-    }
+  const sessionId = typeof run.conversationId === 'string' ? run.conversationId.trim() : '';
+  const sessionRuns = sessionId
+    ? await listRuns({ conversationId: run.conversationId }).catch(() => [])
+    : [];
+  const exportRuns = [];
+  const seenRunIds = new Set();
+  for (const candidate of [...sessionRuns, run]) {
+    if (!candidate?.runId || seenRunIds.has(candidate.runId)) continue;
+    seenRunIds.add(candidate.runId);
+    exportRuns.push(candidate);
   }
-  const payload = {
-    run,
-    events,
+  const entries = [];
+  for (const exportRun of exportRuns) entries.push(await loadTraceExportEntry(exportRun));
+  const isSession = Boolean(sessionId);
+  const payload = buildTraceExportPayload(entries, {
+    sessionId,
     exportedAt: Date.now(),
     exportedByWebBrainVersion: chrome.runtime.getManifest().version || '',
-    schema: 'webbrain-trace/1',
-  };
+  });
   const blob = new Blob([JSON.stringify(sanitizeTraceExport(payload), null, 2)], { type: 'application/json' });
   const url = URL.createObjectURL(blob);
   const a = document.createElement('a');
   a.href = url;
-  a.download = `webbrain-trace-${run.model || 'unknown'}-${run.runId}.json`;
+  a.download = isSession
+    ? `webbrain-session-${safeFilenamePart(sessionId, 'session')}.json`
+    : `webbrain-trace-${run.model || 'unknown'}-${run.runId}.json`;
   document.body.appendChild(a);
   try {
     a.click();
@@ -831,6 +851,14 @@ filterModel.addEventListener('change', renderList);
 function safeClassToken(value, fallback = 'unknown') {
   const token = String(value == null ? '' : value).trim();
   return /^[A-Za-z0-9_-]+$/.test(token) ? token : fallback;
+}
+function safeFilenamePart(value, fallback = 'unknown') {
+  const token = String(value == null ? '' : value)
+    .trim()
+    .replace(/[^A-Za-z0-9._-]+/g, '_')
+    .slice(0, 80)
+    .replace(/^[.-]+|[.-]+$/g, '');
+  return token || fallback;
 }
 function blobToBase64(blob) {
   return new Promise((resolve) => {

--- a/src/firefox/src/agent/trace-export.js
+++ b/src/firefox/src/agent/trace-export.js
@@ -61,7 +61,17 @@ function redactExportValue(value, key = '') {
 }
 
 export function sanitizeTraceExport(payload) {
-  return payload?.run?.lossless === true ? redactExportValue(payload) : payload;
+  if (payload?.run?.lossless === true) return redactExportValue(payload);
+  if (!Array.isArray(payload?.runs)) return payload;
+
+  let changed = false;
+  const runs = payload.runs.map((entry) => {
+    if (entry?.run?.lossless !== true) return entry;
+    changed = true;
+    return redactExportValue(entry);
+  });
+
+  return changed ? { ...payload, runs } : payload;
 }
 
 // Lossless requests carry the full message/tool shape. Render a bounded,

--- a/src/firefox/src/trace/export-contract.js
+++ b/src/firefox/src/trace/export-contract.js
@@ -1,0 +1,45 @@
+/**
+ * Build the versioned JSON envelope used by the Traces page.
+ *
+ * A standalone export keeps the original { run, events } shape. When a
+ * session ID is supplied, the same schema carries { session, runs } so
+ * consumers can preserve session-level lineage without guessing whether a
+ * single record was exported.
+ */
+
+export const TRACE_EXPORT_SCHEMA = 'webbrain-trace/1';
+
+function normalizeEntries(entries) {
+  if (!Array.isArray(entries)) return [];
+  return entries.map((entry) => ({
+    run: entry?.run && typeof entry.run === 'object' ? entry.run : {},
+    events: Array.isArray(entry?.events) ? entry.events : [],
+  }));
+}
+
+export function buildTraceExportPayload(
+  entries,
+  { sessionId = '', exportedAt = Date.now(), exportedByWebBrainVersion = '' } = {},
+) {
+  const normalized = normalizeEntries(entries);
+  const common = {
+    schema: TRACE_EXPORT_SCHEMA,
+    exportedAt,
+    exportedByWebBrainVersion,
+  };
+
+  if (sessionId) {
+    return {
+      ...common,
+      session: { sessionId },
+      runs: normalized,
+    };
+  }
+
+  const first = normalized[0] || { run: {}, events: [] };
+  return {
+    ...common,
+    run: first.run,
+    events: first.events,
+  };
+}

--- a/src/firefox/src/ui/traces.js
+++ b/src/firefox/src/ui/traces.js
@@ -309,6 +309,13 @@ async function renderRun(runId) {
     replaceTimelineObjectUrls(new Set());
     return;
   }
+  const exportButton = document.getElementById('btn-export');
+  const exportSessionId = typeof run.conversationId === 'string'
+    ? run.conversationId.trim()
+    : '';
+  exportButton.title = exportSessionId
+    ? `${t('tr.btn.export')} · ${t('tr.conversation.label')}`
+    : t('tr.btn.export.title');
   const events = await getRunEvents(runId).catch(() => []);
   if (!isCurrentRunRender(requestId, runId)) return;
   const objectUrls = new Set();
@@ -740,7 +747,7 @@ document.getElementById('btn-compare').addEventListener('click', () => {
 });
 
 async function loadTraceExportEntry(run) {
-  const events = await getRunEvents(run.runId).catch(() => []);
+  const events = await getRunEvents(run.runId);
   // Resolve screenshot blobs to base64 for portability.
   for (const ev of events) {
     if (ev.kind === 'screenshot') {
@@ -757,43 +764,69 @@ async function loadTraceExportEntry(run) {
   return { run, events };
 }
 
+function traceExportConfirmation(exportRuns) {
+  const sensitiveRunCount = exportRuns.filter(run => run?.lossless === true).length;
+  const lines = [
+    t('tr.btn.export'),
+    `${t('tr.conversation.label')} · ${t(exportRuns.length === 1 ? 'tr.run' : 'tr.runs', { n: exportRuns.length })}`,
+  ];
+  if (sensitiveRunCount > 0) {
+    lines.push(
+      '',
+      `${t('tr.lossless.badge')} · ${t(sensitiveRunCount === 1 ? 'tr.run' : 'tr.runs', { n: sensitiveRunCount })}`,
+      t('tr.lossless.warning'),
+    );
+  }
+  return lines.join('\n');
+}
+
 document.getElementById('btn-export').addEventListener('click', async () => {
   if (!selectedRunId) return alert(t('tr.select_first'));
   const runId = selectedRunId;
-  const run = await getRun(runId);
-  if (!run) return alert(t('tr.select_first'));
-  const sessionId = typeof run.conversationId === 'string' ? run.conversationId.trim() : '';
-  const sessionRuns = sessionId
-    ? await listRuns({ conversationId: run.conversationId }).catch(() => [])
-    : [];
-  const exportRuns = [];
-  const seenRunIds = new Set();
-  for (const candidate of [...sessionRuns, run]) {
-    if (!candidate?.runId || seenRunIds.has(candidate.runId)) continue;
-    seenRunIds.add(candidate.runId);
-    exportRuns.push(candidate);
-  }
-  const entries = [];
-  for (const exportRun of exportRuns) entries.push(await loadTraceExportEntry(exportRun));
-  const isSession = Boolean(sessionId);
-  const payload = buildTraceExportPayload(entries, {
-    sessionId,
-    exportedAt: Date.now(),
-    exportedByWebBrainVersion: browser.runtime.getManifest().version || '',
-  });
-  const blob = new Blob([JSON.stringify(sanitizeTraceExport(payload), null, 2)], { type: 'application/json' });
-  const url = URL.createObjectURL(blob);
-  const a = document.createElement('a');
-  a.href = url;
-  a.download = isSession
-    ? `webbrain-session-${safeFilenamePart(sessionId, 'session')}.json`
-    : `webbrain-trace-${run.model || 'unknown'}-${run.runId}.json`;
-  document.body.appendChild(a);
   try {
-    a.click();
-  } finally {
-    a.remove();
-    setTimeout(() => URL.revokeObjectURL(url), 7000);
+    const run = await getRun(runId);
+    if (!run) return alert(t('tr.select_first'));
+    const sessionId = typeof run.conversationId === 'string' ? run.conversationId.trim() : '';
+    const sessionRuns = sessionId
+      ? await listRuns({ limit: Number.MAX_SAFE_INTEGER, conversationId: sessionId })
+      : [];
+    const exportRuns = [];
+    const seenRunIds = new Set();
+    for (const candidate of [...sessionRuns, run]) {
+      if (!candidate?.runId || seenRunIds.has(candidate.runId)) continue;
+      seenRunIds.add(candidate.runId);
+      exportRuns.push(candidate);
+    }
+    exportRuns.sort((left, right) => (
+      ((left.startedAt || 0) - (right.startedAt || 0))
+      || String(left.runId).localeCompare(String(right.runId))
+    ));
+    const isSession = Boolean(sessionId);
+    if (isSession && !confirm(traceExportConfirmation(exportRuns))) return;
+    const entries = [];
+    for (const exportRun of exportRuns) entries.push(await loadTraceExportEntry(exportRun));
+    const payload = buildTraceExportPayload(entries, {
+      sessionId,
+      exportedAt: Date.now(),
+      exportedByWebBrainVersion: browser.runtime.getManifest().version || '',
+    });
+    const blob = new Blob([JSON.stringify(sanitizeTraceExport(payload), null, 2)], { type: 'application/json' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = isSession
+      ? `webbrain-session-${safeFilenamePart(sessionId, 'session')}.json`
+      : `webbrain-trace-${run.model || 'unknown'}-${run.runId}.json`;
+    document.body.appendChild(a);
+    try {
+      a.click();
+    } finally {
+      a.remove();
+      setTimeout(() => URL.revokeObjectURL(url), 7000);
+    }
+  } catch (error) {
+    console.error('[traces] export failed:', error);
+    alert(`${t('tr.btn.export')}: ${error?.message || error}`);
   }
 });
 

--- a/src/firefox/src/ui/traces.js
+++ b/src/firefox/src/ui/traces.js
@@ -11,6 +11,7 @@ import { isKnownKind, isIgnorableKind } from '../trace/event-model.js';
 import { buildTraceTrajectory } from '../trace/trajectory.js';
 import { aggregateTraceRuns } from '../trace/stats.js';
 import { buildTraceLineageGroups } from '../trace/lineage.js';
+import { buildTraceExportPayload } from '../trace/export-contract.js';
 import { sanitizeTraceExport } from '../agent/trace-export.js';
 import { t } from './i18n.js';
 import { escapeHtml, escapeAttr } from './utils.js';
@@ -738,36 +739,55 @@ document.getElementById('btn-compare').addEventListener('click', () => {
   renderList();
 });
 
+async function loadTraceExportEntry(run) {
+  const events = await getRunEvents(run.runId).catch(() => []);
+  // Resolve screenshot blobs to base64 for portability.
+  for (const ev of events) {
+    if (ev.kind === 'screenshot') {
+      const shot = await getScreenshot(run.runId, ev.seq);
+      if (shot?.blob) {
+        ev.data = ev.data || {};
+        ev.data.screenshot_base64 = await blobToBase64(shot.blob);
+      } else if (shot?.dataUrl) {
+        ev.data = ev.data || {};
+        ev.data.screenshot_dataUrl = shot.dataUrl;
+      }
+    }
+  }
+  return { run, events };
+}
+
 document.getElementById('btn-export').addEventListener('click', async () => {
   if (!selectedRunId) return alert(t('tr.select_first'));
   const runId = selectedRunId;
   const run = await getRun(runId);
   if (!run) return alert(t('tr.select_first'));
-  const events = await getRunEvents(runId).catch(() => []);
-  // Resolve screenshot blobs to base64 for portability.
-  for (const ev of events) {
-    if (ev.kind === 'screenshot') {
-      const shot = await getScreenshot(runId, ev.seq);
-      if (shot?.blob) {
-        ev.data = ev.data || {};
-        ev.data.screenshot_base64 = await blobToBase64(shot.blob);
-      } else if (shot?.dataUrl) {
-        ev.data.screenshot_dataUrl = shot.dataUrl;
-      }
-    }
+  const sessionId = typeof run.conversationId === 'string' ? run.conversationId.trim() : '';
+  const sessionRuns = sessionId
+    ? await listRuns({ conversationId: run.conversationId }).catch(() => [])
+    : [];
+  const exportRuns = [];
+  const seenRunIds = new Set();
+  for (const candidate of [...sessionRuns, run]) {
+    if (!candidate?.runId || seenRunIds.has(candidate.runId)) continue;
+    seenRunIds.add(candidate.runId);
+    exportRuns.push(candidate);
   }
-  const payload = {
-    run,
-    events,
+  const entries = [];
+  for (const exportRun of exportRuns) entries.push(await loadTraceExportEntry(exportRun));
+  const isSession = Boolean(sessionId);
+  const payload = buildTraceExportPayload(entries, {
+    sessionId,
     exportedAt: Date.now(),
     exportedByWebBrainVersion: browser.runtime.getManifest().version || '',
-    schema: 'webbrain-trace/1',
-  };
+  });
   const blob = new Blob([JSON.stringify(sanitizeTraceExport(payload), null, 2)], { type: 'application/json' });
   const url = URL.createObjectURL(blob);
   const a = document.createElement('a');
   a.href = url;
-  a.download = `webbrain-trace-${run.model || 'unknown'}-${run.runId}.json`;
+  a.download = isSession
+    ? `webbrain-session-${safeFilenamePart(sessionId, 'session')}.json`
+    : `webbrain-trace-${run.model || 'unknown'}-${run.runId}.json`;
   document.body.appendChild(a);
   try {
     a.click();
@@ -831,6 +851,14 @@ filterModel.addEventListener('change', renderList);
 function safeClassToken(value, fallback = 'unknown') {
   const token = String(value == null ? '' : value).trim();
   return /^[A-Za-z0-9_-]+$/.test(token) ? token : fallback;
+}
+function safeFilenamePart(value, fallback = 'unknown') {
+  const token = String(value == null ? '' : value)
+    .trim()
+    .replace(/[^A-Za-z0-9._-]+/g, '_')
+    .slice(0, 80)
+    .replace(/^[.-]+|[.-]+$/g, '');
+  return token || fallback;
 }
 function blobToBase64(blob) {
   return new Promise((resolve) => {

--- a/test/run.js
+++ b/test/run.js
@@ -292,6 +292,12 @@ const { tracesToMarkdown, sanitizeTraceExport } = await import(
 const { tracesToMarkdown: tracesToMarkdownFx, sanitizeTraceExport: sanitizeTraceExportFx } = await import(
   'file://' + path.join(ROOT, 'src/firefox/src/agent/trace-export.js').replace(/\\/g, '/')
 );
+const { buildTraceExportPayload: buildTraceExportPayloadCh } = await import(
+  'file://' + path.join(ROOT, 'src/chrome/src/trace/export-contract.js').replace(/\\/g, '/')
+);
+const { buildTraceExportPayload: buildTraceExportPayloadFx } = await import(
+  'file://' + path.join(ROOT, 'src/firefox/src/trace/export-contract.js').replace(/\\/g, '/')
+);
 const ModelOutputDiagnosticsCh = await import(
   'file://' + path.join(ROOT, 'src/chrome/src/agent/model-output-diagnostics.js').replace(/\\/g, '/')
 );
@@ -9563,6 +9569,66 @@ test('trace lossless tier: JSON exports redact lossless event credentials only',
   }
 });
 
+test('trace lossless tier: session JSON exports redact each lossless run', () => {
+  const payload = {
+    schema: 'webbrain-trace/1',
+    session: { sessionId: 'session-json' },
+    runs: [
+      {
+        run: { runId: 'lossless-run', lossless: true },
+        events: [{ data: { args: { api_key: 'bundle-api-sentinel', note: 'keep-this' } } }],
+      },
+      {
+        run: { runId: 'default-run', lossless: false },
+        events: [{ data: { args: { note: 'default-content' } } }],
+      },
+    ],
+  };
+  for (const [label, sanitize] of [['chrome', sanitizeTraceExport], ['firefox', sanitizeTraceExportFx]]) {
+    const exported = JSON.stringify(sanitize(payload));
+    assert.doesNotMatch(exported, /bundle-api-sentinel/, `${label}: session JSON leaked a lossless credential`);
+    assert.match(exported, /\[redacted\]/, `${label}: session JSON did not mark a lossless credential`);
+    assert.match(exported, /keep-this|default-content/, `${label}: session JSON redacted non-sensitive content`);
+  }
+});
+
+test('trace JSON export contract: preserves legacy runs and supports session bundles', () => {
+  const entries = [
+    { run: { runId: 'run-a', conversationId: 'session-a' }, events: [{ kind: 'turn_start' }] },
+    { run: { runId: 'run-b', conversationId: 'session-a' }, events: [{ kind: 'turn_end' }] },
+  ];
+  const options = {
+    exportedAt: 1_770_000_000_000,
+    exportedByWebBrainVersion: '25.8.5',
+  };
+  for (const [label, build] of [['chrome', buildTraceExportPayloadCh], ['firefox', buildTraceExportPayloadFx]]) {
+    const session = build(entries, { ...options, sessionId: 'session-a' });
+    assert.deepEqual(session, {
+      schema: 'webbrain-trace/1',
+      session: { sessionId: 'session-a' },
+      runs: entries,
+      ...options,
+    }, `${label}: session export contract changed`);
+    assert.equal('run' in session, false, `${label}: session export retained legacy run field`);
+    assert.equal('events' in session, false, `${label}: session export retained legacy events field`);
+
+    const legacy = build([entries[0]], options);
+    assert.deepEqual(legacy, {
+      schema: 'webbrain-trace/1',
+      run: entries[0].run,
+      events: entries[0].events,
+      ...options,
+    }, `${label}: legacy export contract changed`);
+    assert.equal('session' in legacy, false, `${label}: legacy export gained a session field`);
+    assert.equal('runs' in legacy, false, `${label}: legacy export gained a runs field`);
+  }
+  assert.deepEqual(
+    buildTraceExportPayloadFx(entries, { ...options, sessionId: 'session-a' }),
+    buildTraceExportPayloadCh(entries, { ...options, sessionId: 'session-a' }),
+    'Chrome and Firefox export contracts must agree',
+  );
+});
+
 test('trace lossless tier: default-tier privacy guard survives in both builds', () => {
   const chromeRecorder = fs.readFileSync(path.join(ROOT, 'src/chrome/src/trace/recorder.js'), 'utf8');
   const firefoxRecorder = fs.readFileSync(path.join(ROOT, 'src/firefox/src/trace/recorder.js'), 'utf8');
@@ -10027,6 +10093,21 @@ test('trace UI: renders collapsed session lineage groups with bounded-result war
       'tr.lineage.duplicate_id',
       'tr.lineage.cycle',
     ]) assert.match(locale, new RegExp(key.replaceAll('.', '\\.' )), `${browser}: missing ${key} locale fallback`);
+  }
+});
+
+test('trace UI: exports a session bundle while preserving standalone JSON shape', () => {
+  for (const [browser, runtimeName] of [['chrome', 'chrome'], ['firefox', 'browser']]) {
+    const traces = fs.readFileSync(path.join(ROOT, `src/${browser}/src/ui/traces.js`), 'utf8');
+    assert.match(traces, /import \{ buildTraceExportPayload \} from '\.\.\/trace\/export-contract\.js';/, `${browser}: export contract import missing`);
+    assert.match(traces, /async function loadTraceExportEntry\(run\)/, `${browser}: trace entry loader missing`);
+    assert.match(traces, /listRuns\(\{ conversationId: run\.conversationId \}\)/, `${browser}: session export does not use the session index`);
+    assert.match(traces, /for \(const candidate of \[\.\.\.sessionRuns, run\]\)/, `${browser}: selected run is not guaranteed in a session export`);
+    assert.match(traces, /for \(const exportRun of exportRuns\) entries\.push\(await loadTraceExportEntry\(exportRun\)\)/, `${browser}: session export does not load every run's events`);
+    assert.match(traces, /buildTraceExportPayload\(entries, \{[\s\S]*?sessionId,[\s\S]*?exportedAt: Date\.now\(\)/, `${browser}: UI does not build the versioned export envelope`);
+    assert.match(traces, /isSession\s*\?\s*`webbrain-session-\$\{safeFilenamePart\(sessionId, 'session'\)\}\.json`/, `${browser}: session export filename is not bounded`);
+    assert.match(traces, new RegExp(`exportedByWebBrainVersion: ${runtimeName}\\.runtime\\.getManifest\\(\\)\\.version`), `${browser}: export version metadata changed unexpectedly`);
+    assert.match(traces, /sanitizeTraceExport\(payload\)/, `${browser}: session export bypasses privacy sanitization`);
   }
 });
 
@@ -10608,6 +10689,7 @@ test('trace record and JSON exports carry WebBrain version metadata', () => {
     ['firefox', 'src/firefox', 'browser'],
   ]) {
     const recorder = fs.readFileSync(path.join(ROOT, prefix, 'src/trace/recorder.js'), 'utf8');
+    const exportContract = fs.readFileSync(path.join(ROOT, prefix, 'src/trace/export-contract.js'), 'utf8');
     const traceUi = fs.readFileSync(path.join(ROOT, prefix, 'src/ui/traces.js'), 'utf8');
     const agent = fs.readFileSync(path.join(ROOT, prefix, 'src/agent/agent.js'), 'utf8');
     assert.match(recorder, /webbrainVersion: meta\.webbrainVersion \|\| ''/, `${label}: run record should retain the recording version`);
@@ -10620,7 +10702,8 @@ test('trace record and JSON exports carry WebBrain version metadata', () => {
       `${label}: workflow runs should snapshot effective runtime settings too`,
     );
     assert.match(traceUi, new RegExp(`exportedByWebBrainVersion: ${runtimeName}\\.runtime\\.getManifest\\(\\)\\.version`), `${label}: JSON export should identify the exporting build`);
-    assert.match(traceUi, /schema: 'webbrain-trace\/1'/, `${label}: additive version metadata should retain the v1 schema`);
+    assert.match(traceUi, /buildTraceExportPayload\(entries/, `${label}: JSON export should use the shared export contract`);
+    assert.match(exportContract, /TRACE_EXPORT_SCHEMA = 'webbrain-trace\/1'/, `${label}: additive version metadata should retain the v1 schema`);
   }
 });
 
@@ -37265,14 +37348,17 @@ test('trace viewer toolbar actions use a captured run selection across awaits', 
     const exportCaptureIdx = exportBody.indexOf('const runId = selectedRunId;');
     const getRunIdx = exportBody.indexOf('const run = await getRun(runId);');
     const missingRunGuardIdx = exportBody.indexOf("if (!run) return alert(t('tr.select_first'));");
-    const eventsIdx = exportBody.indexOf('const events = await getRunEvents(runId).catch(() => []);');
-    const screenshotIdx = exportBody.indexOf('const shot = await getScreenshot(runId, ev.seq);');
+    const loaderStart = traces.indexOf('async function loadTraceExportEntry(run)');
+    const loaderBody = traces.slice(loaderStart, traces.indexOf("document.getElementById('btn-export')", loaderStart));
+    const eventsIdx = loaderBody.indexOf('const events = await getRunEvents(run.runId).catch(() => []);');
+    const screenshotIdx = loaderBody.indexOf('const shot = await getScreenshot(run.runId, ev.seq);');
     assert.notEqual(exportCaptureIdx, -1, `${label}: trace export should capture selectedRunId once`);
     assert.notEqual(getRunIdx, -1, `${label}: trace export should load the captured run`);
     assert.notEqual(missingRunGuardIdx, -1, `${label}: trace export should handle a missing captured run`);
-    assert.notEqual(eventsIdx, -1, `${label}: trace export should load events for the captured run`);
-    assert.notEqual(screenshotIdx, -1, `${label}: trace export should load screenshots for the captured run`);
-    assert.equal(exportCaptureIdx < getRunIdx && getRunIdx < missingRunGuardIdx && missingRunGuardIdx < eventsIdx && eventsIdx < screenshotIdx, true, `${label}: trace export should keep the same run id across async work`);
+    assert.notEqual(loaderStart, -1, `${label}: trace export entry loader missing`);
+    assert.notEqual(eventsIdx, -1, `${label}: trace export should load events for each captured run`);
+    assert.notEqual(screenshotIdx, -1, `${label}: trace export should load screenshots for each captured run`);
+    assert.equal(exportCaptureIdx < getRunIdx && getRunIdx < missingRunGuardIdx, true, `${label}: trace export should keep the same run selection across async work`);
     assert.doesNotMatch(exportBody, /getRun\(selectedRunId\)|getRunEvents\(selectedRunId\)|getScreenshot\(selectedRunId,/, `${label}: trace export must not reread mutable selectedRunId after starting`);
 
     const deleteStart = traces.indexOf("document.getElementById('btn-delete').addEventListener('click', async () => {");

--- a/test/run.js
+++ b/test/run.js
@@ -6954,6 +6954,82 @@ test('ATIF export: maps a WebBrain run, LLM calls, tools, metrics, and final res
   assert.ok(!JSON.stringify(atif).includes('sensitive-bytes'));
 });
 
+test('ATIF export: folds session bundles into one ordered multi-turn trajectory', () => {
+  const atif = webbrainTraceToAtif({
+    schema: 'webbrain-trace/1',
+    session: { sessionId: 'bundle-session' },
+    exportedAt: 1_770_000_100_000,
+    exportedByWebBrainVersion: '25.8.5',
+    runs: [
+      {
+        run: {
+          runId: 'run-b', conversationId: 'bundle-session', startedAt: 200,
+          userMessage: 'Second turn', model: 'bundle-model', providerId: 'bundle-provider',
+          totalInputTokens: 20, totalOutputTokens: 3,
+        },
+        events: [
+          {
+            runId: 'run-b', seq: 1, kind: 'llm_response',
+            data: { step: 1, toolCalls: [{ id: 'shared-call', name: 'second_tool', args: '{}' }] },
+          },
+          {
+            runId: 'run-b', seq: 2, kind: 'tool',
+            data: { step: 1, name: 'second_tool', result: { ok: true } },
+          },
+        ],
+      },
+      {
+        run: {
+          runId: 'run-a', conversationId: 'bundle-session', startedAt: 100,
+          userMessage: 'First turn', model: 'bundle-model', providerId: 'bundle-provider',
+          totalInputTokens: 10, totalOutputTokens: 2,
+        },
+        events: [
+          {
+            runId: 'run-a', seq: 1, kind: 'llm_response',
+            data: { step: 1, toolCalls: [{ id: 'shared-call', name: 'first_tool', args: '{}' }] },
+          },
+          {
+            runId: 'run-a', seq: 2, kind: 'tool',
+            data: { step: 1, name: 'first_tool', result: { ok: true } },
+          },
+        ],
+      },
+    ],
+  });
+
+  assert.equal(atif.schema_version, 'ATIF-v1.7');
+  assert.equal(atif.session_id, 'bundle-session');
+  assert.equal(atif.trajectory_id, 'bundle-session');
+  assert.equal(atif.agent.version, '25.8.5');
+  assert.equal(atif.agent.model_name, 'bundle-model');
+  assert.equal(atif.agent.extra.webbrain_run_count, 2);
+  assert.deepEqual(atif.steps.map(step => step.step_id), [1, 2, 3, 4]);
+  assert.deepEqual(
+    atif.steps.filter(step => step.source === 'user').map(step => step.message),
+    ['First turn', 'Second turn'],
+  );
+  assert.deepEqual(
+    atif.steps.map(step => step.extra.webbrain_run_id),
+    ['run-a', 'run-a', 'run-b', 'run-b'],
+  );
+  const toolSteps = atif.steps.filter(step => step.tool_calls);
+  assert.deepEqual(
+    toolSteps.map(step => step.tool_calls[0].tool_call_id),
+    ['shared-call', 'shared-call-run-b'],
+  );
+  assert.deepEqual(
+    toolSteps.map(step => step.observation.results[0].source_call_id),
+    ['shared-call', 'shared-call-run-b'],
+  );
+  assert.deepEqual(atif.final_metrics, {
+    total_prompt_tokens: 30,
+    total_completion_tokens: 5,
+    total_steps: 4,
+  });
+  assert.deepEqual(atif.extra.source_run_ids, ['run-a', 'run-b']);
+});
+
 test('ATIF export: synthesizes deterministic tool calls and preserves malformed arguments safely', () => {
   const input = {
     schema: 'webbrain-trace/1',
@@ -7044,6 +7120,16 @@ test('ATIF export: rejects unsupported or malformed WebBrain exports', () => {
     }),
     /event runId "foreign" does not match/,
   );
+  assert.throws(
+    () => webbrainTraceToAtif({ schema: 'webbrain-trace/1', session: {}, runs: [] }),
+    /session\.sessionId must be a non-empty string/,
+  );
+  assert.throws(
+    () => webbrainTraceToAtif({
+      schema: 'webbrain-trace/1', session: { sessionId: 'empty' }, runs: [],
+    }),
+    /runs must be a non-empty array/,
+  );
 });
 
 test('ATIF export: CLI writes a sibling .atif.json file', () => {
@@ -7068,6 +7154,27 @@ test('ATIF export: CLI writes a sibling .atif.json file', () => {
     );
     assert.equal(output.schema_version, 'ATIF-v1.7');
     assert.equal(output.session_id, 'cli-run');
+
+    const bundlePath = path.join(tempDir, 'bundle.json');
+    fs.writeFileSync(bundlePath, JSON.stringify({
+      schema: 'webbrain-trace/1',
+      session: { sessionId: 'cli-session' },
+      runs: [
+        { run: { runId: 'cli-run-a', userMessage: 'First' }, events: [] },
+        { run: { runId: 'cli-run-b', userMessage: 'Second' }, events: [] },
+      ],
+    }));
+    const bundleResult = spawnSync(
+      process.execPath,
+      [path.join(ROOT, 'scripts/trace-to-atif.mjs'), bundlePath],
+      { encoding: 'utf8' },
+    );
+    assert.equal(bundleResult.status, 0, bundleResult.stderr);
+    const bundleOutput = JSON.parse(
+      fs.readFileSync(path.join(tempDir, 'bundle.atif.json'), 'utf8'),
+    );
+    assert.equal(bundleOutput.session_id, 'cli-session');
+    assert.deepEqual(bundleOutput.steps.map(step => step.message), ['First', 'Second']);
   } finally {
     fs.rmSync(tempDir, { recursive: true, force: true });
   }
@@ -10101,13 +10208,18 @@ test('trace UI: exports a session bundle while preserving standalone JSON shape'
     const traces = fs.readFileSync(path.join(ROOT, `src/${browser}/src/ui/traces.js`), 'utf8');
     assert.match(traces, /import \{ buildTraceExportPayload \} from '\.\.\/trace\/export-contract\.js';/, `${browser}: export contract import missing`);
     assert.match(traces, /async function loadTraceExportEntry\(run\)/, `${browser}: trace entry loader missing`);
-    assert.match(traces, /listRuns\(\{ conversationId: run\.conversationId \}\)/, `${browser}: session export does not use the session index`);
+    assert.match(traces, /listRuns\(\{ limit: Number\.MAX_SAFE_INTEGER, conversationId: sessionId \}\)/, `${browser}: session export retains the default 500-run cap`);
     assert.match(traces, /for \(const candidate of \[\.\.\.sessionRuns, run\]\)/, `${browser}: selected run is not guaranteed in a session export`);
+    assert.match(traces, /exportRuns\.sort\(\(left, right\) => \([\s\S]*?left\.startedAt[\s\S]*?left\.runId/, `${browser}: session runs are not ordered deterministically`);
     assert.match(traces, /for \(const exportRun of exportRuns\) entries\.push\(await loadTraceExportEntry\(exportRun\)\)/, `${browser}: session export does not load every run's events`);
     assert.match(traces, /buildTraceExportPayload\(entries, \{[\s\S]*?sessionId,[\s\S]*?exportedAt: Date\.now\(\)/, `${browser}: UI does not build the versioned export envelope`);
     assert.match(traces, /isSession\s*\?\s*`webbrain-session-\$\{safeFilenamePart\(sessionId, 'session'\)\}\.json`/, `${browser}: session export filename is not bounded`);
     assert.match(traces, new RegExp(`exportedByWebBrainVersion: ${runtimeName}\\.runtime\\.getManifest\\(\\)\\.version`), `${browser}: export version metadata changed unexpectedly`);
     assert.match(traces, /sanitizeTraceExport\(payload\)/, `${browser}: session export bypasses privacy sanitization`);
+    assert.match(traces, /function traceExportConfirmation\(exportRuns\)[\s\S]*?sensitiveRunCount[\s\S]*?tr\.lossless\.warning/, `${browser}: session export does not disclose lossless sibling runs`);
+    assert.match(traces, /isSession && !confirm\(traceExportConfirmation\(exportRuns\)\)/, `${browser}: session scope is not confirmed before export`);
+    assert.match(traces, /const exportSessionId = typeof run\.conversationId[\s\S]*?\.trim\(\)[\s\S]*?exportButton\.title = exportSessionId[\s\S]*?tr\.conversation\.label/, `${browser}: export tooltip still claims every download is one selected run`);
+    assert.match(traces, /catch \(error\) \{[\s\S]*?\[traces\] export failed:[\s\S]*?alert\(/, `${browser}: failed session reads can still produce a partial-looking download`);
   }
 });
 
@@ -37350,7 +37462,7 @@ test('trace viewer toolbar actions use a captured run selection across awaits', 
     const missingRunGuardIdx = exportBody.indexOf("if (!run) return alert(t('tr.select_first'));");
     const loaderStart = traces.indexOf('async function loadTraceExportEntry(run)');
     const loaderBody = traces.slice(loaderStart, traces.indexOf("document.getElementById('btn-export')", loaderStart));
-    const eventsIdx = loaderBody.indexOf('const events = await getRunEvents(run.runId).catch(() => []);');
+    const eventsIdx = loaderBody.indexOf('const events = await getRunEvents(run.runId);');
     const screenshotIdx = loaderBody.indexOf('const shot = await getScreenshot(run.runId, ev.seq);');
     assert.notEqual(exportCaptureIdx, -1, `${label}: trace export should capture selectedRunId once`);
     assert.notEqual(getRunIdx, -1, `${label}: trace export should load the captured run`);
@@ -37358,6 +37470,7 @@ test('trace viewer toolbar actions use a captured run selection across awaits', 
     assert.notEqual(loaderStart, -1, `${label}: trace export entry loader missing`);
     assert.notEqual(eventsIdx, -1, `${label}: trace export should load events for each captured run`);
     assert.notEqual(screenshotIdx, -1, `${label}: trace export should load screenshots for each captured run`);
+    assert.doesNotMatch(loaderBody, /getRunEvents\(run\.runId\)\.catch/, `${label}: trace export should not hide a failed event read as an empty run`);
     assert.equal(exportCaptureIdx < getRunIdx && getRunIdx < missingRunGuardIdx, true, `${label}: trace export should keep the same run selection across async work`);
     assert.doesNotMatch(exportBody, /getRun\(selectedRunId\)|getRunEvents\(selectedRunId\)|getScreenshot\(selectedRunId,/, `${label}: trace export must not reread mutable selectedRunId after starting`);
 


### PR DESCRIPTION
## Summary

- Extend the Traces page JSON export to include all persisted runs in the selected conversation.
- Keep standalone exports compatible with the existing `{ run, events }` shape and use `{ session, runs }` for conversation exports under `webbrain-trace/1`.
- Reuse the existing session index and screenshot loading path for every exported run.
- Apply lossless credential redaction to each sensitive run in a session bundle while preserving ordinary run content.
- Keep Chrome and Firefox behavior mirrored and document the export shapes, filenames, and privacy expectations.

## Compatibility

- No trace event or storage schema changes.
- Existing standalone JSON consumers retain their current envelope.
- The export remains local and does not upload data.

## Validation

- `node test/run.js` — 2041 passed, 0 failed
- `npm run test:toolbar-guard` — 33 passed
- `npm run test:security` — 60/60 checks passed