### PR TITLE
feat: add YouTube video loop suggestion

### DIFF
--- a/src/chrome/src/ui/recommended-actions.js
+++ b/src/chrome/src/ui/recommended-actions.js
@@ -473,40 +473,6 @@ export function buildRecommendedActions(pageInfo = {}, options = {}) {
         ['Call read_youtube_transcript for the active tab with timestamps:true, text_limit:6000, and include_segments:false.', 'Summarize the transcript with key points and timestamps when available.'],
       ),
     });
-    addUnique(actions, {
-      id: 'loop-youtube-video',
-      label: 'Loop this video',
-      prompt: `Use execute_js once with exactly this function body, then report whether a video was found and looping was enabled:
-const KEY = '__webbrainYouTubeLoop';
-const previous = window[KEY];
-if (previous?.timer) clearInterval(previous.timer);
-if (previous?.video && previous?.endedHandler) previous.video.removeEventListener('ended', previous.endedHandler);
-const state = { video: null, endedHandler: null, timer: null };
-const enforceLoop = () => {
-  const video = document.querySelector('video');
-  if (!video) return false;
-  if (state.video !== video) {
-    if (state.video && state.endedHandler) state.video.removeEventListener('ended', state.endedHandler);
-    state.video = video;
-    state.endedHandler = () => {
-      video.currentTime = 0;
-      video.play().catch(() => {});
-    };
-    video.addEventListener('ended', state.endedHandler);
-  }
-  video.loop = true;
-  try {
-    const player = document.querySelector('#movie_player');
-    if (player && typeof player.setLoop === 'function') player.setLoop(true);
-  } catch {}
-  return true;
-};
-const found = enforceLoop();
-state.timer = setInterval(enforceLoop, 1000);
-window[KEY] = state;
-return { found, loop: state.video?.loop === true, intervalSet: true, paused: state.video?.paused ?? null, duration: state.video?.duration ?? null };`,
-      mode: 'dev',
-    });
   }
 
   const publicMediaHost = PUBLIC_MEDIA_HOST_RE.test(host);
@@ -519,6 +485,80 @@ return { found, loop: state.video?.loop === true, intervalSet: true, paused: sta
       prompt: publicMediaHost ? publicMediaDownloadPrompt(kind, needsExplicitUrl) : 'Download the video or photo from this post.',
       mode: 'act',
       ...(publicMediaHost ? { runOptions: publicMediaDownloadRunOptions(kind, needsExplicitUrl) } : {}),
+    });
+  }
+
+  if (isYouTubeVideoPage(host, path, pageInfo.url || '')) {
+    addUnique(actions, {
+      id: 'loop-youtube-video',
+      label: 'Loop this video',
+      prompt: `Use execute_js once with exactly this function body, then report whether a video was found and looping was enabled:
+const KEY = '__webbrainYouTubeLoop';
+const previous = window[KEY];
+if (typeof previous?.stop === 'function') {
+  previous.stop();
+} else {
+  if (previous?.timer) clearInterval(previous.timer);
+  if (previous?.video && previous?.endedHandler) previous.video.removeEventListener('ended', previous.endedHandler);
+}
+const state = {
+  route: location.href,
+  video: document.querySelector('video'),
+  player: document.querySelector('#movie_player'),
+  endedHandler: null,
+  navigationHandler: null,
+  pagehideHandler: null,
+  timer: null,
+  stop: null,
+};
+const stop = () => {
+  if (state.timer) {
+    clearInterval(state.timer);
+    state.timer = null;
+  }
+  if (state.video && state.endedHandler) state.video.removeEventListener('ended', state.endedHandler);
+  if (state.navigationHandler) document.removeEventListener('yt-navigate-start', state.navigationHandler);
+  if (state.pagehideHandler) window.removeEventListener('pagehide', state.pagehideHandler);
+  try {
+    if (state.video) state.video.loop = false;
+    if (state.player && typeof state.player.setLoop === 'function') state.player.setLoop(false);
+  } catch {}
+  if (window[KEY] === state) delete window[KEY];
+};
+state.stop = stop;
+const targetIsCurrent = () => location.href === state.route && document.querySelector('video') === state.video;
+const enforceLoop = () => {
+  if (!state.video || !targetIsCurrent()) {
+    stop();
+    return false;
+  }
+  state.video.loop = true;
+  try {
+    if (state.player && typeof state.player.setLoop === 'function') state.player.setLoop(true);
+  } catch {}
+  return true;
+};
+const found = Boolean(state.video);
+if (found) {
+  state.endedHandler = () => {
+    if (!targetIsCurrent()) {
+      stop();
+      return;
+    }
+    state.video.currentTime = 0;
+    state.video.play().catch(() => {});
+  };
+  state.navigationHandler = stop;
+  state.pagehideHandler = stop;
+  state.video.addEventListener('ended', state.endedHandler);
+  document.addEventListener('yt-navigate-start', state.navigationHandler);
+  window.addEventListener('pagehide', state.pagehideHandler);
+  window[KEY] = state;
+  enforceLoop();
+  if (window[KEY] === state) state.timer = setInterval(enforceLoop, 1000);
+}
+return { found, loop: state.video?.loop === true, intervalSet: Boolean(state.timer), paused: state.video?.paused ?? null, duration: state.video?.duration ?? null };`,
+      mode: 'dev',
     });
   }
 

--- a/src/chrome/src/ui/recommended-actions.js
+++ b/src/chrome/src/ui/recommended-actions.js
@@ -473,6 +473,40 @@ export function buildRecommendedActions(pageInfo = {}, options = {}) {
         ['Call read_youtube_transcript for the active tab with timestamps:true, text_limit:6000, and include_segments:false.', 'Summarize the transcript with key points and timestamps when available.'],
       ),
     });
+    addUnique(actions, {
+      id: 'loop-youtube-video',
+      label: 'Loop this video',
+      prompt: `Use execute_js once with exactly this function body, then report whether a video was found and looping was enabled:
+const KEY = '__webbrainYouTubeLoop';
+const previous = window[KEY];
+if (previous?.timer) clearInterval(previous.timer);
+if (previous?.video && previous?.endedHandler) previous.video.removeEventListener('ended', previous.endedHandler);
+const state = { video: null, endedHandler: null, timer: null };
+const enforceLoop = () => {
+  const video = document.querySelector('video');
+  if (!video) return false;
+  if (state.video !== video) {
+    if (state.video && state.endedHandler) state.video.removeEventListener('ended', state.endedHandler);
+    state.video = video;
+    state.endedHandler = () => {
+      video.currentTime = 0;
+      video.play().catch(() => {});
+    };
+    video.addEventListener('ended', state.endedHandler);
+  }
+  video.loop = true;
+  try {
+    const player = document.querySelector('#movie_player');
+    if (player && typeof player.setLoop === 'function') player.setLoop(true);
+  } catch {}
+  return true;
+};
+const found = enforceLoop();
+state.timer = setInterval(enforceLoop, 1000);
+window[KEY] = state;
+return { found, loop: state.video?.loop === true, intervalSet: true, paused: state.video?.paused ?? null, duration: state.video?.duration ?? null };`,
+      mode: 'dev',
+    });
   }
 
   const publicMediaHost = PUBLIC_MEDIA_HOST_RE.test(host);

--- a/src/chrome/src/ui/sidepanel.js
+++ b/src/chrome/src/ui/sidepanel.js
@@ -5121,8 +5121,8 @@ async function runRecommendedAction(action) {
     hideRecommendedActions();
     return;
   }
-  if (action?.mode === 'act') {
-    const ok = await ensureActMode();
+  if (action?.mode === 'act' || action?.mode === 'dev') {
+    const ok = action.mode === 'dev' ? await ensureDevMode() : await ensureActMode();
     if (!ok) return;
     if (!(await recommendedActionSourceStillCurrent(action, tabId)) || currentTabId !== tabId || isProcessing) {
       hideRecommendedActions();

--- a/src/firefox/src/ui/recommended-actions.js
+++ b/src/firefox/src/ui/recommended-actions.js
@@ -457,6 +457,40 @@ export function buildRecommendedActions(pageInfo = {}, options = {}) {
         ['Call read_youtube_transcript for the active tab with timestamps:true, text_limit:6000, and include_segments:false.', 'Summarize the transcript with key points and timestamps when available.'],
       ),
     });
+    addUnique(actions, {
+      id: 'loop-youtube-video',
+      label: 'Loop this video',
+      prompt: `Use execute_js once with exactly this function body, then report whether a video was found and looping was enabled:
+const KEY = '__webbrainYouTubeLoop';
+const previous = window[KEY];
+if (previous?.timer) clearInterval(previous.timer);
+if (previous?.video && previous?.endedHandler) previous.video.removeEventListener('ended', previous.endedHandler);
+const state = { video: null, endedHandler: null, timer: null };
+const enforceLoop = () => {
+  const video = document.querySelector('video');
+  if (!video) return false;
+  if (state.video !== video) {
+    if (state.video && state.endedHandler) state.video.removeEventListener('ended', state.endedHandler);
+    state.video = video;
+    state.endedHandler = () => {
+      video.currentTime = 0;
+      video.play().catch(() => {});
+    };
+    video.addEventListener('ended', state.endedHandler);
+  }
+  video.loop = true;
+  try {
+    const player = document.querySelector('#movie_player');
+    if (player && typeof player.setLoop === 'function') player.setLoop(true);
+  } catch {}
+  return true;
+};
+const found = enforceLoop();
+state.timer = setInterval(enforceLoop, 1000);
+window[KEY] = state;
+return { found, loop: state.video?.loop === true, intervalSet: true, paused: state.video?.paused ?? null, duration: state.video?.duration ?? null };`,
+      mode: 'dev',
+    });
   }
 
   const publicMediaHost = PUBLIC_MEDIA_HOST_RE.test(host);

--- a/src/firefox/src/ui/recommended-actions.js
+++ b/src/firefox/src/ui/recommended-actions.js
@@ -457,40 +457,6 @@ export function buildRecommendedActions(pageInfo = {}, options = {}) {
         ['Call read_youtube_transcript for the active tab with timestamps:true, text_limit:6000, and include_segments:false.', 'Summarize the transcript with key points and timestamps when available.'],
       ),
     });
-    addUnique(actions, {
-      id: 'loop-youtube-video',
-      label: 'Loop this video',
-      prompt: `Use execute_js once with exactly this function body, then report whether a video was found and looping was enabled:
-const KEY = '__webbrainYouTubeLoop';
-const previous = window[KEY];
-if (previous?.timer) clearInterval(previous.timer);
-if (previous?.video && previous?.endedHandler) previous.video.removeEventListener('ended', previous.endedHandler);
-const state = { video: null, endedHandler: null, timer: null };
-const enforceLoop = () => {
-  const video = document.querySelector('video');
-  if (!video) return false;
-  if (state.video !== video) {
-    if (state.video && state.endedHandler) state.video.removeEventListener('ended', state.endedHandler);
-    state.video = video;
-    state.endedHandler = () => {
-      video.currentTime = 0;
-      video.play().catch(() => {});
-    };
-    video.addEventListener('ended', state.endedHandler);
-  }
-  video.loop = true;
-  try {
-    const player = document.querySelector('#movie_player');
-    if (player && typeof player.setLoop === 'function') player.setLoop(true);
-  } catch {}
-  return true;
-};
-const found = enforceLoop();
-state.timer = setInterval(enforceLoop, 1000);
-window[KEY] = state;
-return { found, loop: state.video?.loop === true, intervalSet: true, paused: state.video?.paused ?? null, duration: state.video?.duration ?? null };`,
-      mode: 'dev',
-    });
   }
 
   const publicMediaHost = PUBLIC_MEDIA_HOST_RE.test(host);
@@ -503,6 +469,80 @@ return { found, loop: state.video?.loop === true, intervalSet: true, paused: sta
       prompt: publicMediaHost ? publicMediaDownloadPrompt(kind, needsExplicitUrl) : 'Download the video or photo from this post.',
       mode: 'act',
       ...(publicMediaHost ? { runOptions: publicMediaDownloadRunOptions(kind, needsExplicitUrl) } : {}),
+    });
+  }
+
+  if (isYouTubeVideoPage(host, path, pageInfo.url || '')) {
+    addUnique(actions, {
+      id: 'loop-youtube-video',
+      label: 'Loop this video',
+      prompt: `Use execute_js once with exactly this function body, then report whether a video was found and looping was enabled:
+const KEY = '__webbrainYouTubeLoop';
+const previous = window[KEY];
+if (typeof previous?.stop === 'function') {
+  previous.stop();
+} else {
+  if (previous?.timer) clearInterval(previous.timer);
+  if (previous?.video && previous?.endedHandler) previous.video.removeEventListener('ended', previous.endedHandler);
+}
+const state = {
+  route: location.href,
+  video: document.querySelector('video'),
+  player: document.querySelector('#movie_player'),
+  endedHandler: null,
+  navigationHandler: null,
+  pagehideHandler: null,
+  timer: null,
+  stop: null,
+};
+const stop = () => {
+  if (state.timer) {
+    clearInterval(state.timer);
+    state.timer = null;
+  }
+  if (state.video && state.endedHandler) state.video.removeEventListener('ended', state.endedHandler);
+  if (state.navigationHandler) document.removeEventListener('yt-navigate-start', state.navigationHandler);
+  if (state.pagehideHandler) window.removeEventListener('pagehide', state.pagehideHandler);
+  try {
+    if (state.video) state.video.loop = false;
+    if (state.player && typeof state.player.setLoop === 'function') state.player.setLoop(false);
+  } catch {}
+  if (window[KEY] === state) delete window[KEY];
+};
+state.stop = stop;
+const targetIsCurrent = () => location.href === state.route && document.querySelector('video') === state.video;
+const enforceLoop = () => {
+  if (!state.video || !targetIsCurrent()) {
+    stop();
+    return false;
+  }
+  state.video.loop = true;
+  try {
+    if (state.player && typeof state.player.setLoop === 'function') state.player.setLoop(true);
+  } catch {}
+  return true;
+};
+const found = Boolean(state.video);
+if (found) {
+  state.endedHandler = () => {
+    if (!targetIsCurrent()) {
+      stop();
+      return;
+    }
+    state.video.currentTime = 0;
+    state.video.play().catch(() => {});
+  };
+  state.navigationHandler = stop;
+  state.pagehideHandler = stop;
+  state.video.addEventListener('ended', state.endedHandler);
+  document.addEventListener('yt-navigate-start', state.navigationHandler);
+  window.addEventListener('pagehide', state.pagehideHandler);
+  window[KEY] = state;
+  enforceLoop();
+  if (window[KEY] === state) state.timer = setInterval(enforceLoop, 1000);
+}
+return { found, loop: state.video?.loop === true, intervalSet: Boolean(state.timer), paused: state.video?.paused ?? null, duration: state.video?.duration ?? null };`,
+      mode: 'dev',
     });
   }
 

--- a/src/firefox/src/ui/sidepanel.js
+++ b/src/firefox/src/ui/sidepanel.js
@@ -4956,8 +4956,8 @@ async function runRecommendedAction(action) {
     hideRecommendedActions();
     return;
   }
-  if (action?.mode === 'act') {
-    const ok = await ensureActMode();
+  if (action?.mode === 'act' || action?.mode === 'dev') {
+    const ok = action.mode === 'dev' ? await ensureDevMode() : await ensureActMode();
     if (!ok) return;
     if (!(await recommendedActionSourceStillCurrent(action, tabId)) || currentTabId !== tabId || isProcessing) {
       hideRecommendedActions();

--- a/test/run.js
+++ b/test/run.js
@@ -18398,6 +18398,8 @@ test('YouTube video recommendations start with transcript skill and keep media d
       assert.match(loop?.prompt || '', /document\.querySelector\(['"]video['"]\)/, `loop action should target the active video for ${pageInfo.url}`);
       assert.match(loop?.prompt || '', /setInterval/, `loop action should keep the loop enabled across YouTube updates for ${pageInfo.url}`);
       assert.match(loop?.prompt || '', /addEventListener\(['"]ended['"]/, `loop action should restart videos when they end for ${pageInfo.url}`);
+      assert.match(loop?.prompt || '', /route: location\.href/, `loop action should capture the requested route for ${pageInfo.url}`);
+      assert.match(loop?.prompt || '', /document\.querySelector\(['"]video['"]\) === state\.video/, `loop action should stay scoped to its original video for ${pageInfo.url}`);
 
       const download = actions.find((a) => a.id === 'download-media');
       assert.equal(download?.runOptions?.tool, 'download_public_media', `YouTube download should use public media skill for ${pageInfo.url}`);
@@ -18419,6 +18421,110 @@ test('YouTube video recommendations start with transcript skill and keep media d
       'download_public_media',
       'YouTube embed pages should keep the public media download shortcut',
     );
+
+    const focusedCommentActions = buildRecommendedActions({
+      ...pages[0],
+      activeElement: {
+        tag: 'div',
+        role: 'textbox',
+        editable: true,
+        ariaLabel: 'Add a comment',
+        textPreview: 'This is a draft comment.',
+      },
+    });
+    assert.deepEqual(
+      focusedCommentActions.map((action) => action.id),
+      ['tweet-webbrain', 'rewrite-focused-draft', 'summarize-youtube-video', 'download-media'],
+      'focused YouTube comments should keep the existing download shortcut ahead of the loop action',
+    );
+  }
+});
+
+test('YouTube loop recommendation stops when its route or video target changes', () => {
+  const exerciseCleanup = (action, changeTarget, label) => {
+    let endedHandler = null;
+    const documentHandlers = new Map();
+    const windowHandlers = new Map();
+    const video = {
+      loop: false,
+      paused: false,
+      duration: 120,
+      currentTime: 30,
+      play: () => Promise.resolve(),
+      addEventListener(name, handler) {
+        if (name === 'ended') endedHandler = handler;
+      },
+      removeEventListener(name, handler) {
+        if (name === 'ended' && endedHandler === handler) endedHandler = null;
+      },
+    };
+    const replacementVideo = { loop: false };
+    const playerLoopCalls = [];
+    const player = { setLoop: (enabled) => playerLoopCalls.push(enabled) };
+    let currentVideo = video;
+    const documentMock = {
+      querySelector(selector) {
+        if (selector === 'video') return currentVideo;
+        if (selector === '#movie_player') return player;
+        return null;
+      },
+      addEventListener: (name, handler) => documentHandlers.set(name, handler),
+      removeEventListener(name, handler) {
+        if (documentHandlers.get(name) === handler) documentHandlers.delete(name);
+      },
+    };
+    const windowMock = {
+      addEventListener: (name, handler) => windowHandlers.set(name, handler),
+      removeEventListener(name, handler) {
+        if (windowHandlers.get(name) === handler) windowHandlers.delete(name);
+      },
+    };
+    const locationMock = { href: 'https://www.youtube.com/watch?v=first' };
+    let intervalCallback = null;
+    let clearedTimer = null;
+    const functionBody = action.prompt.slice(action.prompt.indexOf('\n') + 1);
+    const result = Function('window', 'document', 'location', 'setInterval', 'clearInterval', functionBody)(
+      windowMock,
+      documentMock,
+      locationMock,
+      (callback) => {
+        intervalCallback = callback;
+        return 17;
+      },
+      (timer) => {
+        clearedTimer = timer;
+      },
+    );
+
+    assert.deepEqual(result, { found: true, loop: true, intervalSet: true, paused: false, duration: 120 }, `${label}: unexpected initial loop result`);
+    assert.equal(video.loop, true, `${label}: original video should be looped`);
+    assert.equal(typeof endedHandler, 'function', `${label}: ended fallback listener missing`);
+    assert.equal(typeof intervalCallback, 'function', `${label}: enforcement timer missing`);
+    assert.equal(documentHandlers.has('yt-navigate-start'), true, `${label}: YouTube navigation listener missing`);
+    assert.equal(windowHandlers.has('pagehide'), true, `${label}: pagehide listener missing`);
+
+    changeTarget({ location: locationMock, setVideo: (nextVideo) => { currentVideo = nextVideo; }, replacementVideo });
+    intervalCallback();
+
+    assert.equal(clearedTimer, 17, `${label}: enforcement timer should be cleared`);
+    assert.equal(video.loop, false, `${label}: original video loop flag should be reset`);
+    assert.equal(replacementVideo.loop, false, `${label}: replacement video should not be retargeted`);
+    assert.equal(endedHandler, null, `${label}: ended listener should be removed`);
+    assert.equal(documentHandlers.has('yt-navigate-start'), false, `${label}: navigation listener should be removed`);
+    assert.equal(windowHandlers.has('pagehide'), false, `${label}: pagehide listener should be removed`);
+    assert.deepEqual(playerLoopCalls, [true, false], `${label}: player loop state should be disabled during cleanup`);
+    assert.equal(windowMock.__webbrainYouTubeLoop, undefined, `${label}: stale global loop state should be removed`);
+  };
+
+  for (const [label, buildRecommendedActions] of [['chrome', buildRecommendedActionsCh], ['firefox', buildRecommendedActionsFx]]) {
+    const action = buildRecommendedActions({
+      url: 'https://www.youtube.com/watch?v=first',
+      title: 'First video',
+      media: { videoCount: 1, imageCount: 0 },
+    }).find((candidate) => candidate.id === 'loop-youtube-video');
+    assert.ok(action, `${label}: loop recommendation missing`);
+    exerciseCleanup(action, ({ location }) => { location.href = 'https://www.youtube.com/watch?v=second'; }, `${label} route change`);
+    exerciseCleanup(action, ({ setVideo, replacementVideo }) => { setVideo(replacementVideo); }, `${label} video replacement`);
   }
 });
 

--- a/test/run.js
+++ b/test/run.js
@@ -18391,6 +18391,14 @@ test('YouTube video recommendations start with transcript skill and keep media d
       assert.equal(transcript?.runOptions?.autoExecute, true, `transcript summary should auto-execute first tool for ${pageInfo.url}`);
       assert.equal(transcript?.runOptions?.tool, 'read_youtube_transcript', `transcript summary should pin transcript tool for ${pageInfo.url}`);
 
+      const loop = actions.find((a) => a.id === 'loop-youtube-video');
+      assert.equal(loop?.label, 'Loop this video', `expected loop action for ${pageInfo.url}`);
+      assert.equal(loop?.mode, 'dev', `loop action should switch to Dev mode for ${pageInfo.url}`);
+      assert.match(loop?.prompt || '', /execute_js/, `loop action should name the Dev tool for ${pageInfo.url}`);
+      assert.match(loop?.prompt || '', /document\.querySelector\(['"]video['"]\)/, `loop action should target the active video for ${pageInfo.url}`);
+      assert.match(loop?.prompt || '', /setInterval/, `loop action should keep the loop enabled across YouTube updates for ${pageInfo.url}`);
+      assert.match(loop?.prompt || '', /addEventListener\(['"]ended['"]/, `loop action should restart videos when they end for ${pageInfo.url}`);
+
       const download = actions.find((a) => a.id === 'download-media');
       assert.equal(download?.runOptions?.tool, 'download_public_media', `YouTube download should use public media skill for ${pageInfo.url}`);
       assert.equal(download?.runOptions?.skipPlanner, true, `YouTube download should skip planner for ${pageInfo.url}`);
@@ -39858,7 +39866,7 @@ test('sidepanel drops stale recommended-action refreshes after tab changes or ru
   }
 });
 
-test('sidepanel drops stale recommended-action clicks after async act-mode switching', () => {
+test('sidepanel drops stale recommended-action clicks after async mode switching', () => {
   for (const [label, panelRel] of [
     ['chrome', 'src/chrome/src/ui/sidepanel.js'],
     ['firefox', 'src/firefox/src/ui/sidepanel.js'],
@@ -39873,6 +39881,8 @@ test('sidepanel drops stale recommended-action clicks after async act-mode switc
     const sourceGuard = 'recommendedActionSourceStillCurrent(action, tabId)';
     const firstSourceGuardIdx = body.indexOf(sourceGuard);
     const ensureIdx = body.indexOf('await ensureActMode();');
+    const devModeGuardIdx = body.indexOf("action?.mode === 'act' || action?.mode === 'dev'");
+    const ensureDevIdx = body.indexOf('await ensureDevMode()');
     const staleGuard = '!ok) return';
     const staleGuardIdx = body.indexOf(staleGuard);
     const secondSourceGuardIdx = body.indexOf(sourceGuard, firstSourceGuardIdx + 1);
@@ -39888,6 +39898,8 @@ test('sidepanel drops stale recommended-action clicks after async act-mode switc
     assert.notEqual(initialGuardIdx, -1, `${label}: recommended-action click should reject missing tabs before sending`);
     assert.notEqual(firstSourceGuardIdx, -1, `${label}: recommended-action click should re-check the source URL before sending`);
     assert.notEqual(ensureIdx, -1, `${label}: act recommended-action click should await the mode switch`);
+    assert.notEqual(devModeGuardIdx, -1, `${label}: Dev recommended actions should use the guarded mode-switch path`);
+    assert.notEqual(ensureDevIdx, -1, `${label}: Dev recommended-action click should await the Dev mode switch`);
     assert.notEqual(staleGuardIdx, -1, `${label}: stale recommended-action clicks should be dropped after switching modes`);
     assert.notEqual(secondSourceGuardIdx, -1, `${label}: act recommended-action click should re-check the source URL after switching modes`);
     assert.notEqual(inputIdx, -1, `${label}: recommended-action click composer write missing`);


### PR DESCRIPTION
## Summary

- Adds a **Loop this video** suggested action on YouTube watch, Shorts, live, and short-link video pages in both Chrome and Firefox.
- Switches through the existing Dev-mode guard before sending a focused `execute_js` instruction.
- Keeps looping active when YouTube replaces the `<video>` element, while clearing the previous timer and event listener when the action is run again.

## Validation

- Focused Node behavior checks for Chrome/Firefox parity, idempotent reruns, video-element replacement, and ended-event replay
- `node --check` on both recommended-action modules and both side panels
- `git diff --check`
- `npm run test`: all 2,044 unit/regression tests passed, the offline-relevance benchmark completed, and all 60/60 security corpus checks passed

Fixes #2911
