### PR TITLE
Render selected answer text as an attachment

### DIFF
--- a/src/chrome/src/ui/locales/ar.js
+++ b/src/chrome/src/ui/locales/ar.js
@@ -792,6 +792,8 @@ export default {
   "sp.attach.too_large": "{name} كبير جدًا لإرفاقه (الحد الأقصى {max}).",
   "sp.attach.unsupported_type": "{name} ليس نوع مرفق مدعومًا — الملفات المدعومة فقط هي الصور وPDF وJSON وTXT وCSV.",
   "sp.attach.read_failed": "تعذرت قراءة {name}.",
+  "sp.attach.needs_prompt": "أضف سؤالاً لإرساله مع المرفق.",
+  "sp.attach.no_tab": "لا توجد علامة تبويب نشطة لإرفاق النص المحدد بها.",
   "sp.queue.label": "في قائمة الانتظار",
   "sp.queue.label_numbered": "في قائمة الانتظار {index}",
   "sp.queue.edit": "تعديل الرسالة في قائمة الانتظار",

--- a/src/chrome/src/ui/locales/bn.js
+++ b/src/chrome/src/ui/locales/bn.js
@@ -116,6 +116,8 @@ export default {
   'sp.attach.too_large': "{name} সংযুক্ত করার জন্য খুব বড় (সর্বোচ্চ {max})।",
   'sp.attach.unsupported_type': "{name} একটি সমর্থিত সংযুক্তি প্রকার নয় — শুধুমাত্র ছবি, PDF, JSON, TXT, এবং CSV ফাইল সমর্থিত।",
   'sp.attach.read_failed': "{name} পড়া যায়নি।",
+  'sp.attach.needs_prompt': 'সংযুক্তির সঙ্গে পাঠানোর জন্য একটি প্রশ্ন লিখুন।',
+  'sp.attach.no_tab': 'নির্বাচিত লেখা সংযুক্ত করার মতো কোনো সক্রিয় ট্যাব নেই।',
   'sp.queue.label': "সারিবদ্ধ",
   'sp.queue.label_numbered': "সারিবদ্ধ {index}",
   'sp.queue.edit': "সারিবদ্ধ বার্তা সম্পাদনা করুন",

--- a/src/chrome/src/ui/locales/de.js
+++ b/src/chrome/src/ui/locales/de.js
@@ -116,6 +116,8 @@ export default {
   'sp.attach.too_large': '{name} ist zu groß zum Anhängen (max. {max}).',
   'sp.attach.unsupported_type': '{name} ist kein unterstützter Anhangstyp — nur Bilder, PDFs, JSON, TXT- und CSV-Dateien werden unterstützt.',
   'sp.attach.read_failed': '{name} konnte nicht gelesen werden.',
+  'sp.attach.needs_prompt': 'Fügen Sie eine Frage hinzu, die mit dem Anhang gesendet wird.',
+  'sp.attach.no_tab': 'Kein aktiver Tab, an den die Auswahl angehängt werden kann.',
   'sp.queue.label': 'In Warteschlange',
   'sp.queue.label_numbered': 'In Warteschlange {index}',
   'sp.queue.edit': 'Warteschlangen-Nachricht bearbeiten',

--- a/src/chrome/src/ui/locales/en.js
+++ b/src/chrome/src/ui/locales/en.js
@@ -116,6 +116,8 @@ export default {
   'sp.attach.too_large': '{name} is too large to attach (max {max}).',
   'sp.attach.unsupported_type': '{name} is not a supported attachment type — only images, PDFs, JSON, TXT, and CSV files are supported.',
   'sp.attach.read_failed': 'Could not read {name}.',
+  'sp.attach.needs_prompt': 'Add a question to send with your attachment.',
+  'sp.attach.no_tab': 'No active tab to attach the selection to.',
   'sp.queue.label': 'Queued',
   'sp.queue.label_numbered': 'Queued {index}',
   'sp.queue.edit': 'Edit queued message',

--- a/src/chrome/src/ui/locales/es.js
+++ b/src/chrome/src/ui/locales/es.js
@@ -792,6 +792,8 @@ export default {
   "sp.attach.too_large": "{name} es demasiado grande para adjuntarlo (máx. {max}).",
   "sp.attach.unsupported_type": "{name} no es un tipo de adjunto compatible — solo se admiten imágenes, PDF, JSON, TXT y CSV.",
   "sp.attach.read_failed": "No se pudo leer {name}.",
+  "sp.attach.needs_prompt": "Añade una pregunta para enviarla con el archivo adjunto.",
+  "sp.attach.no_tab": "No hay ninguna pestaña activa a la que adjuntar la selección.",
   "sp.queue.label": "En cola",
   "sp.queue.label_numbered": "En cola {index}",
   "sp.queue.edit": "Editar mensaje en cola",

--- a/src/chrome/src/ui/locales/fa.js
+++ b/src/chrome/src/ui/locales/fa.js
@@ -116,6 +116,8 @@ export default {
   'sp.attach.too_large': "{name} برای اتصال بیش از حد بزرگ است (حداکثر {max}).",
   'sp.attach.unsupported_type': "{name} یک نوع پیوست پشتیبانی نمی‌شود - فقط تصاویر، فایل‌های PDF، JSON، TXT و فایل‌های CSV پشتیبانی می‌شوند.",
   'sp.attach.read_failed': "نمی توان {name} را خواند.",
+  'sp.attach.needs_prompt': 'برای ارسال همراه پیوست، یک پرسش بنویسید.',
+  'sp.attach.no_tab': 'هیچ زبانه فعالی برای پیوست کردن متن انتخاب‌شده وجود ندارد.',
   'sp.queue.label': "در صف",
   'sp.queue.label_numbered': "در صف {index}",
   'sp.queue.edit': "ویرایش پیام در صف",

--- a/src/chrome/src/ui/locales/fr.js
+++ b/src/chrome/src/ui/locales/fr.js
@@ -792,6 +792,8 @@ export default {
   "sp.attach.too_large": "{name} est trop volumineux pour être joint (max {max}).",
   "sp.attach.unsupported_type": "{name} n’est pas un type de pièce jointe pris en charge — seuls les images, PDF, JSON, TXT et CSV sont pris en charge.",
   "sp.attach.read_failed": "Impossible de lire {name}.",
+  "sp.attach.needs_prompt": "Ajoutez une question à envoyer avec votre pièce jointe.",
+  "sp.attach.no_tab": "Aucun onglet actif auquel joindre la sélection.",
   "sp.queue.label": "En file d’attente",
   "sp.queue.label_numbered": "En file d’attente {index}",
   "sp.queue.edit": "Modifier le message en file d’attente",

--- a/src/chrome/src/ui/locales/he.js
+++ b/src/chrome/src/ui/locales/he.js
@@ -116,6 +116,8 @@ export default {
   "sp.attach.too_large": "{name} גדול מדי לצירוף (מקסימום {max}).",
   "sp.attach.unsupported_type": "{name} אינו סוג קובץ נתמך. ניתן לצרף רק תמונות וקובצי PDF, JSON, TXT ו-CSV.",
   "sp.attach.read_failed": "לא ניתן לקרוא את {name}.",
+  "sp.attach.needs_prompt": "הוסיפו שאלה שתישלח יחד עם הקובץ המצורף.",
+  "sp.attach.no_tab": "אין לשונית פעילה שאליה אפשר לצרף את הבחירה.",
   "sp.queue.label": "בתור",
   "sp.queue.label_numbered": "בתור {index}",
   "sp.queue.edit": "ערוך הודעה בתור",

--- a/src/chrome/src/ui/locales/hi.js
+++ b/src/chrome/src/ui/locales/hi.js
@@ -116,6 +116,8 @@ export default {
   'sp.attach.too_large': "{name} संलग्न करने के लिए बहुत बड़ा है (अधिकतम {max})।",
   'sp.attach.unsupported_type': "{name} एक समर्थित अनुलग्नक प्रकार नहीं है - केवल छवियां, PDF, JSON, TXT और CSV फ़ाइलें समर्थित हैं।",
   'sp.attach.read_failed': "{name} नहीं पढ़ सका.",
+  'sp.attach.needs_prompt': 'अपने अटैचमेंट के साथ भेजने के लिए एक सवाल लिखें।',
+  'sp.attach.no_tab': 'चयनित टेक्स्ट को जोड़ने के लिए कोई सक्रिय टैब नहीं है।',
   'sp.queue.label': "कतारबद्ध",
   'sp.queue.label_numbered': "कतारबद्ध {index}",
   'sp.queue.edit': "पंक्तिबद्ध संदेश संपादित करें",

--- a/src/chrome/src/ui/locales/id.js
+++ b/src/chrome/src/ui/locales/id.js
@@ -792,6 +792,8 @@ export default {
   "sp.attach.too_large": "{name} terlalu besar untuk dilampirkan (maks {max}).",
   "sp.attach.unsupported_type": "{name} bukan tipe lampiran yang didukung — hanya gambar, PDF, JSON, TXT, dan CSV yang didukung.",
   "sp.attach.read_failed": "Tidak dapat membaca {name}.",
+  "sp.attach.needs_prompt": "Tambahkan pertanyaan untuk dikirim bersama lampiran Anda.",
+  "sp.attach.no_tab": "Tidak ada tab aktif untuk melampirkan teks yang dipilih.",
   "sp.queue.label": "Dalam antrean",
   "sp.queue.label_numbered": "Dalam antrean {index}",
   "sp.queue.edit": "Edit pesan antrean",

--- a/src/chrome/src/ui/locales/ja.js
+++ b/src/chrome/src/ui/locales/ja.js
@@ -792,6 +792,8 @@ export default {
   "sp.attach.too_large": "{name} は大きすぎて添付できません（最大 {max}）。",
   "sp.attach.unsupported_type": "{name} は対応していない添付タイプです — 画像、PDF、JSON、TXT、CSV ファイルのみ対応しています。",
   "sp.attach.read_failed": "{name} を読み取れませんでした。",
+  "sp.attach.needs_prompt": "添付ファイルと一緒に送る質問を入力してください。",
+  "sp.attach.no_tab": "選択したテキストを添付できるアクティブなタブがありません。",
   "sp.queue.label": "キュー済み",
   "sp.queue.label_numbered": "キュー済み {index}",
   "sp.queue.edit": "キュー内のメッセージを編集",

--- a/src/chrome/src/ui/locales/ko.js
+++ b/src/chrome/src/ui/locales/ko.js
@@ -792,6 +792,8 @@ export default {
   "sp.attach.too_large": "{name}은(는) 첨부하기에 너무 큽니다(최대 {max}).",
   "sp.attach.unsupported_type": "{name}은(는) 지원되는 첨부 파일 형식이 아닙니다 — 이미지, PDF, JSON, TXT, CSV 파일만 지원됩니다.",
   "sp.attach.read_failed": "{name}을(를) 읽을 수 없습니다.",
+  "sp.attach.needs_prompt": "첨부 파일과 함께 보낼 질문을 입력하세요.",
+  "sp.attach.no_tab": "선택한 텍스트를 첨부할 활성 탭이 없습니다.",
   "sp.queue.label": "대기 중",
   "sp.queue.label_numbered": "대기 중 {index}",
   "sp.queue.edit": "대기 중인 메시지 편집",

--- a/src/chrome/src/ui/locales/ms.js
+++ b/src/chrome/src/ui/locales/ms.js
@@ -792,6 +792,8 @@ export default {
   "sp.attach.too_large": "{name} terlalu besar untuk dilampirkan (maks {max}).",
   "sp.attach.unsupported_type": "{name} bukan jenis lampiran yang disokong — hanya imej, PDF, JSON, TXT dan CSV disokong.",
   "sp.attach.read_failed": "Tidak dapat membaca {name}.",
+  "sp.attach.needs_prompt": "Tambah soalan untuk dihantar bersama lampiran anda.",
+  "sp.attach.no_tab": "Tiada tab aktif untuk melampirkan teks yang dipilih.",
   "sp.queue.label": "Dalam baris gilir",
   "sp.queue.label_numbered": "Dalam baris gilir {index}",
   "sp.queue.edit": "Edit mesej dalam baris gilir",

--- a/src/chrome/src/ui/locales/nl.js
+++ b/src/chrome/src/ui/locales/nl.js
@@ -116,6 +116,8 @@ export default {
   'sp.attach.too_large': '{name} is te groot om bij te voegen (max {max}).',
   'sp.attach.unsupported_type': "{name} is een niet-ondersteund bijlagetype — alleen afbeeldingen, PDF's, JSON, TXT- en CSV-bestanden worden ondersteund.",
   'sp.attach.read_failed': '{name} kon niet worden gelezen.',
+  'sp.attach.needs_prompt': 'Voeg een vraag toe om met je bijlage te versturen.',
+  'sp.attach.no_tab': 'Geen actief tabblad om de selectie aan toe te voegen.',
   'sp.queue.label': 'In wachtrij',
   'sp.queue.label_numbered': 'In wachtrij {index}',
   'sp.queue.edit': 'Wachtend bericht bewerken',

--- a/src/chrome/src/ui/locales/pl.js
+++ b/src/chrome/src/ui/locales/pl.js
@@ -783,6 +783,8 @@ export default {
   "sp.attach.too_large": "{name} jest za duży, aby go dołączyć (maks. {max}).",
   "sp.attach.unsupported_type": "{name} nie jest obsługiwanym typem załącznika — obsługiwane są tylko obrazy, PDF, JSON, TXT i CSV.",
   "sp.attach.read_failed": "Nie udało się odczytać {name}.",
+  "sp.attach.needs_prompt": "Dodaj pytanie, które zostanie wysłane z załącznikiem.",
+  "sp.attach.no_tab": "Brak aktywnej karty, do której można dołączyć zaznaczenie.",
   "sp.queue.label": "W kolejce",
   "sp.queue.label_numbered": "W kolejce {index}",
   "sp.queue.edit": "Edytuj wiadomość w kolejce",

--- a/src/chrome/src/ui/locales/pt.js
+++ b/src/chrome/src/ui/locales/pt.js
@@ -116,6 +116,8 @@ export default {
   'sp.attach.too_large': "{name} é muito grande para ser conectado (máx. {max}).",
   'sp.attach.unsupported_type': "{name} não é um tipo de anexo compatível – apenas imagens, PDFs, arquivos JSON, TXT e CSV são compatíveis.",
   'sp.attach.read_failed': "Não foi possível ler {name}.",
+  'sp.attach.needs_prompt': 'Adicione uma pergunta para enviar com o anexo.',
+  'sp.attach.no_tab': 'Nenhuma aba ativa para anexar a seleção.',
   'sp.queue.label': "Na fila",
   'sp.queue.label_numbered': "Na fila {index}",
   'sp.queue.edit': "Editar mensagem na fila",

--- a/src/chrome/src/ui/locales/ru.js
+++ b/src/chrome/src/ui/locales/ru.js
@@ -792,6 +792,8 @@ export default {
   "sp.attach.too_large": "{name} слишком велик для вложения (макс. {max}).",
   "sp.attach.unsupported_type": "{name} не является поддерживаемым типом вложения — поддерживаются только изображения, PDF, JSON, TXT и CSV.",
   "sp.attach.read_failed": "Не удалось прочитать {name}.",
+  "sp.attach.needs_prompt": "Добавьте вопрос, чтобы отправить его вместе с вложением.",
+  "sp.attach.no_tab": "Нет активной вкладки, к которой можно прикрепить выделенный текст.",
   "sp.queue.label": "В очереди",
   "sp.queue.label_numbered": "В очереди {index}",
   "sp.queue.edit": "Редактировать сообщение в очереди",

--- a/src/chrome/src/ui/locales/th.js
+++ b/src/chrome/src/ui/locales/th.js
@@ -792,6 +792,8 @@ export default {
   "sp.attach.too_large": "{name} ใหญ่เกินกว่าจะแนบได้ (สูงสุด {max})",
   "sp.attach.unsupported_type": "{name} ไม่ใช่ประเภทไฟล์แนบที่รองรับ — รองรับเฉพาะรูปภาพ, PDF, JSON, TXT และ CSV",
   "sp.attach.read_failed": "อ่าน {name} ไม่ได้",
+  "sp.attach.needs_prompt": "พิมพ์คำถามเพื่อส่งไปพร้อมกับไฟล์แนบ",
+  "sp.attach.no_tab": "ไม่มีแท็บที่ใช้งานอยู่สำหรับแนบข้อความที่เลือก",
   "sp.queue.label": "อยู่ในคิว",
   "sp.queue.label_numbered": "อยู่ในคิว {index}",
   "sp.queue.edit": "แก้ไขข้อความในคิว",

--- a/src/chrome/src/ui/locales/tl.js
+++ b/src/chrome/src/ui/locales/tl.js
@@ -792,6 +792,8 @@ export default {
   "sp.attach.too_large": "Masyadong malaki ang {name} para i-attach (max {max}).",
   "sp.attach.unsupported_type": "Hindi suportadong uri ng attachment ang {name} — mga image, PDF, JSON, TXT, at CSV file lang ang suportado.",
   "sp.attach.read_failed": "Hindi mabasa ang {name}.",
+  "sp.attach.needs_prompt": "Magdagdag ng tanong na ipapadala kasama ng iyong attachment.",
+  "sp.attach.no_tab": "Walang aktibong tab kung saan maidudugtong ang piniling teksto.",
   "sp.queue.label": "Naka-queue",
   "sp.queue.label_numbered": "Naka-queue {index}",
   "sp.queue.edit": "I-edit ang naka-queue na mensahe",

--- a/src/chrome/src/ui/locales/tr.js
+++ b/src/chrome/src/ui/locales/tr.js
@@ -797,6 +797,8 @@ export default {
   "sp.attach.too_large": "{name} eklemek için çok büyük (en fazla {max}).",
   "sp.attach.unsupported_type": "{name} desteklenen bir ek türü değil — yalnızca görseller, PDF, JSON, TXT ve CSV dosyaları desteklenir.",
   "sp.attach.read_failed": "{name} okunamadı.",
+  "sp.attach.needs_prompt": "Ekinizle birlikte göndermek için bir soru yazın.",
+  "sp.attach.no_tab": "Seçimi ekleyebileceğiniz etkin bir sekme yok.",
   "sp.queue.label": "Kuyrukta",
   "sp.queue.label_numbered": "Kuyrukta {index}",
   "sp.queue.edit": "Kuyruktaki mesajı düzenle",

--- a/src/chrome/src/ui/locales/uk.js
+++ b/src/chrome/src/ui/locales/uk.js
@@ -792,6 +792,8 @@ export default {
   "sp.attach.too_large": "{name} завеликий для вкладення (макс. {max}).",
   "sp.attach.unsupported_type": "{name} не є підтримуваним типом вкладення — підтримуються лише зображення, PDF, JSON, TXT і CSV.",
   "sp.attach.read_failed": "Не вдалося прочитати {name}.",
+  "sp.attach.needs_prompt": "Додайте запитання, щоб надіслати його разом із вкладенням.",
+  "sp.attach.no_tab": "Немає активної вкладки, до якої можна прикріпити виділений текст.",
   "sp.queue.label": "У черзі",
   "sp.queue.label_numbered": "У черзі {index}",
   "sp.queue.edit": "Редагувати повідомлення в черзі",

--- a/src/chrome/src/ui/locales/vi.js
+++ b/src/chrome/src/ui/locales/vi.js
@@ -116,6 +116,8 @@ export default {
   'sp.attach.too_large': "{name} quá lớn để đính kèm (tối đa {max}).",
   'sp.attach.unsupported_type': "{name} không phải là loại tệp đính kèm được hỗ trợ - chỉ hỗ trợ các tệp hình ảnh, PDF, JSON, TXT và CSV.",
   'sp.attach.read_failed': "Không thể đọc {name}.",
+  'sp.attach.needs_prompt': 'Hãy nhập câu hỏi để gửi kèm tệp đính kèm.',
+  'sp.attach.no_tab': 'Không có tab đang hoạt động để đính kèm văn bản đã chọn.',
   'sp.queue.label': "Đã xếp hàng",
   'sp.queue.label_numbered': "Đã xếp hàng {index}",
   'sp.queue.edit': "Chỉnh sửa tin nhắn xếp hàng đợi",

--- a/src/chrome/src/ui/locales/zh.js
+++ b/src/chrome/src/ui/locales/zh.js
@@ -792,6 +792,8 @@ export default {
   "sp.attach.too_large": "{name} 太大，无法附加（最大 {max}）。",
   "sp.attach.unsupported_type": "{name} 不是支持的附件类型 — 仅支持图像、PDF、JSON、TXT 和 CSV 文件。",
   "sp.attach.read_failed": "无法读取 {name}。",
+  "sp.attach.needs_prompt": "请输入要与附件一起发送的问题。",
+  "sp.attach.no_tab": "没有可附加所选文本的活动标签页。",
   "sp.queue.label": "已排队",
   "sp.queue.label_numbered": "已排队 {index}",
   "sp.queue.edit": "编辑排队消息",

--- a/src/chrome/src/ui/selection-quote.js
+++ b/src/chrome/src/ui/selection-quote.js
@@ -58,6 +58,25 @@ export function buildSelectionComposerDraft(selectionText, draft = '') {
   return `${quote}${existingDraft}`;
 }
 
+export function buildSelectionTextAttachment(text) {
+  const selection = normalizedSelectionText(text);
+  if (!selection) return null;
+  const bytes = new TextEncoder().encode(selection);
+  let binary = '';
+  for (let offset = 0; offset < bytes.length; offset += 0x8000) {
+    binary += String.fromCharCode(...bytes.subarray(offset, offset + 0x8000));
+  }
+  return {
+    kind: 'text',
+    name: 'selected-text.txt',
+    textContent: selection,
+    dataUrl: `data:text/plain;charset=utf-8;base64,${btoa(binary)}`,
+    mimeType: 'text/plain;charset=utf-8',
+    size: bytes.byteLength,
+    source: 'user_upload',
+  };
+}
+
 export function selectionIsQuoteable({ startTextElement, endTextElement, text } = {}) {
   // A range spanning two bubbles has no unambiguous answer boundary.
   return Boolean(

--- a/src/chrome/src/ui/selection-quote.js
+++ b/src/chrome/src/ui/selection-quote.js
@@ -73,6 +73,9 @@ export function buildSelectionTextAttachment(text) {
     dataUrl: `data:text/plain;charset=utf-8;base64,${btoa(binary)}`,
     mimeType: 'text/plain;charset=utf-8',
     size: bytes.byteLength,
+    // A two-value flag, not a trust level: everything that is not a slash
+    // screenshot normalizes to 'user_upload' before it reaches storage or the
+    // model, and every attachment is wrapped as untrusted regardless of it.
     source: 'user_upload',
   };
 }

--- a/src/chrome/src/ui/sidepanel.js
+++ b/src/chrome/src/ui/sidepanel.js
@@ -8625,6 +8625,11 @@ async function sendMessage(extraChatParams = {}) {
       await releaseOwnedContextMenuClaim({ reason: 'preflight-empty', retryAfterMs: 1_000 });
       return false;
     }
+    // Attachments alone cannot start a run and Send stays enabled while idle, so
+    // a staged chip with an empty composer would otherwise fail silently.
+    if (getPendingAttachmentsForTab(undefined, { create: false }).length) {
+      showComposerToast(t('sp.attach.needs_prompt'));
+    }
     return;
   }
   if (agentPrompt) text = agentPrompt;
@@ -11748,7 +11753,7 @@ function askAboutSelectedAnswer() {
   const tabId = normalizeAttachmentTabId(renderedTabId ?? currentTabId);
   if (tabId == null) {
     dismissSelectionAskAction();
-    showComposerToast(t('sp.attach.read_failed', { name: attachment.name }));
+    showComposerToast(t('sp.attach.no_tab'));
     return;
   }
   const pending = getPendingAttachmentsForTab(tabId);

--- a/src/chrome/src/ui/sidepanel.js
+++ b/src/chrome/src/ui/sidepanel.js
@@ -11748,15 +11748,21 @@ function askAboutSelectedAnswer() {
   const tabId = normalizeAttachmentTabId(renderedTabId ?? currentTabId);
   if (tabId == null) {
     dismissSelectionAskAction();
-    showComposerToast(t('sp.persistence.unavailable'));
+    showComposerToast(t('sp.attach.read_failed', { name: attachment.name }));
     return;
   }
   const pending = getPendingAttachmentsForTab(tabId);
-  const existingIndex = pending.findIndex(att => att?.kind === 'text' && att?.name === attachment.name);
-  if (existingIndex >= 0) {
-    pending[existingIndex] = attachment;
-  } else {
-    pending.push(attachment);
+  // Re-adding the same snippet is a no-op, so repeated clicks cannot pile up
+  // identical chips. A *different* snippet gets its own chip instead of
+  // overwriting the previous one: replacing by filename would silently drop an
+  // earlier selection the user still expects to send, and would clobber an
+  // uploaded file that happens to share the name.
+  const alreadyStaged = pending.some(att => att?.kind === 'text' && att?.textContent === attachment.textContent);
+  if (!alreadyStaged) {
+    const takenNames = new Set(pending.map(att => att?.name));
+    let name = attachment.name;
+    for (let suffix = 2; takenNames.has(name); suffix += 1) name = `selected-text-${suffix}.txt`;
+    pending.push({ ...attachment, name });
   }
   renderAttachmentPreviews();
   dismissSelectionAskAction();

--- a/src/chrome/src/ui/sidepanel.js
+++ b/src/chrome/src/ui/sidepanel.js
@@ -11745,12 +11745,19 @@ function askAboutSelectedAnswer() {
     }
     return;
   }
-  const tabId = normalizeAttachmentTabId(currentTabId);
+  const tabId = normalizeAttachmentTabId(renderedTabId ?? currentTabId);
   if (tabId == null) {
     dismissSelectionAskAction();
+    showComposerToast(t('sp.persistence.unavailable'));
     return;
   }
-  getPendingAttachmentsForTab(tabId).push(attachment);
+  const pending = getPendingAttachmentsForTab(tabId);
+  const existingIndex = pending.findIndex(att => att?.kind === 'text' && att?.name === attachment.name);
+  if (existingIndex >= 0) {
+    pending[existingIndex] = attachment;
+  } else {
+    pending.push(attachment);
+  }
   renderAttachmentPreviews();
   dismissSelectionAskAction();
   window.getSelection?.()?.removeAllRanges();

--- a/src/chrome/src/ui/sidepanel.js
+++ b/src/chrome/src/ui/sidepanel.js
@@ -42,7 +42,7 @@ import { buildMessageInfoPills } from '../message-info.js';
 import { escapeHtml } from './utils.js';
 import { createOfflineRagReadinessController, offlineRagRunPayload } from './offline-rag-readiness.js';
 import {
-  buildSelectionComposerDraft,
+  buildSelectionTextAttachment,
   selectionIsQuoteable,
   selectionRangeIsVisible,
   selectionRangeRect,
@@ -11734,12 +11734,24 @@ function askAboutSelectedAnswer() {
     dismissSelectionAskAction();
     return;
   }
-  const nextDraft = buildSelectionComposerDraft(selection.text, inputEl.value);
-  if (nextDraft === inputEl.value) {
+  const attachment = buildSelectionTextAttachment(selection.text);
+  if (!attachment || attachment.size > MAX_TEXT_ATTACHMENT_BYTES) {
+    dismissSelectionAskAction();
+    if (attachment) {
+      addMessage('system', systemHtml(tSystemHtml('sp.attach.too_large', {
+        name: attachment.name,
+        max: '5MB',
+      })));
+    }
+    return;
+  }
+  const tabId = normalizeAttachmentTabId(currentTabId);
+  if (tabId == null) {
     dismissSelectionAskAction();
     return;
   }
-  inputEl.value = nextDraft;
+  getPendingAttachmentsForTab(tabId).push(attachment);
+  renderAttachmentPreviews();
   dismissSelectionAskAction();
   window.getSelection?.()?.removeAllRanges();
   handleInput();

--- a/src/firefox/src/ui/locales/ar.js
+++ b/src/firefox/src/ui/locales/ar.js
@@ -765,6 +765,8 @@ export default {
   "sp.attach.too_large": "{name} كبير جدًا لإرفاقه (الحد الأقصى {max}).",
   "sp.attach.unsupported_type": "{name} ليس نوع مرفق مدعومًا — الملفات المدعومة فقط هي الصور وPDF وJSON وTXT وCSV.",
   "sp.attach.read_failed": "تعذرت قراءة {name}.",
+  "sp.attach.needs_prompt": "أضف سؤالاً لإرساله مع المرفق.",
+  "sp.attach.no_tab": "لا توجد علامة تبويب نشطة لإرفاق النص المحدد بها.",
   "sp.queue.label": "في قائمة الانتظار",
   "sp.queue.label_numbered": "في قائمة الانتظار {index}",
   "sp.queue.edit": "تعديل الرسالة في قائمة الانتظار",

--- a/src/firefox/src/ui/locales/bn.js
+++ b/src/firefox/src/ui/locales/bn.js
@@ -116,6 +116,8 @@ export default {
   'sp.attach.too_large': "{name} সংযুক্ত করার জন্য খুব বড় (সর্বোচ্চ {max})।",
   'sp.attach.unsupported_type': "{name} একটি সমর্থিত সংযুক্তি প্রকার নয় — শুধুমাত্র ছবি, PDF, JSON, TXT, এবং CSV ফাইল সমর্থিত।",
   'sp.attach.read_failed': "{name} পড়া যায়নি।",
+  'sp.attach.needs_prompt': 'সংযুক্তির সঙ্গে পাঠানোর জন্য একটি প্রশ্ন লিখুন।',
+  'sp.attach.no_tab': 'নির্বাচিত লেখা সংযুক্ত করার মতো কোনো সক্রিয় ট্যাব নেই।',
   'sp.queue.label': "সারিবদ্ধ",
   'sp.queue.label_numbered': "সারিবদ্ধ {index}",
   'sp.queue.edit': "সারিবদ্ধ বার্তা সম্পাদনা করুন",

--- a/src/firefox/src/ui/locales/de.js
+++ b/src/firefox/src/ui/locales/de.js
@@ -116,6 +116,8 @@ export default {
   'sp.attach.too_large': '{name} ist zu groß zum Anhängen (max. {max}).',
   'sp.attach.unsupported_type': '{name} ist kein unterstützter Anhangstyp — nur Bilder, PDFs, JSON, TXT- und CSV-Dateien werden unterstützt.',
   'sp.attach.read_failed': '{name} konnte nicht gelesen werden.',
+  'sp.attach.needs_prompt': 'Fügen Sie eine Frage hinzu, die mit dem Anhang gesendet wird.',
+  'sp.attach.no_tab': 'Kein aktiver Tab, an den die Auswahl angehängt werden kann.',
   'sp.queue.label': 'In Warteschlange',
   'sp.queue.label_numbered': 'In Warteschlange {index}',
   'sp.queue.edit': 'Warteschlangen-Nachricht bearbeiten',

--- a/src/firefox/src/ui/locales/en.js
+++ b/src/firefox/src/ui/locales/en.js
@@ -116,6 +116,8 @@ export default {
   'sp.attach.too_large': '{name} is too large to attach (max {max}).',
   'sp.attach.unsupported_type': '{name} is not a supported attachment type — only images, PDFs, JSON, TXT, and CSV files are supported.',
   'sp.attach.read_failed': 'Could not read {name}.',
+  'sp.attach.needs_prompt': 'Add a question to send with your attachment.',
+  'sp.attach.no_tab': 'No active tab to attach the selection to.',
   'sp.queue.label': 'Queued',
   'sp.queue.label_numbered': 'Queued {index}',
   'sp.queue.edit': 'Edit queued message',

--- a/src/firefox/src/ui/locales/es.js
+++ b/src/firefox/src/ui/locales/es.js
@@ -765,6 +765,8 @@ export default {
   "sp.attach.too_large": "{name} es demasiado grande para adjuntarlo (máx. {max}).",
   "sp.attach.unsupported_type": "{name} no es un tipo de adjunto compatible — solo se admiten imágenes, PDF, JSON, TXT y CSV.",
   "sp.attach.read_failed": "No se pudo leer {name}.",
+  "sp.attach.needs_prompt": "Añade una pregunta para enviarla con el archivo adjunto.",
+  "sp.attach.no_tab": "No hay ninguna pestaña activa a la que adjuntar la selección.",
   "sp.queue.label": "En cola",
   "sp.queue.label_numbered": "En cola {index}",
   "sp.queue.edit": "Editar mensaje en cola",

--- a/src/firefox/src/ui/locales/fa.js
+++ b/src/firefox/src/ui/locales/fa.js
@@ -116,6 +116,8 @@ export default {
   'sp.attach.too_large': "{name} برای اتصال بیش از حد بزرگ است (حداکثر {max}).",
   'sp.attach.unsupported_type': "{name} یک نوع پیوست پشتیبانی نمی‌شود - فقط تصاویر، فایل‌های PDF، JSON، TXT و فایل‌های CSV پشتیبانی می‌شوند.",
   'sp.attach.read_failed': "نمی توان {name} را خواند.",
+  'sp.attach.needs_prompt': 'برای ارسال همراه پیوست، یک پرسش بنویسید.',
+  'sp.attach.no_tab': 'هیچ زبانه فعالی برای پیوست کردن متن انتخاب‌شده وجود ندارد.',
   'sp.queue.label': "در صف",
   'sp.queue.label_numbered': "در صف {index}",
   'sp.queue.edit': "ویرایش پیام در صف",

--- a/src/firefox/src/ui/locales/fr.js
+++ b/src/firefox/src/ui/locales/fr.js
@@ -765,6 +765,8 @@ export default {
   "sp.attach.too_large": "{name} est trop volumineux pour être joint (max {max}).",
   "sp.attach.unsupported_type": "{name} n’est pas un type de pièce jointe pris en charge — seuls les images, PDF, JSON, TXT et CSV sont pris en charge.",
   "sp.attach.read_failed": "Impossible de lire {name}.",
+  "sp.attach.needs_prompt": "Ajoutez une question à envoyer avec votre pièce jointe.",
+  "sp.attach.no_tab": "Aucun onglet actif auquel joindre la sélection.",
   "sp.queue.label": "En file d’attente",
   "sp.queue.label_numbered": "En file d’attente {index}",
   "sp.queue.edit": "Modifier le message en file d’attente",

--- a/src/firefox/src/ui/locales/he.js
+++ b/src/firefox/src/ui/locales/he.js
@@ -116,6 +116,8 @@ export default {
   "sp.attach.too_large": "{name} גדול מדי לצירוף (מקסימום {max}).",
   "sp.attach.unsupported_type": "{name} אינו סוג קובץ נתמך. ניתן לצרף רק תמונות וקובצי PDF, JSON, TXT ו-CSV.",
   "sp.attach.read_failed": "לא ניתן לקרוא את {name}.",
+  "sp.attach.needs_prompt": "הוסיפו שאלה שתישלח יחד עם הקובץ המצורף.",
+  "sp.attach.no_tab": "אין לשונית פעילה שאליה אפשר לצרף את הבחירה.",
   "sp.queue.label": "בתור",
   "sp.queue.label_numbered": "בתור {index}",
   "sp.queue.edit": "ערוך הודעה בתור",

--- a/src/firefox/src/ui/locales/hi.js
+++ b/src/firefox/src/ui/locales/hi.js
@@ -116,6 +116,8 @@ export default {
   'sp.attach.too_large': "{name} संलग्न करने के लिए बहुत बड़ा है (अधिकतम {max})।",
   'sp.attach.unsupported_type': "{name} एक समर्थित अनुलग्नक प्रकार नहीं है - केवल छवियां, PDF, JSON, TXT और CSV फ़ाइलें समर्थित हैं।",
   'sp.attach.read_failed': "{name} नहीं पढ़ सका.",
+  'sp.attach.needs_prompt': 'अपने अटैचमेंट के साथ भेजने के लिए एक सवाल लिखें।',
+  'sp.attach.no_tab': 'चयनित टेक्स्ट को जोड़ने के लिए कोई सक्रिय टैब नहीं है।',
   'sp.queue.label': "कतारबद्ध",
   'sp.queue.label_numbered': "कतारबद्ध {index}",
   'sp.queue.edit': "पंक्तिबद्ध संदेश संपादित करें",

--- a/src/firefox/src/ui/locales/id.js
+++ b/src/firefox/src/ui/locales/id.js
@@ -765,6 +765,8 @@ export default {
   "sp.attach.too_large": "{name} terlalu besar untuk dilampirkan (maks {max}).",
   "sp.attach.unsupported_type": "{name} bukan tipe lampiran yang didukung — hanya gambar, PDF, JSON, TXT, dan CSV yang didukung.",
   "sp.attach.read_failed": "Tidak dapat membaca {name}.",
+  "sp.attach.needs_prompt": "Tambahkan pertanyaan untuk dikirim bersama lampiran Anda.",
+  "sp.attach.no_tab": "Tidak ada tab aktif untuk melampirkan teks yang dipilih.",
   "sp.queue.label": "Dalam antrean",
   "sp.queue.label_numbered": "Dalam antrean {index}",
   "sp.queue.edit": "Edit pesan antrean",

--- a/src/firefox/src/ui/locales/ja.js
+++ b/src/firefox/src/ui/locales/ja.js
@@ -765,6 +765,8 @@ export default {
   "sp.attach.too_large": "{name} は大きすぎて添付できません（最大 {max}）。",
   "sp.attach.unsupported_type": "{name} は対応していない添付タイプです — 画像、PDF、JSON、TXT、CSV ファイルのみ対応しています。",
   "sp.attach.read_failed": "{name} を読み取れませんでした。",
+  "sp.attach.needs_prompt": "添付ファイルと一緒に送る質問を入力してください。",
+  "sp.attach.no_tab": "選択したテキストを添付できるアクティブなタブがありません。",
   "sp.queue.label": "キュー済み",
   "sp.queue.label_numbered": "キュー済み {index}",
   "sp.queue.edit": "キュー内のメッセージを編集",

--- a/src/firefox/src/ui/locales/ko.js
+++ b/src/firefox/src/ui/locales/ko.js
@@ -765,6 +765,8 @@ export default {
   "sp.attach.too_large": "{name}은(는) 첨부하기에 너무 큽니다(최대 {max}).",
   "sp.attach.unsupported_type": "{name}은(는) 지원되는 첨부 파일 형식이 아닙니다 — 이미지, PDF, JSON, TXT, CSV 파일만 지원됩니다.",
   "sp.attach.read_failed": "{name}을(를) 읽을 수 없습니다.",
+  "sp.attach.needs_prompt": "첨부 파일과 함께 보낼 질문을 입력하세요.",
+  "sp.attach.no_tab": "선택한 텍스트를 첨부할 활성 탭이 없습니다.",
   "sp.queue.label": "대기 중",
   "sp.queue.label_numbered": "대기 중 {index}",
   "sp.queue.edit": "대기 중인 메시지 편집",

--- a/src/firefox/src/ui/locales/ms.js
+++ b/src/firefox/src/ui/locales/ms.js
@@ -765,6 +765,8 @@ export default {
   "sp.attach.too_large": "{name} terlalu besar untuk dilampirkan (maks {max}).",
   "sp.attach.unsupported_type": "{name} bukan jenis lampiran yang disokong — hanya imej, PDF, JSON, TXT dan CSV disokong.",
   "sp.attach.read_failed": "Tidak dapat membaca {name}.",
+  "sp.attach.needs_prompt": "Tambah soalan untuk dihantar bersama lampiran anda.",
+  "sp.attach.no_tab": "Tiada tab aktif untuk melampirkan teks yang dipilih.",
   "sp.queue.label": "Dalam baris gilir",
   "sp.queue.label_numbered": "Dalam baris gilir {index}",
   "sp.queue.edit": "Edit mesej dalam baris gilir",

--- a/src/firefox/src/ui/locales/nl.js
+++ b/src/firefox/src/ui/locales/nl.js
@@ -116,6 +116,8 @@ export default {
   'sp.attach.too_large': '{name} is te groot om bij te voegen (max {max}).',
   'sp.attach.unsupported_type': "{name} is een niet-ondersteund bijlagetype — alleen afbeeldingen, PDF's, JSON, TXT- en CSV-bestanden worden ondersteund.",
   'sp.attach.read_failed': '{name} kon niet worden gelezen.',
+  'sp.attach.needs_prompt': 'Voeg een vraag toe om met je bijlage te versturen.',
+  'sp.attach.no_tab': 'Geen actief tabblad om de selectie aan toe te voegen.',
   'sp.queue.label': 'In wachtrij',
   'sp.queue.label_numbered': 'In wachtrij {index}',
   'sp.queue.edit': 'Wachtend bericht bewerken',

--- a/src/firefox/src/ui/locales/pl.js
+++ b/src/firefox/src/ui/locales/pl.js
@@ -756,6 +756,8 @@ export default {
   "sp.attach.too_large": "{name} jest za duży, aby go dołączyć (maks. {max}).",
   "sp.attach.unsupported_type": "{name} nie jest obsługiwanym typem załącznika — obsługiwane są tylko obrazy, PDF, JSON, TXT i CSV.",
   "sp.attach.read_failed": "Nie udało się odczytać {name}.",
+  "sp.attach.needs_prompt": "Dodaj pytanie, które zostanie wysłane z załącznikiem.",
+  "sp.attach.no_tab": "Brak aktywnej karty, do której można dołączyć zaznaczenie.",
   "sp.queue.label": "W kolejce",
   "sp.queue.label_numbered": "W kolejce {index}",
   "sp.queue.edit": "Edytuj wiadomość w kolejce",

--- a/src/firefox/src/ui/locales/pt.js
+++ b/src/firefox/src/ui/locales/pt.js
@@ -116,6 +116,8 @@ export default {
   'sp.attach.too_large': "{name} é muito grande para ser conectado (máx. {max}).",
   'sp.attach.unsupported_type': "{name} não é um tipo de anexo compatível – apenas imagens, PDFs, arquivos JSON, TXT e CSV são compatíveis.",
   'sp.attach.read_failed': "Não foi possível ler {name}.",
+  'sp.attach.needs_prompt': 'Adicione uma pergunta para enviar com o anexo.',
+  'sp.attach.no_tab': 'Nenhuma aba ativa para anexar a seleção.',
   'sp.queue.label': "Na fila",
   'sp.queue.label_numbered': "Na fila {index}",
   'sp.queue.edit': "Editar mensagem na fila",

--- a/src/firefox/src/ui/locales/ru.js
+++ b/src/firefox/src/ui/locales/ru.js
@@ -765,6 +765,8 @@ export default {
   "sp.attach.too_large": "{name} слишком велик для вложения (макс. {max}).",
   "sp.attach.unsupported_type": "{name} не является поддерживаемым типом вложения — поддерживаются только изображения, PDF, JSON, TXT и CSV.",
   "sp.attach.read_failed": "Не удалось прочитать {name}.",
+  "sp.attach.needs_prompt": "Добавьте вопрос, чтобы отправить его вместе с вложением.",
+  "sp.attach.no_tab": "Нет активной вкладки, к которой можно прикрепить выделенный текст.",
   "sp.queue.label": "В очереди",
   "sp.queue.label_numbered": "В очереди {index}",
   "sp.queue.edit": "Редактировать сообщение в очереди",

--- a/src/firefox/src/ui/locales/th.js
+++ b/src/firefox/src/ui/locales/th.js
@@ -765,6 +765,8 @@ export default {
   "sp.attach.too_large": "{name} ใหญ่เกินกว่าจะแนบได้ (สูงสุด {max})",
   "sp.attach.unsupported_type": "{name} ไม่ใช่ประเภทไฟล์แนบที่รองรับ — รองรับเฉพาะรูปภาพ, PDF, JSON, TXT และ CSV",
   "sp.attach.read_failed": "อ่าน {name} ไม่ได้",
+  "sp.attach.needs_prompt": "พิมพ์คำถามเพื่อส่งไปพร้อมกับไฟล์แนบ",
+  "sp.attach.no_tab": "ไม่มีแท็บที่ใช้งานอยู่สำหรับแนบข้อความที่เลือก",
   "sp.queue.label": "อยู่ในคิว",
   "sp.queue.label_numbered": "อยู่ในคิว {index}",
   "sp.queue.edit": "แก้ไขข้อความในคิว",

--- a/src/firefox/src/ui/locales/tl.js
+++ b/src/firefox/src/ui/locales/tl.js
@@ -765,6 +765,8 @@ export default {
   "sp.attach.too_large": "Masyadong malaki ang {name} para i-attach (max {max}).",
   "sp.attach.unsupported_type": "Hindi suportadong uri ng attachment ang {name} — mga image, PDF, JSON, TXT, at CSV file lang ang suportado.",
   "sp.attach.read_failed": "Hindi mabasa ang {name}.",
+  "sp.attach.needs_prompt": "Magdagdag ng tanong na ipapadala kasama ng iyong attachment.",
+  "sp.attach.no_tab": "Walang aktibong tab kung saan maidudugtong ang piniling teksto.",
   "sp.queue.label": "Naka-queue",
   "sp.queue.label_numbered": "Naka-queue {index}",
   "sp.queue.edit": "I-edit ang naka-queue na mensahe",

--- a/src/firefox/src/ui/locales/tr.js
+++ b/src/firefox/src/ui/locales/tr.js
@@ -770,6 +770,8 @@ export default {
   "sp.attach.too_large": "{name} eklemek için çok büyük (en fazla {max}).",
   "sp.attach.unsupported_type": "{name} desteklenen bir ek türü değil — yalnızca görseller, PDF, JSON, TXT ve CSV dosyaları desteklenir.",
   "sp.attach.read_failed": "{name} okunamadı.",
+  "sp.attach.needs_prompt": "Ekinizle birlikte göndermek için bir soru yazın.",
+  "sp.attach.no_tab": "Seçimi ekleyebileceğiniz etkin bir sekme yok.",
   "sp.queue.label": "Kuyrukta",
   "sp.queue.label_numbered": "Kuyrukta {index}",
   "sp.queue.edit": "Kuyruktaki mesajı düzenle",

--- a/src/firefox/src/ui/locales/uk.js
+++ b/src/firefox/src/ui/locales/uk.js
@@ -765,6 +765,8 @@ export default {
   "sp.attach.too_large": "{name} завеликий для вкладення (макс. {max}).",
   "sp.attach.unsupported_type": "{name} не є підтримуваним типом вкладення — підтримуються лише зображення, PDF, JSON, TXT і CSV.",
   "sp.attach.read_failed": "Не вдалося прочитати {name}.",
+  "sp.attach.needs_prompt": "Додайте запитання, щоб надіслати його разом із вкладенням.",
+  "sp.attach.no_tab": "Немає активної вкладки, до якої можна прикріпити виділений текст.",
   "sp.queue.label": "У черзі",
   "sp.queue.label_numbered": "У черзі {index}",
   "sp.queue.edit": "Редагувати повідомлення в черзі",

--- a/src/firefox/src/ui/locales/vi.js
+++ b/src/firefox/src/ui/locales/vi.js
@@ -116,6 +116,8 @@ export default {
   'sp.attach.too_large': "{name} quá lớn để đính kèm (tối đa {max}).",
   'sp.attach.unsupported_type': "{name} không phải là loại tệp đính kèm được hỗ trợ - chỉ hỗ trợ các tệp hình ảnh, PDF, JSON, TXT và CSV.",
   'sp.attach.read_failed': "Không thể đọc {name}.",
+  'sp.attach.needs_prompt': 'Hãy nhập câu hỏi để gửi kèm tệp đính kèm.',
+  'sp.attach.no_tab': 'Không có tab đang hoạt động để đính kèm văn bản đã chọn.',
   'sp.queue.label': "Đã xếp hàng",
   'sp.queue.label_numbered': "Đã xếp hàng {index}",
   'sp.queue.edit': "Chỉnh sửa tin nhắn xếp hàng đợi",

--- a/src/firefox/src/ui/locales/zh.js
+++ b/src/firefox/src/ui/locales/zh.js
@@ -765,6 +765,8 @@ export default {
   "sp.attach.too_large": "{name} 太大，无法附加（最大 {max}）。",
   "sp.attach.unsupported_type": "{name} 不是支持的附件类型 — 仅支持图像、PDF、JSON、TXT 和 CSV 文件。",
   "sp.attach.read_failed": "无法读取 {name}。",
+  "sp.attach.needs_prompt": "请输入要与附件一起发送的问题。",
+  "sp.attach.no_tab": "没有可附加所选文本的活动标签页。",
   "sp.queue.label": "已排队",
   "sp.queue.label_numbered": "已排队 {index}",
   "sp.queue.edit": "编辑排队消息",

--- a/src/firefox/src/ui/selection-quote.js
+++ b/src/firefox/src/ui/selection-quote.js
@@ -58,6 +58,25 @@ export function buildSelectionComposerDraft(selectionText, draft = '') {
   return `${quote}${existingDraft}`;
 }
 
+export function buildSelectionTextAttachment(text) {
+  const selection = normalizedSelectionText(text);
+  if (!selection) return null;
+  const bytes = new TextEncoder().encode(selection);
+  let binary = '';
+  for (let offset = 0; offset < bytes.length; offset += 0x8000) {
+    binary += String.fromCharCode(...bytes.subarray(offset, offset + 0x8000));
+  }
+  return {
+    kind: 'text',
+    name: 'selected-text.txt',
+    textContent: selection,
+    dataUrl: `data:text/plain;charset=utf-8;base64,${btoa(binary)}`,
+    mimeType: 'text/plain;charset=utf-8',
+    size: bytes.byteLength,
+    source: 'user_upload',
+  };
+}
+
 export function selectionIsQuoteable({ startTextElement, endTextElement, text } = {}) {
   // A range spanning two bubbles has no unambiguous answer boundary.
   return Boolean(

--- a/src/firefox/src/ui/selection-quote.js
+++ b/src/firefox/src/ui/selection-quote.js
@@ -73,6 +73,9 @@ export function buildSelectionTextAttachment(text) {
     dataUrl: `data:text/plain;charset=utf-8;base64,${btoa(binary)}`,
     mimeType: 'text/plain;charset=utf-8',
     size: bytes.byteLength,
+    // A two-value flag, not a trust level: everything that is not a slash
+    // screenshot normalizes to 'user_upload' before it reaches storage or the
+    // model, and every attachment is wrapped as untrusted regardless of it.
     source: 'user_upload',
   };
 }

--- a/src/firefox/src/ui/sidepanel.js
+++ b/src/firefox/src/ui/sidepanel.js
@@ -11350,15 +11350,21 @@ function askAboutSelectedAnswer() {
   const tabId = normalizeAttachmentTabId(renderedTabId ?? currentTabId);
   if (tabId == null) {
     dismissSelectionAskAction();
-    showComposerToast(t('sp.persistence.unavailable'));
+    showComposerToast(t('sp.attach.read_failed', { name: attachment.name }));
     return;
   }
   const pending = getPendingAttachmentsForTab(tabId);
-  const existingIndex = pending.findIndex(att => att?.kind === 'text' && att?.name === attachment.name);
-  if (existingIndex >= 0) {
-    pending[existingIndex] = attachment;
-  } else {
-    pending.push(attachment);
+  // Re-adding the same snippet is a no-op, so repeated clicks cannot pile up
+  // identical chips. A *different* snippet gets its own chip instead of
+  // overwriting the previous one: replacing by filename would silently drop an
+  // earlier selection the user still expects to send, and would clobber an
+  // uploaded file that happens to share the name.
+  const alreadyStaged = pending.some(att => att?.kind === 'text' && att?.textContent === attachment.textContent);
+  if (!alreadyStaged) {
+    const takenNames = new Set(pending.map(att => att?.name));
+    let name = attachment.name;
+    for (let suffix = 2; takenNames.has(name); suffix += 1) name = `selected-text-${suffix}.txt`;
+    pending.push({ ...attachment, name });
   }
   renderAttachmentPreviews();
   dismissSelectionAskAction();

--- a/src/firefox/src/ui/sidepanel.js
+++ b/src/firefox/src/ui/sidepanel.js
@@ -42,7 +42,7 @@ import { buildMessageInfoPills } from '../message-info.js';
 import { escapeHtml } from './utils.js';
 import { createOfflineRagReadinessController } from './offline-rag-readiness.js';
 import {
-  buildSelectionComposerDraft,
+  buildSelectionTextAttachment,
   selectionIsQuoteable,
   selectionRangeIsVisible,
   selectionRangeRect,
@@ -11336,12 +11336,24 @@ function askAboutSelectedAnswer() {
     dismissSelectionAskAction();
     return;
   }
-  const nextDraft = buildSelectionComposerDraft(selection.text, inputEl.value);
-  if (nextDraft === inputEl.value) {
+  const attachment = buildSelectionTextAttachment(selection.text);
+  if (!attachment || attachment.size > MAX_TEXT_ATTACHMENT_BYTES) {
+    dismissSelectionAskAction();
+    if (attachment) {
+      addMessage('system', systemHtml(tSystemHtml('sp.attach.too_large', {
+        name: attachment.name,
+        max: '5MB',
+      })));
+    }
+    return;
+  }
+  const tabId = normalizeAttachmentTabId(currentTabId);
+  if (tabId == null) {
     dismissSelectionAskAction();
     return;
   }
-  inputEl.value = nextDraft;
+  getPendingAttachmentsForTab(tabId).push(attachment);
+  renderAttachmentPreviews();
   dismissSelectionAskAction();
   window.getSelection?.()?.removeAllRanges();
   handleInput();

--- a/src/firefox/src/ui/sidepanel.js
+++ b/src/firefox/src/ui/sidepanel.js
@@ -11347,12 +11347,19 @@ function askAboutSelectedAnswer() {
     }
     return;
   }
-  const tabId = normalizeAttachmentTabId(currentTabId);
+  const tabId = normalizeAttachmentTabId(renderedTabId ?? currentTabId);
   if (tabId == null) {
     dismissSelectionAskAction();
+    showComposerToast(t('sp.persistence.unavailable'));
     return;
   }
-  getPendingAttachmentsForTab(tabId).push(attachment);
+  const pending = getPendingAttachmentsForTab(tabId);
+  const existingIndex = pending.findIndex(att => att?.kind === 'text' && att?.name === attachment.name);
+  if (existingIndex >= 0) {
+    pending[existingIndex] = attachment;
+  } else {
+    pending.push(attachment);
+  }
   renderAttachmentPreviews();
   dismissSelectionAskAction();
   window.getSelection?.()?.removeAllRanges();

--- a/src/firefox/src/ui/sidepanel.js
+++ b/src/firefox/src/ui/sidepanel.js
@@ -8284,6 +8284,11 @@ async function sendMessage(extraChatParams = {}) {
       await releaseOwnedContextMenuClaim({ reason: 'preflight-empty', retryAfterMs: 1_000 });
       return false;
     }
+    // Attachments alone cannot start a run and Send stays enabled while idle, so
+    // a staged chip with an empty composer would otherwise fail silently.
+    if (getPendingAttachmentsForTab(undefined, { create: false }).length) {
+      showComposerToast(t('sp.attach.needs_prompt'));
+    }
     return;
   }
   if (agentPrompt) text = agentPrompt;
@@ -11350,7 +11355,7 @@ function askAboutSelectedAnswer() {
   const tabId = normalizeAttachmentTabId(renderedTabId ?? currentTabId);
   if (tabId == null) {
     dismissSelectionAskAction();
-    showComposerToast(t('sp.attach.read_failed', { name: attachment.name }));
+    showComposerToast(t('sp.attach.no_tab'));
     return;
   }
   const pending = getPendingAttachmentsForTab(tabId);

--- a/test/run.js
+++ b/test/run.js
@@ -1462,7 +1462,7 @@ test('selected answer attachments keep the full text outside the composer draft'
   }
 });
 
-test('selected answer attachments deduplicate repeated actions for the same tab', () => {
+test('selected answer attachments deduplicate repeated actions without dropping distinct snippets', () => {
   for (const [label, buildAttachment] of [
     ['chrome', buildSelectionTextAttachment],
     ['firefox', buildSelectionTextAttachmentFx],
@@ -1470,27 +1470,35 @@ test('selected answer attachments deduplicate repeated actions for the same tab'
     const pending = [];
     const stage = (text) => {
       const attachment = buildAttachment(text);
-      const existingIndex = pending.findIndex(att => att?.kind === 'text' && att?.name === attachment.name);
-      if (existingIndex >= 0) {
-        pending[existingIndex] = attachment;
-      } else {
-        pending.push(attachment);
+      const alreadyStaged = pending.some(att => att?.kind === 'text' && att?.textContent === attachment.textContent);
+      if (!alreadyStaged) {
+        const takenNames = new Set(pending.map(att => att?.name));
+        let name = attachment.name;
+        for (let suffix = 2; takenNames.has(name); suffix += 1) name = `selected-text-${suffix}.txt`;
+        pending.push({ ...attachment, name });
       }
     };
 
     stage('First selected snippet');
     assert.equal(pending.length, 1, `${label}: first selection should add an attachment`);
     assert.equal(pending[0].textContent, 'First selected snippet');
+    assert.equal(pending[0].name, 'selected-text.txt');
+
+    stage('First selected snippet');
+    assert.equal(pending.length, 1, `${label}: re-adding the same snippet must not pile up identical chips`);
 
     stage('Second selected snippet');
-    assert.equal(pending.length, 1, `${label}: second selection should replace existing selected-text.txt`);
-    assert.equal(pending[0].textContent, 'Second selected snippet');
+    assert.equal(pending.length, 2, `${label}: a different snippet must not overwrite the earlier selection`);
+    assert.equal(pending[0].textContent, 'First selected snippet');
+    assert.equal(pending[1].textContent, 'Second selected snippet');
+    assert.equal(pending[1].name, 'selected-text-2.txt');
 
     pending.unshift({ kind: 'image', name: 'screenshot.png', source: 'slash_screenshot' });
-    pending.push({ kind: 'text', name: 'uploaded-file.txt', textContent: 'file data', source: 'user_upload' });
+    pending.push({ kind: 'text', name: 'selected-text-3.txt', textContent: 'file data', source: 'user_upload' });
     stage('Third selected snippet');
-    assert.equal(pending.length, 3, `${label}: unrelated attachments must not be overwritten`);
-    assert.equal(pending[1].textContent, 'Third selected snippet');
+    assert.equal(pending.length, 5, `${label}: unrelated attachments must not be overwritten`);
+    assert.equal(pending[4].textContent, 'Third selected snippet');
+    assert.equal(pending[4].name, 'selected-text-4.txt', `${label}: a name already taken by an upload must not be reused`);
   }
 });
 
@@ -1566,11 +1574,14 @@ test('selection answer action stages a visual attachment in both sidepanels', ()
     assert.match(source, /selectionAskActionEl && !selectionAskActionEl\.classList\.contains\('hidden'\)[\s\S]*?dismissSelectionAskAction\(\);/);
     assert.match(selectionActionSource, /buildSelectionTextAttachment\(selection\.text\)/);
     assert.match(selectionActionSource, /normalizeAttachmentTabId\(renderedTabId \?\? currentTabId\)/);
-    assert.match(selectionActionSource, /showComposerToast\(t\('sp\.persistence\.unavailable'\)\)/);
+    assert.match(selectionActionSource, /showComposerToast\(t\('sp\.attach\.read_failed', \{ name: attachment\.name \}\)\)/);
+    assert.doesNotMatch(selectionActionSource, /sp\.persistence\.unavailable/);
     assert.match(selectionActionSource, /const pending = getPendingAttachmentsForTab\(tabId\)/);
-    assert.match(selectionActionSource, /const existingIndex = pending\.findIndex\(att => att\?\.kind === 'text' && att\?\.name === attachment\.name\)/);
-    assert.match(selectionActionSource, /pending\[existingIndex\] = attachment/);
-    assert.match(selectionActionSource, /pending\.push\(attachment\)/);
+    assert.match(selectionActionSource, /const alreadyStaged = pending\.some\(att => att\?\.kind === 'text' && att\?\.textContent === attachment\.textContent\)/);
+    assert.match(selectionActionSource, /const takenNames = new Set\(pending\.map\(att => att\?\.name\)\)/);
+    assert.match(selectionActionSource, /for \(let suffix = 2; takenNames\.has\(name\); suffix \+= 1\) name = `selected-text-\$\{suffix\}\.txt`/);
+    assert.match(selectionActionSource, /pending\.push\(\{ \.\.\.attachment, name \}\)/);
+    assert.doesNotMatch(selectionActionSource, /pending\[existingIndex\] = attachment/);
     assert.match(selectionActionSource, /renderAttachmentPreviews\(\);/);
     assert.doesNotMatch(selectionActionSource, /buildSelectionComposerDraft/);
     assert.match(switchToTabSource, /dismissSelectionAskAction\(\);/);

--- a/test/run.js
+++ b/test/run.js
@@ -1462,6 +1462,38 @@ test('selected answer attachments keep the full text outside the composer draft'
   }
 });
 
+test('selected answer attachments deduplicate repeated actions for the same tab', () => {
+  for (const [label, buildAttachment] of [
+    ['chrome', buildSelectionTextAttachment],
+    ['firefox', buildSelectionTextAttachmentFx],
+  ]) {
+    const pending = [];
+    const stage = (text) => {
+      const attachment = buildAttachment(text);
+      const existingIndex = pending.findIndex(att => att?.kind === 'text' && att?.name === attachment.name);
+      if (existingIndex >= 0) {
+        pending[existingIndex] = attachment;
+      } else {
+        pending.push(attachment);
+      }
+    };
+
+    stage('First selected snippet');
+    assert.equal(pending.length, 1, `${label}: first selection should add an attachment`);
+    assert.equal(pending[0].textContent, 'First selected snippet');
+
+    stage('Second selected snippet');
+    assert.equal(pending.length, 1, `${label}: second selection should replace existing selected-text.txt`);
+    assert.equal(pending[0].textContent, 'Second selected snippet');
+
+    pending.unshift({ kind: 'image', name: 'screenshot.png', source: 'slash_screenshot' });
+    pending.push({ kind: 'text', name: 'uploaded-file.txt', textContent: 'file data', source: 'user_upload' });
+    stage('Third selected snippet');
+    assert.equal(pending.length, 3, `${label}: unrelated attachments must not be overwritten`);
+    assert.equal(pending[1].textContent, 'Third selected snippet');
+  }
+});
+
 test('selectionTextFromContents skips in-bubble chrome and keeps answer text', () => {
   const textNode = (value) => ({ nodeType: 3, nodeValue: value });
   const element = (tagName, className, ...childNodes) => ({
@@ -1533,7 +1565,12 @@ test('selection answer action stages a visual attachment in both sidepanels', ()
     assert.match(source, /const liveSelection = selectedAssistantAnswer\(\);/);
     assert.match(source, /selectionAskActionEl && !selectionAskActionEl\.classList\.contains\('hidden'\)[\s\S]*?dismissSelectionAskAction\(\);/);
     assert.match(selectionActionSource, /buildSelectionTextAttachment\(selection\.text\)/);
-    assert.match(selectionActionSource, /getPendingAttachmentsForTab\(tabId\)\.push\(attachment\)/);
+    assert.match(selectionActionSource, /normalizeAttachmentTabId\(renderedTabId \?\? currentTabId\)/);
+    assert.match(selectionActionSource, /showComposerToast\(t\('sp\.persistence\.unavailable'\)\)/);
+    assert.match(selectionActionSource, /const pending = getPendingAttachmentsForTab\(tabId\)/);
+    assert.match(selectionActionSource, /const existingIndex = pending\.findIndex\(att => att\?\.kind === 'text' && att\?\.name === attachment\.name\)/);
+    assert.match(selectionActionSource, /pending\[existingIndex\] = attachment/);
+    assert.match(selectionActionSource, /pending\.push\(attachment\)/);
     assert.match(selectionActionSource, /renderAttachmentPreviews\(\);/);
     assert.doesNotMatch(selectionActionSource, /buildSelectionComposerDraft/);
     assert.match(switchToTabSource, /dismissSelectionAskAction\(\);/);

--- a/test/run.js
+++ b/test/run.js
@@ -1299,6 +1299,7 @@ const {
 const {
   buildSelectionQuote,
   buildSelectionComposerDraft,
+  buildSelectionTextAttachment,
   selectionIsQuoteable,
   selectionRangeIsVisible,
   selectionRangeRect,
@@ -1310,6 +1311,7 @@ const {
 const {
   buildSelectionQuote: buildSelectionQuoteFx,
   buildSelectionComposerDraft: buildSelectionComposerDraftFx,
+  buildSelectionTextAttachment: buildSelectionTextAttachmentFx,
   selectionIsQuoteable: selectionIsQuoteableFx,
   selectionRangeIsVisible: selectionRangeIsVisibleFx,
   selectionRangeRect: selectionRangeRectFx,
@@ -1428,6 +1430,38 @@ test('selection quote helper stays byte-identical across browser builds', () => 
   assert.equal(selectionQuoteSources[0], selectionQuoteSources[1]);
 });
 
+test('selected answer attachments keep the full text outside the composer draft', () => {
+  const expectedText = '第一行\nSecond line — with UTF-8';
+  const expectedBytes = new TextEncoder().encode(expectedText).byteLength;
+  for (const [label, buildAttachment] of [
+    ['chrome', buildSelectionTextAttachment],
+    ['firefox', buildSelectionTextAttachmentFx],
+  ]) {
+    const attachment = buildAttachment(`  ${expectedText}\n`);
+    assert.deepEqual(
+      {
+        kind: attachment.kind,
+        name: attachment.name,
+        textContent: attachment.textContent,
+        mimeType: attachment.mimeType,
+        size: attachment.size,
+      },
+      {
+        kind: 'text',
+        name: 'selected-text.txt',
+        textContent: expectedText,
+        mimeType: 'text/plain;charset=utf-8',
+        size: expectedBytes,
+      },
+      `${label}: selected answer should become a compact text attachment`,
+    );
+    assert.match(attachment.dataUrl, /^data:text\/plain;charset=utf-8;base64,/);
+    const bytes = Uint8Array.from(atob(attachment.dataUrl.split(',', 2)[1]), char => char.charCodeAt(0));
+    assert.equal(new TextDecoder().decode(bytes), expectedText, `${label}: attachment bytes should preserve selected text`);
+    assert.equal(buildAttachment(''), null, `${label}: empty selections should not create an attachment`);
+  }
+});
+
 test('selectionTextFromContents skips in-bubble chrome and keeps answer text', () => {
   const textNode = (value) => ({ nodeType: 3, nodeValue: value });
   const element = (tagName, className, ...childNodes) => ({
@@ -1459,11 +1493,12 @@ test('selectionTextFromContents skips in-bubble chrome and keeps answer text', (
   assert.equal(isSelectionQuoteChrome(element('CODE', '', textNode('const x = 1;'))), false);
 });
 
-test('selection answer action wiring covers show, dismiss, and tab/conversation changes in both sidepanels', () => {
+test('selection answer action stages a visual attachment in both sidepanels', () => {
   for (const [index, source] of sidepanelSources.entries()) {
     const switchToTabSource = sourceBetween(source, 'async function switchToTab', '\n}\n\nasync function refreshVisibleSidePanelState');
     const clearConversationSource = sourceBetween(source, 'async function renderClearedConversationForTab', '\nconst TOOL_KEYS =');
     const sendMessageSource = sourceBetween(source, 'async function sendMessage', '\nasync function continueAgent');
+    const selectionActionSource = sourceBetween(source, 'function askAboutSelectedAnswer()', '\nfunction addMessage');
     assert.match(source, /document\.addEventListener\('selectionchange', scheduleSelectionAskActionRefresh\)/);
     assert.match(source, /document\.addEventListener\('pointerdown', handleSelectionAskPointerDown/);
     assert.match(source, /function showSelectionAskAction\(selected\)/);
@@ -1497,6 +1532,10 @@ test('selection answer action wiring covers show, dismiss, and tab/conversation 
     assert.match(source, /if \(!range\.startContainer\.isConnected \|\| !range\.endContainer\.isConnected\) return null;/);
     assert.match(source, /const liveSelection = selectedAssistantAnswer\(\);/);
     assert.match(source, /selectionAskActionEl && !selectionAskActionEl\.classList\.contains\('hidden'\)[\s\S]*?dismissSelectionAskAction\(\);/);
+    assert.match(selectionActionSource, /buildSelectionTextAttachment\(selection\.text\)/);
+    assert.match(selectionActionSource, /getPendingAttachmentsForTab\(tabId\)\.push\(attachment\)/);
+    assert.match(selectionActionSource, /renderAttachmentPreviews\(\);/);
+    assert.doesNotMatch(selectionActionSource, /buildSelectionComposerDraft/);
     assert.match(switchToTabSource, /dismissSelectionAskAction\(\);/);
     assert.match(clearConversationSource, /dismissSelectionAskAction\(\);/);
     assert.match(sendMessageSource, /dismissSelectionAskAction\(\);/);
@@ -47959,7 +47998,7 @@ test('context-menu ownership and stale-panel persistence guards are wired in bot
     );
     assert.match(
       panel,
-      /let text = inputEl\.value\.trim\(\);\s*const submittedText = text;\s*if \(!text\) \{\s*if \(contextMenuClaimOwned\) \{\s*await releaseOwnedContextMenuClaim\(\{ reason: 'preflight-empty', retryAfterMs: 1_000 \}\);\s*return false;/,
+      /let text = inputEl\.value\.trim\(\);\s*const submittedText = text;\s*if \(!text\) \{\s*if \(contextMenuClaimOwned\) \{\s*await releaseOwnedContextMenuClaim\(\{ reason: 'preflight-empty', retryAfterMs: 1_000 \}\);\s*return false;\s*\}\s*return;/,
       `${label}: an empty refreshed composer should release and retry an owned prompt`,
     );
     assert.match(

--- a/test/run.js
+++ b/test/run.js
@@ -1601,6 +1601,34 @@ test('selection answer action stages a visual attachment in both sidepanels', ()
   }
 });
 
+test('attachment source stays a slash-screenshot flag, not a claim about who chose the file', () => {
+  // Selected assistant text ships as source 'user_upload' because that is the
+  // only other value the field has, and every attachment is wrapped untrusted
+  // regardless of it. That stays honest only while nothing reads 'user_upload'
+  // as a positive claim that a human picked a file off their disk.
+  const walk = (dir) => fs.readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) return walk(full);
+    return entry.name.endsWith('.js') ? [full] : [];
+  });
+  const branchesOnValue = /(?:[=!]==?)\s*['"]user_upload['"]|['"]user_upload['"]\s*(?:[=!]==?)|case\s+['"]user_upload['"]|includes\(\s*['"]user_upload['"]/;
+
+  let normalizers = 0;
+  for (const build of ['chrome', 'firefox']) {
+    for (const file of walk(path.join(ROOT, 'src', build, 'src'))) {
+      const source = fs.readFileSync(file, 'utf8');
+      if (!source.includes('user_upload')) continue;
+      normalizers += (source.match(/\? 'slash_screenshot' : 'user_upload'/g) || []).length;
+      assert.doesNotMatch(
+        source,
+        branchesOnValue,
+        `${path.relative(ROOT, file)}: 'user_upload' only means "not a slash screenshot", so branching on it would mislabel selected assistant text`,
+      );
+    }
+  }
+  assert.equal(normalizers, 8, 'both builds should keep normalizing source through the same two-value ternary');
+});
+
 console.log('\nscreenshot redaction');
 
 test('selectRedactionRegions blurs password fields always', () => {

--- a/test/run.js
+++ b/test/run.js
@@ -1574,8 +1574,14 @@ test('selection answer action stages a visual attachment in both sidepanels', ()
     assert.match(source, /selectionAskActionEl && !selectionAskActionEl\.classList\.contains\('hidden'\)[\s\S]*?dismissSelectionAskAction\(\);/);
     assert.match(selectionActionSource, /buildSelectionTextAttachment\(selection\.text\)/);
     assert.match(selectionActionSource, /normalizeAttachmentTabId\(renderedTabId \?\? currentTabId\)/);
-    assert.match(selectionActionSource, /showComposerToast\(t\('sp\.attach\.read_failed', \{ name: attachment\.name \}\)\)/);
+    assert.match(selectionActionSource, /showComposerToast\(t\('sp\.attach\.no_tab'\)\)/);
     assert.doesNotMatch(selectionActionSource, /sp\.persistence\.unavailable/);
+    assert.doesNotMatch(selectionActionSource, /sp\.attach\.read_failed/);
+    assert.match(
+      sendMessageSource,
+      /if \(getPendingAttachmentsForTab\(undefined, \{ create: false \}\)\.length\) \{\s*showComposerToast\(t\('sp\.attach\.needs_prompt'\)\);/,
+      'a staged attachment with an empty composer should explain why Send did nothing',
+    );
     assert.match(selectionActionSource, /const pending = getPendingAttachmentsForTab\(tabId\)/);
     assert.match(selectionActionSource, /const alreadyStaged = pending\.some\(att => att\?\.kind === 'text' && att\?\.textContent === attachment\.textContent\)/);
     assert.match(selectionActionSource, /const takenNames = new Set\(pending\.map\(att => att\?\.name\)\)/);
@@ -48046,7 +48052,7 @@ test('context-menu ownership and stale-panel persistence guards are wired in bot
     );
     assert.match(
       panel,
-      /let text = inputEl\.value\.trim\(\);\s*const submittedText = text;\s*if \(!text\) \{\s*if \(contextMenuClaimOwned\) \{\s*await releaseOwnedContextMenuClaim\(\{ reason: 'preflight-empty', retryAfterMs: 1_000 \}\);\s*return false;\s*\}\s*return;/,
+      /let text = inputEl\.value\.trim\(\);\s*const submittedText = text;\s*if \(!text\) \{\s*if \(contextMenuClaimOwned\) \{\s*await releaseOwnedContextMenuClaim\(\{ reason: 'preflight-empty', retryAfterMs: 1_000 \}\);\s*return false;\s*\}[\s\S]*?return;\s*\}/,
       `${label}: an empty refreshed composer should release and retry an owned prompt`,
     );
     assert.match(


### PR DESCRIPTION
## Motivation

When a user selects part of an assistant response and chooses “Add this to Chat”, the selected text was inserted as a full Markdown quote in the composer. Long answers could consume the available input area. Closes #2962.

## Changes

- Represent selected answer text as an existing text attachment named `selected-text.txt`.
- Render it through the existing attachment chip while keeping the composer draft available for a follow-up question.
- Preserve normalized UTF-8 text and original bytes for the model and upload paths in both Chrome and Firefox.

## Validation

- `npm test` — passed (2,194 unit tests; provider-limit, toolbar-guard, offline relevance, and security checks included).
- `node --check` on changed JavaScript files and `git diff --check` — passed.
- Chrome 147 with the unpacked Chrome extension — selected answer rendered as `selected-text.txt`, the existing draft remained unchanged, and no console/page errors were reported.
- `npm run test:fixtures` — 173 passed; 3 unrelated failures also reproduce on a clean baseline (recipient-bound Chrome fixtures and an ArrowDown toolbar audit).
