### PR TITLE
Add Baidu Tieba interaction and reply publishing adapter

### DIFF
--- a/src/chrome/src/agent/adapters.js
+++ b/src/chrome/src/agent/adapters.js
@@ -16173,8 +16173,9 @@ const ADAPTERS = [
     category: 'general',
     matches: isBaiduTiebaUrl,
     notes: `
-- Tieba thread pages use a custom Vue action bar. On the first floor, the share, reply, like, and collect actions are icon-plus-count elements rather than native buttons; use the accessibility tree or interactive-element list and prefer the named "点赞" control over screenshot coordinates.
-- Reply-level likes are separate "赞" controls in each comment row. Re-read the active post or comment container after scrolling, switching "只看楼主", or changing 热门/正序/倒序; indices and visible rows can change.
+- Tieba thread pages use a custom Vue action bar. The first-floor转发、点赞、收藏和更多 controls are icon-based custom elements; the comment count remains a native link. Use the accessibility tree or interactive-element list and prefer semantic controls over screenshot coordinates.
+- Reply rows expose separate "赞", "回复", and "更多" controls. Re-read the active post or comment container after scrolling, switching "只看楼主", or changing 热门/正序/倒序; indices and visible rows can change.
+- The reply prompt and visible "关注楼主"/"关注本吧" controls may be custom wrappers; treat them as state-changing or login-gated actions and verify the resulting UI.
 - "点赞", "关注", "回复", and "发帖" change account or public state. Perform them only when explicitly requested, then verify the icon/count or resulting state; a successful mouse dispatch alone is not proof.
 - The first-floor action bar may be below the initial viewport, while images open a viewer when clicked. Do not click nearby image coordinates or repeat a coordinate after an unexpected viewer opens; close or go back, then re-read the page.
 - Public pages may require Baidu sign-in. If "登录", QR verification, or "百度安全验证" appears, stop for the user and do not bypass, retry, or claim that the requested action succeeded.`,

--- a/src/chrome/src/agent/adapters.js
+++ b/src/chrome/src/agent/adapters.js
@@ -16153,7 +16153,7 @@ const ADAPTERS = [
     notes: `
 - Tieba thread pages use a custom Vue action bar. On the first floor, the share, reply, like, and collect actions are icon-plus-count elements rather than native buttons; use the accessibility tree or interactive-element list and prefer the named "点赞" control over screenshot coordinates.
 - Reply-level likes are separate "赞" controls in each comment row. Re-read the active post or comment container after scrolling, switching "只看楼主", or changing 热门/正序/倒序; indices and visible rows can change.
-- "点赞", "关注", "回复", and "发贴" change account or public state. Perform them only when explicitly requested, then verify the icon/count or resulting state; a successful mouse dispatch alone is not proof.
+- "点赞", "关注", "回复", and "发帖" change account or public state. Perform them only when explicitly requested, then verify the icon/count or resulting state; a successful mouse dispatch alone is not proof.
 - The first-floor action bar may be below the initial viewport, while images open a viewer when clicked. Do not click nearby image coordinates or repeat a coordinate after an unexpected viewer opens; close or go back, then re-read the page.
 - Public pages may require Baidu sign-in. If "登录", QR verification, or "百度安全验证" appears, stop for the user and do not bypass, retry, or claim that the requested action succeeded.`,
   },

--- a/src/chrome/src/agent/adapters.js
+++ b/src/chrome/src/agent/adapters.js
@@ -15734,10 +15734,32 @@ function isDirectBaiduSearchUrl(url) {
   return host === 'news.baidu.com' && /^\/ns(?:\/|$)/.test(path);
 }
 
+function isDirectBaiduTiebaUrl(url) {
+  let parts;
+  try {
+    parts = adapterUrlParts(url);
+  } catch (e) {
+    return false;
+  }
+  return Boolean(parts) && normalizedHostname(parts.parsed.hostname) === 'tieba.baidu.com';
+}
+
 function isBaiduTiebaUrl(url) {
-  const parts = adapterUrlParts(url);
+  if (isDirectBaiduTiebaUrl(url)) return true;
+  let parts;
+  try {
+    parts = adapterUrlParts(url);
+  } catch (e) {
+    return false;
+  }
   if (!parts) return false;
-  return normalizedHostname(parts.parsed.hostname) === 'tieba.baidu.com';
+  const host = parts.parsed.hostname.toLowerCase();
+  if (host !== 'passport.baidu.com' && host !== 'wappass.baidu.com') return false;
+  const targets = [];
+  for (const param of ['backurl', 'u']) {
+    targets.push(...parts.parsed.searchParams.getAll(param));
+  }
+  return targets.length > 0 && targets.every(isDirectBaiduTiebaUrl);
 }
 
 function isBaiduSearchUrl(url) {

--- a/src/chrome/src/agent/adapters.js
+++ b/src/chrome/src/agent/adapters.js
@@ -15734,6 +15734,12 @@ function isDirectBaiduSearchUrl(url) {
   return host === 'news.baidu.com' && /^\/ns(?:\/|$)/.test(path);
 }
 
+function isBaiduTiebaUrl(url) {
+  const parts = adapterUrlParts(url);
+  if (!parts) return false;
+  return normalizedHostname(parts.parsed.hostname) === 'tieba.baidu.com';
+}
+
 function isBaiduSearchUrl(url) {
   if (isDirectBaiduSearchUrl(url)) return true;
   let parts;
@@ -16139,6 +16145,17 @@ const ADAPTERS = [
 - Use image or video cards only after opening the source page or detail view; thumbnails, captions, and neighboring card text can be mismatched or truncated, and lazy-loaded card indices are not stable after scrolling.
 - Read-only web search and result opening do not require sign-in. If "登录" or "扫码登录" appears, ask the user to authenticate only for an explicitly requested account feature; do not block ordinary search, loop on the dialog, or claim that login is required for public results.
 - If wappass.baidu.com/static/captcha shows "百度安全验证", stop and ask the user to complete it manually. After completion, continue the encoded backurl and re-read the results; do not bypass the challenge, discard the query, or loop on the search URL.`,
+  },
+  {
+    name: 'baidu-tieba',
+    category: 'general',
+    matches: isBaiduTiebaUrl,
+    notes: `
+- Tieba thread pages use a custom Vue action bar. On the first floor, the share, reply, like, and collect actions are icon-plus-count elements rather than native buttons; use the accessibility tree or interactive-element list and prefer the named "点赞" control over screenshot coordinates.
+- Reply-level likes are separate "赞" controls in each comment row. Re-read the active post or comment container after scrolling, switching "只看楼主", or changing 热门/正序/倒序; indices and visible rows can change.
+- "点赞", "关注", "回复", and "发贴" change account or public state. Perform them only when explicitly requested, then verify the icon/count or resulting state; a successful mouse dispatch alone is not proof.
+- The first-floor action bar may be below the initial viewport, while images open a viewer when clicked. Do not click nearby image coordinates or repeat a coordinate after an unexpected viewer opens; close or go back, then re-read the page.
+- Public pages may require Baidu sign-in. If "登录", QR verification, or "百度安全验证" appears, stop for the user and do not bypass, retry, or claim that the requested action succeeded.`,
   },
   {
     name: 'slack',

--- a/src/chrome/src/cdp/cdp-client.js
+++ b/src/chrome/src/cdp/cdp-client.js
@@ -2920,6 +2920,9 @@ export class CDPClient {
           ['.follow-wrapper', '关注'], ['.follow-btn', '关注'],
           ['.follow-button', '关注'], ['.send-btn', '发布评论'],
           ['.publish-btn', '发布'], ['.publish-button', '发布'],
+        ] : onHost('tieba.baidu.com') ? [
+          ['.pc-pb-first-floor-interactive .action-item:has(use[*|href="#agree_pb"])', '点赞'],
+          ['.pc-pb-comments-desc .zan-container-dark:has(use[*|href="#agree_comment"])', '赞'],
         ] : [];
         const SELECTORS = [
           'a[href]', 'button', 'input:not([type="hidden"])', 'textarea', 'select',

--- a/src/chrome/src/cdp/cdp-client.js
+++ b/src/chrome/src/cdp/cdp-client.js
@@ -2921,8 +2921,16 @@ export class CDPClient {
           ['.follow-button', '关注'], ['.send-btn', '发布评论'],
           ['.publish-btn', '发布'], ['.publish-button', '发布'],
         ] : onHost('tieba.baidu.com') ? [
+          ['.pc-pb-first-floor-interactive .action-item', '转发', '#share_pb'],
           ['.pc-pb-first-floor-interactive .action-item', '点赞', '#agree_pb'],
+          ['.pc-pb-first-floor-interactive .action-item', '收藏', '#collect'],
+          ['.pc-pb-first-floor-interactive .more-action', '更多', '#ellipsis'],
           ['.pc-pb-comments-desc .zan-container-dark', '赞', '#agree_comment'],
+          ['.pc-pb-comments-desc .reply-container', '回复', '#comment_comment'],
+          ['.pc-pb-comments-desc .more-action', '更多', '#ellipsis_comment'],
+          ['.follow-person-btn', '关注楼主'],
+          ['.follow-forum-btn', '关注本吧'],
+          ['.pc-pb-reply-box', '回复'],
         ] : [];
         const SELECTORS = [
           'a[href]', 'button', 'input:not([type="hidden"])', 'textarea', 'select',

--- a/src/chrome/src/cdp/cdp-client.js
+++ b/src/chrome/src/cdp/cdp-client.js
@@ -2921,8 +2921,8 @@ export class CDPClient {
           ['.follow-button', '关注'], ['.send-btn', '发布评论'],
           ['.publish-btn', '发布'], ['.publish-button', '发布'],
         ] : onHost('tieba.baidu.com') ? [
-          ['.pc-pb-first-floor-interactive .action-item:has(use[*|href="#agree_pb"])', '点赞'],
-          ['.pc-pb-comments-desc .zan-container-dark:has(use[*|href="#agree_comment"])', '赞'],
+          ['.pc-pb-first-floor-interactive .action-item', '点赞', '#agree_pb'],
+          ['.pc-pb-comments-desc .zan-container-dark', '赞', '#agree_comment'],
         ] : [];
         const SELECTORS = [
           'a[href]', 'button', 'input:not([type="hidden"])', 'textarea', 'select',
@@ -2933,10 +2933,34 @@ export class CDPClient {
           ...SITE_RULES.map(([selector]) => selector)
         ];
 
-        function interactiveText(el) {
-          for (const [selector, label] of SITE_RULES) {
+        function matchesSiteRule(el, [selector, , iconHref]) {
+          try {
+            if (!el.matches(selector)) return false;
+          } catch (e) {
+            return false;
+          }
+          if (!iconHref) return true;
+          return Array.from(el.querySelectorAll('use')).some((use) => (
+            use.getAttribute('href') === iconHref
+            || use.getAttribute('xlink:href') === iconHref
+          ));
+        }
+
+        function matchesAnySiteSelector(el) {
+          return SITE_RULES.some(([selector]) => {
             try {
-              if (!el.matches(selector)) continue;
+              return el.matches(selector);
+            } catch (e) {
+              return false;
+            }
+          });
+        }
+
+        function interactiveText(el) {
+          for (const rule of SITE_RULES) {
+            const [selector, label] = rule;
+            try {
+              if (!matchesSiteRule(el, rule)) continue;
             } catch (e) {
               continue;
             }
@@ -2980,6 +3004,7 @@ export class CDPClient {
         let index = 0;
         all.forEach((el) => {
           if (!isVisiblyInteractive(el)) return;
+          if (matchesAnySiteSelector(el) && !SITE_RULES.some(rule => matchesSiteRule(el, rule))) return;
           const rect = el.getBoundingClientRect();
           elements.push({
             index: index++,

--- a/src/chrome/src/cdp/cdp-client.js
+++ b/src/chrome/src/cdp/cdp-client.js
@@ -2931,6 +2931,7 @@ export class CDPClient {
           ['.follow-person-btn', '关注楼主'],
           ['.follow-forum-btn', '关注本吧'],
           ['.pc-pb-reply-box', '回复'],
+          ['.pc-pb-reply-box .publish-btn', '发布'],
         ] : [];
         const SELECTORS = [
           'a[href]', 'button', 'input:not([type="hidden"])', 'textarea', 'select',

--- a/src/chrome/src/cdp/cdp-client.js
+++ b/src/chrome/src/cdp/cdp-client.js
@@ -2933,14 +2933,14 @@ export class CDPClient {
           ['.pc-pb-reply-box', '回复'],
           ['.pc-pb-reply-box .publish-btn', '发布'],
         ] : [];
-        const SELECTORS = [
+        const NATIVE_SELECTORS = [
           'a[href]', 'button', 'input:not([type="hidden"])', 'textarea', 'select',
           '[role="button"]', '[role="link"]', '[role="tab"]', '[role="menuitem"]',
           '[role="textbox"]', '[role="combobox"]', '[role="searchbox"]',
           '[contenteditable=""]', '[contenteditable="true"]', '[contenteditable="plaintext-only"]',
-          '[onclick]', '[data-action]', 'summary', 'label',
-          ...SITE_RULES.map(([selector]) => selector)
+          '[onclick]', '[data-action]', 'summary', 'label'
         ];
+        const SELECTORS = [...NATIVE_SELECTORS, ...SITE_RULES.map(([selector]) => selector)];
 
         function matchesSiteRule(el, [selector, , iconHref]) {
           try {
@@ -2957,6 +2957,16 @@ export class CDPClient {
 
         function matchesAnySiteSelector(el) {
           return SITE_RULES.some(([selector]) => {
+            try {
+              return el.matches(selector);
+            } catch (e) {
+              return false;
+            }
+          });
+        }
+
+        function matchesNativeInteractive(el) {
+          return NATIVE_SELECTORS.some((selector) => {
             try {
               return el.matches(selector);
             } catch (e) {
@@ -3013,7 +3023,7 @@ export class CDPClient {
         let index = 0;
         all.forEach((el) => {
           if (!isVisiblyInteractive(el)) return;
-          if (matchesAnySiteSelector(el) && !SITE_RULES.some(rule => matchesSiteRule(el, rule))) return;
+          if (!matchesNativeInteractive(el) && matchesAnySiteSelector(el) && !SITE_RULES.some(rule => matchesSiteRule(el, rule))) return;
           const rect = el.getBoundingClientRect();
           elements.push({
             index: index++,

--- a/src/chrome/src/content/accessibility-tree.js
+++ b/src/chrome/src/content/accessibility-tree.js
@@ -158,8 +158,16 @@
     baiduTieba: [
       // Match the stable action wrapper, then inspect SVG href/xlink:href via
       // the DOM API because namespaced attribute selectors vary by engine.
+      ['.pc-pb-first-floor-interactive .action-item', '转发', '#share_pb'],
       ['.pc-pb-first-floor-interactive .action-item', '点赞', '#agree_pb'],
+      ['.pc-pb-first-floor-interactive .action-item', '收藏', '#collect'],
+      ['.pc-pb-first-floor-interactive .more-action', '更多', '#ellipsis'],
       ['.pc-pb-comments-desc .zan-container-dark', '赞', '#agree_comment'],
+      ['.pc-pb-comments-desc .reply-container', '回复', '#comment_comment'],
+      ['.pc-pb-comments-desc .more-action', '更多', '#ellipsis_comment'],
+      ['.follow-person-btn', '关注楼主'],
+      ['.follow-forum-btn', '关注本吧'],
+      ['.pc-pb-reply-box', '回复'],
     ],
   };
 

--- a/src/chrome/src/content/accessibility-tree.js
+++ b/src/chrome/src/content/accessibility-tree.js
@@ -155,6 +155,10 @@
       ['.publish-btn', '发布'],
       ['.publish-button', '发布'],
     ],
+    baiduTieba: [
+      ['.pc-pb-first-floor-interactive .action-item:has(use[*|href="#agree_pb"])', '点赞'],
+      ['.pc-pb-comments-desc .zan-container-dark:has(use[*|href="#agree_comment"])', '赞'],
+    ],
   };
 
   function currentSiteInteractionConfig() {
@@ -162,6 +166,7 @@
     const onHost = (domain) => hostname === domain || hostname.endsWith(`.${domain}`);
     if (onHost('bilibili.com')) return { key: 'bilibili', rules: SITE_INTERACTION_RULES.bilibili };
     if (onHost('xiaohongshu.com')) return { key: 'xiaohongshu', rules: SITE_INTERACTION_RULES.xiaohongshu };
+    if (onHost('tieba.baidu.com')) return { key: 'baiduTieba', rules: SITE_INTERACTION_RULES.baiduTieba };
     // LinkedIn's interop shell renders major surfaces (the post composer
     // dialog among them) inside the open #interop-outlet shadow root. No
     // custom interaction rules needed — piercing alone makes the dialog's

--- a/src/chrome/src/content/accessibility-tree.js
+++ b/src/chrome/src/content/accessibility-tree.js
@@ -156,8 +156,10 @@
       ['.publish-button', '发布'],
     ],
     baiduTieba: [
-      ['.pc-pb-first-floor-interactive .action-item:has(use[*|href="#agree_pb"])', '点赞'],
-      ['.pc-pb-comments-desc .zan-container-dark:has(use[*|href="#agree_comment"])', '赞'],
+      // Match the stable action wrapper, then inspect SVG href/xlink:href via
+      // the DOM API because namespaced attribute selectors vary by engine.
+      ['.pc-pb-first-floor-interactive .action-item', '点赞', '#agree_pb'],
+      ['.pc-pb-comments-desc .zan-container-dark', '赞', '#agree_comment'],
     ],
   };
 
@@ -177,11 +179,18 @@
 
   function getSiteInteractionDescriptor(el) {
     if (!el || typeof el.matches !== 'function') return null;
-    for (const [selector, label] of currentSiteInteractionConfig().rules) {
+    for (const [selector, label, iconHref] of currentSiteInteractionConfig().rules) {
       try {
         if (!el.matches(selector)) continue;
       } catch {
         continue;
+      }
+      if (iconHref) {
+        const hasIcon = Array.from(el.querySelectorAll?.('use') || []).some(use => (
+          use.getAttribute('href') === iconHref
+          || use.getAttribute('xlink:href') === iconHref
+        ));
+        if (!hasIcon) continue;
       }
       const explicit = String(
         el.getAttribute('aria-label') || el.getAttribute('title') || ''

--- a/src/chrome/src/content/accessibility-tree.js
+++ b/src/chrome/src/content/accessibility-tree.js
@@ -168,6 +168,7 @@
       ['.follow-person-btn', '关注楼主'],
       ['.follow-forum-btn', '关注本吧'],
       ['.pc-pb-reply-box', '回复'],
+      ['.pc-pb-reply-box .publish-btn', '发布'],
     ],
   };
 

--- a/src/chrome/src/content/content.js
+++ b/src/chrome/src/content/content.js
@@ -258,6 +258,18 @@
     }
   }
 
+  function _isSiteSelectorCandidate(el) {
+    try {
+      return _siteInteractiveSelectors().some(selector => el.matches(selector));
+    } catch {
+      return false;
+    }
+  }
+
+  function _isUsableSiteInteractive(el) {
+    return !_isSiteSelectorCandidate(el) || _isSiteInteractive(el);
+  }
+
   function _composedParent(node) {
     if (!node) return null;
     if (node.assignedSlot) return node.assignedSlot;
@@ -516,6 +528,7 @@
     const out = [];
     for (const el of all) {
       if (!isVisiblyInteractive(el)) continue;
+      if (!_isUsableSiteInteractive(el)) continue;
       // If a modal is open, only include elements that are inside it.
       // This prevents the agent from seeing (and accidentally clicking)
       // elements behind the overlay — the #1 cause of "clicked Export
@@ -3064,6 +3077,7 @@
         try {
           root.querySelectorAll(sel).forEach(el => {
             if (seen.has(el)) return;
+            if (!_isUsableSiteInteractive(el)) return;
             let rect = el.getBoundingClientRect();
             // Use wrapper rect for zero-dimension form inputs
             if ((rect.width < 2 || rect.height < 2) && /^(INPUT|SELECT|TEXTAREA)$/i.test(el.tagName)) {

--- a/src/chrome/src/content/content.js
+++ b/src/chrome/src/content/content.js
@@ -266,8 +266,16 @@
     }
   }
 
+  function _isStandardInteractive(el) {
+    try {
+      return INTERACTIVE_SELECTORS.some(selector => el.matches(selector));
+    } catch {
+      return false;
+    }
+  }
+
   function _isUsableSiteInteractive(el) {
-    return !_isSiteSelectorCandidate(el) || _isSiteInteractive(el);
+    return _isStandardInteractive(el) || !_isSiteSelectorCandidate(el) || _isSiteInteractive(el);
   }
 
   function _composedParent(node) {

--- a/src/firefox/src/agent/adapters.js
+++ b/src/firefox/src/agent/adapters.js
@@ -16172,8 +16172,9 @@ const ADAPTERS = [
     category: 'general',
     matches: isBaiduTiebaUrl,
     notes: `
-- Tieba thread pages use a custom Vue action bar. On the first floor, the share, reply, like, and collect actions are icon-plus-count elements rather than native buttons; use the accessibility tree or interactive-element list and prefer the named "点赞" control over screenshot coordinates.
-- Reply-level likes are separate "赞" controls in each comment row. Re-read the active post or comment container after scrolling, switching "只看楼主", or changing 热门/正序/倒序; indices and visible rows can change.
+- Tieba thread pages use a custom Vue action bar. The first-floor转发、点赞、收藏和更多 controls are icon-based custom elements; the comment count remains a native link. Use the accessibility tree or interactive-element list and prefer semantic controls over screenshot coordinates.
+- Reply rows expose separate "赞", "回复", and "更多" controls. Re-read the active post or comment container after scrolling, switching "只看楼主", or changing 热门/正序/倒序; indices and visible rows can change.
+- The reply prompt and visible "关注楼主"/"关注本吧" controls may be custom wrappers; treat them as state-changing or login-gated actions and verify the resulting UI.
 - "点赞", "关注", "回复", and "发帖" change account or public state. Perform them only when explicitly requested, then verify the icon/count or resulting state; a successful mouse dispatch alone is not proof.
 - The first-floor action bar may be below the initial viewport, while images open a viewer when clicked. Do not click nearby image coordinates or repeat a coordinate after an unexpected viewer opens; close or go back, then re-read the page.
 - Public pages may require Baidu sign-in. If "登录", QR verification, or "百度安全验证" appears, stop for the user and do not bypass, retry, or claim that the requested action succeeded.`,

--- a/src/firefox/src/agent/adapters.js
+++ b/src/firefox/src/agent/adapters.js
@@ -15734,6 +15734,12 @@ function isDirectBaiduSearchUrl(url) {
   return host === 'news.baidu.com' && /^\/ns(?:\/|$)/.test(path);
 }
 
+function isBaiduTiebaUrl(url) {
+  const parts = adapterUrlParts(url);
+  if (!parts) return false;
+  return normalizedHostname(parts.parsed.hostname) === 'tieba.baidu.com';
+}
+
 function isBaiduSearchUrl(url) {
   if (isDirectBaiduSearchUrl(url)) return true;
   let parts;
@@ -16138,6 +16144,17 @@ const ADAPTERS = [
 - Use image or video cards only after opening the source page or detail view; thumbnails, captions, and neighboring card text can be mismatched or truncated, and lazy-loaded card indices are not stable after scrolling.
 - Read-only web search and result opening do not require sign-in. If "登录" or "扫码登录" appears, ask the user to authenticate only for an explicitly requested account feature; do not block ordinary search, loop on the dialog, or claim that login is required for public results.
 - If wappass.baidu.com/static/captcha shows "百度安全验证", stop and ask the user to complete it manually. After completion, continue the encoded backurl and re-read the results; do not bypass the challenge, discard the query, or loop on the search URL.`,
+  },
+  {
+    name: 'baidu-tieba',
+    category: 'general',
+    matches: isBaiduTiebaUrl,
+    notes: `
+- Tieba thread pages use a custom Vue action bar. On the first floor, the share, reply, like, and collect actions are icon-plus-count elements rather than native buttons; use the accessibility tree or interactive-element list and prefer the named "点赞" control over screenshot coordinates.
+- Reply-level likes are separate "赞" controls in each comment row. Re-read the active post or comment container after scrolling, switching "只看楼主", or changing 热门/正序/倒序; indices and visible rows can change.
+- "点赞", "关注", "回复", and "发贴" change account or public state. Perform them only when explicitly requested, then verify the icon/count or resulting state; a successful mouse dispatch alone is not proof.
+- The first-floor action bar may be below the initial viewport, while images open a viewer when clicked. Do not click nearby image coordinates or repeat a coordinate after an unexpected viewer opens; close or go back, then re-read the page.
+- Public pages may require Baidu sign-in. If "登录", QR verification, or "百度安全验证" appears, stop for the user and do not bypass, retry, or claim that the requested action succeeded.`,
   },
   {
     name: 'slack',

--- a/src/firefox/src/agent/adapters.js
+++ b/src/firefox/src/agent/adapters.js
@@ -16152,7 +16152,7 @@ const ADAPTERS = [
     notes: `
 - Tieba thread pages use a custom Vue action bar. On the first floor, the share, reply, like, and collect actions are icon-plus-count elements rather than native buttons; use the accessibility tree or interactive-element list and prefer the named "点赞" control over screenshot coordinates.
 - Reply-level likes are separate "赞" controls in each comment row. Re-read the active post or comment container after scrolling, switching "只看楼主", or changing 热门/正序/倒序; indices and visible rows can change.
-- "点赞", "关注", "回复", and "发贴" change account or public state. Perform them only when explicitly requested, then verify the icon/count or resulting state; a successful mouse dispatch alone is not proof.
+- "点赞", "关注", "回复", and "发帖" change account or public state. Perform them only when explicitly requested, then verify the icon/count or resulting state; a successful mouse dispatch alone is not proof.
 - The first-floor action bar may be below the initial viewport, while images open a viewer when clicked. Do not click nearby image coordinates or repeat a coordinate after an unexpected viewer opens; close or go back, then re-read the page.
 - Public pages may require Baidu sign-in. If "登录", QR verification, or "百度安全验证" appears, stop for the user and do not bypass, retry, or claim that the requested action succeeded.`,
   },

--- a/src/firefox/src/agent/adapters.js
+++ b/src/firefox/src/agent/adapters.js
@@ -15734,10 +15734,32 @@ function isDirectBaiduSearchUrl(url) {
   return host === 'news.baidu.com' && /^\/ns(?:\/|$)/.test(path);
 }
 
+function isDirectBaiduTiebaUrl(url) {
+  let parts;
+  try {
+    parts = adapterUrlParts(url);
+  } catch (e) {
+    return false;
+  }
+  return Boolean(parts) && normalizedHostname(parts.parsed.hostname) === 'tieba.baidu.com';
+}
+
 function isBaiduTiebaUrl(url) {
-  const parts = adapterUrlParts(url);
+  if (isDirectBaiduTiebaUrl(url)) return true;
+  let parts;
+  try {
+    parts = adapterUrlParts(url);
+  } catch (e) {
+    return false;
+  }
   if (!parts) return false;
-  return normalizedHostname(parts.parsed.hostname) === 'tieba.baidu.com';
+  const host = parts.parsed.hostname.toLowerCase();
+  if (host !== 'passport.baidu.com' && host !== 'wappass.baidu.com') return false;
+  const targets = [];
+  for (const param of ['backurl', 'u']) {
+    targets.push(...parts.parsed.searchParams.getAll(param));
+  }
+  return targets.length > 0 && targets.every(isDirectBaiduTiebaUrl);
 }
 
 function isBaiduSearchUrl(url) {

--- a/src/firefox/src/content/accessibility-tree.js
+++ b/src/firefox/src/content/accessibility-tree.js
@@ -158,8 +158,16 @@
     baiduTieba: [
       // Match the stable action wrapper, then inspect SVG href/xlink:href via
       // the DOM API because namespaced attribute selectors vary by engine.
+      ['.pc-pb-first-floor-interactive .action-item', '转发', '#share_pb'],
       ['.pc-pb-first-floor-interactive .action-item', '点赞', '#agree_pb'],
+      ['.pc-pb-first-floor-interactive .action-item', '收藏', '#collect'],
+      ['.pc-pb-first-floor-interactive .more-action', '更多', '#ellipsis'],
       ['.pc-pb-comments-desc .zan-container-dark', '赞', '#agree_comment'],
+      ['.pc-pb-comments-desc .reply-container', '回复', '#comment_comment'],
+      ['.pc-pb-comments-desc .more-action', '更多', '#ellipsis_comment'],
+      ['.follow-person-btn', '关注楼主'],
+      ['.follow-forum-btn', '关注本吧'],
+      ['.pc-pb-reply-box', '回复'],
     ],
   };
 

--- a/src/firefox/src/content/accessibility-tree.js
+++ b/src/firefox/src/content/accessibility-tree.js
@@ -155,6 +155,10 @@
       ['.publish-btn', '发布'],
       ['.publish-button', '发布'],
     ],
+    baiduTieba: [
+      ['.pc-pb-first-floor-interactive .action-item:has(use[*|href="#agree_pb"])', '点赞'],
+      ['.pc-pb-comments-desc .zan-container-dark:has(use[*|href="#agree_comment"])', '赞'],
+    ],
   };
 
   function currentSiteInteractionConfig() {
@@ -162,6 +166,7 @@
     const onHost = (domain) => hostname === domain || hostname.endsWith(`.${domain}`);
     if (onHost('bilibili.com')) return { key: 'bilibili', rules: SITE_INTERACTION_RULES.bilibili };
     if (onHost('xiaohongshu.com')) return { key: 'xiaohongshu', rules: SITE_INTERACTION_RULES.xiaohongshu };
+    if (onHost('tieba.baidu.com')) return { key: 'baiduTieba', rules: SITE_INTERACTION_RULES.baiduTieba };
     // LinkedIn's interop shell renders major surfaces (the post composer
     // dialog among them) inside the open #interop-outlet shadow root. No
     // custom interaction rules needed — piercing alone makes the dialog's

--- a/src/firefox/src/content/accessibility-tree.js
+++ b/src/firefox/src/content/accessibility-tree.js
@@ -156,8 +156,10 @@
       ['.publish-button', '发布'],
     ],
     baiduTieba: [
-      ['.pc-pb-first-floor-interactive .action-item:has(use[*|href="#agree_pb"])', '点赞'],
-      ['.pc-pb-comments-desc .zan-container-dark:has(use[*|href="#agree_comment"])', '赞'],
+      // Match the stable action wrapper, then inspect SVG href/xlink:href via
+      // the DOM API because namespaced attribute selectors vary by engine.
+      ['.pc-pb-first-floor-interactive .action-item', '点赞', '#agree_pb'],
+      ['.pc-pb-comments-desc .zan-container-dark', '赞', '#agree_comment'],
     ],
   };
 
@@ -177,11 +179,18 @@
 
   function getSiteInteractionDescriptor(el) {
     if (!el || typeof el.matches !== 'function') return null;
-    for (const [selector, label] of currentSiteInteractionConfig().rules) {
+    for (const [selector, label, iconHref] of currentSiteInteractionConfig().rules) {
       try {
         if (!el.matches(selector)) continue;
       } catch {
         continue;
+      }
+      if (iconHref) {
+        const hasIcon = Array.from(el.querySelectorAll?.('use') || []).some(use => (
+          use.getAttribute('href') === iconHref
+          || use.getAttribute('xlink:href') === iconHref
+        ));
+        if (!hasIcon) continue;
       }
       const explicit = String(
         el.getAttribute('aria-label') || el.getAttribute('title') || ''

--- a/src/firefox/src/content/accessibility-tree.js
+++ b/src/firefox/src/content/accessibility-tree.js
@@ -168,6 +168,7 @@
       ['.follow-person-btn', '关注楼主'],
       ['.follow-forum-btn', '关注本吧'],
       ['.pc-pb-reply-box', '回复'],
+      ['.pc-pb-reply-box .publish-btn', '发布'],
     ],
   };
 

--- a/src/firefox/src/content/content.js
+++ b/src/firefox/src/content/content.js
@@ -481,6 +481,18 @@
     }
   }
 
+  function _isSiteSelectorCandidate(el) {
+    try {
+      return _siteInteractiveSelectors().some(selector => el.matches(selector));
+    } catch {
+      return false;
+    }
+  }
+
+  function _isUsableSiteInteractive(el) {
+    return !_isSiteSelectorCandidate(el) || _isSiteInteractive(el);
+  }
+
   function _composedParent(node) {
     if (!node) return null;
     if (node.assignedSlot) return node.assignedSlot;
@@ -718,6 +730,7 @@
     const out = [];
     for (const el of all) {
       if (!isVisiblyInteractive(el)) continue;
+      if (!_isUsableSiteInteractive(el)) continue;
       if (modal && !_isComposedAncestor(modal, el)) continue;
       out.push(el);
     }
@@ -843,6 +856,7 @@
         try {
           root.querySelectorAll(sel).forEach(el => {
             if (seen.has(el)) return;
+            if (!_isUsableSiteInteractive(el)) return;
             const rect = el.getBoundingClientRect();
             if (!isUsable(el, rect)) return;
             seen.add(el);

--- a/src/firefox/src/content/content.js
+++ b/src/firefox/src/content/content.js
@@ -489,8 +489,16 @@
     }
   }
 
+  function _isStandardInteractive(el) {
+    try {
+      return INTERACTIVE_SELECTORS.some(selector => el.matches(selector));
+    } catch {
+      return false;
+    }
+  }
+
   function _isUsableSiteInteractive(el) {
-    return !_isSiteSelectorCandidate(el) || _isSiteInteractive(el);
+    return _isStandardInteractive(el) || !_isSiteSelectorCandidate(el) || _isSiteInteractive(el);
   }
 
   function _composedParent(node) {

--- a/test/run.js
+++ b/test/run.js
@@ -4633,22 +4633,28 @@ test('matches Baidu Tieba and exposes custom post like controls', () => {
   assert.equal(axChrome, axFirefox, 'Tieba accessibility shims must remain byte-identical');
   const start = axChrome.indexOf('const SITE_INTERACTION_RULES = {');
   const end = axChrome.indexOf('\n\n  function getRole(el) {', start);
+  assert.ok(start >= 0 && end > start, 'Tieba site interaction helper slice must have valid bounds');
+  assert.doesNotMatch(axChrome, /\*\|href/, 'Tieba selectors must not rely on namespace wildcard syntax');
   const location = { hostname: 'tieba.baidu.com' };
   const context = { window: {}, location };
   vm.runInNewContext(axChrome.slice(start, end), context);
   const api = context.window.__wbSiteInteractions;
-  const likeSelector = '.pc-pb-first-floor-interactive .action-item:has(use[*|href="#agree_pb"])';
-  const replyLikeSelector = '.pc-pb-comments-desc .zan-container-dark:has(use[*|href="#agree_comment"])';
-  const fakeElement = (selector, text) => ({
+  const likeSelector = '.pc-pb-first-floor-interactive .action-item';
+  const replyLikeSelector = '.pc-pb-comments-desc .zan-container-dark';
+  const fakeElement = (selector, text, iconHref) => ({
     innerText: text,
     textContent: text,
     matches: candidate => candidate === selector,
+    querySelectorAll: candidate => candidate === 'use'
+      ? [{ getAttribute: name => ['href', 'xlink:href'].includes(name) ? iconHref : null }]
+      : [],
     getAttribute: () => null,
   });
   assert.ok(api.selectors().includes(likeSelector));
   assert.ok(api.selectors().includes(replyLikeSelector));
-  assert.equal(api.describe(fakeElement(likeSelector, '98')).name, '点赞 98');
-  assert.equal(api.describe(fakeElement(replyLikeSelector, '21')).name, '赞 21');
+  assert.equal(api.describe(fakeElement(likeSelector, '98', '#agree_pb')).name, '点赞 98');
+  assert.equal(api.describe(fakeElement(replyLikeSelector, '21', '#agree_comment')).name, '赞 21');
+  assert.equal(api.describe(fakeElement(likeSelector, '37', '#comment_pb')), null);
   assert.equal(api.shouldPierceShadowRoots(), false);
 
   for (const [label, rel] of [
@@ -4658,12 +4664,14 @@ test('matches Baidu Tieba and exposes custom post like controls', () => {
     const content = fs.readFileSync(path.join(ROOT, rel), 'utf8');
     assert.match(content, /\.\.\._siteInteractiveSelectors\(\)/, `${label}: Tieba selectors must reach content discovery`);
     assert.match(content, /if \(_isSiteInteractive\(node\)\) return true/, `${label}: Tieba controls must be interactive`);
+    assert.match(content, /_isUsableSiteInteractive\(el\)/, `${label}: broad Tieba selectors must filter non-like action wrappers`);
   }
 
   const cdp = fs.readFileSync(path.join(ROOT, 'src/chrome/src/cdp/cdp-client.js'), 'utf8');
   assert.match(cdp, /onHost\('tieba\.baidu\.com'\)/);
   assert.match(cdp, /agree_pb/);
   assert.match(cdp, /agree_comment/);
+  assert.match(cdp, /matchesAnySiteSelector\(el\)[\s\S]*matchesSiteRule\(el, rule\)/);
 });
 
 test('matches twitter.com and x.com', () => {

--- a/test/run.js
+++ b/test/run.js
@@ -4601,6 +4601,71 @@ test('matches Baidu search surfaces without hijacking other Baidu products', () 
   assert.equal(firefoxAdapter?.notes, adapter?.notes);
 });
 
+test('matches Baidu Tieba and exposes custom post like controls', () => {
+  const trustedUrls = [
+    'https://tieba.baidu.com/',
+    'https://tieba.baidu.com/f?kw=python',
+    'https://tieba.baidu.com/p/11007201094?mo_device=1',
+    'https://tieba.baidu.com/mo/q/forum?kw=Python&page=1',
+  ];
+  for (const url of trustedUrls) {
+    assert.equal(getActiveAdapter(url)?.name, 'baidu-tieba');
+    assert.equal(getActiveAdapterFx(url)?.name, 'baidu-tieba');
+  }
+
+  for (const url of [
+    'https://tieba.baidu.com.evil.example/p/11007201094',
+    'https://www.baidu.com/p/11007201094',
+    'https://example.com/?next=https://tieba.baidu.com/p/11007201094',
+  ]) {
+    assert.notEqual(getActiveAdapter(url)?.name, 'baidu-tieba');
+    assert.notEqual(getActiveAdapterFx(url)?.name, 'baidu-tieba');
+  }
+
+  const adapter = getActiveAdapter('https://tieba.baidu.com/p/11007201094?mo_device=1');
+  assert.match(adapter?.notes || '', /custom Vue action bar/);
+  assert.match(adapter?.notes || '', /named "点赞" control/);
+  assert.match(adapter?.notes || '', /百度安全验证/);
+  assert.equal(getActiveAdapterFx('https://tieba.baidu.com/p/11007201094')?.notes, adapter?.notes);
+
+  const axChrome = fs.readFileSync(path.join(ROOT, 'src/chrome/src/content/accessibility-tree.js'), 'utf8');
+  const axFirefox = fs.readFileSync(path.join(ROOT, 'src/firefox/src/content/accessibility-tree.js'), 'utf8');
+  assert.equal(axChrome, axFirefox, 'Tieba accessibility shims must remain byte-identical');
+  const start = axChrome.indexOf('const SITE_INTERACTION_RULES = {');
+  const end = axChrome.indexOf('\n\n  function getRole(el) {', start);
+  const location = { hostname: 'tieba.baidu.com' };
+  const context = { window: {}, location };
+  vm.runInNewContext(axChrome.slice(start, end), context);
+  const api = context.window.__wbSiteInteractions;
+  const likeSelector = '.pc-pb-first-floor-interactive .action-item:has(use[*|href="#agree_pb"])';
+  const replyLikeSelector = '.pc-pb-comments-desc .zan-container-dark:has(use[*|href="#agree_comment"])';
+  const fakeElement = (selector, text) => ({
+    innerText: text,
+    textContent: text,
+    matches: candidate => candidate === selector,
+    getAttribute: () => null,
+  });
+  assert.ok(api.selectors().includes(likeSelector));
+  assert.ok(api.selectors().includes(replyLikeSelector));
+  assert.equal(api.describe(fakeElement(likeSelector, '98')).name, '点赞 98');
+  assert.equal(api.describe(fakeElement(replyLikeSelector, '21')).name, '赞 21');
+  assert.equal(api.shouldPierceShadowRoots(), false);
+
+  for (const [label, rel] of [
+    ['chrome', 'src/chrome/src/content/content.js'],
+    ['firefox', 'src/firefox/src/content/content.js'],
+  ]) {
+    const content = fs.readFileSync(path.join(ROOT, rel), 'utf8');
+    assert.match(content, /\.\.\._siteInteractiveSelectors\(\)/, `${label}: Tieba selectors must reach content discovery`);
+    assert.match(content, /if \(_isSiteInteractive\(node\)\) return true/, `${label}: Tieba controls must be interactive`);
+  }
+
+  const cdp = fs.readFileSync(path.join(ROOT, 'src/chrome/src/cdp/cdp-client.js'), 'utf8');
+  assert.match(cdp, /onHost\('tieba\.baidu\.com'\)/);
+  assert.match(cdp, /agree_pb/);
+  assert.match(cdp, /agree_comment/);
+});
+
 test('matches twitter.com and x.com', () => {
   assert.equal(getActiveAdapter('https://twitter.com/elonmusk')?.name, 'twitter');
   assert.equal(getActiveAdapter('https://x.com/elonmusk')?.name, 'twitter');

--- a/test/run.js
+++ b/test/run.js
@@ -4607,6 +4607,9 @@ test('matches Baidu Tieba and exposes custom post like controls', () => {
     'https://tieba.baidu.com/f?kw=python',
     'https://tieba.baidu.com/p/11007201094?mo_device=1',
     'https://tieba.baidu.com/mo/q/forum?kw=Python&page=1',
+    'https://wappass.baidu.com/passport/?login&tpl=tb&u=https%3A%2F%2Ftieba.baidu.com%2F',
+    'https://passport.baidu.com/v2/?login&backurl=https%3A%2F%2Ftieba.baidu.com%2Fp%2F11007201094',
+    'https://wappass.baidu.com/static/captcha/tuxing_v2.html?backurl=https%3A%2F%2Ftieba.baidu.com%2F&u=https%3A%2F%2Ftieba.baidu.com%2Ff%3Fkw%3Dpython',
   ];
   for (const url of trustedUrls) {
     assert.equal(getActiveAdapter(url)?.name, 'baidu-tieba');
@@ -4617,6 +4620,9 @@ test('matches Baidu Tieba and exposes custom post like controls', () => {
     'https://tieba.baidu.com.evil.example/p/11007201094',
     'https://www.baidu.com/p/11007201094',
     'https://example.com/?next=https://tieba.baidu.com/p/11007201094',
+    'https://passport.baidu.com/v2/?login',
+    'https://passport.baidu.com/v2/?login&u=https%3A%2F%2Ftieba.baidu.com.evil.example%2F',
+    'https://wappass.baidu.com/passport/?backurl=https%3A%2F%2Ftieba.baidu.com%2F&u=https%3A%2F%2Fmap.baidu.com%2F',
   ]) {
     assert.notEqual(getActiveAdapter(url)?.name, 'baidu-tieba');
     assert.notEqual(getActiveAdapterFx(url)?.name, 'baidu-tieba');

--- a/test/run.js
+++ b/test/run.js
@@ -4601,7 +4601,7 @@ test('matches Baidu search surfaces without hijacking other Baidu products', () 
   assert.equal(firefoxAdapter?.notes, adapter?.notes);
 });
 
-test('matches Baidu Tieba and exposes custom post like controls', () => {
+test('matches Baidu Tieba and exposes custom post and reply controls', () => {
   const trustedUrls = [
     'https://tieba.baidu.com/',
     'https://tieba.baidu.com/f?kw=python',
@@ -4630,7 +4630,8 @@ test('matches Baidu Tieba and exposes custom post like controls', () => {
 
   const adapter = getActiveAdapter('https://tieba.baidu.com/p/11007201094?mo_device=1');
   assert.match(adapter?.notes || '', /custom Vue action bar/);
-  assert.match(adapter?.notes || '', /named "点赞" control/);
+  assert.match(adapter?.notes || '', /semantic controls/);
+  assert.match(adapter?.notes || '', /转发.*点赞.*收藏/s);
   assert.match(adapter?.notes || '', /百度安全验证/);
   assert.equal(getActiveAdapterFx('https://tieba.baidu.com/p/11007201094')?.notes, adapter?.notes);
 
@@ -4645,8 +4646,14 @@ test('matches Baidu Tieba and exposes custom post like controls', () => {
   const context = { window: {}, location };
   vm.runInNewContext(axChrome.slice(start, end), context);
   const api = context.window.__wbSiteInteractions;
-  const likeSelector = '.pc-pb-first-floor-interactive .action-item';
+  const firstFloorSelector = '.pc-pb-first-floor-interactive .action-item';
+  const firstFloorMoreSelector = '.pc-pb-first-floor-interactive .more-action';
   const replyLikeSelector = '.pc-pb-comments-desc .zan-container-dark';
+  const replySelector = '.pc-pb-comments-desc .reply-container';
+  const replyMoreSelector = '.pc-pb-comments-desc .more-action';
+  const followPersonSelector = '.follow-person-btn';
+  const followForumSelector = '.follow-forum-btn';
+  const replyBoxSelector = '.pc-pb-reply-box';
   const fakeElement = (selector, text, iconHref) => ({
     innerText: text,
     textContent: text,
@@ -4656,11 +4663,25 @@ test('matches Baidu Tieba and exposes custom post like controls', () => {
       : [],
     getAttribute: () => null,
   });
-  assert.ok(api.selectors().includes(likeSelector));
+  assert.ok(api.selectors().includes(firstFloorSelector));
+  assert.ok(api.selectors().includes(firstFloorMoreSelector));
   assert.ok(api.selectors().includes(replyLikeSelector));
-  assert.equal(api.describe(fakeElement(likeSelector, '98', '#agree_pb')).name, '点赞 98');
+  assert.ok(api.selectors().includes(replySelector));
+  assert.ok(api.selectors().includes(replyMoreSelector));
+  assert.ok(api.selectors().includes(followPersonSelector));
+  assert.ok(api.selectors().includes(followForumSelector));
+  assert.ok(api.selectors().includes(replyBoxSelector));
+  assert.equal(api.describe(fakeElement(firstFloorSelector, '转发', '#share_pb')).name, '转发');
+  assert.equal(api.describe(fakeElement(firstFloorSelector, '98', '#agree_pb')).name, '点赞 98');
+  assert.equal(api.describe(fakeElement(firstFloorSelector, '5', '#collect')).name, '收藏 5');
+  assert.equal(api.describe(fakeElement(firstFloorMoreSelector, '', '#ellipsis')).name, '更多');
   assert.equal(api.describe(fakeElement(replyLikeSelector, '21', '#agree_comment')).name, '赞 21');
-  assert.equal(api.describe(fakeElement(likeSelector, '37', '#comment_pb')), null);
+  assert.equal(api.describe(fakeElement(replySelector, '回复', '#comment_comment')).name, '回复');
+  assert.equal(api.describe(fakeElement(replyMoreSelector, '', '#ellipsis_comment')).name, '更多');
+  assert.equal(api.describe(fakeElement(followPersonSelector, '关注楼主')).name, '关注楼主');
+  assert.equal(api.describe(fakeElement(followForumSelector, '关注本吧')).name, '关注本吧');
+  assert.equal(api.describe(fakeElement(replyBoxSelector, '想说点啥？')).name, '回复 想说点啥？');
+  assert.equal(api.describe(fakeElement(firstFloorSelector, '14', '#comment_pb')), null);
   assert.equal(api.shouldPierceShadowRoots(), false);
 
   for (const [label, rel] of [
@@ -4675,7 +4696,10 @@ test('matches Baidu Tieba and exposes custom post like controls', () => {
 
   const cdp = fs.readFileSync(path.join(ROOT, 'src/chrome/src/cdp/cdp-client.js'), 'utf8');
   assert.match(cdp, /onHost\('tieba\.baidu\.com'\)/);
+  assert.match(cdp, /share_pb/);
   assert.match(cdp, /agree_pb/);
+  assert.match(cdp, /collect/);
+  assert.match(cdp, /comment_comment/);
   assert.match(cdp, /agree_comment/);
   assert.match(cdp, /matchesAnySiteSelector\(el\)[\s\S]*matchesSiteRule\(el, rule\)/);
 });

--- a/test/run.js
+++ b/test/run.js
@@ -4654,6 +4654,7 @@ test('matches Baidu Tieba and exposes custom post and reply controls', () => {
   const followPersonSelector = '.follow-person-btn';
   const followForumSelector = '.follow-forum-btn';
   const replyBoxSelector = '.pc-pb-reply-box';
+  const publishSelector = '.pc-pb-reply-box .publish-btn';
   const fakeElement = (selector, text, iconHref) => ({
     innerText: text,
     textContent: text,
@@ -4671,6 +4672,7 @@ test('matches Baidu Tieba and exposes custom post and reply controls', () => {
   assert.ok(api.selectors().includes(followPersonSelector));
   assert.ok(api.selectors().includes(followForumSelector));
   assert.ok(api.selectors().includes(replyBoxSelector));
+  assert.ok(api.selectors().includes(publishSelector));
   assert.equal(api.describe(fakeElement(firstFloorSelector, '转发', '#share_pb')).name, '转发');
   assert.equal(api.describe(fakeElement(firstFloorSelector, '98', '#agree_pb')).name, '点赞 98');
   assert.equal(api.describe(fakeElement(firstFloorSelector, '5', '#collect')).name, '收藏 5');
@@ -4681,6 +4683,7 @@ test('matches Baidu Tieba and exposes custom post and reply controls', () => {
   assert.equal(api.describe(fakeElement(followPersonSelector, '关注楼主')).name, '关注楼主');
   assert.equal(api.describe(fakeElement(followForumSelector, '关注本吧')).name, '关注本吧');
   assert.equal(api.describe(fakeElement(replyBoxSelector, '想说点啥？')).name, '回复 想说点啥？');
+  assert.equal(api.describe(fakeElement(publishSelector, '发布')).name, '发布');
   assert.equal(api.describe(fakeElement(firstFloorSelector, '14', '#comment_pb')), null);
   assert.equal(api.shouldPierceShadowRoots(), false);
 
@@ -4700,6 +4703,7 @@ test('matches Baidu Tieba and exposes custom post and reply controls', () => {
   assert.match(cdp, /agree_pb/);
   assert.match(cdp, /collect/);
   assert.match(cdp, /comment_comment/);
+  assert.match(cdp, /publish-btn.*发布/);
   assert.match(cdp, /agree_comment/);
   assert.match(cdp, /matchesAnySiteSelector\(el\)[\s\S]*matchesSiteRule\(el, rule\)/);
 });

--- a/test/run.js
+++ b/test/run.js
@@ -4695,6 +4695,26 @@ test('matches Baidu Tieba and exposes custom post and reply controls', () => {
     assert.match(content, /\.\.\._siteInteractiveSelectors\(\)/, `${label}: Tieba selectors must reach content discovery`);
     assert.match(content, /if \(_isSiteInteractive\(node\)\) return true/, `${label}: Tieba controls must be interactive`);
     assert.match(content, /_isUsableSiteInteractive\(el\)/, `${label}: broad Tieba selectors must filter non-like action wrappers`);
+    const filterStart = content.indexOf('  const INTERACTIVE_SELECTORS = [');
+    const filterEnd = content.indexOf('\n\n  function _composedParent', filterStart);
+    assert.ok(filterStart >= 0 && filterEnd > filterStart, `${label}: site-interaction filter slice must have valid bounds`);
+    const filterContext = {
+      window: {
+        __wbSiteInteractions: {
+          selectors: () => [firstFloorSelector],
+          isInteractive: el => el.siteInteractive === true,
+        },
+      },
+    };
+    vm.runInNewContext(`${content.slice(filterStart, filterEnd)}\nthis.isUsableSiteInteractive = _isUsableSiteInteractive;`, filterContext);
+    const candidate = ({ nativeSelector = '', siteInteractive = false } = {}) => ({
+      siteInteractive,
+      matches: selector => selector === firstFloorSelector || selector === nativeSelector,
+    });
+    assert.equal(filterContext.isUsableSiteInteractive(candidate({ siteInteractive: true })), true, `${label}: valid custom actions must remain discoverable`);
+    assert.equal(filterContext.isUsableSiteInteractive(candidate()), false, `${label}: non-interactive broad-selector wrappers must remain filtered`);
+    assert.equal(filterContext.isUsableSiteInteractive(candidate({ nativeSelector: 'a[href]' })), true, `${label}: native links must survive broad site-rule filtering`);
+    assert.equal(filterContext.isUsableSiteInteractive(candidate({ nativeSelector: '[role="button"]' })), true, `${label}: ARIA controls must survive broad site-rule filtering`);
   }
 
   const cdp = fs.readFileSync(path.join(ROOT, 'src/chrome/src/cdp/cdp-client.js'), 'utf8');
@@ -4705,7 +4725,8 @@ test('matches Baidu Tieba and exposes custom post and reply controls', () => {
   assert.match(cdp, /comment_comment/);
   assert.match(cdp, /publish-btn.*发布/);
   assert.match(cdp, /agree_comment/);
-  assert.match(cdp, /matchesAnySiteSelector\(el\)[\s\S]*matchesSiteRule\(el, rule\)/);
+  assert.match(cdp, /NATIVE_SELECTORS[\s\S]*matchesNativeInteractive\(el\)/);
+  assert.match(cdp, /!matchesNativeInteractive\(el\)[\s\S]*matchesAnySiteSelector\(el\)[\s\S]*matchesSiteRule\(el, rule\)/);
 });
 
 test('matches twitter.com and x.com', () => {


### PR DESCRIPTION
## Changes

- Add a hostname-scoped Baidu Tieba adapter for the custom Vue action surfaces.
- Expose first-floor `转发`, `点赞`, `收藏`, and `更多` controls using the stable action wrapper plus DOM-level SVG icon matching (`#share_pb`, `#agree_pb`, `#collect`, `#ellipsis`).
- Expose reply-row `赞`, `回复`, and `更多` controls (`#agree_comment`, `#comment_comment`, `#ellipsis_comment`), plus `关注楼主`, `关注本吧`, and the reply entry surface.
- Expose the Quill reply editor's independent `.publish-btn` as the semantic `发布` control. This fixes the previous failure where the whole reply container was exposed as `回复 test 发布` and coordinate clicks hit the textbox/container instead of the submit button.
- Keep Chrome accessibility tree, Chrome CDP discovery, Firefox accessibility tree, adapter notes, and regression coverage aligned.

## Maintainer follow-up included

The branch includes maintainer commit `2777bb2b`, which restricts Tieba adapter matching on Baidu passport/wappass login and CAPTCHA handoffs to encoded `u`/`backurl` targets that are all direct Tieba URLs, with Chrome/Firefox regression coverage.

## Automated validation

- `node test/run.js` — 2266 passed, 0 failed
- `git diff --check` — passed

## Manual Chrome validation

Validated with WebBrain v34.1.6 in a real logged-in Chrome session using the local OpenAI-compatible proxy:

- `webbrain-traces-1788894789533.md`: first-floor semantic discovery exposed `转发`, `点赞`, `收藏`, and `更多`; the subsequent screenshots showed the like and favorite states highlighted, including `收藏成功`.
- `webbrain-traces-1788896516595.md`: first-floor like/favorite/reply flow; like and favorite state changes were verified, and reply text `test` appeared in the thread after the reply count changed from 17 to 18.
- `webbrain-traces-1788897002870.md`: `click_ax` opened the first-floor share panel, which visibly contained WeChat/QQ QR sharing, Weibo sharing, and copy-link options. No external share was submitted.
- `webbrain-traces-1788895691232.md`: after the publish-control fix, `click_ax` targeted the independent publish control and the new reply `webbrain-publish-control-test` appeared under the original poster's floor; the attached screenshot shows the posted reply.

Firefox real-browser validation is still pending. The Vercel check requires authorization to the maintainer's team and is unrelated to the code changes.