### PR TITLE
chore(mcp-server): add fake extension script for manual bridge testing

### DIFF
--- a/mcp-server/README.md
+++ b/mcp-server/README.md
@@ -184,6 +184,16 @@ npm run build && node --test test/bridge.test.mjs
 
 The suite stands up the real listener and connects a fake extension speaking the exact frames `src/chrome/src/offscreen/cloud-bridge.js` emits — handshake, id correlation under concurrency, error propagation, disconnect mid-command, and the poll/timeout/clarify paths. If the extension's wire format changes, these fail. That is intentional.
 
+For manual poking, [`scripts/fake-extension.mjs`](scripts/fake-extension.mjs) is
+the same fake as a standalone process — run the server, then:
+
+```bash
+node scripts/fake-extension.mjs
+```
+
+It logs every frame in both directions, so you can watch what your MCP client
+actually sends without Chrome in the loop.
+
 ## License
 
 This independently published package remains MIT-licensed. See [`LICENSE`](LICENSE).

--- a/mcp-server/scripts/fake-extension.mjs
+++ b/mcp-server/scripts/fake-extension.mjs
@@ -1,0 +1,93 @@
+#!/usr/bin/env node
+
+// Stands in for the WebBrain extension so the MCP server can be driven without
+// Chrome. Speaks the same frames as src/chrome/src/offscreen/cloud-bridge.js:
+// the `hello` handshake, then canned replies to cloud_run / cloud_status /
+// cloud_respond / cloud_abort. Anything else comes back as an error, which is
+// how you check the server's failure path.
+//
+//   cd mcp-server && node scripts/fake-extension.mjs [ws-url]
+//
+// Defaults to ws://127.0.0.1:17374/extension. Start the server first
+// (npm start), then this, then point your MCP client at the server.
+
+import WebSocket from "ws";
+
+const url = process.argv[2] || "ws://127.0.0.1:17374/extension";
+const socket = new WebSocket(url);
+let lastRunId = null;
+
+function log(...args) {
+  console.log(new Date().toISOString().slice(11, 19), ...args);
+}
+
+socket.on("open", () => {
+  log(`connected to ${url}`);
+  socket.send(
+    JSON.stringify({
+      type: "hello",
+      client: "webbrain-extension",
+      protocolVersion: 2,
+      capabilities: ["saved_workflows_v1", "run_modes_v1", "scheduled_jobs_v1"],
+      status: { enabled: true },
+    }),
+  );
+  log("hello sent");
+});
+
+socket.on("message", (raw) => {
+  let msg;
+  try {
+    msg = JSON.parse(raw.toString());
+  } catch {
+    log("non-JSON frame:", raw.toString());
+    return;
+  }
+  if (!msg.action) {
+    log("<-", JSON.stringify(msg));
+    return;
+  }
+  log(`<-${msg.action} id=${msg.id}`, JSON.stringify(msg.payload ?? {}));
+  const reply = respond(msg);
+  socket.send(JSON.stringify({ id: msg.id, ...reply }));
+  log(
+    `-> ${reply.ok ? "ok" : "err"} id=${msg.id}`,
+    JSON.stringify(reply.result ?? reply.error),
+  );
+});
+
+function respond(msg) {
+  switch (msg.action) {
+    case "cloud_run":
+      lastRunId = `run_${Date.now()}`;
+      return {
+        ok: true,
+        result: {
+          runId: lastRunId,
+          status: "running",
+          mode: msg.payload?.mode === "act" ? "act" : "ask",
+        },
+      };
+    case "cloud_status":
+      return {
+        ok: true,
+        result: {
+          runId: lastRunId,
+          status: "completed",
+          result: { summary: "fake run completed", finalUrl: "https://example.com/" },
+        },
+      };
+    case "cloud_respond":
+    case "cloud_abort":
+      return { ok: true, result: {} };
+    default:
+      return { ok: false, error: `fake extension cannot handle '${msg.action}'` };
+  }
+}
+
+socket.on("close", (code, reason) => {
+  log(`closed code=${code} reason=${reason.toString() || "-"}`);
+});
+socket.on("error", (error) => {
+  log("socket error:", error.message);
+});


### PR DESCRIPTION
The bridge tests in `test/bridge.test.mjs` already stand up a fake extension in-process. This adds the same fake as a standalone script, so you can drive the MCP server from a real client without running Chrome.

`scripts/fake-extension.mjs` connects to the server's extension socket (default `ws://127.0.0.1:17374/extension`), sends the `hello` handshake at protocol version 2, and answers `cloud_run`, `cloud_status`, `cloud_respond`, and `cloud_abort` with canned results. Any other action comes back as an error, which is a cheap way to check the server's failure path. Every frame gets logged in both directions, so you can see what a client actually puts on the wire.

```bash
cd mcp-server
npm start &
node scripts/fake-extension.mjs
```

`ws` is already a runtime dependency, so there is no package change. The README picks it up under Tests.

Tested against a stub listener: handshake, id correlation on `cloud_run`, and the reply all came back as expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CRwghb8f3A4U7R15os4Tr3