### PR TITLE
fix(chrome): route PDF handler read_page through read_pdf

### DIFF
--- a/src/chrome/src/agent/agent.js
+++ b/src/chrome/src/agent/agent.js
@@ -71,7 +71,7 @@ import {
   buildClaudeDocumentBlock,
   PDF_PASSTHROUGH_MAX_BYTES,
 } from './pdf-tools.js';
-import { pdfUrlFromTabUrl } from './pdf-extraction.js';
+import { isPdfHandlerTabUrl, pdfUrlFromTabUrl } from './pdf-extraction.js';
 import { normalizePdfOcrResult, PDF_OCR_SYSTEM_PROMPT } from './pdf-ocr.js';
 import * as trace from '../trace/recorder.js';
 import { buildTerminalRuntimeEvent, enqueueCloudRuntimeEvent, flushCloudRuntimeOutbox } from '../trace/cloud-runtime-outbox.js';
@@ -5359,8 +5359,9 @@ export class Agent extends LoopDetector {
    * Decide whether `pageUrl` is a PDF tab the content-script path
    * cannot reach. Two paths:
    *   - Fast path: URL pattern (`isPdfUrl`). Catches `*.pdf` paths and
-   *     WebBrain's PDF handler URL after unwrapping its `url` parameter.
-   *     `?file=*.pdf` viewer URLs — the bulk of cases.
+   *     `?file=*.pdf` viewer URLs — the bulk of cases. WebBrain's own
+   *     PDF handler URL is unwrapped first, and a handler tab counts as
+   *     a PDF tab outright: we only ever open it for a PDF response.
    *   - Slow path: HEAD probe with credentials. Catches PDFs served
    *     from endpoints whose URL doesn't reveal the type, e.g.
    *     `/download?id=42` returning `Content-Type: application/pdf`.
@@ -5380,7 +5381,7 @@ export class Agent extends LoopDetector {
   async _isPdfTab(tabId, pageUrl) {
     if (!pageUrl) return false;
     const pdfUrl = pdfUrlFromTabUrl(pageUrl);
-    if (isPdfUrl(pdfUrl)) return true;
+    if (isPdfUrl(pdfUrl) || isPdfHandlerTabUrl(pageUrl)) return true;
 
     // Cache hit?
     const cached = this._isPdfTabCache.get(tabId);
@@ -27954,10 +27955,13 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
       try {
         let pdfUrl = String(args.url || '').trim();
         if (!pdfUrl) {
-          // Default to the active tab's URL.
+          // Default to the active tab's URL. On our own viewer page that URL
+          // is the handler wrapping the real one in ?url=; extraction unwraps
+          // it internally, but the document name below is derived from this
+          // string, so unwrap here too.
           try {
             const tab = await chrome.tabs.get(tabId);
-            pdfUrl = tab?.url || '';
+            pdfUrl = pdfUrlFromTabUrl(tab?.url || '');
           } catch {}
         }
         if (!pdfUrl) {

--- a/src/chrome/src/agent/agent.js
+++ b/src/chrome/src/agent/agent.js
@@ -71,6 +71,7 @@ import {
   buildClaudeDocumentBlock,
   PDF_PASSTHROUGH_MAX_BYTES,
 } from './pdf-tools.js';
+import { pdfUrlFromTabUrl } from './pdf-extraction.js';
 import { normalizePdfOcrResult, PDF_OCR_SYSTEM_PROMPT } from './pdf-ocr.js';
 import * as trace from '../trace/recorder.js';
 import { buildTerminalRuntimeEvent, enqueueCloudRuntimeEvent, flushCloudRuntimeOutbox } from '../trace/cloud-runtime-outbox.js';
@@ -5358,6 +5359,7 @@ export class Agent extends LoopDetector {
    * Decide whether `pageUrl` is a PDF tab the content-script path
    * cannot reach. Two paths:
    *   - Fast path: URL pattern (`isPdfUrl`). Catches `*.pdf` paths and
+   *     WebBrain's PDF handler URL after unwrapping its `url` parameter.
    *     `?file=*.pdf` viewer URLs — the bulk of cases.
    *   - Slow path: HEAD probe with credentials. Catches PDFs served
    *     from endpoints whose URL doesn't reveal the type, e.g.
@@ -5377,7 +5379,8 @@ export class Agent extends LoopDetector {
    */
   async _isPdfTab(tabId, pageUrl) {
     if (!pageUrl) return false;
-    if (isPdfUrl(pageUrl)) return true;
+    const pdfUrl = pdfUrlFromTabUrl(pageUrl);
+    if (isPdfUrl(pdfUrl)) return true;
 
     // Cache hit?
     const cached = this._isPdfTabCache.get(tabId);
@@ -5387,9 +5390,9 @@ export class Agent extends LoopDetector {
     // route to read_pdf, and a fetch against chrome:// or about:// just
     // throws.
     let isPdf = false;
-    if (/^https?:/i.test(pageUrl)) {
+    if (/^https?:/i.test(pdfUrl)) {
       try {
-        const res = await fetch(pageUrl, {
+        const res = await fetch(pdfUrl, {
           method: 'HEAD',
           credentials: 'include',
         });
@@ -31533,12 +31536,16 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
       const pageUrl = tabForPdfCheck?.url || '';
       // _isPdfTab does sync URL-pattern match first, then a HEAD probe
       // (credentialed) so PDFs served from extension-less paths like
-      // `/download?id=42` with `Content-Type: application/pdf` are
-      // caught too. Cached per (tabId, pageUrl) — at most one probe
-      // per tab+URL.
+      // `/download?id=42` with `Content-Type: application/pdf` are caught
+      // too. A WebBrain PDF handler URL is unwrapped before both checks.
+      // Cached per (tabId, pageUrl) — at most one probe per tab+URL.
       if (await this._isPdfTab(tabId, pageUrl)) {
         if (name === 'read_page') {
-          const pdfResult = await this.executeTool(tabId, 'read_pdf', { url: pageUrl });
+          const pdfResult = await this.executeTool(
+            tabId,
+            'read_pdf',
+            { url: pdfUrlFromTabUrl(pageUrl) },
+          );
           return {
             ...pdfResult,
             redirectedFrom: 'read_page',

--- a/src/chrome/src/agent/pdf-extraction.js
+++ b/src/chrome/src/agent/pdf-extraction.js
@@ -25,7 +25,7 @@ function pdfHandlerPage(runtime) {
 // When the native MIME handler owns a PDF tab, the tab URL is our own viewer
 // page wrapping the real URL in ?url=. read_pdf falls back to the tab URL when
 // called without an explicit one, so unwrap it before the scheme check.
-function unwrapPdfHandlerUrl(url, runtime = globalThis.chrome?.runtime) {
+export function unwrapPdfHandlerUrl(url, runtime = globalThis.chrome?.runtime) {
   if (url.protocol !== 'chrome-extension:' && url.protocol !== 'moz-extension:') return url;
   if (typeof runtime?.getURL !== 'function') return url;
   let handler;
@@ -42,6 +42,16 @@ function unwrapPdfHandlerUrl(url, runtime = globalThis.chrome?.runtime) {
   } catch {
     return url;
   }
+}
+
+export function pdfUrlFromTabUrl(value, runtime = globalThis.chrome?.runtime) {
+  let url;
+  try {
+    url = new URL(String(value || ''));
+  } catch {
+    return String(value || '');
+  }
+  return unwrapPdfHandlerUrl(url, runtime).href;
 }
 
 export function normalizePdfUrl(value, runtime = globalThis.chrome?.runtime) {

--- a/src/chrome/src/agent/pdf-extraction.js
+++ b/src/chrome/src/agent/pdf-extraction.js
@@ -54,6 +54,23 @@ export function pdfUrlFromTabUrl(value, runtime = globalThis.chrome?.runtime) {
   return unwrapPdfHandlerUrl(url, runtime).href;
 }
 
+// Our viewer page is only ever opened for a response we already identified as
+// a PDF, so a handler tab is a PDF tab by construction. Callers use this to
+// skip the Content-Type probe, which would otherwise decide the question for
+// wrapped URLs like `/download?id=42` — and servers routinely answer HEAD with
+// 405, or drop the Content-Type, or burn a one-shot signed download link.
+export function isPdfHandlerTabUrl(value, runtime = globalThis.chrome?.runtime) {
+  let url;
+  try {
+    url = new URL(String(value || ''));
+  } catch {
+    return false;
+  }
+  // unwrapPdfHandlerUrl returns the same object when there was nothing to
+  // unwrap, so identity is the "this was our handler page" signal.
+  return unwrapPdfHandlerUrl(url, runtime) !== url;
+}
+
 export function normalizePdfUrl(value, runtime = globalThis.chrome?.runtime) {
   let url;
   try {

--- a/src/firefox/src/agent/agent.js
+++ b/src/firefox/src/agent/agent.js
@@ -59,6 +59,7 @@ import {
 import { executeWikipediaSkillTool } from './wikipedia-offline.js';
 import {
   isPdfUrl,
+  pdfUrlFromTabUrl,
   extractPdfText,
   providerSupportsPdfPassthrough,
   buildClaudeDocumentBlock,
@@ -9185,15 +9186,16 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
    */
   async _isPdfTab(tabId, pageUrl) {
     if (!pageUrl) return false;
-    if (isPdfUrl(pageUrl)) return true;
+    const pdfUrl = pdfUrlFromTabUrl(pageUrl);
+    if (isPdfUrl(pdfUrl)) return true;
 
     const cached = this._isPdfTabCache.get(tabId);
     if (cached && cached.url === pageUrl) return cached.isPdf;
 
     let isPdf = false;
-    if (/^https?:/i.test(pageUrl)) {
+    if (/^https?:/i.test(pdfUrl)) {
       try {
-        const res = await fetch(pageUrl, {
+        const res = await fetch(pdfUrl, {
           method: 'HEAD',
           credentials: 'include',
         });
@@ -26047,11 +26049,16 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
       }
       // _isPdfTab does sync URL-pattern match + credentialed HEAD
       // fallback so PDFs served from extension-less paths (e.g.
-      // `/download?id=42` with `Content-Type: application/pdf`) are
-      // also caught. Cached per (tabId, pageUrl).
+      // `/download?id=42` with `Content-Type: application/pdf`) are also
+      // caught. A WebBrain PDF handler URL is unwrapped before both checks.
+      // Cached per (tabId, pageUrl).
       if (await this._isPdfTab(tabId, pageUrl)) {
         if (name === 'read_page') {
-          const pdfResult = await this.executeTool(tabId, 'read_pdf', { url: pageUrl });
+          const pdfResult = await this.executeTool(
+            tabId,
+            'read_pdf',
+            { url: pdfUrlFromTabUrl(pageUrl) },
+          );
           return {
             ...pdfResult,
             redirectedFrom: 'read_page',

--- a/src/firefox/src/agent/agent.js
+++ b/src/firefox/src/agent/agent.js
@@ -59,6 +59,7 @@ import {
 import { executeWikipediaSkillTool } from './wikipedia-offline.js';
 import {
   isPdfUrl,
+  isPdfHandlerTabUrl,
   pdfUrlFromTabUrl,
   extractPdfText,
   providerSupportsPdfPassthrough,
@@ -9187,7 +9188,7 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
   async _isPdfTab(tabId, pageUrl) {
     if (!pageUrl) return false;
     const pdfUrl = pdfUrlFromTabUrl(pageUrl);
-    if (isPdfUrl(pdfUrl)) return true;
+    if (isPdfUrl(pdfUrl) || isPdfHandlerTabUrl(pageUrl)) return true;
 
     const cached = this._isPdfTabCache.get(tabId);
     if (cached && cached.url === pageUrl) return cached.isPdf;
@@ -25209,7 +25210,10 @@ Rules: no prose intro, no conclusion, no "this screenshot shows...", no layout d
         if (!pdfUrl) {
           try {
             const tab = await browser.tabs.get(tabId);
-            pdfUrl = tab?.url || '';
+            // On our own viewer page the tab URL is the handler wrapping the
+            // real URL in ?url=; fetching the handler HTML would hand pdfjs a
+            // document it cannot parse.
+            pdfUrl = pdfUrlFromTabUrl(tab?.url || '');
           } catch {}
         }
         if (!pdfUrl) {

--- a/src/firefox/src/agent/pdf-tools.js
+++ b/src/firefox/src/agent/pdf-tools.js
@@ -23,6 +23,41 @@
  */
 
 let pdfjsModule = null;
+const DEFAULT_PDF_HANDLER_PAGE = 'src/ui/pdf-handler.html';
+
+function pdfHandlerPage(runtime) {
+  const manifest = typeof runtime?.getManifest === 'function' ? runtime.getManifest() : null;
+  return manifest?.mime_types_handler?.['application/pdf']?.handler_url || DEFAULT_PDF_HANDLER_PAGE;
+}
+
+function unwrapPdfHandlerUrl(url, runtime) {
+  if (url.protocol !== 'chrome-extension:' && url.protocol !== 'moz-extension:') return url;
+  if (typeof runtime?.getURL !== 'function') return url;
+  let handler;
+  try {
+    handler = new URL(runtime.getURL(pdfHandlerPage(runtime)));
+  } catch {
+    return url;
+  }
+  if (url.origin !== handler.origin || url.pathname !== handler.pathname) return url;
+  const inner = url.searchParams.get('url');
+  if (!inner) return url;
+  try {
+    return new URL(inner);
+  } catch {
+    return url;
+  }
+}
+
+export function pdfUrlFromTabUrl(value, runtime = globalThis.browser?.runtime || globalThis.chrome?.runtime) {
+  let url;
+  try {
+    url = new URL(String(value || ''));
+  } catch {
+    return String(value || '');
+  }
+  return unwrapPdfHandlerUrl(url, runtime).href;
+}
 
 /**
  * Lazy-load pdfjs only on first PDF read. The legacy bundle is ~1 MB

--- a/src/firefox/src/agent/pdf-tools.js
+++ b/src/firefox/src/agent/pdf-tools.js
@@ -59,6 +59,23 @@ export function pdfUrlFromTabUrl(value, runtime = globalThis.browser?.runtime ||
   return unwrapPdfHandlerUrl(url, runtime).href;
 }
 
+// Our viewer page is only ever opened for a response we already identified as
+// a PDF, so a handler tab is a PDF tab by construction. Callers use this to
+// skip the Content-Type probe, which would otherwise decide the question for
+// wrapped URLs like `/download?id=42` — and servers routinely answer HEAD with
+// 405, or drop the Content-Type, or burn a one-shot signed download link.
+export function isPdfHandlerTabUrl(value, runtime = globalThis.browser?.runtime || globalThis.chrome?.runtime) {
+  let url;
+  try {
+    url = new URL(String(value || ''));
+  } catch {
+    return false;
+  }
+  // unwrapPdfHandlerUrl returns the same object when there was nothing to
+  // unwrap, so identity is the "this was our handler page" signal.
+  return unwrapPdfHandlerUrl(url, runtime) !== url;
+}
+
 /**
  * Lazy-load pdfjs only on first PDF read. The legacy bundle is ~1 MB
  * and the worker is ~2.3 MB; we don't want to pay that startup cost

--- a/test/pdf-mime-handler-e2e.mjs
+++ b/test/pdf-mime-handler-e2e.mjs
@@ -66,20 +66,36 @@ function createMinimalPdf() {
 async function startPdfServer() {
   const pdf = createMinimalPdf();
   let requestCount = 0;
+  const requests = [];
+  const sendPdf = (response, filename) => {
+    response.writeHead(200, {
+      'content-type': pdfMimeType,
+      'content-length': String(pdf.byteLength),
+      'content-disposition': `inline; filename="${filename}"`,
+      'cache-control': 'no-store',
+    });
+    response.end(pdf);
+  };
   const server = createServer((request, response) => {
     const url = new URL(request.url || '/', 'http://127.0.0.1');
+    requests.push(`${request.method} ${url.pathname}`);
+    // The same PDF from a URL that reveals nothing about its type, behind a
+    // server that refuses HEAD. A Content-Type probe learns nothing here, so
+    // this endpoint is what proves the handler page is recognized without one.
+    if (url.pathname === '/opaque-download') {
+      if (request.method === 'HEAD') {
+        response.writeHead(405).end();
+        return;
+      }
+      sendPdf(response, 'document.pdf');
+      return;
+    }
     if (url.pathname !== '/document.pdf') {
       response.writeHead(404).end('not found');
       return;
     }
     requestCount += 1;
-    response.writeHead(200, {
-      'content-type': pdfMimeType,
-      'content-length': String(pdf.byteLength),
-      'content-disposition': 'inline; filename="document.pdf"',
-      'cache-control': 'no-store',
-    });
-    response.end(pdf);
+    sendPdf(response, 'document.pdf');
   });
   await new Promise((resolve, reject) => {
     server.once('error', reject);
@@ -91,7 +107,9 @@ async function startPdfServer() {
     server,
     pdf,
     requestCount: () => requestCount,
+    requests,
     url: `http://127.0.0.1:${address.port}/document.pdf`,
+    opaqueUrl: `http://127.0.0.1:${address.port}/opaque-download?id=42`,
   };
 }
 
@@ -125,6 +143,88 @@ async function inspectPdfRouting(context, url, extensionId, waitMs = 2000) {
       sawNativeHandler: urls.some(value => value.startsWith('chrome-extension://') && !value.startsWith(`chrome-extension://${extensionId}/`)),
       urls,
     };
+  } finally {
+    await page.close();
+  }
+}
+
+// `read_page` cannot use the content-script path on our own PDF viewer, so it
+// redirects to `read_pdf`. That redirect hinges on `_isPdfTab` recognizing the
+// handler page. Recognizing it by URL pattern alone is not enough: the wrapped
+// URL may reveal nothing about its type, and the Content-Type probe that used
+// to decide those cases is a HEAD request servers are free to reject. We only
+// ever open the handler for a response already identified as a PDF, so the
+// page itself is the signal, and no probe should be issued.
+async function assertHandlerTabSkipsContentTypeProbe(context, settings, extensionId, fixture) {
+  const sourceUrl = fixture.opaqueUrl;
+  const page = await context.newPage();
+  try {
+    await page.goto(sourceUrl, { waitUntil: 'commit', timeout: 30_000 });
+
+    const tabId = await settings.waitForFunction(async url => {
+      const tabs = await chrome.tabs.query({});
+      return tabs.find(tab => tab.url === url)?.id ?? null;
+    }, sourceUrl, { timeout: 15_000 }).then(handle => handle.jsonValue());
+    assert.ok(Number.isInteger(tabId) && tabId > 0, 'Could not find the tab showing the opaque PDF.');
+
+    // Exactly what the "Open PDF with WebBrain" context menu does. That entry
+    // is the only route to a wrapped handler URL, and it appears because the
+    // response was application/pdf, not because the URL looked like a PDF.
+    const handlerUrl = await settings.evaluate(async ({ id, url }) => {
+      const viewerUrl = chrome.runtime.getURL(
+        `src/ui/pdf-handler.html?url=${encodeURIComponent(url)}&tabId=${encodeURIComponent(id)}`,
+      );
+      await chrome.tabs.update(id, { url: viewerUrl });
+      return viewerUrl;
+    }, { id: tabId, url: sourceUrl });
+
+    await settings.waitForFunction(async ({ id, expected }) => {
+      const tab = await chrome.tabs.get(id);
+      return tab?.url === expected;
+    }, { id: tabId, expected: handlerUrl }, { timeout: 15_000 });
+
+    const requestsBefore = fixture.requests.length;
+
+    // Dynamic import() is disallowed on ServiceWorkerGlobalScope, so the
+    // settings page stands in: same extension origin, same chrome.* APIs.
+    // Running here also exercises the origin comparison in
+    // `unwrapPdfHandlerUrl` for real. Node's URL parser reports `origin` as
+    // the string "null" for every chrome-extension:// URL, so the unit tests
+    // cannot tell our handler from another extension's.
+    const helpers = await settings.evaluate(async ({ url, source }) => {
+      const module = await import(chrome.runtime.getURL('src/agent/pdf-extraction.js'));
+      return {
+        handlerTab: module.isPdfHandlerTabUrl(url),
+        unwrapped: module.pdfUrlFromTabUrl(url),
+        foreignExtension: module.isPdfHandlerTabUrl(
+          'chrome-extension://aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/src/ui/pdf-handler.html?url=http://example.invalid/x.pdf',
+        ),
+        ordinaryPage: module.isPdfHandlerTabUrl('https://example.invalid/'),
+      };
+    }, { url: handlerUrl, source: sourceUrl });
+    assert.equal(helpers.handlerTab, true, 'isPdfHandlerTabUrl did not recognize our own handler tab.');
+    assert.equal(helpers.unwrapped, sourceUrl, 'The handler tab did not unwrap to its source URL.');
+    assert.equal(helpers.foreignExtension, false, 'A foreign extension id was accepted as our PDF handler.');
+    assert.equal(helpers.ordinaryPage, false, 'An ordinary page was treated as a PDF handler tab.');
+
+    const isPdfTab = await settings.evaluate(async ({ id, url }) => {
+      const { Agent } = await import(chrome.runtime.getURL('src/agent/agent.js'));
+      // Object.create skips the constructor; _isPdfTab only needs this cache.
+      const agent = Object.create(Agent.prototype);
+      agent._isPdfTabCache = new Map();
+      return agent._isPdfTab(id, url);
+    }, { id: tabId, url: handlerUrl });
+    assert.equal(isPdfTab, true, '_isPdfTab did not recognize the PDF handler tab.');
+
+    // The viewer legitimately GETs the PDF to render it; what must not appear
+    // is a HEAD, which is how the routing decision used to be made.
+    const probesDuring = fixture.requests.slice(requestsBefore).filter(entry => entry.startsWith('HEAD'));
+    assert.deepEqual(probesDuring, [], `Recognizing the handler tab issued a probe: ${probesDuring.join(', ')}`);
+    assert.equal(
+      fixture.requests.some(entry => entry.startsWith('HEAD')),
+      false,
+      `The handler tab triggered a Content-Type probe: ${fixture.requests.join(', ')}`,
+    );
   } finally {
     await page.close();
   }
@@ -236,6 +336,9 @@ async function main() {
     assert.equal(disabledAgainRouting.sawWebBrainHandler, false, `Turning PDF handling off still entered WebBrain: ${disabledAgainRouting.urls.join(', ')}`);
     assert.equal(disabledAgainRouting.sawNativeHandler, true, `Turning PDF handling off did not restore Chrome's native viewer: ${disabledAgainRouting.urls.join(', ')}`);
     console.log(`  ✓ Chrome ${browser.version()} keeps native PDF routing aligned with the WebBrain toggle`);
+
+    await assertHandlerTabSkipsContentTypeProbe(context, settings, extensionId, fixture);
+    console.log('  ✓ read_page routing recognizes a PDF handler tab without a Content-Type probe');
   } finally {
     if (browserCdp && extensionId) {
       await browserCdp.send('Extensions.uninstall', { id: extensionId }).catch(() => {});

--- a/test/run.js
+++ b/test/run.js
@@ -1353,9 +1353,10 @@ function test(name, fn) { tests.push({ name, fn }); }
 
 console.log('\nselection quote');
 
-test('read_page redirects WebBrain PDF handler tabs to read_pdf with the source URL', async () => {
+test('read_page redirects PDF handler tabs and probes the unwrapped source URL', async () => {
   const previousChrome = globalThis.chrome;
   const previousBrowser = globalThis.browser;
+  const previousFetch = globalThis.fetch;
   const makeStorageArea = () => ({
     get: async values => {
       if (typeof values === 'string') return {};
@@ -1370,55 +1371,75 @@ test('read_page redirects WebBrain PDF handler tabs to read_pdf with the source 
       ['chrome', AgentCh, 'chrome', 'chrome-extension'],
       ['firefox', AgentFx, 'browser', 'moz-extension'],
     ]) {
-      const sourceUrl = 'https://papers.example.test/handler-source.pdf';
-      const extensionId = `${label}-pdf-routing`;
-      const handlerUrl = `${scheme}://${extensionId}/src/ui/pdf-handler.html?url=${encodeURIComponent(sourceUrl)}&tabId=73`;
-      const storageArea = makeStorageArea();
-      const api = {
-        runtime: {
-          id: extensionId,
-          getURL: path => `${scheme}://${extensionId}/${path}`,
-          getManifest: () => ({
-            mime_types_handler: {
-              'application/pdf': { handler_url: 'src/ui/pdf-handler.html' },
+      for (const { sourceUrl, expectHeadProbe } of [
+        { sourceUrl: 'https://papers.example.test/handler-source.pdf', expectHeadProbe: false },
+        { sourceUrl: 'https://papers.example.test/download?id=42', expectHeadProbe: true },
+      ]) {
+        const extensionId = `${label}-pdf-routing`;
+        const handlerUrl = `${scheme}://${extensionId}/src/ui/pdf-handler.html?url=${encodeURIComponent(sourceUrl)}&tabId=73`;
+        const storageArea = makeStorageArea();
+        const api = {
+          runtime: {
+            id: extensionId,
+            getURL: path => `${scheme}://${extensionId}/${path}`,
+            getManifest: () => ({
+              mime_types_handler: {
+                'application/pdf': { handler_url: 'src/ui/pdf-handler.html' },
+              },
+            }),
+          },
+          storage: {
+            local: storageArea,
+            session: storageArea,
+            onChanged: { addListener: () => {} },
+          },
+          tabs: {
+            get: async () => ({ id: 73, url: handlerUrl }),
+          },
+        };
+        const headRequests = [];
+        globalThis.fetch = async (url, options) => {
+          headRequests.push({ url: String(url), method: options?.method || 'GET' });
+          return {
+            headers: {
+              get: name => name.toLowerCase() === 'content-type' ? 'application/pdf' : '',
             },
-          }),
-        },
-        storage: {
-          local: storageArea,
-          session: storageArea,
-          onChanged: { addListener: () => {} },
-        },
-        tabs: {
-          get: async () => ({ id: 73, url: handlerUrl }),
-        },
-      };
-      globalThis[apiName] = api;
-      const agent = new AgentClass({});
-      agent._richTextToolbarToolBlock = async () => null;
-      const delegated = [];
-      const executeTool = agent.executeTool.bind(agent);
-      agent.executeTool = async (tabId, name, args, ...rest) => {
-        if (name === 'read_pdf') {
-          delegated.push({ tabId, name, args });
-          return { success: true, pages: ['handler source'] };
-        }
-        return executeTool(tabId, name, args, ...rest);
-      };
+          };
+        };
+        globalThis[apiName] = api;
+        const agent = new AgentClass({});
+        agent._richTextToolbarToolBlock = async () => null;
+        const delegated = [];
+        const executeTool = agent.executeTool.bind(agent);
+        agent.executeTool = async (tabId, name, args, ...rest) => {
+          if (name === 'read_pdf') {
+            delegated.push({ tabId, name, args });
+            return { success: true, pages: ['handler source'] };
+          }
+          return executeTool(tabId, name, args, ...rest);
+        };
 
-      const result = await executeTool(73, 'read_page', {});
-      assert.equal(result.redirectedFrom, 'read_page', `${label}: read_page did not redirect`);
-      assert.deepEqual(delegated, [{
-        tabId: 73,
-        name: 'read_pdf',
-        args: { url: sourceUrl },
-      }], `${label}: redirect did not preserve the handler's source URL`);
+        const result = await executeTool(73, 'read_page', {});
+        assert.equal(result.redirectedFrom, 'read_page', `${label}: read_page did not redirect`);
+        assert.deepEqual(delegated, [{
+          tabId: 73,
+          name: 'read_pdf',
+          args: { url: sourceUrl },
+        }], `${label}: redirect did not preserve the handler's source URL`);
+        assert.deepEqual(
+          headRequests,
+          expectHeadProbe ? [{ url: sourceUrl, method: 'HEAD' }] : [],
+          `${label}: HEAD probe should use the unwrapped source URL`,
+        );
+      }
     }
   } finally {
     if (previousChrome === undefined) delete globalThis.chrome;
     else globalThis.chrome = previousChrome;
     if (previousBrowser === undefined) delete globalThis.browser;
     else globalThis.browser = previousBrowser;
+    if (previousFetch === undefined) delete globalThis.fetch;
+    else globalThis.fetch = previousFetch;
   }
 });
 

--- a/test/run.js
+++ b/test/run.js
@@ -1353,6 +1353,75 @@ function test(name, fn) { tests.push({ name, fn }); }
 
 console.log('\nselection quote');
 
+test('read_page redirects WebBrain PDF handler tabs to read_pdf with the source URL', async () => {
+  const previousChrome = globalThis.chrome;
+  const previousBrowser = globalThis.browser;
+  const makeStorageArea = () => ({
+    get: async values => {
+      if (typeof values === 'string') return {};
+      if (Array.isArray(values)) return Object.fromEntries(values.map(key => [key, undefined]));
+      return values || {};
+    },
+    set: async () => {},
+    remove: async () => {},
+  });
+  try {
+    for (const [label, AgentClass, apiName, scheme] of [
+      ['chrome', AgentCh, 'chrome', 'chrome-extension'],
+      ['firefox', AgentFx, 'browser', 'moz-extension'],
+    ]) {
+      const sourceUrl = 'https://papers.example.test/handler-source.pdf';
+      const extensionId = `${label}-pdf-routing`;
+      const handlerUrl = `${scheme}://${extensionId}/src/ui/pdf-handler.html?url=${encodeURIComponent(sourceUrl)}&tabId=73`;
+      const storageArea = makeStorageArea();
+      const api = {
+        runtime: {
+          id: extensionId,
+          getURL: path => `${scheme}://${extensionId}/${path}`,
+          getManifest: () => ({
+            mime_types_handler: {
+              'application/pdf': { handler_url: 'src/ui/pdf-handler.html' },
+            },
+          }),
+        },
+        storage: {
+          local: storageArea,
+          session: storageArea,
+          onChanged: { addListener: () => {} },
+        },
+        tabs: {
+          get: async () => ({ id: 73, url: handlerUrl }),
+        },
+      };
+      globalThis[apiName] = api;
+      const agent = new AgentClass({});
+      agent._richTextToolbarToolBlock = async () => null;
+      const delegated = [];
+      const executeTool = agent.executeTool.bind(agent);
+      agent.executeTool = async (tabId, name, args, ...rest) => {
+        if (name === 'read_pdf') {
+          delegated.push({ tabId, name, args });
+          return { success: true, pages: ['handler source'] };
+        }
+        return executeTool(tabId, name, args, ...rest);
+      };
+
+      const result = await executeTool(73, 'read_page', {});
+      assert.equal(result.redirectedFrom, 'read_page', `${label}: read_page did not redirect`);
+      assert.deepEqual(delegated, [{
+        tabId: 73,
+        name: 'read_pdf',
+        args: { url: sourceUrl },
+      }], `${label}: redirect did not preserve the handler's source URL`);
+    }
+  } finally {
+    if (previousChrome === undefined) delete globalThis.chrome;
+    else globalThis.chrome = previousChrome;
+    if (previousBrowser === undefined) delete globalThis.browser;
+    else globalThis.browser = previousBrowser;
+  }
+});
+
 test('buildSelectionQuote preserves multiline answer text as an editable quote', () => {
   const selected = 'First line\n\n<script>alert("x")</script>';
   const expected = '> First line\n> \n> <script>alert("x")</script>\n\n';

--- a/test/run.js
+++ b/test/run.js
@@ -1353,7 +1353,7 @@ function test(name, fn) { tests.push({ name, fn }); }
 
 console.log('\nselection quote');
 
-test('read_page redirects PDF handler tabs and probes the unwrapped source URL', async () => {
+test('read_page redirects PDF handler tabs to the unwrapped source URL without probing', async () => {
   const previousChrome = globalThis.chrome;
   const previousBrowser = globalThis.browser;
   const previousFetch = globalThis.fetch;
@@ -1371,9 +1371,13 @@ test('read_page redirects PDF handler tabs and probes the unwrapped source URL',
       ['chrome', AgentCh, 'chrome', 'chrome-extension'],
       ['firefox', AgentFx, 'browser', 'moz-extension'],
     ]) {
-      for (const { sourceUrl, expectHeadProbe } of [
-        { sourceUrl: 'https://papers.example.test/handler-source.pdf', expectHeadProbe: false },
-        { sourceUrl: 'https://papers.example.test/download?id=42', expectHeadProbe: true },
+      // The second URL reveals nothing about its type, so it is the case that
+      // would fall back to a Content-Type probe on an ordinary tab. On our own
+      // handler page it must not: we only open that page for a PDF, and the
+      // probe is a HEAD request servers are free to reject.
+      for (const sourceUrl of [
+        'https://papers.example.test/handler-source.pdf',
+        'https://papers.example.test/download?id=42',
       ]) {
         const extensionId = `${label}-pdf-routing`;
         const handlerUrl = `${scheme}://${extensionId}/src/ui/pdf-handler.html?url=${encodeURIComponent(sourceUrl)}&tabId=73`;
@@ -1398,14 +1402,18 @@ test('read_page redirects PDF handler tabs and probes the unwrapped source URL',
           },
         };
         const headRequests = [];
+        // Answers "not a PDF" so a probe, if one were made, would suppress the
+        // redirect — the redirect must come from recognizing the handler page.
         globalThis.fetch = async (url, options) => {
           headRequests.push({ url: String(url), method: options?.method || 'GET' });
           return {
             headers: {
-              get: name => name.toLowerCase() === 'content-type' ? 'application/pdf' : '',
+              get: name => name.toLowerCase() === 'content-type' ? 'text/html' : '',
             },
           };
         };
+        delete globalThis.chrome;
+        delete globalThis.browser;
         globalThis[apiName] = api;
         const agent = new AgentClass({});
         agent._richTextToolbarToolBlock = async () => null;
@@ -1428,8 +1436,8 @@ test('read_page redirects PDF handler tabs and probes the unwrapped source URL',
         }], `${label}: redirect did not preserve the handler's source URL`);
         assert.deepEqual(
           headRequests,
-          expectHeadProbe ? [{ url: sourceUrl, method: 'HEAD' }] : [],
-          `${label}: HEAD probe should use the unwrapped source URL`,
+          [],
+          `${label}: a handler tab should be recognized without a Content-Type probe`,
         );
       }
     }


### PR DESCRIPTION
## Summary

- Recognize WebBrain's Chrome and Firefox `pdf-handler.html?url=...` tabs when deciding whether a tab is a PDF.
- Unwrap the handler URL before PDF detection and HEAD probing.
- Route `read_page` on a PDF handler tab to `read_pdf` with the original PDF URL.
- Add a deterministic Chrome/Firefox regression test that invokes the real `read_page` execution path and verifies the delegated URL.

This fixes the gap where direct `read_pdf` could read the document, but `read_page` on WebBrain's own PDF handler page fell through to an unreachable content-script path.

## Validation

- `node test/run.js` — 2202 passed, 0 failed.
- `npm run test:pdf-read` — 4 passed, 0 failed.
- `npm run test:pdf-mime-handler` — passed on Chrome 152.0.7977.76.
- `node --check` for all changed JavaScript files and `git diff --check` — passed.
- Manual Chrome validation on a real `chrome-extension://.../src/ui/pdf-handler.html?url=...` page: `read_page` returned 14-page PDF metadata and extracted text successfully.

`npm run test:pdf-selection` was not used as a pass gate because the existing local environment lacks Playwright's headless Chromium and has two Windows ESM absolute-path test failures unrelated to this change.