### PR TITLE
fix(linkedin): allow verified contact info links

### DIFF
--- a/src/chrome/src/content/content.js
+++ b/src/chrome/src/content/content.js
@@ -5168,25 +5168,40 @@
       const verifiedLinkedInNavigation = (clicked) => {
         if (params.adapterName !== 'linkedin' || !clicked) return false;
         const link = clicked.closest?.('a[href]');
-        if (!link || !visible(link) || !link.closest?.('nav,[role="navigation"]')) return false;
+        if (!link || !visible(link)) return false;
         // A navigation-looking descendant of a composer/action is not a
         // navigation escape hatch. Keep actual sends and modal controls on
         // the existing recipient-verification path.
         if (clicked.closest?.('button,[role="button"],input,select,textarea,[contenteditable]:not([contenteditable="false"]),[onclick],[data-action]')
-            || link.closest?.('form,dialog,[role="dialog"],[role="alertdialog"]')
+            || link.closest?.('form')
             || link.hasAttribute?.('download')
             || (link.getAttribute?.('role') && link.getAttribute('role') !== 'link')) return false;
         try {
           const href = String(link.getAttribute('href') || '').trim();
           if (!href || href.startsWith('#')) return false;
           const destination = new URL(href, document.baseURI);
-          // Only the site's top-level navigation destinations are known not
-          // to send. Arbitrary action URLs and conversation controls stay
-          // inconclusive, even when their visible label says Home or Jobs.
-          return /^https?:$/.test(destination.protocol)
-            && destination.origin === location.origin
-            && /^(?:www\.)?linkedin\.com$/.test(destination.hostname)
-            && /^\/(?:feed|jobs|mynetwork|messaging|notifications)\/?$/.test(destination.pathname);
+          if (!/^https?:$/.test(destination.protocol)) return false;
+          const isLinkedInHost = (hostname) => /^(?:www\.)?linkedin\.com$/.test(hostname);
+          const linkedInDestination = isLinkedInHost(destination.hostname);
+          const redirectPath = /^\/(?:safety\/go|redir\/redirect)\/?$/.test(destination.pathname);
+          let verifiedExternalRedirect = false;
+          if (linkedInDestination && redirectPath) {
+            const redirectValue = destination.searchParams.get('url') || '';
+            try {
+              const redirectDestination = new URL(redirectValue);
+              verifiedExternalRedirect = /^https?:$/.test(redirectDestination.protocol)
+                && !isLinkedInHost(redirectDestination.hostname);
+            } catch {}
+          }
+          const modal = link.closest?.('dialog,[role="dialog"],[role="alertdialog"]');
+          if (modal) {
+            const contactInfoOverlay = /^\/in\/[^/]+\/overlay\/contact-info\/?$/.test(location.pathname);
+            if (!contactInfoOverlay || !verifiedExternalRedirect) return false;
+          }
+          if (!linkedInDestination) return true;
+          return verifiedExternalRedirect
+            || /^\/(?:feed|jobs|mynetwork|messaging|notifications)\/?$/.test(destination.pathname)
+            || /^\/in\/[^/]+\/overlay\/contact-info\/?$/.test(destination.pathname);
         } catch {
           return false;
         }

--- a/src/chrome/src/content/content.js
+++ b/src/chrome/src/content/content.js
@@ -5165,22 +5165,24 @@
           && railRect.right <= composerRect.left + 64;
       };
 
-      const verifiedLinkedInNavigation = (clicked) => {
-        if (params.adapterName !== 'linkedin' || !clicked) return false;
-        const link = clicked.closest?.('a[href]');
-        if (!link || !visible(link)) return false;
+      const classifyLinkedInNavigation = (clicked) => {
+        if (params.adapterName !== 'linkedin' || !clicked) return 'none';
+        const link = _composedClosestElement(clicked, 'a[href]');
+        if (!link || !visible(link)) return 'none';
         // A navigation-looking descendant of a composer/action is not a
         // navigation escape hatch. Keep actual sends and modal controls on
         // the existing recipient-verification path.
-        if (clicked.closest?.('button,[role="button"],input,select,textarea,[contenteditable]:not([contenteditable="false"]),[onclick],[data-action]')
-            || link.closest?.('form')
+        if (_composedClosestElement(clicked, 'button,[role="button"],input,select,textarea,[contenteditable]:not([contenteditable="false"]),[onclick],[data-action]')
+            || _composedClosestElement(link, 'form')
             || link.hasAttribute?.('download')
-            || (link.getAttribute?.('role') && link.getAttribute('role') !== 'link')) return false;
+            || (link.getAttribute?.('role') && link.getAttribute('role') !== 'link')) return 'blocked';
+        const modal = _composedClosestElement(link, 'dialog,[role="dialog"],[role="alertdialog"]');
+        const unresolved = () => modal ? 'blocked' : 'none';
         try {
           const href = String(link.getAttribute('href') || '').trim();
-          if (!href || href.startsWith('#')) return false;
+          if (!href || href.startsWith('#')) return unresolved();
           const destination = new URL(href, document.baseURI);
-          if (!/^https?:$/.test(destination.protocol)) return false;
+          if (!/^https?:$/.test(destination.protocol)) return unresolved();
           const isLinkedInHost = (hostname) => {
             const normalized = String(hostname || '').toLowerCase().replace(/\.$/, '');
             return normalized === 'linkedin.com' || normalized.endsWith('.linkedin.com');
@@ -5196,17 +5198,18 @@
                 && !isLinkedInHost(redirectDestination.hostname);
             } catch {}
           }
-          const modal = link.closest?.('dialog,[role="dialog"],[role="alertdialog"]');
           if (modal) {
             const contactInfoOverlay = /^\/in\/[^/]+\/overlay\/contact-info\/?$/.test(location.pathname);
-            if (!contactInfoOverlay || !verifiedExternalRedirect) return false;
+            if (!contactInfoOverlay || !verifiedExternalRedirect) return 'blocked';
           }
-          if (!linkedInDestination) return true;
-          return verifiedExternalRedirect
+          if (!linkedInDestination) return 'navigation';
+          return (verifiedExternalRedirect
             || /^\/(?:feed|jobs|mynetwork|messaging|notifications)\/?$/.test(destination.pathname)
-            || /^\/in\/[^/]+\/overlay\/contact-info\/?$/.test(destination.pathname);
+            || /^\/in\/[^/]+\/overlay\/contact-info\/?$/.test(destination.pathname))
+            ? 'navigation'
+            : 'none';
         } catch {
-          return false;
+          return unresolved();
         }
       };
 
@@ -5250,8 +5253,18 @@
         if (!visible(control) || (modal && !_isComposedAncestor(modal, target))) {
           return { success: true, messageSend: null, conclusive: false, identityCandidates: [] };
         }
-        if (verifiedLinkedInNavigation(target)) {
+        const linkedInNavigation = classifyLinkedInNavigation(target);
+        if (linkedInNavigation === 'navigation') {
           return { success: true, messageSend: false, conclusive: true, navigation: true, identityCandidates: [] };
+        }
+        if (linkedInNavigation === 'blocked') {
+          return {
+            success: true,
+            messageSend: null,
+            conclusive: false,
+            navigationBlocked: true,
+            identityCandidates: [],
+          };
         }
         composer = layoutComposer;
         if (!composer) {

--- a/src/chrome/src/content/content.js
+++ b/src/chrome/src/content/content.js
@@ -5176,9 +5176,14 @@
             || _composedClosestElement(link, 'form')
             || link.hasAttribute?.('download')
             || (link.getAttribute?.('role') && link.getAttribute('role') !== 'link')) return 'blocked';
-        const modal = blockingModal && _isComposedAncestor(blockingModal, link)
-          ? blockingModal
-          : _composedClosestElement(link, 'dialog,[role="dialog"],[role="alertdialog"]');
+        const composedModal = _composedClosestElement(
+          link,
+          'dialog,[role="dialog"],[role="alertdialog"],[data-overlay],.modal.show,.modal-overlay,.overlay,'
+            + '[class*="modal"][class*="open"],[class*="overlay"][class*="active"],'
+            + '[class*="DialogOverlay"],[class*="ModalOverlay"]',
+        );
+        const modal = composedModal
+          || (blockingModal && _isComposedAncestor(blockingModal, link) ? blockingModal : null);
         const unresolved = () => modal ? 'blocked' : 'none';
         try {
           const href = String(link.getAttribute('href') || '').trim();

--- a/src/chrome/src/content/content.js
+++ b/src/chrome/src/content/content.js
@@ -5176,7 +5176,7 @@
             || _composedClosestElement(link, 'form')
             || link.hasAttribute?.('download')
             || (link.getAttribute?.('role') && link.getAttribute('role') !== 'link')) return 'blocked';
-        const modal = _composedClosestElement(link, 'dialog,[role="dialog"],[role="alertdialog"]');
+        const modal = _composedClosestElement(link, 'dialog,[role="dialog"],[role="alertdialog"]') || _findTopmostBlockingModal();
         const unresolved = () => modal ? 'blocked' : 'none';
         try {
           const href = String(link.getAttribute('href') || '').trim();

--- a/src/chrome/src/content/content.js
+++ b/src/chrome/src/content/content.js
@@ -348,14 +348,23 @@
 
   function _someComposedDescendant(root, selector, predicate, limit = 2000) {
     const pending = [root];
+    const seen = new Set();
     let visited = 0;
     while (pending.length && visited < limit) {
       const scope = pending.shift();
-      const elements = scope?.querySelectorAll?.('*') || [];
+      const descendants = scope?.querySelectorAll?.('*') || [];
+      const elements = scope?.nodeType === Node.ELEMENT_NODE
+        ? [scope, ...descendants]
+        : descendants;
       for (const element of elements) {
+        if (seen.has(element)) continue;
+        seen.add(element);
         visited += 1;
         if (element.matches?.(selector) && predicate(element)) return true;
         if (element.shadowRoot) pending.push(element.shadowRoot);
+        if (element.tagName === 'SLOT') {
+          pending.push(...(element.assignedElements?.({ flatten: true }) || []));
+        }
         if (visited >= limit) break;
       }
     }

--- a/src/chrome/src/content/content.js
+++ b/src/chrome/src/content/content.js
@@ -5165,7 +5165,7 @@
           && railRect.right <= composerRect.left + 64;
       };
 
-      const classifyLinkedInNavigation = (clicked) => {
+      const classifyLinkedInNavigation = (clicked, blockingModal = null) => {
         if (params.adapterName !== 'linkedin' || !clicked) return 'none';
         const link = _composedClosestElement(clicked, 'a[href]');
         if (!link || !visible(link)) return 'none';
@@ -5176,7 +5176,9 @@
             || _composedClosestElement(link, 'form')
             || link.hasAttribute?.('download')
             || (link.getAttribute?.('role') && link.getAttribute('role') !== 'link')) return 'blocked';
-        const modal = _composedClosestElement(link, 'dialog,[role="dialog"],[role="alertdialog"]') || _findTopmostBlockingModal();
+        const modal = blockingModal && _isComposedAncestor(blockingModal, link)
+          ? blockingModal
+          : _composedClosestElement(link, 'dialog,[role="dialog"],[role="alertdialog"]');
         const unresolved = () => modal ? 'blocked' : 'none';
         try {
           const href = String(link.getAttribute('href') || '').trim();
@@ -5199,8 +5201,19 @@
             } catch {}
           }
           if (modal) {
-            const contactInfoOverlay = /^\/in\/[^/]+\/overlay\/contact-info\/?$/.test(location.pathname);
-            if (!contactInfoOverlay || !verifiedExternalRedirect) return 'blocked';
+            const contactInfoOverlay = /^\/in\/([^/]+)\/overlay\/contact-info\/?$/.exec(location.pathname);
+            const profilePath = contactInfoOverlay ? `/in/${contactInfoOverlay[1]}` : '';
+            const ownsContactInfoRoute = !!profilePath && Array.from(modal.querySelectorAll?.('a[href]') || [])
+              .some((candidate) => {
+                try {
+                  const candidateUrl = new URL(candidate.getAttribute('href'), document.baseURI);
+                  return isLinkedInHost(candidateUrl.hostname)
+                    && candidateUrl.pathname.replace(/\/+$/, '') === profilePath;
+                } catch {
+                  return false;
+                }
+              });
+            if (!ownsContactInfoRoute || !verifiedExternalRedirect) return 'blocked';
           }
           if (!linkedInDestination) return 'navigation';
           return (verifiedExternalRedirect
@@ -5253,7 +5266,7 @@
         if (!visible(control) || (modal && !_isComposedAncestor(modal, target))) {
           return { success: true, messageSend: null, conclusive: false, identityCandidates: [] };
         }
-        const linkedInNavigation = classifyLinkedInNavigation(target);
+        const linkedInNavigation = classifyLinkedInNavigation(target, modal);
         if (linkedInNavigation === 'navigation') {
           return { success: true, messageSend: false, conclusive: true, navigation: true, identityCandidates: [] };
         }

--- a/src/chrome/src/content/content.js
+++ b/src/chrome/src/content/content.js
@@ -5260,6 +5260,7 @@
           }
           if (!linkedInDestination) return 'navigation';
           if (redirectPath) return 'blocked';
+          if (/^\/messaging\/(?:send|compose)\/?$/.test(destination.pathname)) return 'blocked';
           return (/^\/(?:feed|jobs|mynetwork|messaging|notifications)\/?$/.test(destination.pathname)
             || /^\/in\/[^/]+\/overlay\/contact-info\/?$/.test(destination.pathname))
             ? 'navigation'

--- a/src/chrome/src/content/content.js
+++ b/src/chrome/src/content/content.js
@@ -5204,17 +5204,27 @@
         const heuristicModalSelector = '[data-overlay],.modal.show,.modal-overlay,.overlay,'
           + '[class*="modal"][class*="open"],[class*="overlay"][class*="active"],'
           + '[class*="DialogOverlay"],[class*="ModalOverlay"]';
+        const dialogContentSelector = '[class*="DialogContent"],[class*="ModalContent"]';
         const composedModal = _composedClosestElement(
           link,
-          `dialog,[role="dialog"],[role="alertdialog"],${heuristicModalSelector}`,
+          `dialog,[role="dialog"],[role="alertdialog"],${heuristicModalSelector},${dialogContentSelector}`,
         );
         const modal = composedModal
           || (blockingModal && _isComposedAncestor(blockingModal, link) ? blockingModal : null);
+        const contentHasVisibleOverlaySibling = (() => {
+          if (!modal?.matches?.(dialogContentSelector)) return false;
+          const parent = modal.parentElement || modal.parentNode;
+          if (!parent) return false;
+          return Array.from(parent.children).some((sibling) => sibling !== modal
+            && sibling.matches?.('[class*="DialogOverlay"],[class*="ModalOverlay"]')
+            && _hasVisibleBox(sibling, 100, 100));
+        })();
         const modalIsBlocking = !!modal && (
           modal === blockingModal
           || (modal.tagName === 'DIALOG' && modal.hasAttribute('open') && _isNativeBlockingDialog(modal))
           || (/^(?:dialog|alertdialog)$/.test(modal.getAttribute?.('role') || '')
             && modal.getAttribute?.('aria-modal') === 'true')
+          || contentHasVisibleOverlaySibling
           || (() => {
             if (!modal.matches?.(heuristicModalSelector)) return false;
             const rect = modal.getBoundingClientRect();

--- a/src/chrome/src/content/content.js
+++ b/src/chrome/src/content/content.js
@@ -5181,7 +5181,10 @@
           if (!href || href.startsWith('#')) return false;
           const destination = new URL(href, document.baseURI);
           if (!/^https?:$/.test(destination.protocol)) return false;
-          const isLinkedInHost = (hostname) => /^(?:www\.)?linkedin\.com$/.test(hostname);
+          const isLinkedInHost = (hostname) => {
+            const normalized = String(hostname || '').toLowerCase().replace(/\.$/, '');
+            return normalized === 'linkedin.com' || normalized.endsWith('.linkedin.com');
+          };
           const linkedInDestination = isLinkedInHost(destination.hostname);
           const redirectPath = /^\/(?:safety\/go|redir\/redirect)\/?$/.test(destination.pathname);
           let verifiedExternalRedirect = false;

--- a/src/chrome/src/content/content.js
+++ b/src/chrome/src/content/content.js
@@ -346,6 +346,22 @@
     return null;
   }
 
+  function _someComposedDescendant(root, selector, predicate, limit = 2000) {
+    const pending = [root];
+    let visited = 0;
+    while (pending.length && visited < limit) {
+      const scope = pending.shift();
+      const elements = scope?.querySelectorAll?.('*') || [];
+      for (const element of elements) {
+        visited += 1;
+        if (element.matches?.(selector) && predicate(element)) return true;
+        if (element.shadowRoot) pending.push(element.shadowRoot);
+        if (visited >= limit) break;
+      }
+    }
+    return false;
+  }
+
   function isVisiblyInteractive(el) {
     if (!el || el.tagName === 'BODY' || el.tagName === 'HTML') return false;
     // aria-hidden / inert subtrees are non-interactive for assistive tech
@@ -5176,14 +5192,26 @@
             || _composedClosestElement(link, 'form')
             || link.hasAttribute?.('download')
             || (link.getAttribute?.('role') && link.getAttribute('role') !== 'link')) return 'blocked';
+        const heuristicModalSelector = '[data-overlay],.modal.show,.modal-overlay,.overlay,'
+          + '[class*="modal"][class*="open"],[class*="overlay"][class*="active"],'
+          + '[class*="DialogOverlay"],[class*="ModalOverlay"]';
         const composedModal = _composedClosestElement(
           link,
-          'dialog,[role="dialog"],[role="alertdialog"],[data-overlay],.modal.show,.modal-overlay,.overlay,'
-            + '[class*="modal"][class*="open"],[class*="overlay"][class*="active"],'
-            + '[class*="DialogOverlay"],[class*="ModalOverlay"]',
+          `dialog,[role="dialog"],[role="alertdialog"],${heuristicModalSelector}`,
         );
         const modal = composedModal
           || (blockingModal && _isComposedAncestor(blockingModal, link) ? blockingModal : null);
+        const modalIsBlocking = !!modal && (
+          modal === blockingModal
+          || (modal.tagName === 'DIALOG' && modal.hasAttribute('open') && _isNativeBlockingDialog(modal))
+          || (/^(?:dialog|alertdialog)$/.test(modal.getAttribute?.('role') || '')
+            && modal.getAttribute?.('aria-modal') === 'true')
+          || (() => {
+            if (!modal.matches?.(heuristicModalSelector)) return false;
+            const rect = modal.getBoundingClientRect();
+            return rect.width > 100 && rect.height > 100;
+          })()
+        );
         const unresolved = () => modal ? 'blocked' : 'none';
         try {
           const href = String(link.getAttribute('href') || '').trim();
@@ -5208,8 +5236,8 @@
           if (modal) {
             const contactInfoOverlay = /^\/in\/([^/]+)\/overlay\/contact-info\/?$/.exec(location.pathname);
             const profilePath = contactInfoOverlay ? `/in/${contactInfoOverlay[1]}` : '';
-            const ownsContactInfoRoute = !!profilePath && Array.from(modal.querySelectorAll?.('a[href]') || [])
-              .some((candidate) => {
+            const ownsContactInfoRoute = modalIsBlocking && !!profilePath
+              && _someComposedDescendant(modal, 'a[href]', (candidate) => {
                 try {
                   const candidateUrl = new URL(candidate.getAttribute('href'), document.baseURI);
                   return isLinkedInHost(candidateUrl.hostname)
@@ -5219,10 +5247,11 @@
                 }
               });
             if (!ownsContactInfoRoute || !verifiedExternalRedirect) return 'blocked';
+            return 'navigation';
           }
           if (!linkedInDestination) return 'navigation';
-          return (verifiedExternalRedirect
-            || /^\/(?:feed|jobs|mynetwork|messaging|notifications)\/?$/.test(destination.pathname)
+          if (redirectPath) return 'blocked';
+          return (/^\/(?:feed|jobs|mynetwork|messaging|notifications)\/?$/.test(destination.pathname)
             || /^\/in\/[^/]+\/overlay\/contact-info\/?$/.test(destination.pathname))
             ? 'navigation'
             : 'none';

--- a/src/firefox/src/content/content.js
+++ b/src/firefox/src/content/content.js
@@ -4339,9 +4339,14 @@
             || _composedClosestElement(link, 'form')
             || link.hasAttribute?.('download')
             || (link.getAttribute?.('role') && link.getAttribute('role') !== 'link')) return 'blocked';
-        const modal = blockingModal && _isComposedAncestor(blockingModal, link)
-          ? blockingModal
-          : _composedClosestElement(link, 'dialog,[role="dialog"],[role="alertdialog"]');
+        const composedModal = _composedClosestElement(
+          link,
+          'dialog,[role="dialog"],[role="alertdialog"],[data-overlay],.modal.show,.modal-overlay,.overlay,'
+            + '[class*="modal"][class*="open"],[class*="overlay"][class*="active"],'
+            + '[class*="DialogOverlay"],[class*="ModalOverlay"]',
+        );
+        const modal = composedModal
+          || (blockingModal && _isComposedAncestor(blockingModal, link) ? blockingModal : null);
         const unresolved = () => modal ? 'blocked' : 'none';
         try {
           const href = String(link.getAttribute('href') || '').trim();

--- a/src/firefox/src/content/content.js
+++ b/src/firefox/src/content/content.js
@@ -4344,7 +4344,10 @@
           if (!href || href.startsWith('#')) return false;
           const destination = new URL(href, document.baseURI);
           if (!/^https?:$/.test(destination.protocol)) return false;
-          const isLinkedInHost = (hostname) => /^(?:www\.)?linkedin\.com$/.test(hostname);
+          const isLinkedInHost = (hostname) => {
+            const normalized = String(hostname || '').toLowerCase().replace(/\.$/, '');
+            return normalized === 'linkedin.com' || normalized.endsWith('.linkedin.com');
+          };
           const linkedInDestination = isLinkedInHost(destination.hostname);
           const redirectPath = /^\/(?:safety\/go|redir\/redirect)\/?$/.test(destination.pathname);
           let verifiedExternalRedirect = false;

--- a/src/firefox/src/content/content.js
+++ b/src/firefox/src/content/content.js
@@ -4331,25 +4331,40 @@
       const verifiedLinkedInNavigation = (clicked) => {
         if (params.adapterName !== 'linkedin' || !clicked) return false;
         const link = clicked.closest?.('a[href]');
-        if (!link || !visible(link) || !link.closest?.('nav,[role="navigation"]')) return false;
+        if (!link || !visible(link)) return false;
         // A navigation-looking descendant of a composer/action is not a
         // navigation escape hatch. Keep actual sends and modal controls on
         // the existing recipient-verification path.
         if (clicked.closest?.('button,[role="button"],input,select,textarea,[contenteditable]:not([contenteditable="false"]),[onclick],[data-action]')
-            || link.closest?.('form,dialog,[role="dialog"],[role="alertdialog"]')
+            || link.closest?.('form')
             || link.hasAttribute?.('download')
             || (link.getAttribute?.('role') && link.getAttribute('role') !== 'link')) return false;
         try {
           const href = String(link.getAttribute('href') || '').trim();
           if (!href || href.startsWith('#')) return false;
           const destination = new URL(href, document.baseURI);
-          // Only the site's top-level navigation destinations are known not
-          // to send. Arbitrary action URLs and conversation controls stay
-          // inconclusive, even when their visible label says Home or Jobs.
-          return /^https?:$/.test(destination.protocol)
-            && destination.origin === location.origin
-            && /^(?:www\.)?linkedin\.com$/.test(destination.hostname)
-            && /^\/(?:feed|jobs|mynetwork|messaging|notifications)\/?$/.test(destination.pathname);
+          if (!/^https?:$/.test(destination.protocol)) return false;
+          const isLinkedInHost = (hostname) => /^(?:www\.)?linkedin\.com$/.test(hostname);
+          const linkedInDestination = isLinkedInHost(destination.hostname);
+          const redirectPath = /^\/(?:safety\/go|redir\/redirect)\/?$/.test(destination.pathname);
+          let verifiedExternalRedirect = false;
+          if (linkedInDestination && redirectPath) {
+            const redirectValue = destination.searchParams.get('url') || '';
+            try {
+              const redirectDestination = new URL(redirectValue);
+              verifiedExternalRedirect = /^https?:$/.test(redirectDestination.protocol)
+                && !isLinkedInHost(redirectDestination.hostname);
+            } catch {}
+          }
+          const modal = link.closest?.('dialog,[role="dialog"],[role="alertdialog"]');
+          if (modal) {
+            const contactInfoOverlay = /^\/in\/[^/]+\/overlay\/contact-info\/?$/.test(location.pathname);
+            if (!contactInfoOverlay || !verifiedExternalRedirect) return false;
+          }
+          if (!linkedInDestination) return true;
+          return verifiedExternalRedirect
+            || /^\/(?:feed|jobs|mynetwork|messaging|notifications)\/?$/.test(destination.pathname)
+            || /^\/in\/[^/]+\/overlay\/contact-info\/?$/.test(destination.pathname);
         } catch {
           return false;
         }

--- a/src/firefox/src/content/content.js
+++ b/src/firefox/src/content/content.js
@@ -4328,22 +4328,24 @@
           && railRect.right <= composerRect.left + 64;
       };
 
-      const verifiedLinkedInNavigation = (clicked) => {
-        if (params.adapterName !== 'linkedin' || !clicked) return false;
-        const link = clicked.closest?.('a[href]');
-        if (!link || !visible(link)) return false;
+      const classifyLinkedInNavigation = (clicked) => {
+        if (params.adapterName !== 'linkedin' || !clicked) return 'none';
+        const link = _composedClosestElement(clicked, 'a[href]');
+        if (!link || !visible(link)) return 'none';
         // A navigation-looking descendant of a composer/action is not a
         // navigation escape hatch. Keep actual sends and modal controls on
         // the existing recipient-verification path.
-        if (clicked.closest?.('button,[role="button"],input,select,textarea,[contenteditable]:not([contenteditable="false"]),[onclick],[data-action]')
-            || link.closest?.('form')
+        if (_composedClosestElement(clicked, 'button,[role="button"],input,select,textarea,[contenteditable]:not([contenteditable="false"]),[onclick],[data-action]')
+            || _composedClosestElement(link, 'form')
             || link.hasAttribute?.('download')
-            || (link.getAttribute?.('role') && link.getAttribute('role') !== 'link')) return false;
+            || (link.getAttribute?.('role') && link.getAttribute('role') !== 'link')) return 'blocked';
+        const modal = _composedClosestElement(link, 'dialog,[role="dialog"],[role="alertdialog"]');
+        const unresolved = () => modal ? 'blocked' : 'none';
         try {
           const href = String(link.getAttribute('href') || '').trim();
-          if (!href || href.startsWith('#')) return false;
+          if (!href || href.startsWith('#')) return unresolved();
           const destination = new URL(href, document.baseURI);
-          if (!/^https?:$/.test(destination.protocol)) return false;
+          if (!/^https?:$/.test(destination.protocol)) return unresolved();
           const isLinkedInHost = (hostname) => {
             const normalized = String(hostname || '').toLowerCase().replace(/\.$/, '');
             return normalized === 'linkedin.com' || normalized.endsWith('.linkedin.com');
@@ -4359,17 +4361,18 @@
                 && !isLinkedInHost(redirectDestination.hostname);
             } catch {}
           }
-          const modal = link.closest?.('dialog,[role="dialog"],[role="alertdialog"]');
           if (modal) {
             const contactInfoOverlay = /^\/in\/[^/]+\/overlay\/contact-info\/?$/.test(location.pathname);
-            if (!contactInfoOverlay || !verifiedExternalRedirect) return false;
+            if (!contactInfoOverlay || !verifiedExternalRedirect) return 'blocked';
           }
-          if (!linkedInDestination) return true;
-          return verifiedExternalRedirect
+          if (!linkedInDestination) return 'navigation';
+          return (verifiedExternalRedirect
             || /^\/(?:feed|jobs|mynetwork|messaging|notifications)\/?$/.test(destination.pathname)
-            || /^\/in\/[^/]+\/overlay\/contact-info\/?$/.test(destination.pathname);
+            || /^\/in\/[^/]+\/overlay\/contact-info\/?$/.test(destination.pathname))
+            ? 'navigation'
+            : 'none';
         } catch {
-          return false;
+          return unresolved();
         }
       };
 
@@ -4413,8 +4416,18 @@
         if (!visible(control) || (modal && !_isComposedAncestor(modal, target))) {
           return { success: true, messageSend: null, conclusive: false, identityCandidates: [] };
         }
-        if (verifiedLinkedInNavigation(target)) {
+        const linkedInNavigation = classifyLinkedInNavigation(target);
+        if (linkedInNavigation === 'navigation') {
           return { success: true, messageSend: false, conclusive: true, navigation: true, identityCandidates: [] };
+        }
+        if (linkedInNavigation === 'blocked') {
+          return {
+            success: true,
+            messageSend: null,
+            conclusive: false,
+            navigationBlocked: true,
+            identityCandidates: [],
+          };
         }
         composer = layoutComposer;
         if (!composer) {

--- a/src/firefox/src/content/content.js
+++ b/src/firefox/src/content/content.js
@@ -4367,17 +4367,27 @@
         const heuristicModalSelector = '[data-overlay],.modal.show,.modal-overlay,.overlay,'
           + '[class*="modal"][class*="open"],[class*="overlay"][class*="active"],'
           + '[class*="DialogOverlay"],[class*="ModalOverlay"]';
+        const dialogContentSelector = '[class*="DialogContent"],[class*="ModalContent"]';
         const composedModal = _composedClosestElement(
           link,
-          `dialog,[role="dialog"],[role="alertdialog"],${heuristicModalSelector}`,
+          `dialog,[role="dialog"],[role="alertdialog"],${heuristicModalSelector},${dialogContentSelector}`,
         );
         const modal = composedModal
           || (blockingModal && _isComposedAncestor(blockingModal, link) ? blockingModal : null);
+        const contentHasVisibleOverlaySibling = (() => {
+          if (!modal?.matches?.(dialogContentSelector)) return false;
+          const parent = modal.parentElement || modal.parentNode;
+          if (!parent) return false;
+          return Array.from(parent.children).some((sibling) => sibling !== modal
+            && sibling.matches?.('[class*="DialogOverlay"],[class*="ModalOverlay"]')
+            && _hasVisibleBox(sibling, 100, 100));
+        })();
         const modalIsBlocking = !!modal && (
           modal === blockingModal
           || (modal.tagName === 'DIALOG' && modal.hasAttribute('open') && _isNativeBlockingDialog(modal))
           || (/^(?:dialog|alertdialog)$/.test(modal.getAttribute?.('role') || '')
             && modal.getAttribute?.('aria-modal') === 'true')
+          || contentHasVisibleOverlaySibling
           || (() => {
             if (!modal.matches?.(heuristicModalSelector)) return false;
             const rect = modal.getBoundingClientRect();

--- a/src/firefox/src/content/content.js
+++ b/src/firefox/src/content/content.js
@@ -4328,7 +4328,7 @@
           && railRect.right <= composerRect.left + 64;
       };
 
-      const classifyLinkedInNavigation = (clicked) => {
+      const classifyLinkedInNavigation = (clicked, blockingModal = null) => {
         if (params.adapterName !== 'linkedin' || !clicked) return 'none';
         const link = _composedClosestElement(clicked, 'a[href]');
         if (!link || !visible(link)) return 'none';
@@ -4339,7 +4339,9 @@
             || _composedClosestElement(link, 'form')
             || link.hasAttribute?.('download')
             || (link.getAttribute?.('role') && link.getAttribute('role') !== 'link')) return 'blocked';
-        const modal = _composedClosestElement(link, 'dialog,[role="dialog"],[role="alertdialog"]');
+        const modal = blockingModal && _isComposedAncestor(blockingModal, link)
+          ? blockingModal
+          : _composedClosestElement(link, 'dialog,[role="dialog"],[role="alertdialog"]');
         const unresolved = () => modal ? 'blocked' : 'none';
         try {
           const href = String(link.getAttribute('href') || '').trim();
@@ -4362,8 +4364,19 @@
             } catch {}
           }
           if (modal) {
-            const contactInfoOverlay = /^\/in\/[^/]+\/overlay\/contact-info\/?$/.test(location.pathname);
-            if (!contactInfoOverlay || !verifiedExternalRedirect) return 'blocked';
+            const contactInfoOverlay = /^\/in\/([^/]+)\/overlay\/contact-info\/?$/.exec(location.pathname);
+            const profilePath = contactInfoOverlay ? `/in/${contactInfoOverlay[1]}` : '';
+            const ownsContactInfoRoute = !!profilePath && Array.from(modal.querySelectorAll?.('a[href]') || [])
+              .some((candidate) => {
+                try {
+                  const candidateUrl = new URL(candidate.getAttribute('href'), document.baseURI);
+                  return isLinkedInHost(candidateUrl.hostname)
+                    && candidateUrl.pathname.replace(/\/+$/, '') === profilePath;
+                } catch {
+                  return false;
+                }
+              });
+            if (!ownsContactInfoRoute || !verifiedExternalRedirect) return 'blocked';
           }
           if (!linkedInDestination) return 'navigation';
           return (verifiedExternalRedirect
@@ -4416,7 +4429,7 @@
         if (!visible(control) || (modal && !_isComposedAncestor(modal, target))) {
           return { success: true, messageSend: null, conclusive: false, identityCandidates: [] };
         }
-        const linkedInNavigation = classifyLinkedInNavigation(target);
+        const linkedInNavigation = classifyLinkedInNavigation(target, modal);
         if (linkedInNavigation === 'navigation') {
           return { success: true, messageSend: false, conclusive: true, navigation: true, identityCandidates: [] };
         }

--- a/src/firefox/src/content/content.js
+++ b/src/firefox/src/content/content.js
@@ -571,14 +571,23 @@
 
   function _someComposedDescendant(root, selector, predicate, limit = 2000) {
     const pending = [root];
+    const seen = new Set();
     let visited = 0;
     while (pending.length && visited < limit) {
       const scope = pending.shift();
-      const elements = scope?.querySelectorAll?.('*') || [];
+      const descendants = scope?.querySelectorAll?.('*') || [];
+      const elements = scope?.nodeType === Node.ELEMENT_NODE
+        ? [scope, ...descendants]
+        : descendants;
       for (const element of elements) {
+        if (seen.has(element)) continue;
+        seen.add(element);
         visited += 1;
         if (element.matches?.(selector) && predicate(element)) return true;
         if (element.shadowRoot) pending.push(element.shadowRoot);
+        if (element.tagName === 'SLOT') {
+          pending.push(...(element.assignedElements?.({ flatten: true }) || []));
+        }
         if (visited >= limit) break;
       }
     }
@@ -4414,6 +4423,7 @@
           }
           if (!linkedInDestination) return 'navigation';
           if (redirectPath) return 'blocked';
+          if (/^\/messaging\/(?:send|compose)\/?$/.test(destination.pathname)) return 'blocked';
           return (/^\/(?:feed|jobs|mynetwork|messaging|notifications)\/?$/.test(destination.pathname)
             || /^\/in\/[^/]+\/overlay\/contact-info\/?$/.test(destination.pathname))
             ? 'navigation'

--- a/src/firefox/src/content/content.js
+++ b/src/firefox/src/content/content.js
@@ -569,6 +569,22 @@
     return null;
   }
 
+  function _someComposedDescendant(root, selector, predicate, limit = 2000) {
+    const pending = [root];
+    let visited = 0;
+    while (pending.length && visited < limit) {
+      const scope = pending.shift();
+      const elements = scope?.querySelectorAll?.('*') || [];
+      for (const element of elements) {
+        visited += 1;
+        if (element.matches?.(selector) && predicate(element)) return true;
+        if (element.shadowRoot) pending.push(element.shadowRoot);
+        if (visited >= limit) break;
+      }
+    }
+    return false;
+  }
+
   function isVisiblyInteractive(el) {
     if (!el || el.tagName === 'BODY' || el.tagName === 'HTML') return false;
     if (_hasComposedClosest(el, '[aria-hidden="true"], [inert]')) return false;
@@ -4339,14 +4355,26 @@
             || _composedClosestElement(link, 'form')
             || link.hasAttribute?.('download')
             || (link.getAttribute?.('role') && link.getAttribute('role') !== 'link')) return 'blocked';
+        const heuristicModalSelector = '[data-overlay],.modal.show,.modal-overlay,.overlay,'
+          + '[class*="modal"][class*="open"],[class*="overlay"][class*="active"],'
+          + '[class*="DialogOverlay"],[class*="ModalOverlay"]';
         const composedModal = _composedClosestElement(
           link,
-          'dialog,[role="dialog"],[role="alertdialog"],[data-overlay],.modal.show,.modal-overlay,.overlay,'
-            + '[class*="modal"][class*="open"],[class*="overlay"][class*="active"],'
-            + '[class*="DialogOverlay"],[class*="ModalOverlay"]',
+          `dialog,[role="dialog"],[role="alertdialog"],${heuristicModalSelector}`,
         );
         const modal = composedModal
           || (blockingModal && _isComposedAncestor(blockingModal, link) ? blockingModal : null);
+        const modalIsBlocking = !!modal && (
+          modal === blockingModal
+          || (modal.tagName === 'DIALOG' && modal.hasAttribute('open') && _isNativeBlockingDialog(modal))
+          || (/^(?:dialog|alertdialog)$/.test(modal.getAttribute?.('role') || '')
+            && modal.getAttribute?.('aria-modal') === 'true')
+          || (() => {
+            if (!modal.matches?.(heuristicModalSelector)) return false;
+            const rect = modal.getBoundingClientRect();
+            return rect.width > 100 && rect.height > 100;
+          })()
+        );
         const unresolved = () => modal ? 'blocked' : 'none';
         try {
           const href = String(link.getAttribute('href') || '').trim();
@@ -4371,8 +4399,8 @@
           if (modal) {
             const contactInfoOverlay = /^\/in\/([^/]+)\/overlay\/contact-info\/?$/.exec(location.pathname);
             const profilePath = contactInfoOverlay ? `/in/${contactInfoOverlay[1]}` : '';
-            const ownsContactInfoRoute = !!profilePath && Array.from(modal.querySelectorAll?.('a[href]') || [])
-              .some((candidate) => {
+            const ownsContactInfoRoute = modalIsBlocking && !!profilePath
+              && _someComposedDescendant(modal, 'a[href]', (candidate) => {
                 try {
                   const candidateUrl = new URL(candidate.getAttribute('href'), document.baseURI);
                   return isLinkedInHost(candidateUrl.hostname)
@@ -4382,10 +4410,11 @@
                 }
               });
             if (!ownsContactInfoRoute || !verifiedExternalRedirect) return 'blocked';
+            return 'navigation';
           }
           if (!linkedInDestination) return 'navigation';
-          return (verifiedExternalRedirect
-            || /^\/(?:feed|jobs|mynetwork|messaging|notifications)\/?$/.test(destination.pathname)
+          if (redirectPath) return 'blocked';
+          return (/^\/(?:feed|jobs|mynetwork|messaging|notifications)\/?$/.test(destination.pathname)
             || /^\/in\/[^/]+\/overlay\/contact-info\/?$/.test(destination.pathname))
             ? 'navigation'
             : 'none';

--- a/test/fixtures/message-recipient-navigation.mjs
+++ b/test/fixtures/message-recipient-navigation.mjs
@@ -129,6 +129,8 @@ export function registerMessageRecipientNavigationFixtures({
         '/safety/go/',
         '/safety/go/?url=javascript%3Aalert(1)',
         '/safety/go/?url=https%3A%2F%2Flinkedin.com%2Fmessaging%2Fsend',
+        '/safety/go/?url=https%3A%2F%2Fm.linkedin.com%2Fmessaging%2Fsend',
+        '/safety/go/?url=https%3A%2F%2Fm.linkedin.com.%2Fmessaging%2Fsend',
       ]) {
         await page.locator('#safety-portfolio').evaluate((el, value) => el.setAttribute('href', value), href);
         const result = await probe('click', { text: 'portfolio.example', textMatch: 'exact' });
@@ -146,10 +148,14 @@ export function registerMessageRecipientNavigationFixtures({
         '/messaging/compose/',
         '/messaging/send/',
         'https://linkedin.com/messaging/send/',
+        'https://m.linkedin.com/messaging/send/',
+        'https://m.linkedin.com./messaging/send/',
         '/safety/go/',
         '/safety/go/?url=javascript%3Aalert(1)',
         '/safety/go/?url=https%3A%2F%2Fwww.linkedin.com%2Fmessaging%2Fsend',
         '/safety/go/?url=https%3A%2F%2Flinkedin.com%2Fmessaging%2Fsend',
+        '/safety/go/?url=https%3A%2F%2Fm.linkedin.com%2Fmessaging%2Fsend',
+        '/safety/go/?url=https%3A%2F%2Fm.linkedin.com.%2Fmessaging%2Fsend',
       ]) {
         await page.locator('#jobs').evaluate((el, href) => el.setAttribute('href', href), href);
         assert.equal((await guard('click', { text: 'Jobs' }))?.noDispatch, true, href);

--- a/test/fixtures/message-recipient-navigation.mjs
+++ b/test/fixtures/message-recipient-navigation.mjs
@@ -125,6 +125,8 @@ export function registerMessageRecipientNavigationFixtures({
         }
       }
       for (const href of [
+        '#',
+        'mailto:alice@example.com',
         'https://portfolio.example/',
         '/safety/go/',
         '/safety/go/?url=javascript%3Aalert(1)',
@@ -138,6 +140,67 @@ export function registerMessageRecipientNavigationFixtures({
         assert.notEqual(result.navigation, true, `${href}: ${JSON.stringify(result)}`);
         assert.equal((await guard('click', args))?.noDispatch, true, `${href}: recipient guard must fail closed`);
       }
+    });
+
+    register(`${kind}: LinkedIn contact-info redirects honor composed-tree safety boundaries`, async (page) => {
+      const { guard, probe } = await setup(page);
+      const refs = await page.evaluate(() => {
+        history.replaceState(null, '', '/in/alice/overlay/contact-info/');
+        document.querySelector('#chat').hidden = false;
+        const dialog = document.querySelector('#contact-info-dialog');
+        dialog.hidden = false;
+        const addShadowLink = (parent, hostId, text) => {
+          const host = document.createElement('span');
+          host.id = hostId;
+          parent.append(host);
+          const shadow = host.attachShadow({ mode: 'open' });
+          shadow.innerHTML = `<a href="/safety/go/?url=https%3A%2F%2Fportfolio.example%2F" style="display:inline-block;padding:8px">${text}</a>`;
+          return window.__wb_ax_ref(shadow.querySelector('a'));
+        };
+        const form = document.createElement('form');
+        dialog.append(form);
+        const action = document.createElement('span');
+        action.dataset.action = 'send';
+        dialog.append(action);
+        return {
+          safe: addShadowLink(dialog, 'shadow-safe-host', 'Shadow safe link'),
+          form: addShadowLink(form, 'shadow-form-host', 'Shadow form link'),
+          action: addShadowLink(action, 'shadow-action-host', 'Shadow action link'),
+        };
+      });
+      const safeArgs = { ref_id: refs.safe };
+      const safe = await probe('click_ax', safeArgs);
+      assert.equal(safe.navigation, true, JSON.stringify(safe));
+      assert.equal(await guard('click_ax', safeArgs), null);
+      for (const ref_id of [refs.form, refs.action]) {
+        const args = { ref_id };
+        const result = await probe('click_ax', args);
+        assert.equal(result.navigationBlocked, true, JSON.stringify(result));
+        assert.equal(result.conclusive, false, JSON.stringify(result));
+        assert.equal((await guard('click_ax', args))?.noDispatch, true);
+      }
+    });
+
+    register(`${kind}: LinkedIn safety redirects cannot escape a shadow-root modal`, async (page) => {
+      const { guard, probe } = await setup(page);
+      const ref_id = await page.evaluate(() => {
+        document.querySelector('#chat').hidden = false;
+        const modal = document.createElement('div');
+        modal.setAttribute('role', 'dialog');
+        modal.setAttribute('aria-modal', 'true');
+        modal.style.cssText = 'position:fixed;inset:0;background:white';
+        document.body.append(modal);
+        const host = document.createElement('span');
+        modal.append(host);
+        const shadow = host.attachShadow({ mode: 'open' });
+        shadow.innerHTML = '<a href="/safety/go/?url=https%3A%2F%2Fportfolio.example%2F" style="display:inline-block;padding:8px">Shadow modal link</a>';
+        return window.__wb_ax_ref(shadow.querySelector('a'));
+      });
+      const args = { ref_id };
+      const result = await probe('click_ax', args);
+      assert.equal(result.navigationBlocked, true, JSON.stringify(result));
+      assert.equal(result.conclusive, false, JSON.stringify(result));
+      assert.equal((await guard('click_ax', args))?.noDispatch, true);
     });
 
     register(`${kind}: LinkedIn recipient guard rejects ambiguous navigation and action lookalikes`, async (page) => {

--- a/test/fixtures/message-recipient-navigation.mjs
+++ b/test/fixtures/message-recipient-navigation.mjs
@@ -249,6 +249,53 @@ export function registerMessageRecipientNavigationFixtures({
       assert.equal(await guard('click_ax', args), null);
     });
 
+    register(`${kind}: LinkedIn Contact info recognizes shadow-root overlay content siblings`, async (page) => {
+      const { guard, probe } = await setup(page);
+      for (const [index, contentClass] of ['DialogContent', 'ModalContent'].entries()) {
+        const ref_id = await page.evaluate(({ contentClass, index }) => {
+          history.replaceState(null, '', '/in/alice/overlay/contact-info/');
+          document.querySelector('#chat').hidden = false;
+          const host = document.createElement('div');
+          host.id = `shadow-sibling-modal-host-${index}`;
+          document.body.append(host);
+          const shadow = host.attachShadow({ mode: 'open' });
+          shadow.innerHTML = `
+            <div class="DialogOverlay" style="position:fixed;inset:0;background:rgba(0,0,0,.5)"></div>
+            <div class="${contentClass}" style="position:fixed;inset:40px;background:white">
+              <a href="/in/alice/">linkedin.com/in/alice</a>
+              <a id="sibling-modal-link" href="/safety/go/?url=https%3A%2F%2Fportfolio.example%2F"
+                style="display:inline-block;padding:8px">Sibling modal link</a>
+            </div>`;
+          return window.__wb_ax_ref(shadow.querySelector('#sibling-modal-link'));
+        }, { contentClass, index });
+        const args = { ref_id };
+        const result = await probe('click_ax', args);
+        assert.equal(result.navigation, true, `${contentClass}: ${JSON.stringify(result)}`);
+        assert.equal(await guard('click_ax', args), null);
+        await page.evaluate((index) => {
+          document.querySelector(`#shadow-sibling-modal-host-${index}`)?.remove();
+        }, index);
+      }
+      const ref_id = await page.evaluate(() => {
+        const host = document.createElement('div');
+        host.id = 'shadow-content-without-overlay-host';
+        document.body.append(host);
+        const shadow = host.attachShadow({ mode: 'open' });
+        shadow.innerHTML = `
+          <div class="DialogContent" style="position:fixed;inset:40px;background:white">
+            <a href="/in/alice/">linkedin.com/in/alice</a>
+            <a id="content-without-overlay-link"
+              href="/safety/go/?url=https%3A%2F%2Fportfolio.example%2F"
+              style="display:inline-block;padding:8px">Unbacked content link</a>
+          </div>`;
+        return window.__wb_ax_ref(shadow.querySelector('#content-without-overlay-link'));
+      });
+      const result = await probe('click_ax', { ref_id });
+      assert.equal(result.navigationBlocked, true, JSON.stringify(result));
+      assert.equal(result.conclusive, false, JSON.stringify(result));
+      assert.equal((await guard('click_ax', { ref_id }))?.noDispatch, true);
+    });
+
     register(`${kind}: LinkedIn non-blocking dialogs cannot claim Contact info redirects`, async (page) => {
       const { guard, probe } = await setup(page);
       await page.evaluate(() => {

--- a/test/fixtures/message-recipient-navigation.mjs
+++ b/test/fixtures/message-recipient-navigation.mjs
@@ -25,6 +25,15 @@ export function registerMessageRecipientNavigationFixtures({
           <a id="jobs" class="destination" href="/jobs/"><span id="jobs-label">Jobs</span></a>
           <a id="messaging" href="/messaging/">Messaging</a>
         </nav>
+        <main>
+          <a id="portfolio" href="https://portfolio.example/"><span id="portfolio-label">View my portfolio</span></a>
+          <a id="contact-info" href="/in/alice/overlay/contact-info/">Contact info</a>
+        </main>
+        <div id="contact-info-dialog" role="dialog" aria-modal="true" hidden>
+          <button id="close-contact-info" type="button">Close</button>
+          <a id="safety-portfolio" href="/safety/go/?url=https%3A%2F%2Fportfolio.example%2F">portfolio.example</a>
+          <a id="legacy-portfolio" href="/redir/redirect?url=https%3A%2F%2Flegacy-portfolio.example%2F">legacy-portfolio.example</a>
+        </div>
         <form id="chat" hidden>
           <h2>Alice</h2><textarea id="body">Hello Alice</textarea><button id="send" type="button">Send</button>
         </form>`, kind);
@@ -65,9 +74,83 @@ export function registerMessageRecipientNavigationFixtures({
       }
     });
 
+    register(`${kind}: LinkedIn ordinary document links bypass the message recipient guard (#3010)`, async (page) => {
+      const { guard, probe } = await setup(page);
+      for (const open of [false, true]) {
+        await page.evaluate(open => { document.querySelector('#chat').hidden = !open; }, open);
+        const portfolioRef = await page.evaluate(
+          () => window.__wb_ax_ref(document.querySelector('#portfolio-label')),
+        );
+        for (const [tool, args, expected] of [
+          ['click', { text: 'View my portfolio', textMatch: 'exact' }, 'portfolio'],
+          ['click_ax', { ref_id: portfolioRef }, 'portfolio'],
+          ['click', { text: 'Contact info', textMatch: 'exact' }, 'contact-info'],
+        ]) {
+          const result = await probe(tool, args);
+          assert.equal(result.conclusive, true, JSON.stringify(result));
+          assert.equal(result.messageSend, false);
+          assert.equal(result.navigation, true);
+          assert.equal(await guard(tool, args), null);
+          const clicked = await call(page, tool, args);
+          assert.equal(clicked.success, true, JSON.stringify(clicked));
+          assert.equal(await page.evaluate(() => window.fixtureClicks.at(-1)), expected);
+        }
+      }
+    });
+
+    register(`${kind}: LinkedIn contact-info safety redirects navigate inside the modal (#3010)`, async (page) => {
+      const { guard, probe } = await setup(page);
+      await page.evaluate(() => {
+        history.replaceState(null, '', '/in/alice/overlay/contact-info/');
+        document.querySelector('#contact-info-dialog').hidden = false;
+      });
+      for (const open of [false, true]) {
+        await page.evaluate(open => { document.querySelector('#chat').hidden = !open; }, open);
+        const safetyRef = await page.evaluate(
+          () => window.__wb_ax_ref(document.querySelector('#safety-portfolio')),
+        );
+        for (const [tool, args, expected] of [
+          ['click', { text: 'portfolio.example', textMatch: 'exact' }, 'safety-portfolio'],
+          ['click_ax', { ref_id: safetyRef }, 'safety-portfolio'],
+          ['click', { text: 'legacy-portfolio.example', textMatch: 'exact' }, 'legacy-portfolio'],
+        ]) {
+          const result = await probe(tool, args);
+          assert.equal(result.conclusive, true, JSON.stringify(result));
+          assert.equal(result.messageSend, false);
+          assert.equal(result.navigation, true);
+          assert.equal(await guard(tool, args), null);
+          const clicked = await call(page, tool, args);
+          assert.equal(clicked.success, true, JSON.stringify(clicked));
+          assert.equal(await page.evaluate(() => window.fixtureClicks.at(-1)), expected);
+        }
+      }
+      for (const href of [
+        'https://portfolio.example/',
+        '/safety/go/',
+        '/safety/go/?url=javascript%3Aalert(1)',
+        '/safety/go/?url=https%3A%2F%2Flinkedin.com%2Fmessaging%2Fsend',
+      ]) {
+        await page.locator('#safety-portfolio').evaluate((el, value) => el.setAttribute('href', value), href);
+        const result = await probe('click', { text: 'portfolio.example', textMatch: 'exact' });
+        assert.notEqual(result.navigation, true, `${href}: ${JSON.stringify(result)}`);
+      }
+    });
+
     register(`${kind}: LinkedIn recipient guard rejects ambiguous navigation and action lookalikes`, async (page) => {
       const { guard } = await setup(page);
-      for (const href of ['#', 'javascript:void(0)', 'https://example.com/jobs/', '/messaging/compose/', '/messaging/send/']) {
+      for (const href of [
+        '#',
+        'javascript:void(0)',
+        'mailto:alice@example.com',
+        '/in/alice/',
+        '/messaging/compose/',
+        '/messaging/send/',
+        'https://linkedin.com/messaging/send/',
+        '/safety/go/',
+        '/safety/go/?url=javascript%3Aalert(1)',
+        '/safety/go/?url=https%3A%2F%2Fwww.linkedin.com%2Fmessaging%2Fsend',
+        '/safety/go/?url=https%3A%2F%2Flinkedin.com%2Fmessaging%2Fsend',
+      ]) {
         await page.locator('#jobs').evaluate((el, href) => el.setAttribute('href', href), href);
         assert.equal((await guard('click', { text: 'Jobs' }))?.noDispatch, true, href);
       }

--- a/test/fixtures/message-recipient-navigation.mjs
+++ b/test/fixtures/message-recipient-navigation.mjs
@@ -31,6 +31,7 @@ export function registerMessageRecipientNavigationFixtures({
         </main>
         <div id="contact-info-dialog" role="dialog" aria-modal="true" hidden>
           <button id="close-contact-info" type="button">Close</button>
+          <a id="contact-profile" href="/in/alice/">linkedin.com/in/alice</a>
           <a id="safety-portfolio" href="/safety/go/?url=https%3A%2F%2Fportfolio.example%2F">portfolio.example</a>
           <a id="legacy-portfolio" href="/redir/redirect?url=https%3A%2F%2Flegacy-portfolio.example%2F">legacy-portfolio.example</a>
         </div>
@@ -184,6 +185,7 @@ export function registerMessageRecipientNavigationFixtures({
     register(`${kind}: LinkedIn safety redirects cannot escape a shadow-root modal`, async (page) => {
       const { guard, probe } = await setup(page);
       const ref_id = await page.evaluate(() => {
+        history.replaceState(null, '', '/in/alice/overlay/contact-info/');
         document.querySelector('#chat').hidden = false;
         const modal = document.createElement('div');
         modal.setAttribute('role', 'dialog');
@@ -201,6 +203,24 @@ export function registerMessageRecipientNavigationFixtures({
       assert.equal(result.navigationBlocked, true, JSON.stringify(result));
       assert.equal(result.conclusive, false, JSON.stringify(result));
       assert.equal((await guard('click_ax', args))?.noDispatch, true);
+    });
+
+    register(`${kind}: LinkedIn safety redirects cannot escape a heuristic modal`, async (page) => {
+      const { guard, probe } = await setup(page);
+      await page.evaluate(() => {
+        history.replaceState(null, '', '/in/alice/overlay/contact-info/');
+        document.querySelector('#chat').hidden = false;
+        const modal = document.createElement('div');
+        modal.className = 'modal show';
+        modal.style.cssText = 'position:fixed;inset:0;background:white';
+        modal.innerHTML = '<a id="heuristic-modal-link" href="/safety/go/?url=https%3A%2F%2Fportfolio.example%2F" style="display:inline-block;padding:8px">Heuristic modal link</a>';
+        document.body.append(modal);
+      });
+      const args = { selector: '#heuristic-modal-link' };
+      const result = await probe('click', args);
+      assert.equal(result.navigationBlocked, true, JSON.stringify(result));
+      assert.equal(result.conclusive, false, JSON.stringify(result));
+      assert.equal((await guard('click', args))?.noDispatch, true);
     });
 
     register(`${kind}: LinkedIn recipient guard rejects ambiguous navigation and action lookalikes`, async (page) => {

--- a/test/fixtures/message-recipient-navigation.mjs
+++ b/test/fixtures/message-recipient-navigation.mjs
@@ -222,6 +222,33 @@ export function registerMessageRecipientNavigationFixtures({
       assert.equal(await guard('click', args), null);
     });
 
+    register(`${kind}: LinkedIn Contact info ownership follows flattened slots`, async (page) => {
+      const { guard, probe } = await setup(page);
+      const ref_id = await page.evaluate(() => {
+        history.replaceState(null, '', '/in/alice/overlay/contact-info/');
+        document.querySelector('#contact-info-dialog').remove();
+        const host = document.createElement('div');
+        const profile = document.createElement('a');
+        profile.slot = 'profile';
+        profile.href = '/in/alice/';
+        profile.textContent = 'linkedin.com/in/alice';
+        host.append(profile);
+        document.body.append(host);
+        const shadow = host.attachShadow({ mode: 'open' });
+        shadow.innerHTML = `
+          <div role="dialog" aria-modal="true" style="position:fixed;inset:0;background:white">
+            <slot name="profile"></slot>
+            <a id="slotted-ownership-link" href="/safety/go/?url=https%3A%2F%2Fportfolio.example%2F"
+              style="display:inline-block;padding:8px">Slotted ownership link</a>
+          </div>`;
+        return window.__wb_ax_ref(shadow.querySelector('#slotted-ownership-link'));
+      });
+      const args = { ref_id };
+      const result = await probe('click_ax', args);
+      assert.equal(result.navigation, true, JSON.stringify(result));
+      assert.equal(await guard('click_ax', args), null);
+    });
+
     register(`${kind}: LinkedIn non-blocking dialogs cannot claim Contact info redirects`, async (page) => {
       const { guard, probe } = await setup(page);
       await page.evaluate(() => {
@@ -280,17 +307,28 @@ export function registerMessageRecipientNavigationFixtures({
     });
 
     register(`${kind}: LinkedIn recipient guard rejects ambiguous navigation and action lookalikes`, async (page) => {
-      const { guard } = await setup(page);
-      for (const href of [
-        '#',
-        'javascript:void(0)',
-        'mailto:alice@example.com',
-        '/in/alice/',
+      const { guard, probe } = await setup(page);
+      const messageActionHrefs = [
         '/messaging/compose/',
         '/messaging/send/',
         'https://linkedin.com/messaging/send/',
         'https://m.linkedin.com/messaging/send/',
         'https://m.linkedin.com./messaging/send/',
+      ];
+      await page.evaluate(() => { document.querySelector('#chat').hidden = false; });
+      for (const href of messageActionHrefs) {
+        await page.locator('#jobs').evaluate((el, value) => el.setAttribute('href', value), href);
+        const args = { text: 'Jobs' };
+        const result = await probe('click', args);
+        assert.equal(result.navigationBlocked, true, `${href}: ${JSON.stringify(result)}`);
+        assert.equal((await guard('click', args))?.noDispatch, true, href);
+      }
+      await page.evaluate(() => { document.querySelector('#chat').hidden = true; });
+      for (const href of [
+        '#',
+        'javascript:void(0)',
+        'mailto:alice@example.com',
+        '/in/alice/',
         '/safety/go/?url=https%3A%2F%2Fportfolio.example%2F',
         '/safety/go/',
         '/safety/go/?url=javascript%3Aalert(1)',

--- a/test/fixtures/message-recipient-navigation.mjs
+++ b/test/fixtures/message-recipient-navigation.mjs
@@ -133,8 +133,10 @@ export function registerMessageRecipientNavigationFixtures({
         '/safety/go/?url=https%3A%2F%2Fm.linkedin.com.%2Fmessaging%2Fsend',
       ]) {
         await page.locator('#safety-portfolio').evaluate((el, value) => el.setAttribute('href', value), href);
-        const result = await probe('click', { text: 'portfolio.example', textMatch: 'exact' });
+        const args = { text: 'portfolio.example', textMatch: 'exact' };
+        const result = await probe('click', args);
         assert.notEqual(result.navigation, true, `${href}: ${JSON.stringify(result)}`);
+        assert.equal((await guard('click', args))?.noDispatch, true, `${href}: recipient guard must fail closed`);
       }
     });
 

--- a/test/fixtures/message-recipient-navigation.mjs
+++ b/test/fixtures/message-recipient-navigation.mjs
@@ -205,6 +205,41 @@ export function registerMessageRecipientNavigationFixtures({
       assert.equal((await guard('click_ax', args))?.noDispatch, true);
     });
 
+    register(`${kind}: LinkedIn Contact info ownership crosses open shadow roots`, async (page) => {
+      const { guard, probe } = await setup(page);
+      await page.evaluate(() => {
+        history.replaceState(null, '', '/in/alice/overlay/contact-info/');
+        const dialog = document.querySelector('#contact-info-dialog');
+        dialog.hidden = false;
+        const profile = document.querySelector('#contact-profile');
+        const host = document.createElement('span');
+        dialog.append(host);
+        host.attachShadow({ mode: 'open' }).append(profile);
+      });
+      const args = { text: 'portfolio.example', textMatch: 'exact' };
+      const result = await probe('click', args);
+      assert.equal(result.navigation, true, JSON.stringify(result));
+      assert.equal(await guard('click', args), null);
+    });
+
+    register(`${kind}: LinkedIn non-blocking dialogs cannot claim Contact info redirects`, async (page) => {
+      const { guard, probe } = await setup(page);
+      await page.evaluate(() => {
+        history.replaceState(null, '', '/in/alice/overlay/contact-info/');
+        document.querySelector('#chat').hidden = false;
+        document.body.insertAdjacentHTML('beforeend', `
+          <div role="dialog" style="position:fixed;inset:120px;background:white">
+            <a href="/in/alice/">linkedin.com/in/alice</a>
+            <a id="non-blocking-dialog-link" href="/safety/go/?url=https%3A%2F%2Fportfolio.example%2F">Non-blocking dialog link</a>
+          </div>`);
+      });
+      const args = { selector: '#non-blocking-dialog-link' };
+      const result = await probe('click', args);
+      assert.equal(result.navigationBlocked, true, JSON.stringify(result));
+      assert.equal(result.conclusive, false, JSON.stringify(result));
+      assert.equal((await guard('click', args))?.noDispatch, true);
+    });
+
     register(`${kind}: LinkedIn safety redirects cannot escape a heuristic modal`, async (page) => {
       const { guard, probe } = await setup(page);
       await page.evaluate(() => {
@@ -256,6 +291,7 @@ export function registerMessageRecipientNavigationFixtures({
         'https://linkedin.com/messaging/send/',
         'https://m.linkedin.com/messaging/send/',
         'https://m.linkedin.com./messaging/send/',
+        '/safety/go/?url=https%3A%2F%2Fportfolio.example%2F',
         '/safety/go/',
         '/safety/go/?url=javascript%3Aalert(1)',
         '/safety/go/?url=https%3A%2F%2Fwww.linkedin.com%2Fmessaging%2Fsend',

--- a/test/fixtures/message-recipient-navigation.mjs
+++ b/test/fixtures/message-recipient-navigation.mjs
@@ -223,6 +223,27 @@ export function registerMessageRecipientNavigationFixtures({
       assert.equal((await guard('click', args))?.noDispatch, true);
     });
 
+    register(`${kind}: LinkedIn safety redirects cannot escape a shadow-root heuristic modal`, async (page) => {
+      const { guard, probe } = await setup(page);
+      const ref_id = await page.evaluate(() => {
+        history.replaceState(null, '', '/in/alice/overlay/contact-info/');
+        document.querySelector('#chat').hidden = false;
+        const host = document.createElement('div');
+        document.body.append(host);
+        const shadow = host.attachShadow({ mode: 'open' });
+        shadow.innerHTML = `
+          <div class="modal show" style="position:fixed;inset:0;background:white">
+            <a href="/safety/go/?url=https%3A%2F%2Fportfolio.example%2F" style="display:inline-block;padding:8px">Shadow heuristic modal link</a>
+          </div>`;
+        return window.__wb_ax_ref(shadow.querySelector('a'));
+      });
+      const args = { ref_id };
+      const result = await probe('click_ax', args);
+      assert.equal(result.navigationBlocked, true, JSON.stringify(result));
+      assert.equal(result.conclusive, false, JSON.stringify(result));
+      assert.equal((await guard('click_ax', args))?.noDispatch, true);
+    });
+
     register(`${kind}: LinkedIn recipient guard rejects ambiguous navigation and action lookalikes`, async (page) => {
       const { guard } = await setup(page);
       for (const href of [


### PR DESCRIPTION
## Summary

- classify ordinary external LinkedIn anchors as navigation instead of possible message sends
- allow verified `/safety/go` and `/redir/redirect` external HTTP(S) links only inside the active, owning profile Contact info modal
- keep redirects outside modals, malformed redirects, LinkedIn and subdomain message destinations, forms, buttons, action controls, downloads, and non-Contact-info modal links on the existing fail-closed recipient-verification path
- terminally block LinkedIn `/messaging/send/` and `/messaging/compose/` destinations before conversation-selection heuristics can reclassify them
- traverse composed-tree ancestry, open shadow roots, and flattened slot assignments so form/action ancestry, modal boundaries, and canonical profile ownership cannot be bypassed or lost through Shadow DOM
- add matching Chrome and Firefox regression coverage for `click` and `click_ax`

## Problem

LinkedIn profile website links are rendered inside the Contact info dialog and point through LinkedIn's `/safety/go/?url=...` redirect. The recipient guard rejected dialog-contained links before classifying the resolved external destination, so both text `click` and `click_ax` failed with `message_send_classification_inconclusive` even though the Accessibility Tree had resolved the correct link.

## Safety boundaries

The navigation classifier has three outcomes: verified navigation, terminal blocked, or no classification. Invalid modal redirects, LinkedIn message-action destinations, and links inside composed-tree form/action ancestors terminate as blocked before conversation-selection heuristics can run. LinkedIn apex, subdomain, and trailing-dot hostnames remain internal and cannot be unwrapped as external destinations.

A safety redirect is allowed only when the active blocking modal owns the target, the current route is `/in/<slug>/overlay/contact-info/`, and that same modal contains the canonical `/in/<same-slug>/` profile link. The ownership search includes open child shadow roots and flattened slot assignments. Redirects outside modals and non-blocking semantic dialogs remain terminally blocked, so the route alone cannot authorize a redirect from an unrelated surface.

## Validation

- `node test/run.js` — passed
- `npm run test:fixtures` — all Chrome and Firefox LinkedIn #2999/#3010 scenarios passed, including flattened slot ownership, message-action fallthrough with an open composer, malformed redirects, LinkedIn subdomains, redirects outside modals, non-blocking semantic dialogs, terminal fail-closed behavior, composed-tree ancestry and ownership, heuristic overlays, and Contact info modal ownership; latest full run completed with 200 passed and 4 unrelated timing-sensitive failures in existing recipient-bound deadline, Firefox selection-dialog, and rich-text toolbar fixtures
- GitHub Actions `smoke` — passed on commit `60736d5f`
- real Chrome/LinkedIn test after reloading the unpacked extension:
  - opened Contact info with `click_ax`
  - refreshed the Accessibility Tree and used the new `juejin.cn` ref
  - `click_ax` returned `success: true` and opened the external page in a background tab
  - zero `navigate` fallback calls
  - zero `message_send_classification_inconclusive` errors

The real trace contains personal profile data, so only the above redacted results are included here.

Fixes #3010