### PR TITLE
fix(trace): preserve stats when repairing interrupted runs

### DIFF
--- a/src/chrome/src/trace/repair.js
+++ b/src/chrome/src/trace/repair.js
@@ -1,5 +1,6 @@
 import { makeEvent } from './event-model.js';
 import { normalizeErrorCode } from './error-codes.js';
+import { buildTraceStats } from './stats.js';
 
 // A run can legitimately take a while, so repair only treats records older
 // than this conservative window as abandoned. Callers/tests may provide a
@@ -108,14 +109,30 @@ export function buildTraceRepairPlan(run, events, {
 
   const maxStep = orderedEvents.reduce((max, event) => Math.max(max, eventStep(event) ?? 0), 0);
   const startedAt = Number(run.startedAt);
+  const persistedEvents = repairedEvents.filter(Boolean);
+  // The run record may still contain its start-time zero snapshot because the
+  // normal endRun reducer never ran. Rebuild every durable metric from the
+  // original log plus the synthetic terminal events we are about to persist.
+  const stats = buildTraceStats([...orderedEvents, ...persistedEvents]);
   return {
-    events: repairedEvents.filter(Boolean),
+    events: persistedEvents,
     run: {
       ...run,
       endedAt: now,
       durationMs: Math.max(0, now - startedAt),
       status: 'error',
-      stepCount: Math.max(Number(run.stepCount) || 0, maxStep),
+      stepCount: Math.max(Number(run.stepCount) || 0, stats.stepCount, maxStep),
+      totalInputTokens: stats.totalInputTokens,
+      totalOutputTokens: stats.totalOutputTokens,
+      totalCost: stats.totalCost,
+      llmRequestCount: stats.llmRequestCount,
+      llmResponseCount: stats.llmResponseCount,
+      toolCallCount: stats.toolCallCount,
+      visionSubCallCount: stats.visionSubCallCount,
+      errorCount: stats.errorCount,
+      retryCount: stats.retryCount,
+      totalLlmLatencyMs: stats.totalLlmLatencyMs,
+      totalToolLatencyMs: stats.totalToolLatencyMs,
       repairedBy: TRACE_REPAIR_MARKER,
       repairedAt: now,
       repairReason: TRACE_REPAIR_REASON,

--- a/src/chrome/src/trace/stats.js
+++ b/src/chrome/src/trace/stats.js
@@ -36,12 +36,14 @@ export function createTraceStats() {
 export function addTraceEvent(stats, event) {
   if (!stats || !event || typeof event !== 'object') return stats;
   const data = event.data && typeof event.data === 'object' ? event.data : {};
+  if (event.kind === 'step_start' || event.kind === 'step_end' || event.kind === 'llm_response') {
+    stats.stepCount = Math.max(stats.stepCount, stepNumber(data.step));
+  }
 
   if (event.kind === 'llm_request') {
     stats.llmRequestCount += 1;
   } else if (event.kind === 'llm_response') {
     stats.llmResponseCount += 1;
-    stats.stepCount = Math.max(stats.stepCount, stepNumber(data.step));
     const usage = data.usage && typeof data.usage === 'object' ? data.usage : {};
     stats.totalInputTokens += nonNegativeNumber(usage.prompt_tokens);
     stats.totalOutputTokens += nonNegativeNumber(usage.completion_tokens);

--- a/src/firefox/src/trace/repair.js
+++ b/src/firefox/src/trace/repair.js
@@ -1,5 +1,6 @@
 import { makeEvent } from './event-model.js';
 import { normalizeErrorCode } from './error-codes.js';
+import { buildTraceStats } from './stats.js';
 
 // A run can legitimately take a while, so repair only treats records older
 // than this conservative window as abandoned. Callers/tests may provide a
@@ -108,14 +109,30 @@ export function buildTraceRepairPlan(run, events, {
 
   const maxStep = orderedEvents.reduce((max, event) => Math.max(max, eventStep(event) ?? 0), 0);
   const startedAt = Number(run.startedAt);
+  const persistedEvents = repairedEvents.filter(Boolean);
+  // The run record may still contain its start-time zero snapshot because the
+  // normal endRun reducer never ran. Rebuild every durable metric from the
+  // original log plus the synthetic terminal events we are about to persist.
+  const stats = buildTraceStats([...orderedEvents, ...persistedEvents]);
   return {
-    events: repairedEvents.filter(Boolean),
+    events: persistedEvents,
     run: {
       ...run,
       endedAt: now,
       durationMs: Math.max(0, now - startedAt),
       status: 'error',
-      stepCount: Math.max(Number(run.stepCount) || 0, maxStep),
+      stepCount: Math.max(Number(run.stepCount) || 0, stats.stepCount, maxStep),
+      totalInputTokens: stats.totalInputTokens,
+      totalOutputTokens: stats.totalOutputTokens,
+      totalCost: stats.totalCost,
+      llmRequestCount: stats.llmRequestCount,
+      llmResponseCount: stats.llmResponseCount,
+      toolCallCount: stats.toolCallCount,
+      visionSubCallCount: stats.visionSubCallCount,
+      errorCount: stats.errorCount,
+      retryCount: stats.retryCount,
+      totalLlmLatencyMs: stats.totalLlmLatencyMs,
+      totalToolLatencyMs: stats.totalToolLatencyMs,
       repairedBy: TRACE_REPAIR_MARKER,
       repairedAt: now,
       repairReason: TRACE_REPAIR_REASON,

--- a/src/firefox/src/trace/stats.js
+++ b/src/firefox/src/trace/stats.js
@@ -36,12 +36,14 @@ export function createTraceStats() {
 export function addTraceEvent(stats, event) {
   if (!stats || !event || typeof event !== 'object') return stats;
   const data = event.data && typeof event.data === 'object' ? event.data : {};
+  if (event.kind === 'step_start' || event.kind === 'step_end' || event.kind === 'llm_response') {
+    stats.stepCount = Math.max(stats.stepCount, stepNumber(data.step));
+  }
 
   if (event.kind === 'llm_request') {
     stats.llmRequestCount += 1;
   } else if (event.kind === 'llm_response') {
     stats.llmResponseCount += 1;
-    stats.stepCount = Math.max(stats.stepCount, stepNumber(data.step));
     const usage = data.usage && typeof data.usage === 'object' ? data.usage : {};
     stats.totalInputTokens += nonNegativeNumber(usage.prompt_tokens);
     stats.totalOutputTokens += nonNegativeNumber(usage.completion_tokens);

--- a/test/run.js
+++ b/test/run.js
@@ -9982,6 +9982,59 @@ test('trace repair: stale interrupted runs receive one ordered terminal repair',
   assert.equal(plan.run.repairedAt, 100_000);
 });
 
+test('trace repair: reconstructs the durable statistics snapshot before closing a run', () => {
+  const run = {
+    runId: 'run_with_metrics',
+    startedAt: 1_000,
+    status: 'running',
+    stepCount: 0,
+    totalInputTokens: 0,
+    totalOutputTokens: 0,
+    totalCost: 0,
+    llmRequestCount: 0,
+    llmResponseCount: 0,
+    toolCallCount: 0,
+    errorCount: 0,
+    retryCount: 0,
+    totalLlmLatencyMs: 0,
+    totalToolLatencyMs: 0,
+  };
+  const events = [
+    { runId: run.runId, seq: 1, kind: 'step_start', data: { step: 1 } },
+    { runId: run.runId, seq: 2, kind: 'llm_request', data: { step: 1 } },
+    { runId: run.runId, seq: 3, kind: 'llm_response', data: {
+      step: 1,
+      usage: { prompt_tokens: 10, completion_tokens: 4, cost: 0.12 },
+      latencyMs: 300,
+    } },
+    { runId: run.runId, seq: 4, kind: 'tool', data: { step: 1, latencyMs: 35, result: { success: false } } },
+    { runId: run.runId, seq: 5, kind: 'note', data: { step: 1, note: 'llm_retry' } },
+    { runId: run.runId, seq: 6, kind: 'error', data: { step: 1, phase: 'loop', code: 'TRANSPORT' } },
+  ];
+  const plan = TRACE_REPAIR_CH.buildTraceRepairPlan(run, events, {
+    now: 100_000,
+    staleAfterMs: 60_000,
+  });
+
+  assert.ok(plan, 'an old running run must produce a repair plan');
+  assert.equal(plan.run.stepCount, 1);
+  assert.equal(plan.run.totalInputTokens, 10);
+  assert.equal(plan.run.totalOutputTokens, 4);
+  assert.equal(plan.run.totalCost, 0.12);
+  assert.equal(plan.run.llmRequestCount, 1);
+  assert.equal(plan.run.llmResponseCount, 1);
+  assert.equal(plan.run.toolCallCount, 1);
+  assert.equal(plan.run.errorCount, 2, 'the repair error must join the existing error snapshot');
+  assert.equal(plan.run.retryCount, 1);
+  assert.equal(plan.run.totalLlmLatencyMs, 300);
+  assert.equal(plan.run.totalToolLatencyMs, 35);
+  assert.deepEqual(
+    TRACE_REPAIR_FX.buildTraceRepairPlan(run, events, { now: 100_000, staleAfterMs: 60_000 }).run,
+    plan.run,
+    'Firefox repair statistics must match Chrome',
+  );
+});
+
 test('trace repair: ignores recent and already repaired runs, with mirrored helpers', () => {
   const recent = { runId: 'recent', startedAt: 95_000, status: 'running' };
   const activeLongRun = { runId: 'active_long', startedAt: 1_000, status: 'running' };
@@ -10168,6 +10221,17 @@ test('trace stats: aggregates event metrics and mirrors browser modules', () => 
     hasLoopError: true,
   });
   assert.deepEqual(TRACE_STATS_FX.buildTraceStats(events), stats, 'Chrome/Firefox stats aggregators must agree');
+});
+
+test('trace stats: counts started steps when no response was recorded', () => {
+  const events = [
+    { kind: 'step_start', data: { step: 1 } },
+    { kind: 'step_end', data: { step: 1, ok: false, code: 'TRANSPORT' } },
+    { kind: 'step_start', data: { step: 2 } },
+  ];
+  const stats = TRACE_STATS_CH.buildTraceStats(events);
+  assert.equal(stats.stepCount, 2, 'failed or interrupted steps must remain visible in run statistics');
+  assert.equal(TRACE_STATS_FX.buildTraceStats(events).stepCount, 2, 'Firefox statistics must count the same incomplete steps');
 });
 
 test('trace stats: aggregates durable run snapshots without replaying events', () => {


### PR DESCRIPTION
## Summary

- Rebuild persisted run metrics when a service-worker interruption is repaired.
- Preserve token usage, reported cost, request/response counts, tool timing, errors, retries, and LLM latency from the recorded event log.
- Count lifecycle steps even when a step ends before an LLM response is recorded.
- Keep Chrome and Firefox trace behavior aligned.

## Compatibility

- Existing repair events and interruption status are unchanged.
- Repaired records now receive the same metric snapshot shape as normally finalized runs.
- No export format, privacy policy, provider propagation, or UI behavior changes.

## Validation

- `node test/run.js` — 2045 passed; 2 unrelated repository baseline failures remain:
  - the newest changelog entry does not match the package version
  - the tracked Chrome store archive is absent
- `npm run test:toolbar-guard` — 33 passed
- `npm run test:security` — 60/60 checks passed
- `git diff --check` — passed