### PR TITLE
Simplify Apocalypse chat controls

### DIFF
--- a/src/chrome/src/ui/theme-bootstrap.js
+++ b/src/chrome/src/ui/theme-bootstrap.js
@@ -14,6 +14,14 @@
     var params = new URLSearchParams(window.location.search);
     if (params.get('standalone') === 'true') {
       document.documentElement.setAttribute('data-standalone', 'true');
+      // Standalone chat has no History strip. Reuse the existing New chat
+      // button so its confirmation and event wiring remain unchanged.
+      window.addEventListener('DOMContentLoaded', function () {
+        var headerActions = document.querySelector('#header .header-right');
+        var newChat = document.getElementById('btn-clear');
+        var expand = document.getElementById('btn-expand');
+        if (headerActions && newChat) headerActions.insertBefore(newChat, expand);
+      }, { once: true });
     }
   } catch (_) { /* ignore */ }
 

--- a/src/chrome/styles/sidepanel.css
+++ b/src/chrome/styles/sidepanel.css
@@ -3028,7 +3028,23 @@ html[data-ui-scale-ready="false"] body { visibility: hidden; }
    ASK / ACT MODE TOGGLE
    ========================================================================== */
 
-html[data-standalone="true"] #mode-toggle {
+html[data-standalone="true"] .composer-control-row {
+  display: none;
+}
+
+html[data-standalone="true"] #header #btn-expand {
+  display: none;
+}
+
+html[data-standalone="true"] #header #btn-clear {
+  width: 26px;
+  min-width: 26px;
+  height: 26px;
+  padding: 0;
+  justify-content: center;
+}
+
+html[data-standalone="true"] #header #btn-clear .conversation-action-label {
   display: none;
 }
 

--- a/src/firefox/src/ui/theme-bootstrap.js
+++ b/src/firefox/src/ui/theme-bootstrap.js
@@ -14,6 +14,14 @@
     var params = new URLSearchParams(window.location.search);
     if (params.get('standalone') === 'true') {
       document.documentElement.setAttribute('data-standalone', 'true');
+      // Standalone chat has no History strip. Reuse the existing New chat
+      // button so its confirmation and event wiring remain unchanged.
+      window.addEventListener('DOMContentLoaded', function () {
+        var headerActions = document.querySelector('#header .header-right');
+        var newChat = document.getElementById('btn-clear');
+        var expand = document.getElementById('btn-expand');
+        if (headerActions && newChat) headerActions.insertBefore(newChat, expand);
+      }, { once: true });
     }
   } catch (_) { /* ignore */ }
 

--- a/src/firefox/styles/sidepanel.css
+++ b/src/firefox/styles/sidepanel.css
@@ -2854,7 +2854,23 @@ html[data-ui-scale-ready="false"] body { visibility: hidden; }
    ASK / ACT MODE TOGGLE
    ========================================================================== */
 
-html[data-standalone="true"] #mode-toggle {
+html[data-standalone="true"] .composer-control-row {
+  display: none;
+}
+
+html[data-standalone="true"] #header #btn-expand {
+  display: none;
+}
+
+html[data-standalone="true"] #header #btn-clear {
+  width: 26px;
+  min-width: 26px;
+  height: 26px;
+  padding: 0;
+  justify-content: center;
+}
+
+html[data-standalone="true"] #header #btn-clear .conversation-action-label {
   display: none;
 }
 

--- a/test/run.js
+++ b/test/run.js
@@ -46252,7 +46252,11 @@ test('standalone window transport, sizing, and translations are mirrored', async
     assert.match(markup, /id="btn-expand"[\s\S]*?<svg data-icon="external-link"[\s\S]*?M10 14 21 3[\s\S]*?M18 13v6/, `${label}: standalone launcher does not use the external-window icon`);
     assert.doesNotMatch(markup, /id="btn-expand"[\s\S]*?M9 21H3v-6[\s\S]*?M3 21l7-7/, `${label}: standalone launcher still uses the maximize icon`);
     assert.match(bootstrap, /params\.get\('standalone'\) === 'true'[\s\S]*?setAttribute\('data-standalone', 'true'\)/, `${label}: standalone mode is not marked before first paint`);
-    assert.match(css, /html\[data-standalone="true"\] #mode-toggle \{\s*display: none;/, `${label}: standalone window still shows the mode selector`);
+    assert.match(css, /html\[data-standalone="true"\] \.composer-control-row \{\s*display: none;/, `${label}: standalone window still shows the History control bar`);
+    assert.match(bootstrap, /params\.get\('standalone'\) === 'true'[\s\S]*?window\.addEventListener\('DOMContentLoaded'[\s\S]*?document\.querySelector\('#header \.header-right'\)[\s\S]*?document\.getElementById\('btn-clear'\)[\s\S]*?headerActions\.insertBefore\(newChat, expand\);/, `${label}: standalone New chat control is not moved to the header before interaction`);
+    assert.match(css, /html\[data-standalone="true"\] #header #btn-expand \{\s*display: none;/, `${label}: standalone header still reserves the far-right position for its redundant launcher`);
+    assert.match(css, /html\[data-standalone="true"\] #header #btn-clear \{[\s\S]*?width: 26px;[\s\S]*?height: 26px;[\s\S]*?justify-content: center;/, `${label}: standalone New chat should be a compact header icon`);
+    assert.match(css, /html\[data-standalone="true"\] #header #btn-clear \.conversation-action-label \{\s*display: none;/, `${label}: standalone New chat should not retain its wide text label`);
     assert.match(panel, /function normalizeAgentMode\(mode\) \{\s*if \(isStandaloneWindow\) return 'ask';/, `${label}: standalone mode is not pinned to Ask`);
     assert.match(panel, /function setMode\(mode\) \{\s*mode = normalizeAgentMode\(mode\);/, `${label}: visible mode changes bypass the standalone Ask boundary`);
     assert.match(panel, /function modeForMessageText\(text\) \{\s*if \(isStandaloneWindow\) return 'ask';/, `${label}: slash commands can change standalone mode`);


### PR DESCRIPTION
## Summary

- remove the History control bar from standalone Apocalypse chat
- move New chat into the top header as a compact plus icon
- preserve the regular sidepanel layout and mirror Chrome/Firefox behavior
- add standalone layout regression coverage

## Verification

- rendered standalone and regular layouts inspected in Chrome
- `git diff --check`
- `node test/run.js`: 2,194 passed; 2 unrelated release-state failures remain (CHANGELOG 34.1.4 vs package 34.1.5, and missing `dist/webbrain-chrome-34.1.5.zip`)
- reviewer found no actionable defect