### PR TITLE
fix(mcp): surface stable permission decisions

### DIFF
--- a/lmstudio-plugin/src/index.ts
+++ b/lmstudio-plugin/src/index.ts
@@ -235,11 +235,20 @@ const browserRespondTool = tool({
   description:
     "Answer a question from a browser run whose status is needs_user_input, then wait " +
     "for the run to continue. The answer must come from the user; never invent it. Use " +
-    "the runId and clarifyId returned by browser_task or browser_status.",
+    "the runId and clarifyId returned by browser_task or browser_status. When that result " +
+    "carries a `decisions` list, the pause is a structured gate (permission, form submission, " +
+    "saved-workflow repair): send exactly one of those values, never a localized label, " +
+    "because the extension fails closed on an unknown decision.",
   parameters: {
     runId: z.string().min(1).describe("The browser run waiting for an answer."),
     clarifyId: z.string().min(1).describe("The pending clarification to answer."),
-    answer: z.string().min(1).describe("The user's answer, forwarded verbatim."),
+    answer: z
+      .string()
+      .min(1)
+      .describe(
+        "The user's answer, forwarded verbatim — or, when the pause reported a `decisions` " +
+          "list, exactly one of those stable values.",
+      ),
     timeout: z
       .number()
       .optional()

--- a/lmstudio-plugin/src/tools/browserTask.ts
+++ b/lmstudio-plugin/src/tools/browserTask.ts
@@ -29,6 +29,8 @@ export interface BrowserTaskResult {
   needsUserInput?: boolean;
   question?: string;
   clarifyId?: string;
+  /** Stable values a structured gate accepts. Absent for free-text clarifications. */
+  decisions?: string[];
   stillRunning?: boolean;
   finalUrl?: string;
   text?: string;
@@ -65,9 +67,38 @@ function bodyOf(snapshot: CloudSnapshot): string {
   return snapshot.content || snapshot.summary || "";
 }
 
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  value != null && typeof value === "object" && !Array.isArray(value);
+
+/**
+ * Permission, form-submission and workflow-repair pauses are structured gates,
+ * not questions: the extension accepts only the stable values it offers in
+ * `options` and fails closed on anything else, so a localized approval relayed
+ * verbatim ("允许") silently denies the action. Only the plain `clarify` tool
+ * takes free text.
+ */
+function decisionsOf(pending: Record<string, unknown>): string[] {
+  if (!isRecord(pending.permission) && !isRecord(pending.submitConfirmation)
+    && !isRecord(pending.workflowHealing)) {
+    return [];
+  }
+  const candidateIds = isRecord(pending.workflowHealing) && Array.isArray(pending.workflowHealing.candidates)
+    ? pending.workflowHealing.candidates
+      .map((candidate) => (isRecord(candidate) ? String(candidate.id ?? "").trim() : ""))
+      .filter((id) => id !== "")
+    : [];
+  const options = Array.isArray(pending.options)
+    ? pending.options
+      .filter((option): option is string => typeof option === "string" && option.trim() !== "")
+      .map((option) => option.trim())
+    : [];
+  return [...candidateIds, ...options];
+}
+
 function resultOf(snapshot: CloudSnapshot, timedOut = false): BrowserTaskResult {
   if (snapshot.status === "needs_user_input") {
     const pending = snapshot.pendingInput ?? {};
+    const decisions = decisionsOf(pending);
     return {
       ok: false,
       runId: snapshot.runId,
@@ -75,10 +106,15 @@ function resultOf(snapshot: CloudSnapshot, timedOut = false): BrowserTaskResult 
       needsUserInput: true,
       question: String(pending.question ?? "(no question text supplied)"),
       clarifyId: String(pending.clarifyId ?? pending.clarify_id ?? ""),
-      hint:
-        "WebBrain paused because a human decision is required. Ask the user this " +
-        "question, then call browser_respond with this runId and clarifyId. Do not " +
-        "guess on their behalf.",
+      ...(decisions.length ? { decisions } : {}),
+      hint: decisions.length
+        ? "WebBrain paused on a structured decision. Ask the user this question, then call " +
+          `browser_respond with this runId, clarifyId, and exactly one of: ${decisions.join(", ")}. ` +
+          "Do not send a localized label or other free text — the extension fails closed on an " +
+          "unknown value — and do not decide on their behalf."
+        : "WebBrain paused because a human decision is required. Ask the user this " +
+          "question, then call browser_respond with this runId and clarifyId. Do not " +
+          "guess on their behalf.",
     };
   }
 

--- a/mcp-server/README.md
+++ b/mcp-server/README.md
@@ -118,6 +118,10 @@ explicitly requests a persistent grant. Localized labels such as "allow" must
 not be forwarded as the permission value because the extension deliberately
 fails closed on unknown decisions.
 
+Form-submission confirmations and saved-workflow repair prompts are structured
+the same way, and fail closed the same way. Each lists the values it accepts on
+a `decisions:` line in the status text — send one of those exactly.
+
 ### Example
 
 > "Open my Stripe dashboard and list last week's failed payments."

--- a/mcp-server/README.md
+++ b/mcp-server/README.md
@@ -110,6 +110,14 @@ in Chromium browsers only, not Firefox.
 | `webbrain_abort` | Stop a run. Actions already taken are not undone. |
 | `webbrain_connection` | Report whether the extension is attached, and how to fix it if not. |
 
+When a run pauses for an ordinary clarification, relay the question and pass the
+user's answer verbatim to `webbrain_respond`. Permission prompts are structured:
+after the user explicitly decides, send the exact stable value `once`, `always`,
+or `deny`. A normal approval maps to `once`; use `always` only when the user
+explicitly requests a persistent grant. Localized labels such as "allow" must
+not be forwarded as the permission value because the extension deliberately
+fails closed on unknown decisions.
+
 ### Example
 
 > "Open my Stripe dashboard and list last week's failed payments."

--- a/mcp-server/src/index.ts
+++ b/mcp-server/src/index.ts
@@ -293,11 +293,21 @@ server.registerTool(
     description:
       "Supply the user's answer to a run sitting at status 'needs_user_input', then keep " +
       "waiting for it to settle. The answer must come from the user — WebBrain pauses " +
-      "precisely because a human decision is required.",
+      "precisely because a human decision is required. For an ordinary clarification, pass " +
+      "the user's answer verbatim. For a structured permission prompt, map the user's explicit " +
+      "decision to the exact stable value shown by WebBrain: 'once', 'always', or 'deny'. Never " +
+      "infer permission, and use 'always' only when the user explicitly requests a persistent grant.",
     inputSchema: {
       run_id: z.string().describe("The run that is waiting."),
       clarify_id: z.string().describe("The clarify_id reported alongside the question."),
-      answer: z.string().min(1).describe("The user's answer, passed through verbatim."),
+      answer: z
+        .string()
+        .min(1)
+        .describe(
+          "For an ordinary clarification, the user's answer passed through verbatim. For a " +
+            "permission prompt, the exact stable decision 'once', 'always', or 'deny' after the " +
+            "user explicitly chooses it; a normal one-time approval maps to 'once'.",
+        ),
       timeout_seconds: z
         .number()
         .int()

--- a/mcp-server/src/index.ts
+++ b/mcp-server/src/index.ts
@@ -296,7 +296,9 @@ server.registerTool(
       "precisely because a human decision is required. For an ordinary clarification, pass " +
       "the user's answer verbatim. For a structured permission prompt, map the user's explicit " +
       "decision to the exact stable value shown by WebBrain: 'once', 'always', or 'deny'. Never " +
-      "infer permission, and use 'always' only when the user explicitly requests a persistent grant.",
+      "infer permission, and use 'always' only when the user explicitly requests a persistent grant. " +
+      "Any other structured gate (form-submission confirmation, saved-workflow repair) lists its own " +
+      "stable values on a 'decisions:' line — send one of those exactly, never a localized label.",
     inputSchema: {
       run_id: z.string().describe("The run that is waiting."),
       clarify_id: z.string().describe("The clarify_id reported alongside the question."),
@@ -306,7 +308,8 @@ server.registerTool(
         .describe(
           "For an ordinary clarification, the user's answer passed through verbatim. For a " +
             "permission prompt, the exact stable decision 'once', 'always', or 'deny' after the " +
-            "user explicitly chooses it; a normal one-time approval maps to 'once'.",
+            "user explicitly chooses it; a normal one-time approval maps to 'once'. For any other " +
+            "structured gate, one of the exact values listed on its 'decisions:' line.",
         ),
       timeout_seconds: z
         .number()

--- a/mcp-server/src/runs.ts
+++ b/mcp-server/src/runs.ts
@@ -134,6 +134,29 @@ export async function awaitSettled(
   return { snapshot: last, timedOut: true };
 }
 
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  value != null && typeof value === "object" && !Array.isArray(value);
+
+/**
+ * The stable decision values a structured prompt accepts, in the order the
+ * extension offers them. `pendingInput.options` is authoritative — hardcoding
+ * the list here would silently advertise a choice the gate no longer takes —
+ * but a snapshot that predates it still has to render something usable.
+ */
+function promptChoices(pendingInput: Record<string, unknown>, fallback: string[]): string[] {
+  const options = pendingInput.options;
+  if (!Array.isArray(options)) return fallback;
+  const choices = options
+    .filter((option): option is string => typeof option === "string" && option.trim() !== "")
+    .map((option) => option.trim());
+  return choices.length ? choices : fallback;
+}
+
+function renderTarget(value: unknown): string {
+  const text = typeof value === "string" ? value : JSON.stringify(value ?? null);
+  return text.length > 200 ? `${text.slice(0, 200)}…` : text;
+}
+
 /** Render a snapshot as the text an calling agent actually needs to read. */
 export function describeSnapshot(snapshot: CloudSnapshot, timedOut = false): string {
   const lines: string[] = [];
@@ -143,21 +166,53 @@ export function describeSnapshot(snapshot: CloudSnapshot, timedOut = false): str
   if (snapshot.finalUrl) lines.push(`final_url: ${snapshot.finalUrl}`);
 
   if (snapshot.status === "needs_user_input" && snapshot.pendingInput) {
-    const clarifyId = snapshot.pendingInput.clarifyId || snapshot.pendingInput.clarify_id || "";
-    const question = snapshot.pendingInput.question || "(no question text supplied)";
-    const permission = snapshot.pendingInput.permission;
-    const isPermissionPrompt = permission != null && typeof permission === "object";
+    // Three of the pauses the extension raises are structured gates, not
+    // questions: each accepts a fixed set of stable values and fails closed on
+    // anything else. Only the plain `clarify` tool takes free text — its
+    // `options` are suggestions the model reads back, so forcing exact values
+    // there would throw away a perfectly good answer.
+    const pending = snapshot.pendingInput;
+    const clarifyId = pending.clarifyId || pending.clarify_id || "";
+    const question = pending.question || "(no question text supplied)";
+    const permission = pending.permission;
+    const submitConfirmation = pending.submitConfirmation;
+    const workflowHealing = pending.workflowHealing;
     lines.push("");
     lines.push("WebBrain is waiting on a human decision before it continues.");
     lines.push(`question: ${question}`);
     lines.push(`clarify_id: ${clarifyId}`);
-    if (isPermissionPrompt) {
-      lines.push("permission_decisions: once | always | deny");
+    if (isRecord(permission)) {
+      lines.push(
+        `permission_decisions: ${promptChoices(pending, ["once", "always", "deny"]).join(" | ")}`,
+      );
       lines.push(
         "Relay this permission request to the user. After they decide, send the exact stable value " +
           "`once` for an explicit one-time approval, `always` only when they explicitly request a " +
           "persistent grant, or `deny` for a refusal. Do not pass localized labels or other free text, " +
           "and do not decide on the user's behalf.",
+      );
+    } else if (isRecord(submitConfirmation)) {
+      lines.push(`decisions: ${promptChoices(pending, ["once", "deny"]).join(" | ")}`);
+      lines.push(
+        "Relay this form-submission confirmation to the user. After they decide, send the exact stable " +
+          "value `once` for an explicit confirmation or `deny` for a refusal. Do not pass localized " +
+          "labels or other free text, and do not decide on the user's behalf.",
+      );
+    } else if (isRecord(workflowHealing)) {
+      const candidates = Array.isArray(workflowHealing.candidates) ? workflowHealing.candidates : [];
+      const candidateIds: string[] = [];
+      for (const candidate of candidates) {
+        if (!isRecord(candidate)) continue;
+        const id = String(candidate.id ?? "").trim();
+        if (!id) continue;
+        candidateIds.push(id);
+        lines.push(`${id}: ${renderTarget(candidate.target)}`);
+      }
+      lines.push(`decisions: ${[...candidateIds, ...promptChoices(pending, ["deny"])].join(" | ")}`);
+      lines.push(
+        "Relay this saved-workflow repair choice to the user. After they decide, send the exact " +
+          "candidate id they picked, or `deny` to leave the workflow untouched. Do not pass localized " +
+          "labels or other free text, and do not decide on the user's behalf.",
       );
     } else {
       lines.push(

--- a/mcp-server/src/runs.ts
+++ b/mcp-server/src/runs.ts
@@ -145,14 +145,26 @@ export function describeSnapshot(snapshot: CloudSnapshot, timedOut = false): str
   if (snapshot.status === "needs_user_input" && snapshot.pendingInput) {
     const clarifyId = snapshot.pendingInput.clarifyId || snapshot.pendingInput.clarify_id || "";
     const question = snapshot.pendingInput.question || "(no question text supplied)";
+    const permission = snapshot.pendingInput.permission;
+    const isPermissionPrompt = permission != null && typeof permission === "object";
     lines.push("");
     lines.push("WebBrain is waiting on a human decision before it continues.");
     lines.push(`question: ${question}`);
     lines.push(`clarify_id: ${clarifyId}`);
-    lines.push(
-      "Relay this to the user and send their answer with webbrain_respond. " +
-        "Do not invent an answer on their behalf.",
-    );
+    if (isPermissionPrompt) {
+      lines.push("permission_decisions: once | always | deny");
+      lines.push(
+        "Relay this permission request to the user. After they decide, send the exact stable value " +
+          "`once` for an explicit one-time approval, `always` only when they explicitly request a " +
+          "persistent grant, or `deny` for a refusal. Do not pass localized labels or other free text, " +
+          "and do not decide on the user's behalf.",
+      );
+    } else {
+      lines.push(
+        "Relay this to the user and send their free-text answer verbatim with webbrain_respond. " +
+          "Do not invent an answer on their behalf.",
+      );
+    }
   }
 
   if (snapshot.error) {

--- a/mcp-server/test/bridge.test.mjs
+++ b/mcp-server/test/bridge.test.mjs
@@ -320,6 +320,48 @@ test("describeSnapshot surfaces stable permission decision values", () => {
   assert.doesNotMatch(text, /free-text answer verbatim/);
 });
 
+test("describeSnapshot surfaces stable submit-confirmation decision values", () => {
+  const text = describeSnapshot({
+    runId: "r",
+    status: "needs_user_input",
+    pendingInput: {
+      clarifyId: "submit_42",
+      question: "WebBrain wants to submit this form on example.com.",
+      submitConfirmation: { host: "example.com", tool: "click" },
+      options: ["once", "deny"],
+    },
+  });
+
+  assert.match(text, /decisions: once \| deny/);
+  assert.match(text, /`once` for an explicit confirmation or `deny` for a refusal/);
+  assert.match(text, /Do not pass localized labels or other free text/);
+  assert.doesNotMatch(text, /free-text answer verbatim/);
+});
+
+test("describeSnapshot surfaces workflow-healing candidate ids", () => {
+  const text = describeSnapshot({
+    runId: "r",
+    status: "needs_user_input",
+    pendingInput: {
+      clarifyId: "workflow_heal_42",
+      question: "Choose a replacement target for saved workflow step 2.",
+      workflowHealing: {
+        candidates: [
+          { id: "candidate_0", target: "#submit" },
+          { id: "candidate_1", target: { selector: ".send" } },
+        ],
+      },
+      options: ["deny"],
+    },
+  });
+
+  assert.match(text, /candidate_0: #submit/);
+  assert.match(text, /candidate_1: \{"selector":"\.send"\}/);
+  assert.match(text, /decisions: candidate_0 \| candidate_1 \| deny/);
+  assert.match(text, /send the exact candidate id they picked/);
+  assert.doesNotMatch(text, /free-text answer verbatim/);
+});
+
 test("awaitSettled reports a timeout without aborting the run", async () => {
   const bridge = new WebBrainBridge();
   await bridge.start();

--- a/mcp-server/test/bridge.test.mjs
+++ b/mcp-server/test/bridge.test.mjs
@@ -293,10 +293,31 @@ test("awaitSettled stops on needs_user_input and surfaces clarify_id", async () 
   const text = describeSnapshot(snapshot);
   assert.match(text, /clarify_id: c_42/);
   assert.match(text, /Which account should I use\?/);
+  assert.match(text, /free-text answer verbatim/);
   assert.match(text, /Do not invent an answer/);
 
   ext.close();
   await bridge.stop();
+});
+
+test("describeSnapshot surfaces stable permission decision values", () => {
+  const text = describeSnapshot({
+    runId: "r",
+    status: "needs_user_input",
+    pendingInput: {
+      clarifyId: "perm_42",
+      question: "WebBrain wants to navigate to example.com. Allow it?",
+      permission: { capability: "navigate", host: "example.com" },
+      options: ["once", "always", "deny"],
+    },
+  });
+
+  assert.match(text, /permission_decisions: once \| always \| deny/);
+  assert.match(text, /`once` for an explicit one-time approval/);
+  assert.match(text, /`always` only when they explicitly request a persistent grant/);
+  assert.match(text, /Do not pass localized labels or other free text/);
+  assert.match(text, /do not decide on the user's behalf/i);
+  assert.doesNotMatch(text, /free-text answer verbatim/);
 });
 
 test("awaitSettled reports a timeout without aborting the run", async () => {

--- a/mcp-server/test/catalog.test.mjs
+++ b/mcp-server/test/catalog.test.mjs
@@ -51,6 +51,11 @@ test("MCP catalog exposes structured extraction alongside run controls", async (
     assert.deepEqual(extract.inputSchema.required, ["task", "output_schema"]);
     assert.equal(extract.inputSchema.properties.output_schema.type, "object");
     assert.match(extract.description, /always uses WebBrain Ask mode/i);
+
+    const respond = tools.find((tool) => tool.name === "webbrain_respond");
+    assert.ok(respond, "respond tool is missing");
+    assert.match(respond.description, /exact stable value shown by WebBrain: 'once', 'always', or 'deny'/i);
+    assert.match(respond.inputSchema.properties.answer.description, /one-time approval maps to 'once'/i);
   } finally {
     await client.close().catch(() => {});
   }


### PR DESCRIPTION
## Summary

- distinguish structured permission prompts from ordinary free-text clarifications
- expose the stable `once`, `always`, and `deny` decisions to MCP clients
- guide clients to map an explicit normal approval to `once`, while reserving `always` for an explicitly persistent grant
- keep ordinary clarification answers verbatim and preserve fail-closed behavior for unknown permission values
- document the permission contract and add regression coverage

## Problem

The MCP tool previously told clients to forward every user answer verbatim. For a structured permission prompt, a localized approval such as Chinese “允许” could therefore be sent directly to the extension. The extension intentionally accepts only `once`, `always`, or `deny`, so an unknown value failed closed and the requested action was denied.

## Testing

- `npm run build`
- `node --test test/bridge.test.mjs test/catalog.test.mjs` — 13/13 passed
- manual local MCP + Chrome test: an explicit Chinese approval was mapped to `once`, WebBrain navigated the selected tab, and the final Chrome URL was independently verified

A cold-start test in a separate Codex conversation did not reach the permission step because the configured model provider returned empty completions without tool calls, so that scenario remains inconclusive rather than failed. Full-suite runs on this Windows machine also encountered timing-sensitive failures in existing timeout and stdio-shutdown tests under load; the changed test files pass cleanly.