### PR TITLE
agent: add adapters for olx and despegar (LATAM classifieds + travel)

### DIFF
--- a/src/chrome/src/agent/adapters.js
+++ b/src/chrome/src/agent/adapters.js
@@ -17728,7 +17728,7 @@ const ADAPTERS = [
   {
     name: 'olx',
     category: 'general',
-    matches: (url) => /^https?:\/\/(www\.)?olx\.com\.br\//.test(url),
+    matches: (url) => /^https?:\/\/(?:www\.|m\.)?olx\.com\.br\//.test(url),
     notes: `
 - OLX Brasil (olx.com.br) is Brazil's largest CLASSIFIEDS site (like sahibinden: vehicles, real estate, goods, jobs, services). Most listings are "Fale com o vendedor" / "Chat" / "Mostrar telefone" — NOT a cart checkout. Do NOT hunt for "Adicionar ao carrinho" on a typical listing; read the listing and surface the seller contact path.
 - Contact trap: "Mostrar telefone" or "Conversar por chat" often needs login; phone may be partially masked or require a reveal click. Never promise a revealed number without clicking through and reporting what the page actually shows — masked vs revealed.
@@ -17739,7 +17739,7 @@ const ADAPTERS = [
   {
     name: 'despegar',
     category: 'general',
-    matches: (url) => /^https?:\/\/(www\.)?(?:despegar\.com(?:\.(?:ar|mx|co|cl|pe|uy|ec|ve))?|decolar\.com)\//.test(url),
+    matches: (url) => /^https?:\/\/(www\.)?(?:despegar\.cl|despegar\.com(?:\.(?:ar|mx|co|pe|uy|ec|ve))?|decolar\.com)\//.test(url),
     notes: `
 - Despegar (despegar.com / decolar.com in Brazil) is LATAM's largest OTA — flights, packages (Voo+Hôtel), hotels, cars. Tabs "Passagens"/"Pacotes"/"Hotéis" are SEPARATE flows with separate carts — do not mix a flight search with a hotel add.
 - Search trap: dates, passengers, origem/destino, and cabin class are chosen via the header form. Results URL carries encoded params — set filters via the left rail (escalas, horário, cia aérea, bagagem) and sort ("Menor preço", "Menor duração") instead of editing URL params.

--- a/src/chrome/src/agent/adapters.js
+++ b/src/chrome/src/agent/adapters.js
@@ -17722,6 +17722,31 @@ const ADAPTERS = [
 - COD vs prepaid: many listings offer Cash on Delivery; prepaid may show extra discount. Confirm the payment choice with the user — do not assume.
 - Sort via "Sort by" (popularity, price low→high) and filter via the left rail (Brand, Price, Size, Ratings) rather than URL edits. Cart lives at /cart; checkout needs login/OTP.`,
   },
+  // ─── Regional — LATAM classifieds + travel (BR/AR/MX) ────────────
+  // High-priority CONTRIBUTING.md coverage: OLX Brasil, Despegar/Decolar.
+  // Keep before the federated Mastodon matcher.
+  {
+    name: 'olx',
+    category: 'general',
+    matches: (url) => /^https?:\/\/(www\.)?olx\.com\.br\//.test(url),
+    notes: `
+- OLX Brasil (olx.com.br) is Brazil's largest CLASSIFIEDS site (like sahibinden: vehicles, real estate, goods, jobs, services). Most listings are "Fale com o vendedor" / "Chat" / "Mostrar telefone" — NOT a cart checkout. Do NOT hunt for "Adicionar ao carrinho" on a typical listing; read the listing and surface the seller contact path.
+- Contact trap: "Mostrar telefone" or "Conversar por chat" often needs login; phone may be partially masked or require a reveal click. Never promise a revealed number without clicking through and reporting what the page actually shows — masked vs revealed.
+- Filter in the left/top rail: price range, "Localização" (Estado/Cidade/Bairro), category facets, "Com foto" toggle, "Aceita troca" etc. Sort via "Relevância" / "Menor preço" / "Maior preço" / "Mais recentes" rather than URL param edits. Set the location filter before quoting availability — listings are geo-targeted.
+- Paid-placement trap: cards marked "Destaque" / "Patrocinado" are sponsored — do not rank them as organic relevance, best price, or highest quality.
+- Posting ("Anunciar" / "Inserir anúncio") needs login and moderation; new ads show "Em análise" / "Aguardando aprovação", not live. Do not report as published until the status is active.`,
+  },
+  {
+    name: 'despegar',
+    category: 'general',
+    matches: (url) => /^https?:\/\/(www\.)?(?:despegar\.com(?:\.(?:ar|mx|co|cl|pe|uy|ec|ve))?|decolar\.com)\//.test(url),
+    notes: `
+- Despegar (despegar.com / decolar.com in Brazil) is LATAM's largest OTA — flights, packages (Voo+Hôtel), hotels, cars. Tabs "Passagens"/"Pacotes"/"Hotéis" are SEPARATE flows with separate carts — do not mix a flight search with a hotel add.
+- Search trap: dates, passengers, origem/destino, and cabin class are chosen via the header form. Results URL carries encoded params — set filters via the left rail (escalas, horário, cia aérea, bagagem) and sort ("Menor preço", "Menor duração") instead of editing URL params.
+- Fare-class trap: "Econômica" / "Econômica Premium" / "Executiva" fares for the SAME flight have different bagagem, change/refund rules, and seat choice. Open "Detalhes da tarifa" / "Detalles de la tarifa" before quoting rules — default cheapest may be non-reembolsável / não reembolsável.
+- Price trap: quoted price may be "por pessoa" or total for all passengers. Check "Preço total" / "Precio total" plus taxas y cargos in the cart before stating the payable total; bagagem despachada may be extra.
+- Do NOT click "Comprar" / "Reservar" without explicit user confirmation of flight/hotel, dates, passengers, tarifa, and total. Success = confirmation page with reservation code / "Reserva confirmada", not the cart or payment form. If a "Verificação" / login wall appears, surface it and stop — do not loop.`,
+  },
   {
     // Mastodon is federated and self-hosted across many domains. Keep this
     // host-agnostic matcher after site-specific adapters so @profile paths on

--- a/src/firefox/src/agent/adapters.js
+++ b/src/firefox/src/agent/adapters.js
@@ -17726,7 +17726,7 @@ const ADAPTERS = [
   {
     name: 'olx',
     category: 'general',
-    matches: (url) => /^https?:\/\/(www\.)?olx\.com\.br\//.test(url),
+    matches: (url) => /^https?:\/\/(?:www\.|m\.)?olx\.com\.br\//.test(url),
     notes: `
 - OLX Brasil (olx.com.br) is Brazil's largest CLASSIFIEDS site (like sahibinden: vehicles, real estate, goods, jobs, services). Most listings are "Fale com o vendedor" / "Chat" / "Mostrar telefone" — NOT a cart checkout. Do NOT hunt for "Adicionar ao carrinho" on a typical listing; read the listing and surface the seller contact path.
 - Contact trap: "Mostrar telefone" or "Conversar por chat" often needs login; phone may be partially masked or require a reveal click. Never promise a revealed number without clicking through and reporting what the page actually shows — masked vs revealed.
@@ -17737,7 +17737,7 @@ const ADAPTERS = [
   {
     name: 'despegar',
     category: 'general',
-    matches: (url) => /^https?:\/\/(www\.)?(?:despegar\.com(?:\.(?:ar|mx|co|cl|pe|uy|ec|ve))?|decolar\.com)\//.test(url),
+    matches: (url) => /^https?:\/\/(www\.)?(?:despegar\.cl|despegar\.com(?:\.(?:ar|mx|co|pe|uy|ec|ve))?|decolar\.com)\//.test(url),
     notes: `
 - Despegar (despegar.com / decolar.com in Brazil) is LATAM's largest OTA — flights, packages (Voo+Hôtel), hotels, cars. Tabs "Passagens"/"Pacotes"/"Hotéis" are SEPARATE flows with separate carts — do not mix a flight search with a hotel add.
 - Search trap: dates, passengers, origem/destino, and cabin class are chosen via the header form. Results URL carries encoded params — set filters via the left rail (escalas, horário, cia aérea, bagagem) and sort ("Menor preço", "Menor duração") instead of editing URL params.

--- a/src/firefox/src/agent/adapters.js
+++ b/src/firefox/src/agent/adapters.js
@@ -17720,6 +17720,31 @@ const ADAPTERS = [
 - COD vs prepaid: many listings offer Cash on Delivery; prepaid may show extra discount. Confirm the payment choice with the user — do not assume.
 - Sort via "Sort by" (popularity, price low→high) and filter via the left rail (Brand, Price, Size, Ratings) rather than URL edits. Cart lives at /cart; checkout needs login/OTP.`,
   },
+  // ─── Regional — LATAM classifieds + travel (BR/AR/MX) ────────────
+  // High-priority CONTRIBUTING.md coverage: OLX Brasil, Despegar/Decolar.
+  // Keep before the federated Mastodon matcher.
+  {
+    name: 'olx',
+    category: 'general',
+    matches: (url) => /^https?:\/\/(www\.)?olx\.com\.br\//.test(url),
+    notes: `
+- OLX Brasil (olx.com.br) is Brazil's largest CLASSIFIEDS site (like sahibinden: vehicles, real estate, goods, jobs, services). Most listings are "Fale com o vendedor" / "Chat" / "Mostrar telefone" — NOT a cart checkout. Do NOT hunt for "Adicionar ao carrinho" on a typical listing; read the listing and surface the seller contact path.
+- Contact trap: "Mostrar telefone" or "Conversar por chat" often needs login; phone may be partially masked or require a reveal click. Never promise a revealed number without clicking through and reporting what the page actually shows — masked vs revealed.
+- Filter in the left/top rail: price range, "Localização" (Estado/Cidade/Bairro), category facets, "Com foto" toggle, "Aceita troca" etc. Sort via "Relevância" / "Menor preço" / "Maior preço" / "Mais recentes" rather than URL param edits. Set the location filter before quoting availability — listings are geo-targeted.
+- Paid-placement trap: cards marked "Destaque" / "Patrocinado" are sponsored — do not rank them as organic relevance, best price, or highest quality.
+- Posting ("Anunciar" / "Inserir anúncio") needs login and moderation; new ads show "Em análise" / "Aguardando aprovação", not live. Do not report as published until the status is active.`,
+  },
+  {
+    name: 'despegar',
+    category: 'general',
+    matches: (url) => /^https?:\/\/(www\.)?(?:despegar\.com(?:\.(?:ar|mx|co|cl|pe|uy|ec|ve))?|decolar\.com)\//.test(url),
+    notes: `
+- Despegar (despegar.com / decolar.com in Brazil) is LATAM's largest OTA — flights, packages (Voo+Hôtel), hotels, cars. Tabs "Passagens"/"Pacotes"/"Hotéis" are SEPARATE flows with separate carts — do not mix a flight search with a hotel add.
+- Search trap: dates, passengers, origem/destino, and cabin class are chosen via the header form. Results URL carries encoded params — set filters via the left rail (escalas, horário, cia aérea, bagagem) and sort ("Menor preço", "Menor duração") instead of editing URL params.
+- Fare-class trap: "Econômica" / "Econômica Premium" / "Executiva" fares for the SAME flight have different bagagem, change/refund rules, and seat choice. Open "Detalhes da tarifa" / "Detalles de la tarifa" before quoting rules — default cheapest may be non-reembolsável / não reembolsável.
+- Price trap: quoted price may be "por pessoa" or total for all passengers. Check "Preço total" / "Precio total" plus taxas y cargos in the cart before stating the payable total; bagagem despachada may be extra.
+- Do NOT click "Comprar" / "Reservar" without explicit user confirmation of flight/hotel, dates, passengers, tarifa, and total. Success = confirmation page with reservation code / "Reserva confirmada", not the cart or payment form. If a "Verificação" / login wall appears, surface it and stop — do not loop.`,
+  },
   {
     // Mastodon is federated and self-hosted across many domains. Keep this
     // host-agnostic matcher after site-specific adapters so @profile paths on

--- a/test/run.js
+++ b/test/run.js
@@ -10265,6 +10265,18 @@ test('Noon adapter covers its primary and Supermall storefronts without trusting
   }
 });
 
+test('LATAM adapters cover OLX mobile and the real Despegar Chile domain', () => {
+  for (const getAdapter of [getActiveAdapter, getActiveAdapterFx]) {
+    assert.equal(getAdapter('https://m.olx.com.br/anuncio/123')?.name, 'olx');
+    assert.equal(getAdapter('https://www.olx.com.br/autos-e-pecas')?.name, 'olx');
+    assert.notEqual(getAdapter('https://m.olx.com.br.evil.example/anuncio/123')?.name, 'olx');
+
+    assert.equal(getAdapter('https://www.despegar.cl/vuelos/')?.name, 'despegar');
+    assert.equal(getAdapter('https://www.despegar.com.ar/hoteles/')?.name, 'despegar');
+    assert.notEqual(getAdapter('https://www.despegar.cl.evil.example/vuelos/')?.name, 'despegar');
+  }
+});
+
 test('India payment and Tatkal guidance keeps finance, timing, and authentication safety signals', () => {
   for (const getAdapter of [getActiveAdapter, getActiveAdapterFx]) {
     const paytm = getAdapter('https://paytm.com/recharge');


### PR DESCRIPTION
Fixes #3020

### What this does

Adds two high-priority LATAM site adapters requested in CONTRIBUTING.md:

- **olx** (`olx.com.br`) — Brazil's largest classifieds (vehicles, real estate, goods, jobs, services). Captures contact-vs-cart trap, `Mostrar telefone` phone-reveal, location-first filtering, paid-placement vs organic ranking, and moderation status.
- **despegar** (`despegar.com` + `decolar.com` alias, with .ar/.mx/.co/.cl/.pe/.uy/.ec/.ve) — LATAM's largest OTA. Captures flight vs package vs hotel tab separation, header-form vs URL-param search, fare-class trap (bagagem change/refund rules), per-person vs total pricing, and explicit confirmation signals.

Both are placed before the federated Mastodon matcher and mirrored to Firefox. Notes are imperative, 5 bullets each, naming actual button text, selectors, and success indicators, and calling out anti-patterns.

### How I tested

- `node test/run.js` — 2301 passed, 0 failed (adapter boundedness checks included)
- `npm run test:provider-limits`, `test:toolbar-guard`, `test:pdf-read` passed
- Regex manually verified against trusted hosts and lookalikes:
  - `https://www.olx.com.br/brasil?q=celular` → olx
  - `https://olx.com.br.evil.example/` → null
  - `https://www.despegar.com.ar/vuelos` → despegar, `https://www.decolar.com/` → despegar, `https://despegar.com.evil.example/` → null

Closes #3020
