### PR TITLE
fix: harden large tab-chat image persistence

### DIFF
--- a/src/chrome/src/ui/tab-chat-persistence.js
+++ b/src/chrome/src/ui/tab-chat-persistence.js
@@ -6,11 +6,94 @@ const TAB_CHAT_QUOTA_RETRY_BUDGET = 256 * 1024;
 export const TRANSPARENT_PIXEL_PNG_DATA_URL =
   'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNkYPhfDwAChwGA60e6kgAAAABJRU5ErkJggg==';
 
+const IMAGE_DATA_URL_PREFIX = 'data:image/';
+const BASE64_DATA_URL_MARKER = ';base64,';
+
+function asciiLowerCode(code) {
+  return code >= 65 && code <= 90 ? code + 32 : code;
+}
+
+function matchesAsciiIgnoreCase(source, offset, expected) {
+  if (offset + expected.length > source.length) return false;
+  for (let i = 0; i < expected.length; i++) {
+    if (asciiLowerCode(source.charCodeAt(offset + i))
+      !== asciiLowerCode(expected.charCodeAt(i))) return false;
+  }
+  return true;
+}
+
+function isMimeTypeCode(code) {
+  return (code >= 48 && code <= 57)
+    || (code >= 65 && code <= 90)
+    || (code >= 97 && code <= 122)
+    || code === 43
+    || code === 45
+    || code === 46;
+}
+
+function isBase64Code(code) {
+  return (code >= 48 && code <= 57)
+    || (code >= 65 && code <= 90)
+    || (code >= 97 && code <= 122)
+    || code === 43
+    || code === 47
+    || code === 61;
+}
+
+function findImageDataUrl(source, start) {
+  const firstCode = IMAGE_DATA_URL_PREFIX.charCodeAt(0);
+  for (let index = start; index <= source.length - IMAGE_DATA_URL_PREFIX.length; index++) {
+    if (asciiLowerCode(source.charCodeAt(index)) !== firstCode) continue;
+    if (matchesAsciiIgnoreCase(source, index, IMAGE_DATA_URL_PREFIX)) return index;
+  }
+  return -1;
+}
+
+function imageDataPayloadEnd(source, marker) {
+  let cursor = marker + IMAGE_DATA_URL_PREFIX.length;
+  const mimeStart = cursor;
+  while (cursor < source.length && isMimeTypeCode(source.charCodeAt(cursor))) cursor++;
+  if (cursor === mimeStart) return -1;
+
+  // Walk the short metadata section without applying a regexp to the image
+  // bytes. A comma before `;base64,` means this is not a base64 data URL.
+  while (cursor < source.length) {
+    if (source.charCodeAt(cursor) === 44) return -1;
+    if (matchesAsciiIgnoreCase(source, cursor, BASE64_DATA_URL_MARKER)) {
+      cursor += BASE64_DATA_URL_MARKER.length;
+      const payloadStart = cursor;
+      while (cursor < source.length && isBase64Code(source.charCodeAt(cursor))) cursor++;
+      return cursor > payloadStart ? cursor : -1;
+    }
+    cursor++;
+  }
+  return -1;
+}
+
 export function stripImagePayloadsForPersist(html) {
-  return String(html || '').replace(
-    /data:image\/[a-z0-9.+-]+(?:;[^,]*)?;base64,[a-z0-9+/=]+/gi,
-    TRANSPARENT_PIXEL_PNG_DATA_URL,
-  );
+  const source = String(html || '');
+  const chunks = [];
+  let copyCursor = 0;
+  let searchCursor = 0;
+  let replaced = false;
+
+  while (searchCursor < source.length) {
+    const marker = findImageDataUrl(source, searchCursor);
+    if (marker < 0) break;
+    const end = imageDataPayloadEnd(source, marker);
+    if (end < 0) {
+      searchCursor = marker + IMAGE_DATA_URL_PREFIX.length;
+      continue;
+    }
+    chunks.push(source.slice(copyCursor, marker), TRANSPARENT_PIXEL_PNG_DATA_URL);
+    copyCursor = end;
+    searchCursor = end;
+    replaced = true;
+  }
+
+  if (!replaced) return source;
+  chunks.push(source.slice(copyCursor));
+  return chunks.join('');
 }
 
 function findHtmlTagEnd(source, start) {

--- a/src/chrome/src/ui/tab-chat-persistence.js
+++ b/src/chrome/src/ui/tab-chat-persistence.js
@@ -40,6 +40,17 @@ function isBase64Code(code) {
     || code === 61;
 }
 
+function isMediaParameterCode(code) {
+  return isMimeTypeCode(code)
+    || code === 33
+    || code === 37
+    || code === 39
+    || code === 42
+    || code === 61
+    || code === 95
+    || code === 126;
+}
+
 function findImageDataUrl(source, start) {
   const firstCode = IMAGE_DATA_URL_PREFIX.charCodeAt(0);
   for (let index = start; index <= source.length - IMAGE_DATA_URL_PREFIX.length; index++) {
@@ -56,9 +67,13 @@ function imageDataPayloadEnd(source, marker) {
   if (cursor === mimeStart) return -1;
 
   // Walk the short metadata section without applying a regexp to the image
-  // bytes. A comma before `;base64,` means this is not a base64 data URL.
-  while (cursor < source.length) {
-    if (source.charCodeAt(cursor) === 44) return -1;
+  // bytes. Only `;name=value` media-type parameters may sit between the MIME
+  // type and `;base64,`, so the walk stops at the first character that cannot
+  // belong to one (a quote, a tag boundary, whitespace, or the comma that
+  // starts a non-base64 payload). Without that bound the scan would run past
+  // the attribute it started in and swallow every character up to the next
+  // image in the document.
+  while (cursor < source.length && source.charCodeAt(cursor) === 59) {
     if (matchesAsciiIgnoreCase(source, cursor, BASE64_DATA_URL_MARKER)) {
       cursor += BASE64_DATA_URL_MARKER.length;
       const payloadStart = cursor;
@@ -66,6 +81,7 @@ function imageDataPayloadEnd(source, marker) {
       return cursor > payloadStart ? cursor : -1;
     }
     cursor++;
+    while (cursor < source.length && isMediaParameterCode(source.charCodeAt(cursor))) cursor++;
   }
   return -1;
 }

--- a/src/firefox/src/ui/tab-chat-persistence.js
+++ b/src/firefox/src/ui/tab-chat-persistence.js
@@ -6,11 +6,94 @@ const TAB_CHAT_QUOTA_RETRY_BUDGET = 256 * 1024;
 export const TRANSPARENT_PIXEL_PNG_DATA_URL =
   'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNkYPhfDwAChwGA60e6kgAAAABJRU5ErkJggg==';
 
+const IMAGE_DATA_URL_PREFIX = 'data:image/';
+const BASE64_DATA_URL_MARKER = ';base64,';
+
+function asciiLowerCode(code) {
+  return code >= 65 && code <= 90 ? code + 32 : code;
+}
+
+function matchesAsciiIgnoreCase(source, offset, expected) {
+  if (offset + expected.length > source.length) return false;
+  for (let i = 0; i < expected.length; i++) {
+    if (asciiLowerCode(source.charCodeAt(offset + i))
+      !== asciiLowerCode(expected.charCodeAt(i))) return false;
+  }
+  return true;
+}
+
+function isMimeTypeCode(code) {
+  return (code >= 48 && code <= 57)
+    || (code >= 65 && code <= 90)
+    || (code >= 97 && code <= 122)
+    || code === 43
+    || code === 45
+    || code === 46;
+}
+
+function isBase64Code(code) {
+  return (code >= 48 && code <= 57)
+    || (code >= 65 && code <= 90)
+    || (code >= 97 && code <= 122)
+    || code === 43
+    || code === 47
+    || code === 61;
+}
+
+function findImageDataUrl(source, start) {
+  const firstCode = IMAGE_DATA_URL_PREFIX.charCodeAt(0);
+  for (let index = start; index <= source.length - IMAGE_DATA_URL_PREFIX.length; index++) {
+    if (asciiLowerCode(source.charCodeAt(index)) !== firstCode) continue;
+    if (matchesAsciiIgnoreCase(source, index, IMAGE_DATA_URL_PREFIX)) return index;
+  }
+  return -1;
+}
+
+function imageDataPayloadEnd(source, marker) {
+  let cursor = marker + IMAGE_DATA_URL_PREFIX.length;
+  const mimeStart = cursor;
+  while (cursor < source.length && isMimeTypeCode(source.charCodeAt(cursor))) cursor++;
+  if (cursor === mimeStart) return -1;
+
+  // Walk the short metadata section without applying a regexp to the image
+  // bytes. A comma before `;base64,` means this is not a base64 data URL.
+  while (cursor < source.length) {
+    if (source.charCodeAt(cursor) === 44) return -1;
+    if (matchesAsciiIgnoreCase(source, cursor, BASE64_DATA_URL_MARKER)) {
+      cursor += BASE64_DATA_URL_MARKER.length;
+      const payloadStart = cursor;
+      while (cursor < source.length && isBase64Code(source.charCodeAt(cursor))) cursor++;
+      return cursor > payloadStart ? cursor : -1;
+    }
+    cursor++;
+  }
+  return -1;
+}
+
 export function stripImagePayloadsForPersist(html) {
-  return String(html || '').replace(
-    /data:image\/[a-z0-9.+-]+(?:;[^,]*)?;base64,[a-z0-9+/=]+/gi,
-    TRANSPARENT_PIXEL_PNG_DATA_URL,
-  );
+  const source = String(html || '');
+  const chunks = [];
+  let copyCursor = 0;
+  let searchCursor = 0;
+  let replaced = false;
+
+  while (searchCursor < source.length) {
+    const marker = findImageDataUrl(source, searchCursor);
+    if (marker < 0) break;
+    const end = imageDataPayloadEnd(source, marker);
+    if (end < 0) {
+      searchCursor = marker + IMAGE_DATA_URL_PREFIX.length;
+      continue;
+    }
+    chunks.push(source.slice(copyCursor, marker), TRANSPARENT_PIXEL_PNG_DATA_URL);
+    copyCursor = end;
+    searchCursor = end;
+    replaced = true;
+  }
+
+  if (!replaced) return source;
+  chunks.push(source.slice(copyCursor));
+  return chunks.join('');
 }
 
 function findHtmlTagEnd(source, start) {

--- a/src/firefox/src/ui/tab-chat-persistence.js
+++ b/src/firefox/src/ui/tab-chat-persistence.js
@@ -40,6 +40,17 @@ function isBase64Code(code) {
     || code === 61;
 }
 
+function isMediaParameterCode(code) {
+  return isMimeTypeCode(code)
+    || code === 33
+    || code === 37
+    || code === 39
+    || code === 42
+    || code === 61
+    || code === 95
+    || code === 126;
+}
+
 function findImageDataUrl(source, start) {
   const firstCode = IMAGE_DATA_URL_PREFIX.charCodeAt(0);
   for (let index = start; index <= source.length - IMAGE_DATA_URL_PREFIX.length; index++) {
@@ -56,9 +67,13 @@ function imageDataPayloadEnd(source, marker) {
   if (cursor === mimeStart) return -1;
 
   // Walk the short metadata section without applying a regexp to the image
-  // bytes. A comma before `;base64,` means this is not a base64 data URL.
-  while (cursor < source.length) {
-    if (source.charCodeAt(cursor) === 44) return -1;
+  // bytes. Only `;name=value` media-type parameters may sit between the MIME
+  // type and `;base64,`, so the walk stops at the first character that cannot
+  // belong to one (a quote, a tag boundary, whitespace, or the comma that
+  // starts a non-base64 payload). Without that bound the scan would run past
+  // the attribute it started in and swallow every character up to the next
+  // image in the document.
+  while (cursor < source.length && source.charCodeAt(cursor) === 59) {
     if (matchesAsciiIgnoreCase(source, cursor, BASE64_DATA_URL_MARKER)) {
       cursor += BASE64_DATA_URL_MARKER.length;
       const payloadStart = cursor;
@@ -66,6 +81,7 @@ function imageDataPayloadEnd(source, marker) {
       return cursor > payloadStart ? cursor : -1;
     }
     cursor++;
+    while (cursor < source.length && isMediaParameterCode(source.charCodeAt(cursor))) cursor++;
   }
   return -1;
 }

--- a/test/run.js
+++ b/test/run.js
@@ -43802,6 +43802,30 @@ test('tab-chat persistence strips large and mixed-case image data URLs without c
   assert.equal(chromeResult, firefoxResult, 'chrome/firefox image compaction diverged');
 });
 
+test('tab-chat persistence keeps markup between a bare image MIME mention and a later payload', () => {
+  const input = [
+    '<div>paste as data:image/png here</div>',
+    '<b>kept</b>',
+    `<img src="data:image/gif;base64,${'A'.repeat(64)}">`,
+  ].join('');
+  const expected = [
+    '<div>paste as data:image/png here</div>',
+    '<b>kept</b>',
+    `<img src="${TabChatPersistenceCh.TRANSPARENT_PIXEL_PNG_DATA_URL}">`,
+  ].join('');
+
+  for (const [label, persistence] of [
+    ['chrome', TabChatPersistenceCh],
+    ['firefox', TabChatPersistenceFx],
+  ]) {
+    assert.equal(
+      persistence.stripImagePayloadsForPersist(input),
+      expected,
+      `${label}: markup between a bare MIME mention and a later image payload was swallowed`,
+    );
+  }
+});
+
 test('tab-chat persistence never evicts other chats when shared quota remains exhausted', async () => {
   for (const [label, persistence] of [
     ['chrome', TabChatPersistenceCh],

--- a/test/run.js
+++ b/test/run.js
@@ -43780,6 +43780,28 @@ test('tab-chat persistence recovers when several sub-threshold chats exceed the 
   }
 });
 
+test('tab-chat persistence strips large and mixed-case image data URLs without changing other data URLs', () => {
+  const payload = 'A'.repeat(6 * 1024 * 1024);
+  const input = [
+    '<div>before</div>',
+    `<img src="DATA:IMAGE/WEBP;charset=utf-8;BASE64,${payload}">`,
+    '<img src="data:image/svg+xml,not-base64">',
+    '<div>after</div>',
+  ].join('');
+  const expected = [
+    '<div>before</div>',
+    `<img src="${TabChatPersistenceCh.TRANSPARENT_PIXEL_PNG_DATA_URL}">`,
+    '<img src="data:image/svg+xml,not-base64">',
+    '<div>after</div>',
+  ].join('');
+
+  const chromeResult = TabChatPersistenceCh.stripImagePayloadsForPersist(input);
+  const firefoxResult = TabChatPersistenceFx.stripImagePayloadsForPersist(input);
+  assert.equal(chromeResult, expected, 'chrome: large image data URL was not compacted exactly');
+  assert.equal(firefoxResult, expected, 'firefox: large image data URL was not compacted exactly');
+  assert.equal(chromeResult, firefoxResult, 'chrome/firefox image compaction diverged');
+});
+
 test('tab-chat persistence never evicts other chats when shared quota remains exhausted', async () => {
   for (const [label, persistence] of [
     ['chrome', TabChatPersistenceCh],


### PR DESCRIPTION
## Summary

- Replace the large-payload regular expression in tab-chat image compaction with a linear scanner.
- Preserve existing image data URL behavior, including MIME parameters and mixed-case markers.
- Keep Chrome and Firefox implementations aligned and add a 6 MB regression case.

## Context

The latest upstream main still contained the implementation discussed in PR #2982. The reported Maximum call stack size exceeded was intermittent: the original code passed two full runs and 20 isolated reproductions in this environment. This change removes the risky large-payload regex path and makes the reported 6 MB scenario explicit in the test suite.

## Validation

- npm test: 2202 passed, 0 failed
- Security corpus: 60/60
- Provider model limits: passed
- Rich-text toolbar guard: 33 passed
